### PR TITLE
Update to mathlib 4.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The code is **not** a complete proof: many declarations end with `sorry`.  The g
 
 ## Building
 
-The Lean files require **Lean 4** together with **mathlib4** (version ≥ 4.8.0).
+The Lean files require **Lean 4** together with **mathlib4** (version ≥ 4.22.0).
 A minimal `lakefile.lean` and `lean-toolchain` are included.  Install `elan` (which also provides the `lake` tool, e.g. via `sudo apt-get install elan`) and run
 
 ```bash

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -3,7 +3,7 @@ open Lake DSL
 
 package pnp2
 
-require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.8.0"
+require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.22.0-rc2"
 
 @[default_target]
 lean_lib Pnp2 where


### PR DESCRIPTION
## Summary
- bump mathlib dependency to `v4.22.0-rc2`
- update README with the new minimum mathlib version

## Testing
- `lake exe cache get` *(downloaded dependencies)*
- `lake build` *(partial build output shown; interrupted)*
- `lake env lean --run scripts/smoke.lean` *(failed: unknown module prefix)*


------
https://chatgpt.com/codex/tasks/task_e_686735037880832b8fa08d907ee99147