### PR TITLE
Port NP_separation stub

### DIFF
--- a/pnp/Pnp.lean
+++ b/pnp/Pnp.lean
@@ -9,4 +9,5 @@ import Pnp.Sunflower.RSpread
 import Pnp.Sunflower.Sunflower
 import Pnp.CanonicalCircuit
 import Pnp.ComplexityClasses
+import Pnp.NPSeparation
 import Pnp.Cover

--- a/pnp/Pnp/NPSeparation.lean
+++ b/pnp/Pnp/NPSeparation.lean
@@ -1,0 +1,4 @@
+import Pnp.ComplexityClasses
+
+/-- Placeholder declarations for future NP separation results. -/
+def NPSeparation.dummy : Unit := ()

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -5,6 +5,7 @@ import Pnp.Agreement
 import Pnp.Boolcube
 import Pnp.CanonicalCircuit
 import Pnp.ComplexityClasses
+import Pnp.NPSeparation
 import Pnp.Entropy
 import Pnp.Collentropy
 import Pnp.LowSensitivityCover


### PR DESCRIPTION
## Summary
- add a placeholder `NPSeparation` module under `pnp` namespace
- register the new module in `Pnp` and tests

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68730cdae748832ba0b932ea3ec45d02