### PR TITLE
Implement wrapper for family entropy cover

### DIFF
--- a/family_entropy_cover.lean
+++ b/family_entropy_cover.lean
@@ -1,8 +1,10 @@
 import Boolcube
+import Cover
 
 namespace Boolcube
 
 open Entropy
+open Cover
 
 /--
 Family version of the collision entropy covering lemma.  The full proof
@@ -10,14 +12,18 @@ is nontrivial and currently omitted; this declaration serves as a
 placeholder so that other parts of the development can depend on it.
 -/
 /--
-`familyCollisionEntropyCover` is stated as a theorem rather than an axiom.
-The body is still unfinished and uses `sorry` as a placeholder.
+`familyCollisionEntropyCover` wraps the existential statement `Cover.cover_exists`
+for easier use in downstream files.  It asserts that a family of Boolean
+functions with bounded collision entropy admits a small set of jointly
+monochromatic subcubes covering all `1`‑inputs of every function in the family.
 -/
 theorem familyCollisionEntropyCover
-  {n : ℕ} (F : Family n) (h : ℝ) (hH : H₂ F ≤ h) :
+  {n : ℕ} (F : Family n) {h : ℕ} (hH : H₂ F ≤ (h : ℝ)) :
   ∃ (T : Finset (Subcube n)),
-    (∀ f ∈ F, ∀ x, (∃ C ∈ T, C.Mem x) → f x = true) ∨
-    (∀ f ∈ F, ∀ x, (∃ C ∈ T, C.Mem x) → f x = false) := by
-  sorry
+    (∀ C ∈ T, Subcube.monochromaticForFamily C F) ∧
+    (∀ f ∈ F, ∀ x, f x = true → ∃ C, C ∈ T ∧ C.Mem x) ∧
+    T.card ≤ mBound n h := by
+  classical
+  simpa using Cover.cover_exists (F := F) (h := h) hH
 
 end Boolcube


### PR DESCRIPTION
## Summary
- implement `familyCollisionEntropyCover` using `Cover.cover_exists`
- describe the lemma and include Cover imports

## Testing
- `lean` compiler not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_684e28f6f2f8832bbb1c49964fbecff2