### PR TITLE
Update migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ This is still a research prototype. The core-agreement lemma is fully proven, an
 The project is currently undergoing a major refactoring.  All modules are being
 relocated from the historical `Pnp2` namespace to the new `pnp` directory under
 `Pnp`.  Each file is migrated together with dedicated tests to ensure that the
-statements still compile and the existing proofs remain valid.  Only once this
+statements still compile and the existing proofs remain valid.  Several modules
+have already been ported, including `BoolFunc`, `DecisionTree`, `Agreement`,
+`Boolcube`, `Collentropy`, `Entropy` and `LowSensitivityCover`. Only once this
 move is complete will new lemmas and theorems be added.
 
 ## Development plan

--- a/docs/collision_entropy_solution.md
+++ b/docs/collision_entropy_solution.md
@@ -2,7 +2,7 @@
 
 This note summarises the definition of **collision entropy** for a
 single Boolean function and shows how it is formalised in Lean.  The
-implementation can be found in `Pnp2/collentropy.lean`.
+implementation can be found in `pnp/Pnp/Collentropy.lean`.
 
 ## Definition
 
@@ -66,7 +66,7 @@ These facts provide the basic groundwork for further entropy arguments.
 To compile the `collentropy` module run:
 ```bash
 lake exe cache get
-lake build Pnp2.collentropy
+lake build Pnp.Collentropy
 ```
 The first command downloads pre-built Mathlib binaries. If the download fails or is skipped, the build step may take a long time as it compiles Mathlib from source.
 

--- a/migration.md
+++ b/migration.md
@@ -4,32 +4,36 @@ The project is undergoing a gradual move from the historical `Pnp2` namespace to
 
 ## Already migrated
 
-- `BoolFunc.lean` together with the subdirectory `BoolFunc/` (including `Support.lean` and `Sensitivity.lean`).
+The following modules now live under `pnp/Pnp/` and compile in the new
+namespace:
+
+- `BoolFunc.lean` together with the subdirectory `BoolFunc/` (including
+  `Support.lean` and `Sensitivity.lean`).
 - `DecisionTree.lean`.
 - `Agreement.lean`.
+- `Boolcube.lean`.
+- `Collentropy.lean`.
+- `Entropy.lean`.
+- `LowSensitivityCover.lean`.
 - `Pnp.lean` acting as the root module.
 
 ## Remaining to migrate
 
 The following modules are still located under `Pnp2` and need to be copied into `pnp` while keeping the tests in sync:
 
-- `Boolcube.lean`
-- `ComplexityClasses.lean`
-- `NP_separation.lean`
-- `Sunflower/RSpread.lean`
-- `acc_mcsp_sat.lean`
-- `bound.lean`
-- `canonical_circuit.lean`
-- `collentropy.lean`
-- `cover.lean`
-- `cover_numeric.lean`
-- `entropy.lean`
-- `examples.lean`
-- `family_entropy_cover.lean`
-- `low_sensitivity.lean`
-- `low_sensitivity_cover.lean`
-- `merge_low_sens.lean`
-- `sunflower.lean`
-- `table_locality.lean`
+ - `ComplexityClasses.lean`
+ - `NP_separation.lean`
+ - `Sunflower/RSpread.lean`
+ - `acc_mcsp_sat.lean`
+ - `bound.lean`
+ - `canonical_circuit.lean`
+ - `cover.lean`
+ - `cover_numeric.lean`
+ - `examples.lean`
+ - `family_entropy_cover.lean`
+ - `low_sensitivity.lean`
+ - `merge_low_sens.lean`
+ - `sunflower.lean`
+ - `table_locality.lean`
 
 Once all these files have been ported and compile successfully under the `pnp` namespace, the old `Pnp2` directory can be removed.


### PR DESCRIPTION
## Summary
- document modules already moved under the new `pnp` namespace
- update references in the collision entropy note
- mention migration progress in the README

## Testing
- `lake build`
- `lake env lean --run scripts/smoke.lean`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6872ec3e685c832b9aebc2de0588556b