### PR TITLE
Fix subset selection syntax

### DIFF
--- a/Pnp2/BoolFunc/Support.lean
+++ b/Pnp2/BoolFunc/Support.lean
@@ -29,13 +29,18 @@ lemma eval_eq_of_agree_on_support
 lemma exists_true_on_support {f : BFunc n} (h : support f ≠ ∅) :
     ∃ x, f x = true := by
   classical
-  -- iterate over all points, looking for one where flipping a bit changes the
-  -- value from `0` to `1`
-  by_contra hnone
-  push_neg at hnone
-  have : support f = ∅ := by
-    -- if no bit can be flipped on any point, the support is empty
-    ext i; simp [support, hnone]
-  exact h this
+  rcases Finset.nonempty_iff_ne_empty.2 h with ⟨i, hi⟩
+  rcases mem_support_iff.mp hi with ⟨x, hx⟩
+  cases hfx : f x
+  · have : f (Point.update x i (!x i)) = true := by
+      have hneq := hx
+      simp [hfx] at hneq
+      cases hupdate : f (Point.update x i (!x i)) with
+      | true => simpa [hupdate]
+      | false =>
+          have : False := by simpa [hupdate] using hneq
+          contradiction
+    exact ⟨Point.update x i (!x i), this⟩
+  · exact ⟨x, by simpa [hfx]⟩
 
 end BoolFunc

--- a/Pnp2/Sunflower/RSpread.lean
+++ b/Pnp2/Sunflower/RSpread.lean
@@ -41,18 +41,21 @@ lemma RSpread.card_bound {R : ℝ} {A : Finset (Finset α)}
     have : 0 < A.card := Finset.card_pos.mpr h.1
     exact_mod_cast this
   have hcond := h.2 S
-  have := (div_le_iff hpos).mp hcond
+  have := (div_le_iff₀ hpos).1 hcond
   simpa [mul_comm] using this
 
 lemma RSpread.one_of_nonempty {A : Finset (Finset α)}
     (hA : A.Nonempty) :
     RSpread (R:=1) A := by
+  classical
   refine ⟨hA, ?_⟩
   intro S
+  classical
   have hsubset : (A.filter fun T ↦ S ⊆ T) ⊆ A := by
-    exact Finset.filter_subset _
+    intro T hT
+    exact (Finset.mem_filter.mp hT).1
   have hle_nat : (A.filter fun T ↦ S ⊆ T).card ≤ A.card :=
-    Finset.card_le_of_subset hsubset
+    Finset.card_mono hsubset
   have hpos_nat : 0 < A.card := Finset.card_pos.mpr hA
   have hpos : 0 < (A.card : ℝ) := by exact_mod_cast hpos_nat
   have hle_real : ((A.filter fun T ↦ S ⊆ T).card : ℝ) ≤ A.card := by
@@ -60,7 +63,7 @@ lemma RSpread.one_of_nonempty {A : Finset (Finset α)}
   have hdiv_le :
       ((A.filter fun T ↦ S ⊆ T).card : ℝ) / A.card ≤ A.card / A.card := by
     have hnonneg : 0 ≤ (A.card : ℝ) := le_of_lt hpos
-    exact div_le_div_of_le_of_nonneg hle_real hnonneg
+    exact div_le_div_of_nonneg_right hle_real hnonneg
   have hcard_div : (A.card : ℝ) / A.card = 1 := by
     have hne : (A.card : ℝ) ≠ 0 := by exact_mod_cast (ne_of_gt hpos_nat)
     field_simp [hne]
@@ -77,6 +80,6 @@ lemma RSpread.card_filter_le {R : ℝ} {A : Finset (Finset α)}
     have hc : 0 < A.card := Finset.card_pos.mpr h.1
     exact_mod_cast hc
   have hbound := h.2 S
-  have := (div_le_iff hpos).1 hbound
+  have := (div_le_iff₀ hpos).1 hbound
   simpa [mul_comm] using this
 

--- a/Pnp2/sunflower.lean
+++ b/Pnp2/sunflower.lean
@@ -67,7 +67,7 @@ lemma sunflower_exists_easy
   classical
   -- pick any `p` distinct sets
   obtain ⟨T, hsub, hcardT⟩ :=
-    Finset.exists_subset_card_eq (s := 𝒜) (k := p) (by simpa using hcard)
+    Finset.exists_subset_card_eq (s := 𝒜) (n := p) (by simpa using hcard)
   -- the intersection of all sets in `T` will serve as the core
   let core : Finset α :=
     (Finset.interFinset T).getD (Finset.card_pos.2 (by

--- a/Pnp2/sunflower.lean
+++ b/Pnp2/sunflower.lean
@@ -67,8 +67,7 @@ lemma sunflower_exists_easy
   classical
   -- pick any `p` distinct sets
   obtain ⟨T, hsub, hcardT⟩ :=
-    (Finset.exists_subset_card_eq p).2 (by
-      simpa using hcard)
+    Finset.exists_subset_card_eq (s := 𝒜) (k := p) (by simpa using hcard)
   -- the intersection of all sets in `T` will serve as the core
   let core : Finset α :=
     (Finset.interFinset T).getD (Finset.card_pos.2 (by


### PR DESCRIPTION
## Summary
- correct subset selection in `sunflower_exists_easy`

## Testing
- `lake build`
- `lake -Kwarn test` *(fails: Pnp2.BoolFunc.Support, Pnp2.sunflower, Pnp2.entropy)*

------
https://chatgpt.com/codex/tasks/task_e_6871801637fc832b8e96ed459b86a885