### PR TITLE
Fix support and agreement proofs

### DIFF
--- a/Pnp2/Agreement.lean
+++ b/Pnp2/Agreement.lean
@@ -24,6 +24,7 @@ modules no longer depend on unproven stubs.
 
 import Pnp2.BoolFunc
 import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
 import Mathlib.Data.Set.Function
 import Mathlib.InformationTheory.Hamming
 
@@ -69,18 +70,18 @@ def Subcube.fromPoint (x : Point n) (I : Finset (Fin n)) : Subcube n where
 /-! ### Core‑agreement lemma with CoreClosed assumption -/
 
 /--
-**Core‑Agreement Lemma**  
+**Core-Agreement Lemma**
 
 Let `x₁, x₂ : Point n` be two inputs such that
 
-* There exists a set of coordinates `I` with  
-  `I.card ≥ n - ℓ` **and** `x₁ i = x₂ i` for every `i ∈ I`;
-* Every function `f ∈ F` outputs `1` on *both* `x₁` and `x₂`.
+* There exists a set of coordinates `I` with
+  `I.card ≥ n - ℓ` and `x₁ i = x₂ i` for every `i ∈ I`;
+* Every function `f ∈ F` outputs `1` on both `x₁` and `x₂`.
 
 Assuming `CoreClosed ℓ F`, the subcube obtained by fixing the coordinates in `I`
-to their shared values is **monochromatic** of colour `1` for the entire family.
+to their shared values is monochromatic of colour `1` for the entire family.
 
-This is exactly Lemma 4.3 of the formal specification. -/
+This is exactly Lemma 4.3 of the formal specification. -/
 -- We move the statement of the core agreement lemma below, after proving a
 -- helper about the Hamming distance of points that agree on many coordinates.
 

--- a/Pnp2/BoolFunc/Support.lean
+++ b/Pnp2/BoolFunc/Support.lean
@@ -15,9 +15,13 @@ lemma eval_eq_of_agree_on_support
   -- Otherwise there exists a coordinate where the values differ.
   by_contra hneq
   obtain ⟨i, hi⟩ : ∃ i : Fin n, x i ≠ y i := by
+    classical
     by_cases hxy : x = y
     · simpa [hxy] using hneq
-    · push_neg at hxy; exact hxy
+    · -- if the points are distinct, they differ in some coordinate
+      have : ¬∀ j, x j = y j := by
+        intro hall; apply hxy; funext j; exact hall j
+      simpa using this
   have hisupp : i ∈ support f := by
     -- use the definition of `support`
     unfold support


### PR DESCRIPTION
## Summary
- refine `eval_eq_of_agree_on_support` proof
- clean up Core-Agreement doc comment
- import `Finset.Card` for `Agreement` proofs

## Testing
- `lake build`


------
https://chatgpt.com/codex/tasks/task_e_68717773d2f4832b9da68810f7e1f74a