### PR TITLE
Add subcube dimension lemmas

### DIFF
--- a/Boolcube.lean
+++ b/Boolcube.lean
@@ -37,7 +37,23 @@ namespace Subcube
 
 /‑ Fix exactly one coordinate. -/ @[simp] def fixOne (i : Fin n) (b : Bool) : Subcube n := ⟨fun j ↦ if h : j = i then some b else none⟩
 
-@[simp] lemma mem_fixOne_iff {i b x} : (fixOne (n:=n) i b).Mem x ↔ x i = b := by constructor · intro h; simpa using h i · intro h j; by_cases hj : j = i · cases hj; simp [fixOne, h] · simp [fixOne, hj]
+@[simp] lemma mem_fixOne_iff {i b x} :
+  (fixOne (n := n) i b).Mem x ↔ x i = b := by
+  constructor
+  · intro h; simpa using h i
+  · intro h j; by_cases hj : j = i
+    · cases hj; simp [fixOne, h]
+    · simp [fixOne, hj]
+
+@[simp] lemma dim_full (n : ℕ) :
+  (Subcube.full : Subcube n).dim = n := by
+  classical
+  simp [Subcube.dim, Subcube.support]
+
+@[simp] lemma dim_point (x : Point n) :
+  (Subcube.point (n := n) x).dim = 0 := by
+  classical
+  simp [Subcube.dim, Subcube.support]
 
 end Subcube
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains experimental Lean code attempting to formalize aspects of a hypothetical proof that `P ≠ NP`. The development is highly incomplete. Several files include placeholders (`sorry` or `admit`). In particular:
 
-- `Boolcube.lean` defines basic structures and begins a construction for rectangle covers. The major lemmas rely on unproven assumptions.
+- `Boolcube.lean` defines basic structures and begins a construction for rectangle covers. The major lemmas rely on unproven assumptions.  It now also provides helper lemmas `dim_full` and `dim_point` describing trivial subcube dimensions.
 - `family_entropy_cover.lean` and `merge_low_sens.lean` previously declared axioms. They now contain theorem statements with proof holes marked by `sorry`.
 
 The repository is mainly a research sketch rather than a working proof. See `experiments/` for a small Python script exploring combinatorial data.


### PR DESCRIPTION
## Summary
- add lemmas `dim_full` and `dim_point` for trivial subcubes
- mention these helper lemmas in the README

## Testing
- `lake` command not available so no build was run

------
https://chatgpt.com/codex/tasks/task_e_684e1a8585f0832bbc991e9a96d53003