### PR TITLE
Update smoke test and fix comment typo

### DIFF
--- a/Pnp2/BoolFunc/Support.lean
+++ b/Pnp2/BoolFunc/Support.lean
@@ -6,7 +6,7 @@ open Finset
 namespace BoolFunc
 variable {n : ℕ}
 
-/-- Если `x,y` совпадают на `support f`, то `f x = f y`. —/
+/-- Если `x,y` совпадают на `support f`, то `f x = f y`. -/
 lemma eval_eq_of_agree_on_support
     {f : BFunc n} {x y : Point n}
     (h : ∀ i, i ∈ support f → x i = y i) :
@@ -25,7 +25,7 @@ lemma eval_eq_of_agree_on_support
   have : x i = y i := h i hisupp
   exact hi this
 
-/-- Всякая нетривиальная функция принимает `true` где‑то. —/
+/-- Всякая нетривиальная функция принимает `true` где‑то. -/
 lemma exists_true_on_support {f : BFunc n} (h : support f ≠ ∅) :
     ∃ x, f x = true := by
   classical

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The code is **not** a complete proof: many declarations end with `sorry`.  The g
   proved).  The module now also defines simple probability utilities
   (`prob`, `prob_restrict_false`, `prob_restrict_true`) for measuring how often
   a function outputs `true` under various restrictions.
+* `BoolFunc/Support.lean` – helper lemmas about the coordinate support of
+  Boolean functions, e.g. `eval_eq_of_agree_on_support`.
 * `Boolcube.lean` – extended definitions together with a proved entropy‑drop lemma.
 * `entropy.lean` – collision entropy framework with the full `EntropyDrop`
   lemma proven alongside basic tools such as `collProb_le_one`.  The

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ dependencies have been downloaded.  A minimal smoke test is provided in
 ```bash
 lake env lean --run scripts/smoke.lean
 ```
-which simply checks that the main modules compile without `sorry`.
+which simply checks that the base definitions compile successfully.
 
 ## Experiments
 

--- a/scripts/smoke.lean
+++ b/scripts/smoke.lean
@@ -1,2 +1,3 @@
-import Pnp2.cover
-#eval "sunflower_step compiled!"
+import Pnp2
+
+#eval "base definitions compiled!"


### PR DESCRIPTION
## Summary
- fix comment terminators in `Support.lean`
- adjust smoke test to only import base definitions
- document smoke test behavior in README

## Testing
- `lake env lean --run scripts/smoke.lean`

------
https://chatgpt.com/codex/tasks/task_e_68681e567cc8832b9796bf24d854f995