### PR TITLE
Update merge_low_sens to use entropy cover builder

### DIFF
--- a/Pnp2/merge_low_sens.lean
+++ b/Pnp2/merge_low_sens.lean
@@ -1,17 +1,20 @@
 import Pnp2.Boolcube
+import Pnp2.Cover
+
+open Cover
 
 namespace Boolcube
 
-/--
-Combine the low-sensitivity cover with the entropy-based family cover.
-This theorem is currently a stub: we simply reuse `buildCover` and leave a
-complete constructive proof for future work.
+/-!
+`mergeLowSensitivityCover` simply re-exports the entropy-based cover
+construction `Cover.buildCover` so that downstream files can obtain a
+set of subcubes covering all ones of `F` without referring to the full
+`Cover` infrastructure.  It takes the entropy bound as a natural number
+`h` and returns the list of rectangles produced by `buildCover`.
 -/
-theorem mergeLowSensitivityCover
-  {n : ℕ} (F : Family n) (h : ℝ) (hH : Entropy.H₂ F ≤ h) :
-  Cover F := by
-  classical
-  -- We defer a full proof and simply reuse the existing cover builder.
-  exact buildCover F
+noncomputable def mergeLowSensitivityCover
+  {n : ℕ} (F : Family n) (h : ℕ) (hH : Entropy.H₂ F ≤ (h : ℝ)) :
+  Finset (Subcube n) :=
+  Cover.buildCover (F := F) (h := h) hH
 
 end Boolcube


### PR DESCRIPTION
## Summary
- rework `mergeLowSensitivityCover`
  - import `Cover` and open the namespace
  - expose a wrapper returning the rectangles from `Cover.buildCover`

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_68606ee53eec832b92527e3cea5ac6a2