### PR TITLE
Add firstUncovered helper and tests

### DIFF
--- a/pnp/Pnp/Cover.lean
+++ b/pnp/Pnp/Cover.lean
@@ -2,6 +2,7 @@ import Pnp.BoolFunc
 import Pnp.Boolcube
 import Pnp.Agreement
 import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Set.Lattice
 import Mathlib.Tactic
 
 open Classical
@@ -32,7 +33,10 @@ def uncovered (F : Family n) (Rset : Finset (Subcube n)) : Set ((BFunc n) × Poi
 
 /-- Optionally returns the *first* uncovered ⟨f, x⟩. -/
 noncomputable
-def firstUncovered (_F : Family n) (_Rset : Finset (Subcube n)) : Option ((BFunc n) × Point n) :=
-  none
+def firstUncovered (F : Family n) (Rset : Finset (Subcube n)) : Option ((BFunc n) × Point n) :=
+  if h : (uncovered (F := F) (Rset := Rset)).Nonempty then
+    some h.some
+  else
+    none
 
 end Cover

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -220,5 +220,16 @@ example : ∃ k ≤ 1, True := by
   classical
   simpa using Boolcube.tableLocal (n := 1) 1 (by decide)
 
+-- Numeric bound on cover size is trivial to verify for small parameters.
+example : 2 * 0 + 1 ≤ Cover.mBound 1 0 := by
+  have hn : 0 < (1 : ℕ) := by decide
+  exact Cover.numeric_bound (n := 1) (h := 0) hn
+
+-- When no functions and no rectangles are present, there is no uncovered point.
+example :
+    Cover.firstUncovered (F := (∅ : BoolFunc.Family 1)) (Rset := (∅ : Finset (BoolFunc.Subcube 1))) = none := by
+  classical
+  simp [Cover.firstUncovered, Cover.uncovered, Cover.NotCovered]
+
 
 end BasicTests


### PR DESCRIPTION
## Summary
- implement `firstUncovered` in `Cover` using `Nonempty.some`
- expand Basic tests for the helper and adjust numeric bound example

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6873ba63d5a0832b9e91deb1ae76bdd3