### PR TITLE
Port mergeLowSensitivityCover definition

### DIFF
--- a/pnp/Pnp/MergeLowSens.lean
+++ b/pnp/Pnp/MergeLowSens.lean
@@ -1,6 +1,7 @@
 import Pnp.Boolcube
 import Pnp.Cover
 import Pnp.Entropy
+import Pnp.FamilyEntropyCover
 
 open Cover
 open BoolFunc
@@ -15,8 +16,8 @@ set of subcubes covering all ones of `F` without referring to the full
 `h` and returns the list of rectangles produced by `buildCover`.
 -/
 noncomputable def mergeLowSensitivityCover
-  {n : ℕ} (_F : Family n) (_h : ℕ) (_hH : BoolFunc.H₂ _F ≤ (_h : ℝ)) :
-  Finset (Subcube n) :=
-  (∅ : Finset (Subcube n))
+  {n : ℕ} (F : Family n) (h : ℕ) (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+  Finset (BoolFunc.Subcube n) :=
+  (familyEntropyCover (F := F) (h := h) hH).rects
 
 end Boolcube

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -212,7 +212,7 @@ example {n s : ℕ} (F : Finset (BoolFunc.Point n → Bool))
 
 -- Wrapper for entropy-based cover construction.
 noncomputable example {n : ℕ} (F : Family n) (h : ℕ) (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
-    Finset (Boolcube.Subcube n) :=
+    Finset (BoolFunc.Subcube n) :=
   Boolcube.mergeLowSensitivityCover F h hH
 
 -- Table locality reduces to `k = n` for the placeholder version.


### PR DESCRIPTION
## Summary
- port the `mergeLowSensitivityCover` definition from the old code
- adjust Basic tests to use `BoolFunc.Subcube`

## Testing
- `lake build`
- `lake test`
- `lake env lean --run test/Main.lean`

------
https://chatgpt.com/codex/tasks/task_e_6873ba63d5a0832b9e91deb1ae76bdd3