### PR TITLE
Add descending count option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ python3 experiments/lemma_b_search.py     # exhaustive search of small circuits
 python3 experiments/single_gate_count.py  # list functions from a single gate
 python3 experiments/collision_entropy.py 3 1         # log2 of unique functions
 python3 experiments/collision_entropy.py 3 1 --circuits  # weight by circuit count
+python3 experiments/collision_entropy.py 3 1 --list-counts  # table counts
+python3 experiments/collision_entropy.py 3 1 --list-counts --descending
+python3 experiments/collision_entropy.py 3 1 --list-counts --top 5
 ```
 
 ## Status

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -23,6 +23,9 @@ python3 lemma_b_search.py 4 1      # four inputs, at most one gate
 python3 single_gate_count.py       # tables from one gate on three inputs
 python3 collision_entropy.py 3 1         # log2 of unique functions for n=3
 python3 collision_entropy.py 3 1 --circuits  # weight by circuit count
+python3 collision_entropy.py 3 1 --list-counts  # print truth table counts
+python3 collision_entropy.py 3 1 --list-counts --descending
+python3 collision_entropy.py 3 1 --list-counts --top 5
 ```
 
 Note that the enumeration grows rapidly with both ``n`` and ``max_gates``.


### PR DESCRIPTION
## Summary
- extend `collision_entropy.py` with `--descending` sort flag
- mention new options in READMEs
- add `--top` to limit counts printed when listing

## Testing
- `python3 -m py_compile experiments/collision_entropy.py`


------
https://chatgpt.com/codex/tasks/task_e_685c5dd62364832ba27249c1e68c28e7