### PR TITLE
Add lemma for nonempty witness in cover

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -125,9 +125,17 @@ partial def buildCover (F : Family n) (h : ℕ)
         -- implementation would first test the quantitative sunflower bound.
         have ⟨i, b, hdrop⟩ := BoolFunc.exists_coord_entropy_drop (F := F)
             (hn := by decide) (hF := by
-              -- card > 1 follows from the fact we still have an uncovered
-              -- input (namely `x`); full proof deferred
-              sorry)
+              -- `firstUncovered` yielded `⟨f,x⟩`, so `F` is nonempty
+              classical
+              have hx : (⟨f, x⟩ : Σ f : BoolFunc n, Vector Bool n) ∈ uncovered F Rset := by
+                simpa [firstUncovered] using Set.choose?_mem (S := uncovered F Rset) hfu
+              have hf : f ∈ F :=
+                (by
+                  rcases (by
+                    simpa [uncovered] using hx
+                  ) with ⟨hf, -, -⟩
+                  exact hf)
+              exact Finset.card_pos.mpr ⟨f, hf⟩)
         -- New upper‑bound on entropy: `H₂ (F.restrict i b) ≤ h - 1`
         have hH0 : BoolFunc.H₂ (F.restrict i b) ≤ (h - 1 : ℝ) := by
           have : BoolFunc.H₂ F ≤ h := hH

--- a/Utils/Finset.lean
+++ b/Utils/Finset.lean
@@ -1,0 +1,19 @@
+import Std.Data.Finset
+
+open Classical
+open Finset
+
+namespace Utils
+
+/-- `card_filter_lt_card` states that if a finset `s` contains an element which
+fails the predicate `p`, then the filtered set is strictly smaller. -/
+lemma card_filter_lt_card {α} [DecidableEq α] {s : Finset α} {p : α → Bool}
+    (h : ∃ a, a ∈ s ∧ p a = false) :
+    (s.filter p).card < s.card := by
+  classical
+  obtain ⟨a, ha, hpa⟩ := h
+  have : a ∉ s.filter p := by
+    simpa [Finset.mem_filter, ha, hpa]
+  exact Finset.card_filter_lt_card this
+
+end Utils


### PR DESCRIPTION
## Summary
- add lemma in `Utils/Finset.lean`
- use the witness from `firstUncovered` to prove the family is nonempty in `buildCover`

## Testing
- `lake build` *(fails: access to reservoir.lean-lang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ffc798804832bbc42a01d87a4193f