### PR TITLE
Update FCE lemma statement

### DIFF
--- a/Task description
+++ b/Task description
@@ -125,7 +125,7 @@ Finally, we formulate a precise technical plan for proving the FCE-Lemma and pre
 
 Formal Statement of FCE-Lemma
 
-Lemma (Family Collision-Entropy Lemma). Let $F$ be a family of boolean functions on $n$ bits, $F \subseteq {0,1}^{{0,1}^n}$, such that the collision entropy $H_2(F) \le h$ for some constant $h = O(1)$ (or more generally $h = o(n)$). Then there exists a collection $\mathcal{R}$ of at most $;2^{o(n)}$ monochromatic rectangles that simultaneously cover the truth table of every function $f \in F$. In other words, for every $f\in F$ and for every input $x\in{0,1}^n$, there is a rectangle $R \in \mathcal{R}$ such that $x \in R$ (meaning $x$ satisfies the subcube’s conditions) and $f$ is constant on $R$. Moreover, the rectangles can be chosen to have additional nice properties:
+Lemma (Family Collision-Entropy Lemma). Let $F$ be a family of boolean functions on $n$ bits, $F \subseteq {0,1}^{\{0,1\}^n}$, such that the collision entropy $H_2(F) \le h$ for some $h = o(n)$. Then there exists a collection $\mathcal{R}$ of at most $;2^{o(n)}$ monochromatic rectangles that simultaneously cover the truth table of every function $f \in F$. In other words, for every $f\in F$ and for every input $x\in{0,1}^n$, there is a rectangle $R \in \mathcal{R}$ such that $x \in R$ (meaning $x$ satisfies the subcube’s conditions) and $f$ is constant on $R$. Moreover, the rectangles can be chosen to have additional nice properties:
 
 Each rectangle $R \in \mathcal{R}$ is a subcube: it is specified by a (possibly partial) assignment to some subset of the $n$ variables. (So $R = {x \in {0,1}^n: x_i = b_i ;\forall i\in I_R}$ for some coordinate set $I_R$ and bits $b_i$ for $i\in I_R$.) The dimension of $R$ is $n - |I_R|$ (number of free bits).
 

--- a/fce lemma proof
+++ b/fce lemma proof
@@ -22,7 +22,7 @@ Let $\{0,1\}^n$ denote the Boolean cube, and let $f: \{0,1\}^n \to \{0,1\}$ be a
 
 ## 3. The FCE-Lemma (Main Theorem)
 
-**Theorem.** Let $F$ be a family of Boolean functions on $n$ bits with $H_2(F) \le h$, where $h = O(1)$ or $o(n)$. Then there exists a collection $\mathcal{R} = \{ R_1, \dots, R_m \}$ of monochromatic subcubes such that:
+**Theorem.** Let $F$ be a family of Boolean functions on $n$ bits with $H_2(F) \le h$, where $h = o(n)$. Then there exists a collection $\mathcal{R} = \{ R_1, \dots, R_m \}$ of monochromatic subcubes such that:
 
 1. Each $R \in \mathcal{R}$ is monochromatic for all $f \in F$;
 2. For every $f \in F$, the union of $\{ R \in \mathcal{R} : f(x) = 1 \text{ on } R \}$ covers all 1-points of $f$;


### PR DESCRIPTION
## Summary
- clarify the entropy bound in `fce lemma proof`
- match the same bound in the project `Task description`

## Testing
- `lean --run examples.lean` *(fails: `lean` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e1ffb4f94832bb86d31ae448fae7c