### PR TITLE
Add monochromatic_point lemma

### DIFF
--- a/Pnp2/Boolcube.lean
+++ b/Pnp2/Boolcube.lean
@@ -56,6 +56,13 @@ namespace Subcube
   classical
   simp [Subcube.dim, Subcube.support]
 
+@[simp] lemma monochromatic_point (x : Point n) (f : BoolFun n) :
+    Subcube.monochromaticFor (Subcube.point (n := n) x) f := by
+  refine ⟨f x, ?_⟩
+  intro y hy
+  have hy' : y = x := (Subcube.mem_point_iff (x := x) (y := y)).1 hy
+  simpa [hy']
+
 end Subcube
 
 abbrev BoolFun (n : ℕ) := Point n → Bool abbrev Family  (n : ℕ) := Finset (BoolFun n)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ serves as a record of ongoing progress towards a full argument.
   low-sensitivity cover.
 * `Boolcube.lean` – extended definitions.  The old sunflower branch of
   `buildCover` has been removed, leaving a simplified entropy-based
-  construction without remaining `sorry`s.
+  construction without remaining `sorry`s.  A new lemma
+  `monochromatic_point` shows that single-point subcubes are automatically
+  monochromatic for any Boolean function.
 * `entropy.lean` – collision entropy framework with the full `EntropyDrop`
   lemma proven alongside basic tools such as `collProb_le_one`.  The
   auxiliary lemma `exists_restrict_half` shows that some input bit


### PR DESCRIPTION
## Summary
- define `monochromatic_point` showing a point subcube is monochromatic for a single Boolean function
- document the lemma in the README

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687109330db0832b93f59eef22e3ea9e