### PR TITLE
Port monochromatic point lemma

### DIFF
--- a/pnp/Pnp/Agreement.lean
+++ b/pnp/Pnp/Agreement.lean
@@ -42,6 +42,20 @@ def Subcube.fromPoint (x : Point n) (I : Finset (Fin n)) : Subcube n where
     (Subcube.fromPoint x I).dimension = n - I.card := by
   rfl
 
+@[simp] lemma Subcube.monochromatic_point
+    {x : Point n} {f : BFunc n} :
+    (Subcube.fromPoint x (Finset.univ : Finset (Fin n))).monochromaticFor f := by
+  classical
+  refine ⟨f x, ?_⟩
+  intro y hy
+  have hy_eq : y = x := by
+    ext i
+    have h :=
+      (fromPoint_mem (x := x) (I := (Finset.univ : Finset (Fin n))) (y := y)).1
+        hy i (by simp)
+    exact h
+  simp [hy_eq]
+
 /-- Helper: if `y` matches `x` on `I` of size ≥ `n - ℓ`, then
     `hammingDist x y ≤ ℓ`. -/
 lemma dist_le_of_compl_subset

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -65,4 +65,10 @@ example :
     simp [hempty] at hmem
   exact BoolFunc.exists_true_on_support (f := fun y : Point 1 => y 0) hsupp
 
+-- A single-point subcube is monochromatic for any function.
+example {n : ℕ} (x : Point n) (f : BFunc n) :
+    (Agreement.Subcube.fromPoint (n := n) x Finset.univ).monochromaticFor f := by
+  classical
+  exact Agreement.Subcube.monochromatic_point (x := x) (f := f)
+
 end BasicTests


### PR DESCRIPTION
## Summary
- port lemma showing a single-point subcube is monochromatic for any function
- add a regression example to the test suite

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6872bbea1304832b94ecff9248ca6489