### PR TITLE
Remove unnecessary simpa

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -72,7 +72,7 @@ example :
 example (n : ℕ) :
     (Boolcube.Subcube.full : Boolcube.Subcube n).dim = n := by
   classical
-  simp [Boolcube.Subcube.dim_full (n := n)]
+  simp
 
 -- Basic bounds on collision probability.
 example (F : Family 0) :

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -72,7 +72,7 @@ example :
 example (n : ℕ) :
     (Boolcube.Subcube.full : Boolcube.Subcube n).dim = n := by
   classical
-  simpa using Boolcube.Subcube.dim_full (n := n)
+  simp [Boolcube.Subcube.dim_full (n := n)]
 
 -- Basic bounds on collision probability.
 example (F : Family 0) :


### PR DESCRIPTION
## Summary
- fix linter warning by using `simp` in `Basic.lean`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6872d2b0dd8c832b9c4f72ed434d4788