### PR TITLE
Fix BoolFunc support helpers

### DIFF
--- a/Pnp2/Agreement.lean
+++ b/Pnp2/Agreement.lean
@@ -113,18 +113,17 @@ to the subcube obtained from `x₀` by freezing `K`.
 lemma mem_fromPoint_of_agree {n : ℕ} {K : Finset (Fin n)} {x₀ x : Point n}
     (h : ∀ i, i ∈ K → x i = x₀ i) :
     x ∈ₛ Subcube.fromPoint x₀ K := by
-  classical
-  -- Proof omitted
-  sorry
+  intro i hi
+  exact h i hi
 
 /-- If two points agree on all coordinates in `K`, then the subcubes
 obtained by freezing `K` according to these points coincide. -/
 lemma Subcube.point_eq_core {n : ℕ} {K : Finset (Fin n)} {x₀ x : Point n}
     (h : ∀ i, i ∈ K → x i = x₀ i) :
     Subcube.fromPoint x K = Subcube.fromPoint x₀ K := by
-  classical
-  -- Proof omitted
-  sorry
+  cases x₀
+  cases x
+  simp [Subcube.fromPoint, h, Function.funext_iff]
 
 end Agreement
 

--- a/Pnp2/BoolFunc/Support.lean
+++ b/Pnp2/BoolFunc/Support.lean
@@ -34,13 +34,17 @@ lemma eval_eq_of_agree_on_support
 /--
 Flipping bits outside the support of `f` keeps its value.
 -/
-lemma flip_outside_support (f : BFunc n) (x : Point n) :
-    let y : Point n := fun i => if h : i ∈ support f then x i else !(x i)
-    f x = f y := by
+lemma flip_outside_support (f : BFunc n) (x : Point n) {i : Fin n}
+    (hi : i ∉ support f) :
+    f x = f (Point.update x i (!x i)) := by
   classical
-  have hagree : ∀ i, i ∈ support f → x i = (fun i => if h : i ∈ support f then x i else !(x i)) i :=
-    by intro i hi; simp [hi]
-  simpa [y] using eval_eq_of_agree_on_support (x:=x) (y:=fun i => if h : i ∈ support f then x i else !(x i)) hagree
+  have hagree : ∀ j, j ∈ support f → x j = (Point.update x i (!x i)) j := by
+    intro j hj
+    by_cases hji : j = i
+    · subst hji; exact (hi hj).elim
+    · simp [Point.update, hji]
+  simpa using
+    (eval_eq_of_agree_on_support (f := f) (x := x) (y := Point.update x i (!x i)) hagree)
 
 
 


### PR DESCRIPTION
## Summary
- format `Pnp2/BoolFunc/Support.lean`
- close the namespace explicitly
- fix `flip_outside_support` to use `Point.update x i (!x i)`
- fill in two helper lemmas in `Agreement` needed by `cover.lean`

## Testing
- `lake build`
- `lake env lean --run scripts/smoke.lean` *(fails: object file for `Pnp2.cover` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6867fcbd6670832bb2f05876e6c50719