### PR TITLE
Implement basic family entropy cover wrapper

### DIFF
--- a/Pnp2/family_entropy_cover.lean
+++ b/Pnp2/family_entropy_cover.lean
@@ -6,16 +6,14 @@ namespace Boolcube
 open Entropy
 open Cover
 
-/--
-Family version of the collision entropy covering lemma.  The full proof
-is nontrivial and currently omitted; this declaration serves as a
-placeholder so that other parts of the development can depend on it.
--/
-/--
-`familyCollisionEntropyCover` wraps the existential statement `Cover.cover_exists`
-for easier use in downstream files.  It asserts that a family of Boolean
-functions with bounded collision entropy admits a small set of jointly
-monochromatic subcubes covering all `1`‑inputs of every function in the family.
+/-!
+`familyCollisionEntropyCover` wraps the existential statement
+`Cover.cover_exists` for easier use in downstream files.  It asserts that a
+family of Boolean functions with bounded collision entropy admits a small set of
+jointly monochromatic subcubes covering all `1`‑inputs of every function in the
+family.  The full proof is nontrivial and omitted; this declaration merely
+re‑exports the existential lemma so that other parts of the development can rely
+on it.
 -/
 theorem familyCollisionEntropyCover
   {n : ℕ} (F : Family n) {h : ℕ} (hH : H₂ F ≤ (h : ℝ)) :
@@ -25,5 +23,32 @@ theorem familyCollisionEntropyCover
     T.card ≤ mBound n h := by
   classical
   simpa using Cover.cover_exists (F := F) (h := h) hH
+
+/-!
+### A convenience record for covers returned by `familyEntropyCover`.
+This bundles the list of rectangles together with proofs that each
+is monochromatic for the whole family, that the rectangles cover all
+`1`‑inputs, and that their number is bounded by `mBound`.
+-/
+structure FamilyCover {n : ℕ} (F : Family n) (h : ℕ) where
+  rects   : Finset (Subcube n)
+  mono    : ∀ C ∈ rects, Subcube.monochromaticForFamily C F
+  covers  : ∀ f ∈ F, ∀ x, f x = true → ∃ C ∈ rects, x ∈ₛ C
+  bound   : rects.card ≤ mBound n h
+
+/--
+`familyEntropyCover` packages `familyCollisionEntropyCover` as a concrete
+object.  It simply uses classical choice to extract a witnessing set of
+rectangles from the existential statement. -/
+noncomputable def familyEntropyCover
+    {n : ℕ} (F : Family n) {h : ℕ} (hH : H₂ F ≤ (h : ℝ)) :
+    FamilyCover F h := by
+  classical
+  obtain ⟨T, hmono, hcov, hcard⟩ :=
+    familyCollisionEntropyCover (F := F) (h := h) hH
+  refine ⟨T, hmono, ?_, hcard⟩
+  intro f hf x hx
+  rcases hcov f hf x hx with ⟨C, hC, hxC⟩
+  exact ⟨C, hC, hxC⟩
 
 end Boolcube

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ The code is **not** a complete proof: many declarations end with `sorry`.  The g
   uses `exists_coord_entropy_drop`, leaving only the sunflower branch
   unfinished.
 * `bound.lean` – arithmetic bounds deriving the subexponential size estimate.
-* `family_entropy_cover.lean` – placeholder for the family version of the cover.
+* `family_entropy_cover.lean` – wrappers for the family cover existence lemma.
+  Defines a `FamilyCover` record bundling rectangles with proofs and
+  provides `familyEntropyCover` to construct such a cover.
 * `merge_low_sens.lean` – stub combining low‑sensitivity and entropy covers.
 * `canonical_circuit.lean` – Boolean circuits with a basic canonicalisation function.
 * `table_locality.lean` – statement of the table locality lemma (roadmap B‑2).


### PR DESCRIPTION
## Summary
- add `FamilyCover` record for the family covering lemma
- expose `familyEntropyCover` to obtain a concrete cover
- document the new wrappers in README

## Testing
- `lake exe cache get`
- `lake build`


------
https://chatgpt.com/codex/tasks/task_e_686041e6babc832b9306d9700a79be03