### PR TITLE
Fix linter warning in tests

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -287,7 +287,7 @@ example :
     Bound.mBound 20000 0 < Nat.pow 2 (20000 / 100) := by
   have h0 : (20000 : ℕ) ≥ Bound.n₀ 0 := by
     simp [Bound.n₀]
-  simpa using Bound.mBound_lt_subexp (h := 0) (n := 20000) h0
+  exact Bound.mBound_lt_subexp (h := 0) (n := 20000) h0
 
 
 end BasicTests


### PR DESCRIPTION
## Summary
- remove an unnecessary `simpa` in `test/Basic.lean`

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6873f8560f08832b96c371f3a15b1494