### PR TITLE
Port encodeCanon lemma

### DIFF
--- a/pnp/Pnp/CanonicalCircuit.lean
+++ b/pnp/Pnp/CanonicalCircuit.lean
@@ -119,6 +119,35 @@ def codeLen {n : ℕ} : Canon n → ℕ
   | Canon.and c₁ c₂ => 1 + codeLen c₁ + codeLen c₂
   | Canon.or c₁ c₂  => 1 + codeLen c₁ + codeLen c₂
 
+/-/ Encode a canonical circuit as a list of bits.  The exact format is
+irrelevant, we merely track the length for a later bound. -/
+def encodeCanon {n : ℕ} : Canon n → List Bool
+  | Canon.var _       => List.replicate (Nat.log2 n + 1) false
+  | Canon.const b     => [b]
+  | Canon.not c       => false :: encodeCanon c
+  | Canon.and c₁ c₂   => true :: encodeCanon c₁ ++ encodeCanon c₂
+  | Canon.or c₁ c₂    => true :: encodeCanon c₁ ++ encodeCanon c₂
+
+lemma encodeCanon_length {n : ℕ} (c : Canon n) :
+    (encodeCanon c).length ≤ codeLen c := by
+  induction c with
+  | var _ =>
+      simp [encodeCanon, codeLen]
+  | const b =>
+      simp [encodeCanon, codeLen]
+  | not c ih =>
+      have h := Nat.succ_le_succ ih
+      simpa [encodeCanon, codeLen, Nat.succ_eq_add_one, Nat.add_comm,
+        Nat.add_left_comm, Nat.add_assoc] using h
+  | and c₁ c₂ ih₁ ih₂ =>
+      have := Nat.add_le_add ih₁ ih₂
+      simpa [encodeCanon, codeLen, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+        using Nat.succ_le_succ this
+  | or c₁ c₂ ih₁ ih₂ =>
+      have := Nat.add_le_add ih₁ ih₂
+      simpa [encodeCanon, codeLen, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+        using Nat.succ_le_succ this
+
 end Circuit
 
 end Boolcube

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -173,6 +173,12 @@ example {n : ℕ} {c₁ c₂ : Boolcube.Circuit n}
   have hfun := Boolcube.Circuit.canonical_inj (c₁ := c₁) (c₂ := c₂) h
   simpa using hfun x
 
+-- Encoding length of a canonical circuit is bounded by `codeLen`.
+example {n : ℕ} (c : Boolcube.Circuit.Canon n) :
+    (Boolcube.Circuit.encodeCanon c).length ≤
+      Boolcube.Circuit.codeLen c := by
+  simpa using Boolcube.Circuit.encodeCanon_length (c := c)
+
 -- A trivial Turing machine that always rejects in constant time.
 def constFalseTM : TM :=
   { runTime := fun _ => 1,


### PR DESCRIPTION
## Summary
- implement `encodeCanon` and `encodeCanon_length` in `CanonicalCircuit`
- test the new lemma in `Basic`

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6873ba63d5a0832b9e91deb1ae76bdd3