### PR TITLE
Add Lake project config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,17 @@ The code is **not** a complete proof: many declarations end with `sorry`.  The g
 
 ## Building
 
-The Lean files require **Lean 4** together with **mathlib4** (≥ 2025‑05‑20).  The repository does not include a `lakefile`; to experiment, create a Lean project that depends on mathlib and add these files, or invoke `lean` directly once mathlib is available.
+The Lean files require **Lean 4** together with **mathlib4** (≥ 2025‑05‑20).  A
+`lakefile.lean` and `lean-toolchain` are included.  After installing `lake`
+and `elan`, fetch the cached dependencies and build the project with:
 
-`examples.lean` can be executed with `lean --run examples.lean` after the dependencies are set up.
+```bash
+lake exe cache get
+lake build
+```
+
+`examples.lean` can also be executed directly with `lean --run examples.lean` once
+the dependencies have been downloaded.
 
 ## Experiments
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,16 @@ The code is **not** a complete proof: many declarations end with `sorry`.  The g
 
 ## Building
 
-The Lean files require **Lean 4** together with **mathlib4** (≥ 2025‑05‑20).  A
-`lakefile.lean` and `lean-toolchain` are included.  After installing `lake`
-and `elan`, fetch the cached dependencies and build the project with:
+The Lean files require **Lean 4** together with **mathlib4** (≥ 2025‑05‑20).
+A minimal `lakefile.lean` and `lean-toolchain` are included.  Install `elan`
+(which also provides the `lake` tool) and run
+
+```bash
+elan toolchain install $(cat lean-toolchain)
+```
+
+to set up the compiler.  Then fetch the cached dependencies and build the
+project with:
 
 ```bash
 lake exe cache get

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,0 +1,5 @@
+import Lake
+open Lake DSL
+
+package pnp2
+require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "6e08340fe7c928dd55c20625ccf419477f5dd106"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.21.0-rc3


### PR DESCRIPTION
## Summary
- add `lakefile.lean` using current mathlib commit
- specify Lean version in `lean-toolchain`
- document `lake` commands in README

## Testing
- `lake exe cache get` *(fails: command not found)*
- `lake build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c91cd3df0832b98a855f9cfb38061