### PR TITLE
Port ComplexityClasses to pnp

### DIFF
--- a/migration.md
+++ b/migration.md
@@ -8,13 +8,13 @@ The project is undergoing a gradual move from the historical `Pnp2` namespace to
 - `DecisionTree.lean`.
 - `Agreement.lean`.
 - `Pnp.lean` acting as the root module.
+- `ComplexityClasses.lean`.
 
 ## Remaining to migrate
 
 The following modules are still located under `Pnp2` and need to be copied into `pnp` while keeping the tests in sync:
 
 - `Boolcube.lean`
-- `ComplexityClasses.lean`
 - `NP_separation.lean`
 - `Sunflower/RSpread.lean`
 - `acc_mcsp_sat.lean`

--- a/pnp/Pnp.lean
+++ b/pnp/Pnp.lean
@@ -5,3 +5,4 @@ import Pnp.Agreement
 import Pnp.Boolcube
 import Pnp.Entropy
 import Pnp.Collentropy
+import Pnp.ComplexityClasses

--- a/pnp/Pnp/ComplexityClasses.lean
+++ b/pnp/Pnp/ComplexityClasses.lean
@@ -1,0 +1,66 @@
+import Pnp.Boolcube
+
+open Boolcube
+
+/-- A bitstring of length `n`. -/
+abbrev Bitstring (n : ℕ) := Fin n → Bool
+
+/-- A language over `{0,1}`. `L n x` interprets `x` as an input of length `n`. -/
+abbrev Language := ∀ n, Bitstring n → Bool
+
+/-- A small model of deterministic Turing machines. -/
+structure TM where
+  runTime : ℕ → ℕ
+  accepts : ∀ n, Bitstring n → Bool
+
+/-- A simple inductive datatype for Boolean circuits. -/
+inductive Circuit (n : ℕ) where
+  | var   : Fin n → Circuit n
+  | const : Bool → Circuit n
+  | not   : Circuit n → Circuit n
+  | and   : Circuit n → Circuit n → Circuit n
+  | or    : Circuit n → Circuit n → Circuit n
+  deriving DecidableEq
+
+namespace Circuit
+
+/-- Evaluate a circuit on a Boolean input vector. -/
+noncomputable def eval {n : ℕ} : Circuit n → Point n → Bool
+  | var i, x      => x i
+  | const b, _    => b
+  | not c, x      => !(eval c x)
+  | and c₁ c₂, x  => eval c₁ x && eval c₂ x
+  | or c₁ c₂, x   => eval c₁ x || eval c₂ x
+
+end Circuit
+
+/-- A language has a polynomial-time decider if some Turing machine decides it within time `n^c + c`. -/
+def polyTimeDecider (L : Language) : Prop :=
+  ∃ (T : TM) (c : ℕ),
+    (∀ n, T.runTime n ≤ n^c + c) ∧
+    (∀ n x, T.accepts n x = L n x)
+
+/-- The class `P` of polynomial-time decidable languages. -/
+def P : Set Language := { L | polyTimeDecider L }
+
+/-- A language has a polynomial-time verifier if there exists a Turing machine
+checking membership in polynomial time, possibly using certificates of length
+`n^k`.  The precise encoding of certificates is omitted here. -/
+def polyTimeVerifier (L : Language) : Prop :=
+  ∃ (k : ℕ) (T : TM) (c : ℕ),
+    (∀ n, T.runTime n ≤ n^c + c) ∧ True
+
+/-- The class `NP` defined via polynomial-time verifiers. -/
+def NP : Set Language := { L | polyTimeVerifier L }
+
+/-- A language has polynomial-size circuits if there exists a family of circuits of polynomial size deciding it. -/
+structure InPpoly (L : Language) where
+  polyBound : ℕ → ℕ
+  polyBound_poly : ∃ k, ∀ n, polyBound n ≤ n^k + k
+  circuits : ∀ n, Circuit n
+  size_ok : ∀ n, sizeOf (circuits n) ≤ polyBound n
+  correct : ∀ n (x : Bitstring n), Circuit.eval (circuits n) x = L n x
+
+/-- The non-uniform class `P/poly`. -/
+def Ppoly : Set Language := { L | ∃ h : InPpoly L, True }
+

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -6,6 +6,7 @@ import Pnp.Boolcube
 import Pnp.Entropy
 import Pnp.Collentropy
 import Pnp.LowSensitivityCover
+import Pnp.ComplexityClasses
 
 open BoolFunc
 
@@ -131,6 +132,12 @@ example (n : ℕ) :
       BoolFunc.exists_coord_entropy_drop
         (F := {(fun _ : Point 1 => true), (fun _ : Point 1 => false)})
         hn hF
+
+-- A trivial language with a constant false decider lies in `P`.
+example : polyTimeDecider (fun _ _ => false) := by
+  refine ⟨{ runTime := fun _ => 0, accepts := fun _ _ => false }, 1, ?time, ?acc⟩
+  · intro n; simp
+  · intro n x; rfl
 
 
 end BasicTests


### PR DESCRIPTION
## Summary
- port `ComplexityClasses.lean` into the `pnp` namespace
- expose the new module via `Pnp.lean`
- update tests to import the module and add a simple example
- mark the file as migrated in `migration.md`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6872ebcc0428832b8186b0fc7147da91