### PR TITLE
Add sensitivity helper lemmas

### DIFF
--- a/Pnp2.lean
+++ b/Pnp2.lean
@@ -1,1 +1,3 @@
 import Pnp2.BoolFunc
+import Pnp2.BoolFunc.Sensitivity
+import Pnp2.low_sensitivity_cover

--- a/Pnp2/BoolFunc/Sensitivity.lean
+++ b/Pnp2/BoolFunc/Sensitivity.lean
@@ -1,0 +1,30 @@
+import Pnp2.BoolFunc
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Finset.Lattice.Fold
+
+open Finset
+
+namespace BoolFunc
+
+variable {n : ℕ} [Fintype (Point n)]
+
+/-- `sensitivityAt f x` is the number of coordinates on which flipping the
+    input changes the value of `f`. -/
+def sensitivityAt (f : BFunc n) (x : Point n) : ℕ :=
+  (Finset.univ.filter fun i => f (Point.update x i (!x i)) ≠ f x).card
+
+/-- The (block) sensitivity of a Boolean function.  We take the maximum of
+    `sensitivityAt` over all points of the cube. -/
+def sensitivity (f : BFunc n) : ℕ :=
+  (Finset.univ.sup fun x => sensitivityAt f x)
+
+lemma sensitivityAt_le (f : BFunc n) (x : Point n) :
+    sensitivityAt f x ≤ sensitivity f :=
+  by
+    classical
+    have hx : x ∈ (Finset.univ : Finset (Point n)) := by simp
+    exact Finset.le_sup (s := Finset.univ) hx
+
+end BoolFunc
+

--- a/Pnp2/Sunflower/RSpread.lean
+++ b/Pnp2/Sunflower/RSpread.lean
@@ -1,5 +1,5 @@
-import Mathlib.Probability
 import Mathlib.Data.Finset.Card
+import Mathlib.Data.Real.Basic
 
 open Finset
 

--- a/Pnp2/low_sensitivity_cover.lean
+++ b/Pnp2/low_sensitivity_cover.lean
@@ -1,0 +1,28 @@
+import Pnp2.BoolFunc.Sensitivity
+import Pnp2.BoolFunc
+
+open BoolFunc
+
+namespace BoolFunc
+
+variable {n : ℕ}
+
+/-- **Low-sensitivity cover** (statement only).  If every function in the
+    family has sensitivity at most `s`, then there exists a small set of
+    subcubes covering all ones of the family.  The proof will use decision
+    trees or the Gopalan--Moshkovitz--Oliveira bound.  Here we only record the
+    statement. -/
+lemma low_sensitivity_cover (F : Family n) (s : ℕ)
+    [Fintype (Point n)]
+    (Hsens : ∀ f ∈ F, sensitivity f ≤ s) :
+    ∃ Rset : Finset (Subcube n),
+      (∀ R ∈ Rset, Subcube.monochromaticForFamily R F) ∧
+      (∀ f ∈ F, ∀ x, f x = true → ∃ R ∈ Rset, x ∈ₛ R) ∧
+      Rset.card ≤ Nat.pow 2 (10 * s * Nat.log2 (Nat.succ n)) := by
+  classical
+  -- A full proof would build a decision tree for each `f` of depth ≤ C * s * log n
+  -- and collect the resulting subcubes.  This is beyond the current development.
+  admit
+
+end BoolFunc
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ serves as a record of ongoing progress towards a full argument.
   a function outputs `true` under various restrictions.
 * `BoolFunc/Support.lean` – helper lemmas about the coordinate support of
   Boolean functions, e.g. `eval_eq_of_agree_on_support`.
+* `BoolFunc/Sensitivity.lean` – defines sensitivity and basic lemmas used by the
+  low-sensitivity cover.
 * `Boolcube.lean` – extended definitions together with a proved entropy‑drop lemma.
 * `entropy.lean` – collision entropy framework with the full `EntropyDrop`
   lemma proven alongside basic tools such as `collProb_le_one`.  The
@@ -91,4 +93,13 @@ python3 experiments/collision_entropy.py 3 1 --list-counts --top 5
 
 ## Status
 
-This is still a research prototype. The core-agreement lemma is fully proven, and `buildCover` now splits on uncovered inputs via `sunflower_step` or an entropy drop. A statement of `low_sensitivity_cover` and a stub `acc_mcsp_sat.lean` link the cover to a SAT algorithm. Numeric counting bounds remain open, so the repository documents ongoing progress rather than a finished proof.
+This is still a research prototype. The core-agreement lemma is fully proven, and `buildCover` now splits on uncovered inputs via `sunflower_step` or an entropy drop. A formal definition of sensitivity together with the lemma statement `low_sensitivity_cover` has been added, and `acc_mcsp_sat.lean` sketches the SAT connection. Numeric counting bounds remain open, so the repository documents ongoing progress rather than a finished proof.
+
+## Development plan
+
+The next milestone is completing the Family Collision-Entropy Lemma in Lean. Key missing components are:
+1. `exists_coord_card_drop` and `exists_coord_entropy_drop` to formalise the entropy step.
+2. `sunflower_step` to extract a common subcube once entropy can no longer drop.
+3. `buildCover` proofs showing coverage and the final bound `mBound_lt_subexp`.
+4. A constructive proof of `low_sensitivity_cover` using decision-tree bounds.
+Once these are proven the lemma `FCE_lemma` will follow.

--- a/docs/master_blueprint.md
+++ b/docs/master_blueprint.md
@@ -58,7 +58,7 @@ maintain a public repository with Lean scripts and accompanying notes.
 Much of the foundational material (Step 0) is available in print but only partly
 formalised.  Steps 1–3 are active research; the key missing piece is proving a
 rectangular cover of `ACC⁰ ∘ MCSP` tables of size at most `2^{N - N^{\delta}}`.
-Recent commits formalise the `coreAgreement` lemma and implement a recursive `buildCover` using `sunflower_step` and `exists_coord_entropy_drop`. Lemma statements for `low_sensitivity_cover` are in place, and `acc_mcsp_sat.lean` outlines the SAT reduction. The next steps depend on this breakthrough.
+Recent commits formalise the `coreAgreement` lemma and implement a recursive `buildCover` using `sunflower_step` and `exists_coord_entropy_drop`. Definitions of sensitivity now reside in `BoolFunc/Sensitivity.lean` together with a lemma statement `low_sensitivity_cover`. The file `acc_mcsp_sat.lean` sketches the SAT reduction. The next steps depend on this breakthrough.
 
 This document records the plan for future reference and serves as a pointer for
 contributors interested in the overarching project.


### PR DESCRIPTION
## Summary
- define `sensitivityAt` and `sensitivity` for boolean functions
- outline a `low_sensitivity_cover` lemma as a placeholder
- document the sensitivity module in the README and master blueprint

## Testing
- `lake build`
- `lake env lean --run scripts/smoke.lean`


------
https://chatgpt.com/codex/tasks/task_e_6869cb3e47ec832b93d98a5b0c5d1f09