### PR TITLE
Add simple CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  push:
+    paths:
+      - '**.lean'
+      - lean-toolchain
+      - lakefile.lean
+      - lake-manifest.json
+  pull_request:
+    paths:
+      - '**.lean'
+      - lean-toolchain
+      - lakefile.lean
+      - lake-manifest.json
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: leanprover/elan-action@v1
+      - name: Cache mathlib
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.elan
+            lake-packages
+            .lake
+          key: ${{ runner.os }}-elan-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+      - name: Build
+        run: |
+          lake exe cache get || echo 'No cache available'
+          lake build


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that installs elan and builds the project with `lake`

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_68609f3e4e4c832b99876f283d977e08