### PR TITLE
Add exists_true_on_support lemma

### DIFF
--- a/pnp/Pnp/BoolFunc/Support.lean
+++ b/pnp/Pnp/BoolFunc/Support.lean
@@ -24,4 +24,24 @@ lemma eval_update_not_support {f : BFunc n} {i : Fin n}
       cases hxi : x i <;> cases hbv : b <;> simp [hxi, hbv] at *
     simpa [hb'] using hx
 
+/-- Every non-trivial function evaluates to `true` at some point. -/
+lemma exists_true_on_support {f : BFunc n} (h : support f ≠ ∅) :
+    ∃ x, f x = true := by
+  classical
+  rcases Finset.nonempty_iff_ne_empty.2 h with ⟨i, hi⟩
+  rcases mem_support_iff.mp hi with ⟨x, hx⟩
+  cases hxfx : f x
+  · -- if `f x = false`, the witness from `mem_support_iff` shows
+    -- that flipping coordinate `i` yields `true`.
+    have : f (Point.update x i (!x i)) = true := by
+      -- otherwise we contradict `hx`
+      cases hupdate : f (Point.update x i (!x i)) with
+      | true => simpa [hupdate]
+      | false =>
+          have := hx
+          simp [hxfx, hupdate] at this
+    exact ⟨Point.update x i (!x i), this⟩
+  · -- otherwise `x` itself evaluates to `true`
+    exact ⟨x, by simpa [hxfx]⟩
+
 end BoolFunc


### PR DESCRIPTION
## Summary
- extend `BoolFunc.Support` with a lemma proving that a boolean function with
  non-empty support attains `true`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6872a701c5c4832bbde67ca9c28a164f