### PR TITLE
Port collentropy definitions

### DIFF
--- a/pnp/Pnp.lean
+++ b/pnp/Pnp.lean
@@ -4,3 +4,4 @@ import Pnp.DecisionTree
 import Pnp.Agreement
 import Pnp.Boolcube
 import Pnp.Entropy
+import Pnp.Collentropy

--- a/pnp/Pnp/Collentropy.lean
+++ b/pnp/Pnp/Collentropy.lean
@@ -1,0 +1,40 @@
+-- Partial port of collentropy.lean
+
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Base
+import Pnp.BoolFunc
+
+open Classical
+open Real
+
+namespace BoolFunc
+
+noncomputable section
+
+variable {n : Nat} [Fintype (Point n)]
+
+/-- Collision probability of a Boolean function `f` under the uniform
+measure on `Point n`.  If `p = prob f` is the probability that `f`
+outputs `true`, then `collProbFun f = p ^ 2 + (1 - p) ^ 2`. -/
+@[simp] def collProbFun (f : BFunc n) : Real :=
+  let p := prob f
+  p * p + (1 - p) * (1 - p)
+
+/-- Collision entropy of a Boolean function in bits. -/
+@[simp] def H₂Fun (f : BFunc n) : Real :=
+  -Real.logb 2 (collProbFun f)
+
+lemma collProbFun_const_false : collProbFun (fun _ => false : BFunc n) = 1 := by
+  classical
+  unfold collProbFun prob ones
+  simp
+
+lemma collProbFun_const_true : collProbFun (fun _ => true : BFunc n) = 1 := by
+  classical
+  unfold collProbFun prob ones
+  simp
+
+end
+
+end BoolFunc
+

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -4,6 +4,7 @@ import Pnp.DecisionTree
 import Pnp.Agreement
 import Pnp.Boolcube
 import Pnp.Entropy
+import Pnp.Collentropy
 
 open BoolFunc
 
@@ -80,6 +81,12 @@ example (F : Family 0) :
   constructor
   · simpa using BoolFunc.collProb_nonneg (F := F)
   · simpa using BoolFunc.collProb_le_one (F := F)
+
+-- Collision probability of a constant function is one.
+example (n : ℕ) :
+    BoolFunc.collProbFun (fun _ : Point n => false) = 1 := by
+  classical
+  simpa using BoolFunc.collProbFun_const_false (n := n)
 
 -- A single-point subcube is monochromatic for any function.
 example {n : ℕ} (x : Point n) (f : BFunc n) :


### PR DESCRIPTION
## Summary
- add partial `Collentropy` module with collision probability definitions
- expose it via `Pnp.lean`
- test the constant collision probability lemma

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6872d687013c832b8ee5925658f1b406