### PR TITLE
Port firstUncovered_none_iff

### DIFF
--- a/pnp/Pnp/Cover.lean
+++ b/pnp/Pnp/Cover.lean
@@ -39,4 +39,12 @@ def firstUncovered (F : Family n) (Rset : Finset (Subcube n)) : Option ((BFunc n
   else
     none
 
+set_option linter.unusedSimpArgs false in
+@[simp] lemma firstUncovered_none_iff (R : Finset (Subcube n)) :
+    firstUncovered (F := F) R = none ↔ uncovered (F := F) R = ∅ := by
+  classical
+  by_cases h : (uncovered (F := F) (Rset := R)).Nonempty
+  · simp [firstUncovered, h, Set.nonempty_iff_ne_empty]
+  · simp [firstUncovered, h, Set.nonempty_iff_ne_empty]
+
 end Cover


### PR DESCRIPTION
## Summary
- port the `firstUncovered_none_iff` lemma from the old codebase
  to the `pnp` namespace

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6873eaf147cc832b8896787012d6243e