### PR TITLE
Port initial entropy lemmas

### DIFF
--- a/pnp/Pnp.lean
+++ b/pnp/Pnp.lean
@@ -2,3 +2,4 @@ import Pnp.BoolFunc.Sensitivity
 import Pnp.BoolFunc.Support
 import Pnp.DecisionTree
 import Pnp.Agreement
+import Pnp.Entropy

--- a/pnp/Pnp/Entropy.lean
+++ b/pnp/Pnp/Entropy.lean
@@ -1,0 +1,79 @@
+import Pnp.BoolFunc
+import Mathlib.Analysis.SpecialFunctions.Log.Base
+import Mathlib.Algebra.Order.Field.Basic
+
+open Classical
+open Real
+open BoolFunc
+
+namespace BoolFunc
+
+/-! ### Collision probability and entropy -/
+
+/-- *Collision probability* of a *uniform* family `F` of Boolean functions.
+We work in `ℝ` so that later analytic lemmas can apply. -/
+noncomputable
+def collProb {n : ℕ} (F : Family n) : ℝ :=
+  if h : F.card = 0 then 0 else (F.card : ℝ)⁻¹
+
+@[simp] lemma collProb_pos {n : ℕ} {F : Family n} (h : 0 < F.card) :
+    collProb F = (F.card : ℝ)⁻¹ := by
+  simp [collProb, h.ne']
+
+@[simp] lemma collProb_zero {n : ℕ} {F : Family n} (h : F.card = 0) :
+    collProb F = 0 := by
+  simp [collProb, h]
+
+lemma collProb_nonneg {n : ℕ} (F : Family n) :
+    0 ≤ collProb F := by
+  by_cases h : F.card = 0
+  · simp [collProb, h]
+  · have : 0 < (F.card : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero h
+    simpa [collProb, h] using inv_nonneg.mpr (le_of_lt this)
+
+lemma collProb_le_one {n : ℕ} (F : Family n) :
+    collProb F ≤ 1 := by
+  classical
+  by_cases h : F.card = 0
+  · simp [collProb, h]
+  · have hpos : 0 < (F.card : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero h
+    have hcoll : collProb F = 1 / (F.card : ℝ) := by
+      simp [collProb, h]
+    have hge : (1 : ℝ) ≤ (F.card : ℝ) := by
+      exact_mod_cast Nat.succ_le_of_lt (Nat.pos_of_ne_zero h)
+    have hbound : 1 / (F.card : ℝ) ≤ 1 := by
+      have := (div_le_one (hb := hpos)).mpr hge
+      simpa using this
+    simpa [hcoll] using hbound
+
+@[simp] lemma collProb_card_one {n : ℕ} {F : Family n} (h : F.card = 1) :
+    collProb F = 1 := by
+  simp [collProb, h]
+
+lemma collProb_ne_zero_of_pos {n : ℕ} {F : Family n} (h : 0 < F.card) :
+    collProb F ≠ 0 := by
+  have : (F.card : ℝ) ≠ 0 := by exact_mod_cast (Nat.ne_of_gt h)
+  simpa [collProb, h] using inv_ne_zero this
+
+/-- **Collision entropy** `H₂(F)` (base‑2). -/
+noncomputable def H₂ {n : ℕ} (F : Family n) : ℝ :=
+  Real.logb 2 F.card
+
+@[simp] lemma H₂_eq_log_card {n : ℕ} (F : Family n) :
+    H₂ F = Real.logb 2 F.card := rfl
+
+@[simp] lemma H₂_card_one {n : ℕ} (F : Family n) (h : F.card = 1) :
+    H₂ F = 0 := by
+  simp [H₂, h]
+
+/-!
+`Family.restrict i b` fixes one input bit of every function in `F`.
+This can only decrease the cardinality of the family.
+-/
+lemma card_restrict_le {n : ℕ} (F : Family n) (i : Fin n) (b : Bool) :
+    (F.restrict i b).card ≤ F.card := by
+  classical
+  simpa [Family.restrict] using
+    (Finset.card_image_le (s := F) (f := fun f : BFunc n => f.restrictCoord i b))
+
+end BoolFunc

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -2,6 +2,7 @@ import Pnp.BoolFunc
 import Pnp.BoolFunc.Support
 import Pnp.DecisionTree
 import Pnp.Agreement
+import Pnp.Entropy
 
 open BoolFunc
 
@@ -64,5 +65,12 @@ example :
     intro hempty
     simp [hempty] at hmem
   exact BoolFunc.exists_true_on_support (f := fun y : Point 1 => y 0) hsupp
+
+-- Basic bounds on collision probability.
+example (F : Family 0) :
+    0 ≤ collProb F ∧ collProb F ≤ 1 := by
+  constructor
+  · simpa using BoolFunc.collProb_nonneg (F := F)
+  · simpa using BoolFunc.collProb_le_one (F := F)
 
 end BasicTests


### PR DESCRIPTION
## Summary
- port `Entropy` module with collision probability and basic lemmas
- import this new file in `Pnp.lean`
- extend basic tests to check simple bounds on `collProb`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6872bbe78358832b801450782c01042f