### PR TITLE
Add minimal RSpread test

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -20,5 +20,5 @@ lean_exe tests where
 
 @[test_driver]
 lean_lib Tests where
-  globs := #[`Basic]
+  globs := #[`Basic, `CoverExtra]
   srcDir := "test"

--- a/pnp/Pnp/AccMcspSat.lean
+++ b/pnp/Pnp/AccMcspSat.lean
@@ -11,15 +11,15 @@ open Classical
 namespace ACCSAT
 
 /-! Placeholder type for polynomials over `F_2` in `n` variables. -/
-def AccPolynomial (n : ℕ) : Type := Unit
+def AccPolynomial (_n : ℕ) : Type := Unit
 def polyDefault {n : ℕ} : AccPolynomial n := ()
 
 /-- Razborov–Smolensky: every `ACC^0` circuit can be expressed as a low-degree
 polynomial over `F_2`.  The bound on the degree is schematic and stated in
 big-O form. -/
-lemma acc_circuit_poly {n d : ℕ} (C : Boolcube.Circuit n)
-    (hdepth : True := by trivial) :
-    ∃ P : AccPolynomial n, True :=
+lemma acc_circuit_poly {n _d : ℕ} (_C : Boolcube.Circuit n)
+    (_hdepth : True := by trivial) :
+    ∃ _ : AccPolynomial n, True :=
   ⟨polyDefault, trivial⟩
 
 /-- Split an `N`-bit vector into `k` left bits and `ℓ` right bits
@@ -39,8 +39,8 @@ MCSP truth tables. The algorithm loops over the rectangles and computes partial
 sums on the left and right halves. Whenever a non-zero product is detected the
 circuit is satisfiable. This stub merely returns `false`. -/
 noncomputable def SATViaCover {N : ℕ}
-    (Φ : Boolcube.Circuit N)
-    (cover : Finset (Finset (Fin N) × Finset (Fin N))) : Bool :=
+    (_Φ : Boolcube.Circuit N)
+    (_cover : Finset (Finset (Fin N) × Finset (Fin N))) : Bool :=
   false
 
 end ACCSAT

--- a/test/CoverExtra.lean
+++ b/test/CoverExtra.lean
@@ -1,0 +1,22 @@
+import Pnp.BoolFunc
+import Pnp.Boolcube
+import Pnp.Sunflower.RSpread
+-- Additional cover modules are still incomplete, so we test RSpread only.
+
+open BoolFunc
+open Boolcube
+
+namespace CoverExtraTests
+
+
+
+/-- A nonempty family is `1`-spread. -/
+example : RSpread (R := 1) ({∅} : Finset (Finset (Fin 1))) := by
+  have hA : ({∅} : Finset (Finset (Fin 1))).Nonempty := by simp
+  simpa using RSpread.one_of_nonempty (A := {∅}) (hA := hA)
+
+
+-- Further cover lemmas are not yet available in the migrated code.
+
+end CoverExtraTests
+


### PR DESCRIPTION
## Summary
- add `test/CoverExtra.lean` with a simple RSpread example
- register new test module in `lakefile.lean`

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687318baa96c832ba1630286cbefad3b