### PR TITLE
Add lemma supports_card_le

### DIFF
--- a/Pnp2/BoolFunc.lean
+++ b/Pnp2/BoolFunc.lean
@@ -224,6 +224,12 @@ def supports (F : Family n) : Finset (Finset (Fin n)) :=
   · rintro ⟨f, hf, rfl⟩
     exact Finset.mem_image.mpr ⟨f, hf, rfl⟩
 
+@[simp] lemma supports_card_le (F : Family n) :
+    (supports F).card ≤ F.card := by
+  classical
+  simpa [supports] using
+    (Finset.card_image_le (s := F) (f := support))
+
 end Family
 
 /-! ## Re‑exports to avoid long qualified names downstream -/


### PR DESCRIPTION
## Summary
- prove a new lemma `supports_card_le` to bound the number of essential supports in a family of Boolean functions

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_68603818377c832bbe3d5ea09f435af9