### PR TITLE
Port lemma exists_true_on_support

### DIFF
--- a/pnp/Pnp/BoolFunc/Support.lean
+++ b/pnp/Pnp/BoolFunc/Support.lean
@@ -24,4 +24,18 @@ lemma eval_update_not_support {f : BFunc n} {i : Fin n}
       cases hxi : x i <;> cases hbv : b <;> simp [hxi, hbv] at *
     simpa [hb'] using hx
 
+/-- Every non-trivial function evaluates to `true` at some point. -/
+lemma exists_true_on_support {f : BFunc n} (h : support f ≠ ∅) :
+    ∃ x, f x = true := by
+  classical
+  obtain ⟨i, hi⟩ := Finset.nonempty_iff_ne_empty.2 h
+  obtain ⟨x, hx⟩ := mem_support_iff.mp hi
+  by_cases hfx : f x = true
+  · exact ⟨x, hfx⟩
+  · have hxne : f (Point.update x i (!x i)) ≠ f x := by simpa using hx.symm
+    cases hupdate : f (Point.update x i (!x i))
+    · have : False := by simpa [hfx, hupdate] using hx
+      contradiction
+    · exact ⟨Point.update x i (!x i), by simpa [hupdate]⟩
+
 end BoolFunc

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -43,4 +43,19 @@ example :
       (t := (DecisionTree.leaf true : DecisionTree 1))
   exact hx
 
+-- There exists a point where a non-trivial function evaluates to `true`.
+example :
+    ∃ x, (fun y : Point 1 => y 0) x = true := by
+  classical
+  have hmem : (0 : Fin 1) ∈ support (fun y : Point 1 => y 0) := by
+    classical
+    have hx : (fun y : Point 1 => y 0) (fun _ => false) ≠
+        (fun y : Point 1 => y 0) (Point.update (fun _ => false) 0 true) := by
+      simp [Point.update]
+    exact mem_support_iff.mpr ⟨fun _ => false, hx⟩
+  have hsupp : support (fun y : Point 1 => y 0) ≠ (∅ : Finset (Fin 1)) := by
+    intro hempty
+    simpa [hempty] using hmem
+  exact BoolFunc.exists_true_on_support (f := fun y : Point 1 => y 0) hsupp
+
 end BasicTests


### PR DESCRIPTION
## Summary
- ported `exists_true_on_support` to `Pnp.BoolFunc.Support`
- added a Basic test covering the new lemma

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6872a701c5c4832bbde67ca9c28a164f