### PR TITLE
Port FCE lemmas

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -243,5 +243,12 @@ example :
   classical
   simp [Cover.firstUncovered, Cover.uncovered, Cover.NotCovered]
 
+-- The Family Collision-Entropy Lemma bounds the size of the entropy cover.
+example {n h : ℕ} (F : Family n) (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hn : n ≥ Bound.n₀ h) :
+    (Boolcube.familyEntropyCover (F := F) (h := h) hH).rects.card <
+      Nat.pow 2 (n / 100) := by
+  simpa using Bound.FCE_lemma (F := F) (h := h) hH hn
+
 
 end BasicTests


### PR DESCRIPTION
## Summary
- import entropy definitions in `Bound`
- port `FCE_lemma` and `family_collision_entropy_lemma`
- test new lemmas in `Basic` test suite

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6873ceb89830832b8dfe1c7da683d9c3