### PR TITLE
Port canonical length lemma

### DIFF
--- a/pnp/Pnp/CanonicalCircuit.lean
+++ b/pnp/Pnp/CanonicalCircuit.lean
@@ -148,6 +148,14 @@ lemma encodeCanon_length {n : ℕ} (c : Canon n) :
       simpa [encodeCanon, codeLen, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
         using Nat.succ_le_succ this
 
+/-! ### Size bound for canonical descriptions
+
+The canonical code length of a circuit is bounded by its size times
+`Nat.log2 n + 1`.  This captures the `O(m log n)` estimate used in the
+roadmap.  The detailed proof is omitted here. -/
+axiom canonical_desc_length {n : ℕ} (c : Circuit n) :
+    codeLen (canonical c) ≤ (sizeOf c) * (Nat.log2 n + 1) + 1
+
 end Circuit
 
 end Boolcube

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -203,6 +203,13 @@ example {n : ℕ} (c : Boolcube.Circuit.Canon n) :
       Boolcube.Circuit.codeLen c := by
   simpa using Boolcube.Circuit.encodeCanon_length (c := c)
 
+-- The canonical description length of a circuit grows at most linearly with
+-- its size (up to a logarithmic factor).
+example {n : ℕ} (c : Boolcube.Circuit n) :
+    Boolcube.Circuit.codeLen (Boolcube.Circuit.canonical c) ≤
+      (sizeOf c) * (Nat.log2 n + 1) + 1 := by
+  simpa using Boolcube.Circuit.canonical_desc_length (c := c)
+
 -- A trivial Turing machine that always rejects in constant time.
 def constFalseTM : TM :=
   { runTime := fun _ => 1,


### PR DESCRIPTION
## Summary
- add placeholder lemma `canonical_desc_length` in `CanonicalCircuit`
- test canonical description length bound in `Basic` tests

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6873ddd7a270832b92d8b7b75c0fb066