### PR TITLE
Fix warnings in support lemmas and tests

### DIFF
--- a/pnp/Pnp/BoolFunc/Support.lean
+++ b/pnp/Pnp/BoolFunc/Support.lean
@@ -12,8 +12,11 @@ lemma eval_update_not_support {f : BFunc n} {i : Fin n}
     (hi : i ∉ support f) (x : Point n) (b : Bool) :
     f x = f (Point.update x i b) := by
   classical
+  -- Unfolding the definition of `support`, `hi` tells us that flipping the
+  -- `i`-th bit never changes the value of `f`.
   have hxall : ∀ z : Point n, f z = f (Point.update z i (!z i)) := by
-    simpa [mem_support_iff] using hi
+    simp [mem_support_iff] at hi
+    exact hi
   have hx := hxall x
   by_cases hb : b = x i
   · subst hb
@@ -22,7 +25,9 @@ lemma eval_update_not_support {f : BFunc n} {i : Fin n}
     simp [hupdate]
   · have hb' : b = !x i := by
       cases hxi : x i <;> cases hbv : b <;> simp [hxi, hbv] at *
-    simpa [hb'] using hx
+    -- Rewrite `hx` using the reverse orientation of `hb'` before finishing.
+    simp [hb'.symm] at hx
+    exact hx
 
 /-- Every non-trivial function evaluates to `true` at some point. -/
 lemma exists_true_on_support {f : BFunc n} (h : support f ≠ ∅) :

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -62,7 +62,8 @@ example :
     exact mem_support_iff.mpr ⟨fun _ => false, hx⟩
   have hsupp : support (fun y : Point 1 => y 0) ≠ (∅ : Finset (Fin 1)) := by
     intro hempty
-    simpa [hempty] using hmem
+    -- Rewrite `hmem` using `hempty`; the contradiction closes the goal.
+    simp [hempty] at hmem
   exact BoolFunc.exists_true_on_support (f := fun y : Point 1 => y 0) hsupp
 
 end BasicTests


### PR DESCRIPTION
## Summary
- tidy BoolFunc.Support lemmas by replacing `simpa` calls with more explicit `simp`
- update Basic tests accordingly

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6872b421fb38832b8f1829c7176849fe