### PR TITLE
Fix linter warning in Basic test

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -18,6 +18,6 @@ example (x : Point 2) (b : Bool) :
   classical
   let f : BFunc 2 := fun y => y 0
   have hneq : (0 : Fin 2) ≠ 1 := by decide
-  simp [f, Point.update, hneq]
+  simp [Point.update, hneq]
 
 end BasicTests


### PR DESCRIPTION
## Summary
- address `unusedSimpArgs` warning in `test/Basic.lean`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687273c035e8832bb2cca90194dc2ec7