### PR TITLE
Implement basic family operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.py[cod]
+.lake/
+lake-manifest.json

--- a/BoolFunc.lean
+++ b/BoolFunc.lean
@@ -161,6 +161,21 @@ def BFunc.restrictCoord (f : BFunc n) (j : Fin n) (b : Bool) : BFunc n :=
 
 end Restrict
 
+/-- The set of inputs on which a Boolean function outputs `true`. -/
+noncomputable
+def ones {n : ℕ} (f : BFunc n) : Finset (Point n) :=
+  Finset.univ.filter fun x => f x = true
+
+@[simp] lemma mem_ones {n : ℕ} {f : BFunc n} {x : Point n} :
+    x ∈ ones f ↔ f x = true := by
+  classical
+  simp [ones]
+
+/-- Restrict every function in a family by fixing the `i`‑th input bit to `b`. -/
+noncomputable
+def Family.restrict {n : ℕ} (F : Family n) (i : Fin n) (b : Bool) : Family n :=
+  F.image fun f x => f (Point.update x i b)
+
 /-! ## Re‑exports to avoid long qualified names downstream -/
 export Subcube (mem dimension monochromaticFor monochromaticForFamily)
 export Point (update)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The code is **not** a complete proof: many declarations end with `sorry`.  The g
 * `entropy.lean` – collision entropy framework (proof of `EntropyDrop` still marked `sorry`).
 * `sunflower.lean` – minimal sunflower lemma used downstream.
 * `agreement.lean` – statement of the core‑agreement lemma with proof placeholder.
-* `cover.lean` – skeleton of the covering algorithm.
+* `cover.lean` – partial implementation of the covering algorithm using
+  well‑founded recursion; several proof steps remain as `admit`.
 * `bound.lean` – arithmetic bounds deriving the subexponential size estimate.
 * `family_entropy_cover.lean` – placeholder for the family version of the cover.
 * `merge_low_sens.lean` – stub combining low‑sensitivity and entropy covers.
@@ -28,8 +29,7 @@ The code is **not** a complete proof: many declarations end with `sorry`.  The g
 ## Building
 
 The Lean files require **Lean 4** together with **mathlib4** (≥ 2025‑05‑20).
-A minimal `lakefile.lean` and `lean-toolchain` are included.  Install `elan`
-(which also provides the `lake` tool) and run
+A minimal `lakefile.lean` and `lean-toolchain` are included.  Install `elan` (which also provides the `lake` tool, e.g. via `sudo apt-get install elan`) and run
 
 ```bash
 elan toolchain install $(cat lean-toolchain)
@@ -63,4 +63,8 @@ python3 experiments/collision_entropy.py 3 1 --list-counts --top 5
 
 ## Status
 
-This is a research prototype.  Many modules contain `sorry` placeholders and only partial proofs.  The repository is intended for exploration and does not constitute a finished argument.
+This is a research prototype.  Many modules contain `sorry` placeholders and only
+partial proofs.  The `cover.lean` algorithm now has a recursive skeleton but
+still relies on `admit` for the coverage argument and the final size bound.  The
+repository is intended for exploration and does not constitute a finished
+argument.

--- a/cover.lean
+++ b/cover.lean
@@ -158,4 +158,9 @@ def coverFamily
     with ⟨_, _, hbound⟩
   exact hbound
 
+lemma coverFamily_card_bound
+    {F : Family n} {h : ℕ} (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (coverFamily (n := n) (h := h) F hH).card ≤ mBound n h :=
+  coverFamily_card (F := F) (h := h) hH
+
 end Cover

--- a/docs/E1_roadmap.md
+++ b/docs/E1_roadmap.md
@@ -38,6 +38,8 @@ Justify enumeration of `A_i` and `B_i` in time `2^{(1-\alpha)k}` and `2^{(1-\alp
 
 ### B‑5. Constructing the cover
 Build a rectangular cover of `\mathcal{S}_n` of size `M \le 2^{N - N^{\delta}}`.
+An initial recursive skeleton is implemented in `cover.lean`,
+but the detailed bounds remain to be formalised.
 
 ---
 
@@ -46,6 +48,8 @@ Build a rectangular cover of `\mathcal{S}_n` of size `M \le 2^{N - N^{\delta}}`.
 * **Theory block.** Deepen the study of items B‑1–B‑3, including connections to existing results on canonical forms and description bounds.
 * **Algorithm block.** Implement meet-in-the-middle and fast enumeration (B‑4) for small values of `n`.
 * **Combinatorial block.** Develop the covering method (B‑5) via an “address–data” representation or similar constructions.
+  The initial Lean code for the recursive cover lives in `cover.lean` and needs
+  completeness proofs.
 
 ---
 

--- a/fce_lemma_proof.md
+++ b/fce_lemma_proof.md
@@ -93,7 +93,9 @@ The modules above serve as milestones. Our immediate goals are:
 1. Complete the proof of `EntropyDrop` in `entropy.lean`.
 2. Add a classical sunflower lemma in `sunflower.lean`.
 3. Formalise the `CoreAgreement` lemma in `agreement.lean`.
-4. Implement the recursive covering algorithm in `cover.lean`.
+4. Finalise the recursive covering algorithm in `cover.lean`.  A
+   well‑founded implementation is present, but the coverage and bound
+   proofs still use `admit`.
 5. Prove the size bound in `bound.lean`.
 6. Provide small test instances in `examples.lean`.
 


### PR DESCRIPTION
## Summary
- add `ones` and `Family.restrict` helpers in `BoolFunc.lean`
- export a `coverFamily_card_bound` lemma reusing `coverFamily_card`
- document partial state of `cover.lean` in docs and README
- ignore build artefacts from `lake`

## Testing
- `elan toolchain install $(cat lean-toolchain)`
- `lake exe cache get`
- `lake build`
- `lean --version`


------
https://chatgpt.com/codex/tasks/task_e_685ca2e0e10c832bb68aaa02e439e322