### PR TITLE
Fix module casing in cover imports

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -12,10 +12,10 @@ the final numeric bound remain open.
 -/
 
 import Pnp2.BoolFunc
-import Pnp2.Entropy
-import Pnp2.Sunflower
+import Pnp2.entropy
+import Pnp2.sunflower
 import Pnp2.Agreement
-import Mathlib.Data.Nat.Pow
+import Mathlib.Data.Nat.Basic
 import Mathlib.Tactic
 
 open Classical


### PR DESCRIPTION
## Summary
- adjust `cover.lean` imports so they refer to `entropy` and `sunflower`
- use `Mathlib.Data.Nat.Basic` for natural number lemmas

## Testing
- `lake build Pnp2.cover` *(fails: unresolved definitions in `entropy.lean`)*
- `lake env lean --run scripts/smoke.lean` *(fails: object file for `Pnp2.cover` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867ef28e824832bb9d52d77f0aafe71