### PR TITLE
Add example for exists_restrict_half

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -147,6 +147,30 @@ example (n : ℕ) (f : BFunc n) :
         (F := {(fun _ : Point 1 => true), (fun _ : Point 1 => false)})
         hn hF
 
+-- There exists a coordinate whose restriction halves the family size.
+example :
+    ∃ i : Fin 1, ∃ b : Bool,
+      (({(fun _ : Point 1 => true), (fun _ : Point 1 => false)} :
+        Family 1).restrict i b).card ≤
+      ({(fun _ : Point 1 => true), (fun _ : Point 1 => false)} :
+        Family 1).card / 2 := by
+  classical
+  have hn : 0 < (1 : ℕ) := by decide
+  have hF : 1 < ({(fun _ : Point 1 => true), (fun _ : Point 1 => false)} :
+      Family 1).card := by
+    classical
+    have hne : (fun _ : Point 1 => true) ≠ (fun _ : Point 1 => false) := by
+      intro h
+      have := congrArg (fun f => f (fun _ => false)) h
+      simp at this
+    have hcard : ({(fun _ : Point 1 => true), (fun _ : Point 1 => false)} :
+        Family 1).card = 2 := by
+      simp [hne]
+    simp [hcard]
+  simpa using
+    BoolFunc.exists_restrict_half
+      (F := {(fun _ : Point 1 => true), (fun _ : Point 1 => false)}) hn hF
+
 -- Evaluate a simple Boolean circuit.
 example (x : Point 2) :
     Boolcube.Circuit.eval


### PR DESCRIPTION
## Summary
- add a new test in `Basic.lean` using `exists_restrict_half`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6873cebd2158832b990109461f199dff