### PR TITLE
Add numeric bound stub and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,11 @@
-name: CI
-on:
-  push:
-    paths:
-      - '**.lean'
-      - lean-toolchain
-      - lakefile.lean
-      - lake-manifest.json
-  pull_request:
-    paths:
-      - '**.lean'
-      - lean-toolchain
-      - lakefile.lean
-      - lake-manifest.json
+name: lake-build
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: leanprover/elan-action@v1
-      - name: Cache mathlib
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.elan
-            lake-packages
-            .lake
-          key: ${{ runner.os }}-elan-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
-      - name: Build
-        run: |
-          lake exe cache get || echo 'No cache available'
-          lake build
+    - uses: actions/checkout@v4
+    - uses: leanprover/lean-action@v1
+      with:
+        lean-version: "leanprover/lean4:v4.8.0"
+        mathlib: true

--- a/Pnp2/cover_numeric.lean
+++ b/Pnp2/cover_numeric.lean
@@ -1,0 +1,16 @@
+import Pnp2.family_entropy_cover
+
+open BoolFunc
+
+namespace CoverNumeric
+
+variable {N Nδ : ℕ} (F : Family N)
+
+-- Placeholder definitions if needed
+-- We assume `minCoverSize` and `buildCover_size_bound` are provided elsewhere.
+
+lemma numeric_bound
+    (h₀ : H₂ F ≤ N - Nδ) : (minCoverSize F) ≤ 2^(N - Nδ) := by
+  simpa using buildCover_size_bound (F := F) h₀
+
+end CoverNumeric


### PR DESCRIPTION
## Summary
- stub out `CoverNumeric.numeric_bound` lemma
- replace CI workflow with simpler job using lean-action

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_68680fab0528832bb7e95c670dfd6a92