### PR TITLE
Continue migrating BoolFunc modules

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -20,5 +20,5 @@ lean_exe tests where
 
 @[test_driver]
 lean_lib Tests where
-  globs := #[`Basic]
+  globs := #[`Basic, `Support]
   srcDir := "test"

--- a/pnp/Pnp.lean
+++ b/pnp/Pnp.lean
@@ -1,1 +1,2 @@
 import Pnp.BoolFunc.Sensitivity
+import Pnp.BoolFunc.Support

--- a/pnp/Pnp/BoolFunc/Support.lean
+++ b/pnp/Pnp/BoolFunc/Support.lean
@@ -1,0 +1,67 @@
+import Mathlib.Data.Finset.Basic
+import Pnp.BoolFunc
+
+open Finset
+
+namespace BoolFunc
+variable {n : ℕ}
+
+/-- If a coordinate is not in the `support` of `f`, updating that coordinate does
+not change the value of `f`. -/
+lemma eval_update_not_support {f : BFunc n} {i : Fin n}
+    (hi : i ∉ support f) (x : Point n) (b : Bool) :
+    f x = f (Point.update x i b) := by
+  classical
+  have hxall : ∀ z : Point n, f z = f (Point.update z i (!z i)) := by
+    have hxne := not_exists.mp (by simpa [mem_support_iff] using hi)
+    intro z
+    by_contra hx
+    exact hxne z hx
+  have hx := hxall x
+  by_cases hb : b = x i
+  · subst hb; simp
+  · have hb' : b = !x i := by
+      cases x i <;> cases b <;> simp [hb] at *
+    simpa [hb'] using hx
+
+/-/-- If `x` and `y` agree on `support f`, then `f x = f y`. -/
+lemma eval_eq_of_agree_on_support
+    {f : BFunc n} {x y : Point n}
+    (h : ∀ i, i ∈ support f → x i = y i) :
+    f x = f y := by
+  classical
+  -- Otherwise there exists a coordinate where the values differ.
+  by_contra hneq
+  obtain ⟨i, hi⟩ : ∃ i : Fin n, x i ≠ y i := by
+    classical
+    have hxy' : ¬ ∀ j, x j = y j := by
+      intro hxy
+      apply hneq
+      funext j; exact hxy j
+    simpa [not_forall] using hxy'
+  have hisupp : i ∈ support f := by
+    -- use the definition of `support`
+    unfold support
+    simp [Finset.mem_filter] at *
+  have : x i = y i := h i hisupp
+  exact hi this
+
+/-/-- Every non-trivial function evaluates to `true` at some point. -/
+lemma exists_true_on_support {f : BFunc n} (h : support f ≠ ∅) :
+    ∃ x, f x = true := by
+  classical
+  rcases Finset.nonempty_iff_ne_empty.2 h with ⟨i, hi⟩
+  rcases mem_support_iff.mp hi with ⟨x, hx⟩
+  cases hfx : f x
+  · have : f (Point.update x i (!x i)) = true := by
+      have hneq := hx
+      simp [hfx] at hneq
+      cases hupdate : f (Point.update x i (!x i)) with
+      | true => simpa [hupdate]
+      | false =>
+          have : False := by simpa [hupdate] using hneq
+          contradiction
+    exact ⟨Point.update x i (!x i), this⟩
+  · exact ⟨x, by simpa [hfx]⟩
+
+end BoolFunc

--- a/test/Main.lean
+++ b/test/Main.lean
@@ -1,4 +1,5 @@
 import Basic
+import Support
 
 def main : IO UInt32 :=
   pure 0

--- a/test/Support.lean
+++ b/test/Support.lean
@@ -1,0 +1,47 @@
+import Pnp.BoolFunc.Support
+
+open BoolFunc
+
+namespace SupportTests
+
+/-- Updating a coordinate outside the support leaves a constant function unchanged. -/
+example (n : ℕ) (x : Point n) (i : Fin n) (b : Bool) :
+    let f : BFunc n := fun _ => true
+    f x = f (Point.update x i b) := by
+  classical
+  intro f
+  have hi : i ∉ support f := by
+    ext j
+    simp [support, f]
+  simpa [f] using eval_update_not_support (f := f) hi x b
+
+/-- If two points agree on the support, the function values coincide. -/
+example (x y : Point 2) (hx : x 0 = y 0) (hy : x 1 = y 1) :
+    let f : BFunc 2 := fun z => z 0 && z 1
+    f x = f y := by
+  classical
+  intro f
+  have hsupp : support f = {0, 1} := by
+    ext i
+    fin_cases i <;> simp [support, f]
+  have hx' : ∀ i, i ∈ support f → x i = y i := by
+    intro i hi
+    have hi' : i = 0 ∨ i = 1 := by
+      simpa [hsupp] using hi
+    cases hi' with
+    | inl h0 => cases h0; simpa [hx]
+    | inr h1 => cases h1; simpa [hy]
+  simpa [f] using eval_eq_of_agree_on_support (f := f) hx'
+
+/-- A nontrivial function evaluates to `true` somewhere on its support. -/
+example :
+    let f : BFunc 1 := fun z => z 0
+    ∃ x, f x = true := by
+  classical
+  intro f
+  have hsupp : support f ≠ (∅ : Finset (Fin 1)) := by
+    classical
+    simp [support, f]
+  simpa [f] using exists_true_on_support (f := f) hsupp
+
+end SupportTests


### PR DESCRIPTION
## Summary
- migrate support lemmas from `Pnp2` to `pnp`
- provide tests exercising the new module
- include new module in the test driver

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68727913fcd8832ba06d0de1bd56d774