### PR TITLE
Fix linter warning in Basic tests

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -78,8 +78,8 @@ example (n : ℕ) :
 example (F : Family 0) :
     0 ≤ collProb F ∧ collProb F ≤ 1 := by
   constructor
-  · simpa using BoolFunc.collProb_nonneg (F := F)
-  · simpa using BoolFunc.collProb_le_one (F := F)
+  · simp [BoolFunc.collProb_nonneg (F := F)]
+  · simp [BoolFunc.collProb_le_one (F := F)]
 
 -- A single-point subcube is monochromatic for any function.
 example {n : ℕ} (x : Point n) (f : BFunc n) :


### PR DESCRIPTION
## Summary
- simplify the proof of `collProb` bounds by using `simp`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6872d687013c832b8ee5925658f1b406