### PR TITLE
Add support lemmas and begin sunflower proof

### DIFF
--- a/Pnp2/BoolFunc.lean
+++ b/Pnp2/BoolFunc.lean
@@ -38,6 +38,7 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Real.Basic
+import Pnp2.BoolFunc.Support
 
 noncomputable section
 
@@ -141,6 +142,12 @@ def Point.update (x : Point n) (i : Fin n) (b : Bool) : Point n :=
   by_cases hk : k = i
   · subst hk; simp [Point.update]
   · simp [Point.update, hk]
+
+/-- **A constant point** with the same Boolean value in every coordinate. -/
+def Point.const (n : ℕ) (b : Bool) : Point n := fun _ => b
+
+@[simp] lemma Point.const_apply (n : ℕ) (b : Bool) (i : Fin n) :
+    (Point.const n b) i = b := rfl
 
 end PointOps
 

--- a/Pnp2/BoolFunc/Support.lean
+++ b/Pnp2/BoolFunc/Support.lean
@@ -1,0 +1,57 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Tactic
+import Pnp2.BoolFunc
+
+open Finset
+
+namespace BoolFunc
+
+variable {n : ℕ}
+
+/--
+If two points agree on every coordinate in the *support* of `f`,
+then `f` takes the same value on these points.
+-/
+lemma eval_eq_of_agree_on_support
+    {f : BFunc n} {x y : Point n}
+    (h : ∀ i, i ∈ support f → x i = y i) :
+    f x = f y := by
+  classical
+  by_contra hneq
+  have hxy : ∃ i : Fin n, x i ≠ y i := by
+    by_cases hxy' : x = y
+    · have : f x = f y := by simpa [hxy'] using rfl
+      exact (hneq this).elim
+    · push_neg at hxy'
+      exact hxy'
+  rcases hxy with ⟨i, hi⟩
+  have hi_supp : i ∈ support f := by
+    unfold BoolFunc.support
+    simp [Finset.mem_filter, hi]
+  have : x i = y i := h i hi_supp
+  exact hi this
+
+/--
+Flipping bits outside the support of `f` keeps its value.
+-/
+lemma flip_outside_support (f : BFunc n) (x : Point n) :
+    let y : Point n := fun i => if h : i ∈ support f then x i else !(x i)
+    f x = f y := by
+  classical
+  have hagree : ∀ i, i ∈ support f → x i = (fun i => if h : i ∈ support f then x i else !(x i)) i :=
+    by intro i hi; simp [hi]
+  simpa [y] using eval_eq_of_agree_on_support (x:=x) (y:=fun i => if h : i ∈ support f then x i else !(x i)) hagree
+
+
+
+/--
+If `support f ⊆ S` and `x` and `y` agree on all coordinates in `S`,
+then `f` takes the same value on `x` and `y`.
+-/
+lemma eval_eq_of_agree_on_superset {f : BFunc n} {S : Finset (Fin n)}
+    {x y : Point n}
+    (hSup : support f ⊆ S) (h : ∀ i, i ∈ S → x i = y i) :
+    f x = f y :=
+  eval_eq_of_agree_on_support (x:=x) (y:=y) (fun i hi => h i (hSup hi))
+
+end BoolFunc

--- a/Pnp2/agreement.lean
+++ b/Pnp2/agreement.lean
@@ -122,6 +122,17 @@ lemma dist_le_of_compl_subset
             have := Nat.sub_le_sub_right h_size 0; simpa using this
   simpa using this
 
+open Finset
+
+/--
+If two points coincide on the set `K`, then both belong
+to the subcube obtained from `x₀` by freezing `K`.
+-/
+lemma mem_fromPoint_of_agree {n : ℕ} {K : Finset (Fin n)} {x₀ x : Point n}
+    (h : ∀ i, i ∈ K → x i = x₀ i) :
+    x ∈ Subcube.fromPoint x₀ K := by
+  simpa [Subcube.fromPoint] using h
+
 end Agreement
 
 lemma agree_on_refl {α β : Type _} (f : α → β) (s : Set α) : Set.EqOn f f s :=

--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -92,12 +92,16 @@ lemma sunflower_step
   let R : Subcube n := Agreement.Subcube.fromPoint x₀ K
   refine ⟨R, ?_, ?_⟩
   ·
-    -- Each set in the sunflower corresponds to a function whose support
-    -- contains `K`.  Restricting to `R` fixes the core bits, and the disjoint
-    -- petals no longer interfere.  We therefore obtain at least `t` functions
-    -- that evaluate to `true` on all of `R`.
-    -- The formal combinatorial argument is omitted.
-    sorry
+    -- Each `A ∈ 𝓣` is the support of some function `f_A ∈ F`.
+    have exists_f : ∀ A ∈ 𝓣, ∃ f ∈ F, support f = A := by
+      intro A hA
+      have hA' := h𝓣sub hA
+      simpa using (Family.mem_supports.mp hA')
+    choose f hfF hfSupp using exists_f
+    -- A complete combinatorial construction of a suitable point is omitted here.
+    have : (F.filter fun f ↦ ∀ x, x ∈ₛ R → f x = true).card ≥ t := by
+      admit
+    exact this
   ·
     -- `R` has dimension `n - K.card`.  The sunflower lemma ensures `K` is a
     -- proper subset of each support in the sunflower, so `K.card < n` and the

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.21.0-rc3
+leanprover/lean4:v4.22.0-rc2


### PR DESCRIPTION
## Summary
- upgrade toolchain to Lean 4.22.0-rc2
- extend `Support.lean` with an additional lemma
- start filling `sunflower_step` with a witness selection argument

## Testing
- `lake build` *(fails: unknown constant `Lean.Parser.Tactic.tacticHave_` in dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6866f1871a88832b9a92d1b8141b065c