### PR TITLE
Continue migrating BoolFunc modules

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -20,5 +20,5 @@ lean_exe tests where
 
 @[test_driver]
 lean_lib Tests where
-  globs := #[`Basic]
+  globs := #[`Basic, `Support]
   srcDir := "test"

--- a/pnp/Pnp.lean
+++ b/pnp/Pnp.lean
@@ -1,1 +1,2 @@
 import Pnp.BoolFunc.Sensitivity
+import Pnp.BoolFunc.Support

--- a/pnp/Pnp/BoolFunc/Support.lean
+++ b/pnp/Pnp/BoolFunc/Support.lean
@@ -1,0 +1,65 @@
+import Mathlib.Data.Finset.Basic
+import Pnp.BoolFunc
+
+open Finset
+
+namespace Pnp.BoolFunc
+
+variable {n : ℕ}
+
+/-- If a coordinate is not in the `support` of `f`, updating that coordinate does
+not change the value of `f`. -/
+theorem eval_update_not_support {f : BFunc n} {i : Fin n} (hi : i ∉ support f)
+    (x : Point n) (b : Bool) :
+    f x = f (x.update i b) := by
+  classical
+  have eq_all : ∀ z, f z = f (z.update i (!z i)) := by
+    intro z
+    have : ¬ ∃ z, f z ≠ f (z.update i (!z i)) := by
+      simpa [mem_support_iff, not_exists] using hi
+    simp [this]
+  by_cases hb : b = x i
+  · simp [hb]
+  ·
+    have : b = ! x i := by
+      cases x i <;> cases b <;> simp [hb]
+    calc
+      f x = f (x.update i (!x i)) := eq_all x
+      _ = f (x.update i b) := by simp [this]
+
+/-- If `x` and `y` agree on `support f`, then `f x = f y`. -/
+theorem eval_eq_of_agree_on_support {f : BFunc n} {x y : Point n}
+    (h : ∀ i ∈ support f, x i = y i) :
+    f x = f y := by
+  classical
+  let toFix := (Finset.univ : Finset (Fin n)) \ support f
+  have : f x = (toFix.fold (fun z p => p.update z (y z)) x) := by
+    induction toFix using Finset.induction_on with
+    | empty =>
+        simp [Finset.fold_empty]
+    | @insert i s hi ih =>
+        simp [Finset.fold_insert hi]
+        have hi' : i ∉ support f := by simp [Finset.mem_diff, hi]
+        have := eval_update_not_support hi' x (y i)
+        simp [this] at ih
+        calc
+          f x = f (x.update i (y i)) := by simpa using this
+          _ = f (s.fold (fun z p => p.update z (y z)) (x.update i (y i))) := by
+                simpa using ih
+  simpa using this
+
+/-- Every non-trivial function evaluates to `true` at some point. -/
+theorem exists_true_on_support {f : BFunc n} (h : support f ≠ ∅) :
+    ∃ x, f x = true := by
+  classical
+  rcases Finset.nonempty_iff_ne_empty.1 h with ⟨i, hi⟩
+  rcases mem_support_iff.1 hi with ⟨x, hf⟩
+  by_cases hfx : f x = true
+  · exact ⟨x, hfx⟩
+  ·
+    have : f (x.update i (!x i)) = true := by
+      simp [hfx] at hf
+      cases hf_update : f (x.update i (!x i)) <;> simp_all at hf
+    exact ⟨x.update i (!x i), this⟩
+
+end Pnp.BoolFunc

--- a/test/Main.lean
+++ b/test/Main.lean
@@ -1,4 +1,5 @@
 import Basic
+import Support
 
 def main : IO UInt32 :=
   pure 0

--- a/test/Support.lean
+++ b/test/Support.lean
@@ -1,0 +1,47 @@
+import Pnp.BoolFunc.Support
+
+open Pnp.BoolFunc
+
+namespace SupportTests
+
+/-- Updating a coordinate outside the support leaves a constant function unchanged. -/
+example (n : ℕ) (x : Point n) (i : Fin n) (b : Bool) :
+    let f : BFunc n := fun _ => true
+    f x = f (x.update i b) := by
+  classical
+  intro f
+  have hi : i ∉ support f := by
+    ext j
+    simp [support, f]
+  simpa [f] using eval_update_not_support (f := f) hi x b
+
+/-- If two points agree on the support, the function values coincide. -/
+example (x y : Point 2) (hx : x 0 = y 0) (hy : x 1 = y 1) :
+    let f : BFunc 2 := fun z => z 0 && z 1
+    f x = f y := by
+  classical
+  intro f
+  have hsupp : support f = {0, 1} := by
+    ext i
+    fin_cases i <;> simp [support, f]
+  have hx' : ∀ i, i ∈ support f → x i = y i := by
+    intro i hi
+    have hi' : i = 0 ∨ i = 1 := by
+      simpa [hsupp] using hi
+    cases hi' with
+    | inl h0 => cases h0; simpa [hx]
+    | inr h1 => cases h1; simpa [hy]
+  simpa [f] using eval_eq_of_agree_on_support (f := f) hx'
+
+/-- A nontrivial function evaluates to `true` somewhere on its support. -/
+example :
+    let f : BFunc 1 := fun z => z 0
+    ∃ x, f x = true := by
+  classical
+  intro f
+  have hsupp : support f ≠ (∅ : Finset (Fin 1)) := by
+    classical
+    simp [support, f]
+  simpa [f] using exists_true_on_support (f := f) hsupp
+
+end SupportTests


### PR DESCRIPTION
## Summary
- refine support lemmas in `Pnp.BoolFunc.Support`
- update tests to use the new namespace and dot notation

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68727913fcd8832ba06d0de1bd56d774