### PR TITLE
Add reflexive EqOn lemma

### DIFF
--- a/Pnp2/agreement.lean
+++ b/Pnp2/agreement.lean
@@ -25,6 +25,7 @@ stable.
 
 import Pnp2.BoolFunc
 import Std.Data.Finset
+import Mathlib.Data.Set.Function
 
 open Classical
 open BoolFunc
@@ -113,3 +114,7 @@ lemma dist_le_of_compl_subset
     _ ≤ ℓ := by linarith [h_size]
 
 end Agreement
+
+lemma agree_on_refl {α β : Type _} (f : α → β) (s : Set α) : Set.EqOn f f s :=
+  fun x hx => rfl
+


### PR DESCRIPTION
## Summary
- import `Mathlib.Data.Set.Function` in `agreement.lean`
- implement `agree_on_refl` using `rfl`
- define `α`, `β` types explicitly for lemma

## Testing
- `lake build` *(failed: could not fetch dependencies or complete build)*

------
https://chatgpt.com/codex/tasks/task_e_68601bf41d3c832bb18c7faa6d610feb