### PR TITLE
Add FamilyEntropyCover and ACCSAT module

### DIFF
--- a/pnp/Pnp/AccMcspSat.lean
+++ b/pnp/Pnp/AccMcspSat.lean
@@ -1,0 +1,46 @@
+-- acc_mcsp_sat.lean
+-- ==================
+-- Outline of the meet-in-the-middle SAT algorithm for `ACC^0 ∘ MCSP`.
+-- The statements are placeholders and proofs are omitted.
+
+import Pnp.BoolFunc
+import Pnp.CanonicalCircuit
+
+open Classical
+
+namespace ACCSAT
+
+/-! Placeholder type for polynomials over `F_2` in `n` variables. -/
+def AccPolynomial (n : ℕ) : Type := Unit
+def polyDefault {n : ℕ} : AccPolynomial n := ()
+
+/-- Razborov–Smolensky: every `ACC^0` circuit can be expressed as a low-degree
+polynomial over `F_2`.  The bound on the degree is schematic and stated in
+big-O form. -/
+lemma acc_circuit_poly {n d : ℕ} (C : Boolcube.Circuit n)
+    (hdepth : True := by trivial) :
+    ∃ P : AccPolynomial n, True :=
+  ⟨polyDefault, trivial⟩
+
+/-- Split an `N`-bit vector into `k` left bits and `ℓ` right bits
+(`N = k + ℓ`).  The helper functions project the appropriate coordinates. -/
+def leftBits (N k ℓ : ℕ) (h : N = k + ℓ)
+    (x : Fin N → Bool) : Fin k → Bool := by
+  subst h
+  exact fun i => x (Fin.castAdd ℓ i)
+
+def rightBits (N k ℓ : ℕ) (h : N = k + ℓ)
+    (x : Fin N → Bool) : Fin ℓ → Bool := by
+  subst h
+  exact fun j => x (Fin.cast (Nat.add_comm ℓ k) (Fin.addNat j k))
+
+/-- Schematic meet-in-the-middle SAT algorithm using a rectangular cover of the
+MCSP truth tables. The algorithm loops over the rectangles and computes partial
+sums on the left and right halves. Whenever a non-zero product is detected the
+circuit is satisfiable. This stub merely returns `false`. -/
+noncomputable def SATViaCover {N : ℕ}
+    (Φ : Boolcube.Circuit N)
+    (cover : Finset (Finset (Fin N) × Finset (Fin N))) : Bool :=
+  false
+
+end ACCSAT

--- a/pnp/Pnp/Cover.lean
+++ b/pnp/Pnp/Cover.lean
@@ -1,4 +1,5 @@
 import Pnp.BoolFunc
+import Pnp.Agreement
 import Mathlib.Data.Nat.Basic
 import Mathlib.Tactic
 
@@ -13,14 +14,18 @@ namespace Cover
 
 @[simp] def mBound (n h : ℕ) : ℕ := n * (h + 2) * 2 ^ (10 * h)
 
-lemma numeric_bound (n h : ℕ) : 2 * h + n ≤ mBound n h := by
-  have : 1 ≤ 2 ^ (10 * h) := Nat.one_le_pow _ _ (by decide : 0 < (2 : ℕ))
-  have : (2 * h + n : ℕ) ≤ n * (h + 2) * 2 ^ (10 * h) := by
-    have : 2 * h + n ≤ n * (h + 2) := by
-      have h0 : 0 ≤ (h : ℤ) := by exact_mod_cast Nat.zero_le _
-      nlinarith
+lemma numeric_bound (n h : ℕ) (hn : 0 < n) : 2 * h + n ≤ mBound n h := by
+  have hpow : 1 ≤ 2 ^ (10 * h) := Nat.one_le_pow _ _ (by decide : 0 < (2 : ℕ))
+  have hlin : (2 * h + n : ℤ) ≤ (n : ℤ) * (h + 2) := by
+    have hn' : (1 : ℤ) ≤ n := by exact_mod_cast hn
+    have h0 : 0 ≤ (h : ℤ) := by exact_mod_cast Nat.zero_le _
+    nlinarith
+  have hlin_nat : (2 * h + n : ℕ) ≤ n * (h + 2) := by exact_mod_cast hlin
+  have hstep : n * (h + 2) ≤ n * (h + 2) * 2 ^ (10 * h) := by
     simpa [mul_comm, mul_left_comm, mul_assoc] using
-      Nat.mul_le_mul_left (n * (h + 2)) (Nat.succ_le_iff.mpr this)
-  simpa [mBound] using this
+      Nat.mul_le_mul_left (n * (h + 2)) hpow
+  have hmul : (2 * h + n : ℕ) ≤ n * (h + 2) * 2 ^ (10 * h) :=
+    le_trans hlin_nat hstep
+  simpa [mBound] using hmul
 
 end Cover

--- a/pnp/Pnp/FamilyEntropyCover.lean
+++ b/pnp/Pnp/FamilyEntropyCover.lean
@@ -1,0 +1,54 @@
+import Pnp.Boolcube
+import Pnp.Cover
+
+namespace Boolcube
+
+open Entropy
+open Cover
+
+/-!
+`familyCollisionEntropyCover` wraps the existential statement
+`Cover.cover_exists` for easier use in downstream files.  It asserts that a
+family of Boolean functions with bounded collision entropy admits a small set of
+jointly monochromatic subcubes covering all `1`-inputs of every function in the
+family.  The full proof is nontrivial and omitted; this declaration merely
+re-exports the existential lemma so that other parts of the development can rely
+on it.
+-/
+ theorem familyCollisionEntropyCover
+  {n : ℕ} (F : Family n) {h : ℕ} (hH : H₂ F ≤ (h : ℝ)) :
+  ∃ (T : Finset (Subcube n)),
+    (∀ C ∈ T, Subcube.monochromaticForFamily C F) ∧
+    (∀ f ∈ F, ∀ x, f x = true → ∃ C, C ∈ T ∧ C.Mem x) ∧
+    T.card ≤ mBound n h := by
+  classical
+  simpa using Cover.cover_exists (F := F) (h := h) hH
+
+/-!
+### A convenience record for covers returned by `familyEntropyCover`.
+This bundles the list of rectangles together with proofs that each
+is monochromatic for the whole family, that the rectangles cover all
+`1`-inputs, and that their number is bounded by `mBound`.
+-/
+structure FamilyCover {n : ℕ} (F : Family n) (h : ℕ) where
+  rects   : Finset (Subcube n)
+  mono    : ∀ C ∈ rects, Subcube.monochromaticForFamily C F
+  covers  : ∀ f ∈ F, ∀ x, f x = true → ∃ C ∈ rects, x ∈ₛ C
+  bound   : rects.card ≤ mBound n h
+
+/--
+`familyEntropyCover` packages `familyCollisionEntropyCover` as a concrete
+object.  It simply uses classical choice to extract a witnessing set of
+rectangles from the existential statement. -/
+noncomputable def familyEntropyCover
+    {n : ℕ} (F : Family n) {h : ℕ} (hH : H₂ F ≤ (h : ℝ)) :
+    FamilyCover F h := by
+  classical
+  obtain ⟨T, hmono, hcov, hcard⟩ :=
+    familyCollisionEntropyCover (F := F) (h := h) hH
+  refine ⟨T, hmono, ?_, hcard⟩
+  intro f hf x hx
+  rcases hcov f hf x hx with ⟨C, hC, hxC⟩
+  exact ⟨C, hC, hxC⟩
+
+end Boolcube

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -8,6 +8,7 @@ import Pnp.ComplexityClasses
 import Pnp.Entropy
 import Pnp.Collentropy
 import Pnp.LowSensitivityCover
+import Pnp.AccMcspSat
 
 open BoolFunc
 
@@ -176,6 +177,11 @@ example : polyTimeDecider (fun _ _ => false) := by
   refine ⟨constFalseTM, 1, ?h_run, ?h_accept⟩
   · intro n; simp [constFalseTM]
   · intro n x; rfl
+
+-- Splitting a small vector using `leftBits`.
+example (x : Fin 3 → Bool) :
+    ACCSAT.leftBits (N := 3) (k := 1) (ℓ := 2) rfl x ⟨0, by decide⟩ = x 0 := by
+  rfl
 
 
 end BasicTests


### PR DESCRIPTION
## Summary
- add `FamilyEntropyCover` with wrapper for `cover_exists`
- migrate skeleton `AccMcspSat` with simple helpers
- tweak `Cover.numeric_bound` to require `0 < n`
- extend tests with `ACCSAT.leftBits` example

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68730cdeedac832bb2674ad2937c8cca