### PR TITLE
Fill small lemma in canonical circuit module

### DIFF
--- a/Pnp2/canonical_circuit.lean
+++ b/Pnp2/canonical_circuit.lean
@@ -182,8 +182,22 @@ def encodeCanon {n : ℕ} : Canon n → List Bool
 
 lemma encodeCanon_length {n : ℕ} (c : Canon n) :
     (encodeCanon c).length ≤ codeLen c := by
-  -- Proof postponed.  The encoding above is only schematic.
-  admit
+  induction c with
+  | var i =>
+      simp [encodeCanon, codeLen]
+  | const b =>
+      simp [encodeCanon, codeLen]
+  | not c ih =>
+      simpa [encodeCanon, codeLen] using
+        Nat.succ_le_succ ih
+  | and c₁ c₂ ih₁ ih₂ =>
+      have := Nat.add_le_add ih₁ ih₂
+      simpa [encodeCanon, codeLen, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
+        Nat.succ_le_succ this
+  | or c₁ c₂ ih₁ ih₂ =>
+      have := Nat.add_le_add ih₁ ih₂
+      simpa [encodeCanon, codeLen, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using
+        Nat.succ_le_succ this
 
 /-- The set of circuits on `n` inputs whose size does not exceed `m`. -/
 def circuitsUpTo (n m : ℕ) : Set (Circuit n) := {c | sizeOf c ≤ m}


### PR DESCRIPTION
## Summary
- prove the `encodeCanon_length` lemma

## Testing
- `lake exe cache get` *(fails: domain not in allowlist)*
- `lake build` *(fails: domain not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6860035f37b0832b8772dcf9b5cbc886