### PR TITLE
Move DecisionTree module to pnp

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -20,5 +20,5 @@ lean_exe tests where
 
 @[test_driver]
 lean_lib Tests where
-  globs := #[`Basic]
+  globs := #[`Basic, `DecisionTree]
   srcDir := "test"

--- a/pnp/Pnp.lean
+++ b/pnp/Pnp.lean
@@ -1,1 +1,2 @@
 import Pnp.BoolFunc.Sensitivity
+import Pnp.DecisionTree

--- a/pnp/Pnp/DecisionTree.lean
+++ b/pnp/Pnp/DecisionTree.lean
@@ -1,4 +1,4 @@
-import Pnp2.BoolFunc
+import Pnp.BoolFunc
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 
 namespace BoolFunc

--- a/test/DecisionTree.lean
+++ b/test/DecisionTree.lean
@@ -1,0 +1,11 @@
+import Pnp.DecisionTree
+
+open BoolFunc DecisionTree
+
+namespace DecisionTreeTests
+
+/-- A tree with a single leaf has depth zero. -/
+example (b : Bool) : depth (DecisionTree.leaf (n:=1) b) = 0 := by
+  rfl
+
+end DecisionTreeTests

--- a/test/Main.lean
+++ b/test/Main.lean
@@ -1,4 +1,5 @@
 import Basic
+import DecisionTree
 
 def main : IO UInt32 :=
   pure 0


### PR DESCRIPTION
## Summary
- copy `DecisionTree` to the new `pnp` namespace
- hook the module into the top-level `Pnp` import
- add a small DecisionTree test and enable it in lakefile

## Testing
- `lake exe tests`
- `lake env lean --run scripts/smoke.lean`


------
https://chatgpt.com/codex/tasks/task_e_68727913fcd8832ba06d0de1bd56d774