### PR TITLE
Port collProbFun_ge_half lemma

### DIFF
--- a/pnp/Pnp/Collentropy.lean
+++ b/pnp/Pnp/Collentropy.lean
@@ -46,6 +46,17 @@ lemma H₂Fun_const_true :
   unfold H₂Fun collProbFun prob ones
   simp
 
+lemma collProbFun_ge_half (f : BFunc n) :
+    (1 / 2 : ℝ) ≤ collProbFun f := by
+  classical
+  have h : collProbFun f = (1 / 2 : ℝ) + 2 * (prob f - 1 / 2) ^ 2 := by
+    unfold collProbFun
+    ring
+  have hx : 0 ≤ 2 * (prob f - 1 / 2) ^ 2 := by positivity
+  have hx' : (1 / 2 : ℝ) ≤ (1 / 2 : ℝ) + 2 * (prob f - 1 / 2) ^ 2 :=
+    le_add_of_nonneg_right hx
+  exact le_of_le_of_eq hx' h.symm
+
 end
 
 end BoolFunc

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -89,7 +89,13 @@ example (n : ℕ) :
   classical
   simpa using BoolFunc.collProbFun_const_false (n := n)
 
--- A single-point subcube is monochromatic for any function.
+-- Collision probability is bounded below by one half.
+example (n : ℕ) (f : BFunc n) :
+    (1 / 2 : ℝ) ≤ BoolFunc.collProbFun f := by
+  classical
+  simpa using BoolFunc.collProbFun_ge_half (f := f)
+
+  -- A single-point subcube is monochromatic for any function.
   example {n : ℕ} (x : Point n) (f : BFunc n) :
       (Agreement.Subcube.fromPoint (n := n) x Finset.univ).monochromaticFor f := by
     classical


### PR DESCRIPTION
## Summary
- port `collProbFun_ge_half` from the old version
- add a corresponding unit test in `Basic.lean`

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6872ebc731f8832b80914ab6855be70c