### PR TITLE
Port aux_growth lemma

### DIFF
--- a/pnp/Pnp/Bound.lean
+++ b/pnp/Pnp/Bound.lean
@@ -41,8 +41,20 @@ def n₀ (h : ℕ) : ℕ :=
     It simply bounds a linear expression in `h` by the dominating
     exponential term appearing in `n₀`.  The statement is far from sharp
     but suffices for our purposes.  -/
-axiom aux_growth (h : ℕ) :
-    (18 + 22 * h : ℝ) < 100 * (h + 2) * 2 ^ (10 * h)
+lemma aux_growth (h : ℕ) :
+    (18 + 22 * h : ℝ) < 100 * (h + 2) * 2 ^ (10 * h) := by
+  -- First bound `(18 + 22 * h)` by a simpler linear expression.
+  have hbase : (18 + 22 * h : ℝ) < 100 * (h + 2) := by
+    nlinarith
+  -- Note that `2 ^ (10 * h) ≥ 1` for all `h`.
+  have hpow : (1 : ℝ) ≤ (2 : ℝ) ^ (10 * h) := by
+    simpa using (one_le_pow₀ (n := 10 * h) (a := (2 : ℝ)) (by norm_num : (1 : ℝ) ≤ 2))
+  -- Multiplying the linear bound by the positive factor `2 ^ (10 * h)`
+  -- yields the desired inequality.
+  have hbnd : 100 * (h + 2) ≤ 100 * (h + 2) * (2 : ℝ) ^ (10 * h) := by
+    have hpos : (0 : ℝ) ≤ 100 * (h + 2) := by positivity
+    simpa using mul_le_mul_of_nonneg_left hpow hpos
+  exact lt_of_lt_of_le hbase hbnd
 
 axiom mBound_lt_subexp
     (h : ℕ) (n : ℕ) (hn : n ≥ n₀ h) :

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -203,6 +203,11 @@ example (h : ℕ) : 0 < Bound.n₀ h := by
   dsimp [Bound.n₀]
   exact hpos
 
+-- `aux_growth` bounds the linear term by the exponential one.
+example (h : ℕ) :
+    (18 + 22 * h : ℝ) < 100 * (h + 2) * 2 ^ (10 * h) := by
+  simpa using Bound.aux_growth h
+
 -- Entropy-based numeric bound on cover size.
 example {N Nδ : ℕ} (F : Family N)
     (h₂ : BoolFunc.H₂ F ≤ N - Nδ) :


### PR DESCRIPTION
## Summary
- implement `Bound.aux_growth` instead of leaving it as an axiom
- add a basic test for `aux_growth`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6873c47dbcd4832ba4ebf512d016e845