### PR TITLE
Add CI smoke test and build check script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,3 +6,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: leanprover/lean-action@v1
+    - name: Run smoke test
+      run: lake env lean --run scripts/smoke.lean

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -17,3 +17,5 @@ jobs:
         run: lake exe cache get
       - name: Build project
         run: lake build
+      - name: Run smoke test
+        run: lake env lean --run scripts/smoke.lean

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ lake env lean --run scripts/smoke.lean
 ```
 which simply checks that the base definitions compile successfully.
 
+For a full consistency check that builds the entire project and runs the smoke
+test in one go, you can use:
+
+```bash
+./scripts/check.sh
+```
+
 ## Experiments
 
 The `experiments/` directory contains Python scripts that enumerate small

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Full project compilation and smoke test.
+set -euo pipefail
+
+lake build
+lake env lean --run scripts/smoke.lean


### PR DESCRIPTION
## Summary
- add a simple check script that builds the project and runs the smoke test
- describe the new script in the README
- update CI workflows to run the smoke test after building

## Testing
- `./scripts/check.sh`
- `lake build`
- `lake env lean --run scripts/smoke.lean`


------
https://chatgpt.com/codex/tasks/task_e_686e5eb89654832b9254caba44627b66