### PR TITLE
Fix complexity class warning and add tests

### DIFF
--- a/pnp/Pnp.lean
+++ b/pnp/Pnp.lean
@@ -5,3 +5,5 @@ import Pnp.Agreement
 import Pnp.Boolcube
 import Pnp.Entropy
 import Pnp.Collentropy
+import Pnp.CanonicalCircuit
+import Pnp.ComplexityClasses

--- a/pnp/Pnp/CanonicalCircuit.lean
+++ b/pnp/Pnp/CanonicalCircuit.lean
@@ -1,0 +1,26 @@
+import Pnp.Boolcube
+
+namespace Boolcube
+
+/-- A simple inductive datatype for Boolean circuits with AND/OR/NOT gates. -/
+inductive Circuit (n : ℕ) where
+  | var   : Fin n → Circuit n
+  | const : Bool → Circuit n
+  | not   : Circuit n → Circuit n
+  | and   : Circuit n → Circuit n → Circuit n
+  | or    : Circuit n → Circuit n → Circuit n
+  deriving DecidableEq
+
+namespace Circuit
+
+/-- Evaluate a circuit on a Boolean input vector. -/
+noncomputable def eval {n : ℕ} : Circuit n → Point n → Bool
+  | var i, x      => x i
+  | const b, _    => b
+  | not c, x      => !(eval c x)
+  | and c₁ c₂, x  => eval c₁ x && eval c₂ x
+  | or c₁ c₂, x   => eval c₁ x || eval c₂ x
+
+end Circuit
+
+end Boolcube

--- a/pnp/Pnp/ComplexityClasses.lean
+++ b/pnp/Pnp/ComplexityClasses.lean
@@ -1,0 +1,57 @@
+import Pnp.CanonicalCircuit
+
+open Boolcube
+
+/-- A bitstring of length `n`. -/
+abbrev Bitstring (n : ℕ) := Fin n → Bool
+
+/-- A language over `{0,1}`.  `L n x` interprets `x` as an input of length `n`. -/
+abbrev Language := ∀ n, Bitstring n → Bool
+
+/-- A very small model of deterministic Turing machines.
+`runTime n` is the claimed running time on inputs of length `n`, and `accepts` is the machine's decision procedure.  No operational semantics are provided; this stub merely allows one to state complexity-theoretic definitions. -/
+structure TM where
+  runTime : ℕ → ℕ
+  accepts : ∀ n, Bitstring n → Bool
+
+/-- A language has a polynomial-time decider if some Turing machine decides it within time `n^c + c`. -/
+def polyTimeDecider (L : Language) : Prop :=
+  ∃ (T : TM) (c : ℕ),
+    (∀ n, T.runTime n ≤ n^c + c) ∧
+    (∀ n x, T.accepts n x = L n x)
+
+/-- The class `P` of polynomial-time decidable languages. -/
+def P : Set Language := { L | polyTimeDecider L }
+
+/-- A language has a polynomial-time verifier if there is a Turing machine which, given a certificate of length `n^k`, checks membership in polynomial time.  The certificate is fed to the machine after the input. -/
+def polyTimeVerifier (L : Language) : Prop :=
+  ∃ (k : ℕ) (T : TM) (c : ℕ),
+    (∀ n, T.runTime n ≤ n^c + c) ∧
+    (∀ n x, L n x ↔ ∃ w : Bitstring (n^k),
+      T.accepts (n := n + n^k) (fun i =>
+        if h : (i : ℕ) < n then
+          x ⟨i, h⟩
+        else
+          w ⟨i - n, by
+            have hi : n ≤ (i : ℕ) := Nat.le_of_not_lt h
+            have hlt : (i : ℕ) < n + n^k := by exact i.is_lt
+            have := Nat.sub_lt_sub_right (a := (i : ℕ)) (b := n + n^k) (c := n) hi hlt
+            simpa [Nat.add_comm] using this
+          ⟩
+      ) = true)
+
+/-- The class `NP` defined via polynomial-time verifiers. -/
+def NP : Set Language := { L | polyTimeVerifier L }
+
+/-- A language has polynomial-size circuits if there exists a family of circuits of polynomial size deciding it. -/
+structure InPpoly (L : Language) where
+  polyBound : ℕ → ℕ
+  polyBound_poly : ∃ k, ∀ n, polyBound n ≤ n^k + k
+  circuits : ∀ n, Circuit n
+  size_ok : ∀ n, sizeOf (circuits n) ≤ polyBound n
+  correct : ∀ n (x : Bitstring n),
+    Circuit.eval (circuits n) x = L n x
+
+/-- The non-uniform class `P/poly`. -/
+def Ppoly : Set Language := { L | ∃ _ : InPpoly L, True }
+

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -3,6 +3,8 @@ import Pnp.BoolFunc.Support
 import Pnp.DecisionTree
 import Pnp.Agreement
 import Pnp.Boolcube
+import Pnp.CanonicalCircuit
+import Pnp.ComplexityClasses
 import Pnp.Entropy
 import Pnp.Collentropy
 import Pnp.LowSensitivityCover
@@ -131,6 +133,29 @@ example (n : ℕ) :
       BoolFunc.exists_coord_entropy_drop
         (F := {(fun _ : Point 1 => true), (fun _ : Point 1 => false)})
         hn hF
+
+-- Evaluate a simple Boolean circuit.
+example (x : Point 2) :
+    Boolcube.Circuit.eval
+      (Boolcube.Circuit.or
+        (Boolcube.Circuit.and (Boolcube.Circuit.var 0)
+                               (Boolcube.Circuit.not (Boolcube.Circuit.var 1)))
+        (Boolcube.Circuit.var 1))
+      x =
+    (x 0 && !x 1) || x 1 := by
+  classical
+  cases hx : x 0 <;> cases hy : x 1 <;> simp [Boolcube.Circuit.eval, hx, hy]
+
+-- A trivial Turing machine that always rejects in constant time.
+def constFalseTM : TM :=
+  { runTime := fun _ => 1,
+    accepts := fun _ _ => false }
+
+-- This machine decides the constantly false language in polynomial time.
+example : polyTimeDecider (fun _ _ => false) := by
+  refine ⟨constFalseTM, 1, ?h_run, ?h_accept⟩
+  · intro n; simp [constFalseTM]
+  · intro n x; rfl
 
 
 end BasicTests


### PR DESCRIPTION
## Summary
- suppress unused variable warning in `Ppoly`
- add basic circuit and decider examples to the test suite

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6872ebc731f8832b80914ab6855be70c