### PR TITLE
Add familyCollisionEntropyCover lemma

### DIFF
--- a/pnp/Pnp/FamilyEntropyCover.lean
+++ b/pnp/Pnp/FamilyEntropyCover.lean
@@ -12,9 +12,10 @@ open Cover
 family of Boolean functions with bounded collision entropy admits a small set of
 jointly monochromatic subcubes covering all `1`-inputs of every function in the
 family.  The full proof is nontrivial and omitted; this declaration merely
-re-exports the existential lemma so that other parts of the development can rely
-on it.
--/
+  re-exports the existential lemma so that other parts of the development can rely
+  on it.
+  -/
+
 /-!
 ### A convenience record for covers returned by `familyEntropyCover`.
 This bundles the list of rectangles together with proofs that each
@@ -32,5 +33,19 @@ structure FamilyCover {n : ℕ} (F : Family n) (h : ℕ) where
 axiom familyEntropyCover
     {n : ℕ} (F : Family n) {h : ℕ} (hH : H₂ F ≤ (h : ℝ)) :
     FamilyCover F h
+
+/-- ### Existence of a small jointly monochromatic cover. -/
+theorem familyCollisionEntropyCover
+    {n : ℕ} (F : Family n) {h : ℕ} (hH : H₂ F ≤ (h : ℝ)) :
+    ∃ (T : Finset (BoolFunc.Subcube n)),
+      (∀ C ∈ T, BoolFunc.Subcube.monochromaticForFamily C F) ∧
+      (∀ f ∈ F, ∀ x, f x = true → ∃ C, C ∈ T ∧ x ∈ₛ C) ∧
+      T.card ≤ mBound n h := by
+  classical
+  let FC := familyEntropyCover (F := F) (h := h) hH
+  refine ⟨FC.rects, FC.mono, ?_, FC.bound⟩
+  intro f hf x hx
+  rcases FC.covers f hf x hx with ⟨C, hC, hxC⟩
+  exact ⟨C, hC, hxC⟩
 
 end Boolcube


### PR DESCRIPTION
## Summary
- port `familyCollisionEntropyCover` from legacy namespace
- expose lemma in new `pnp` hierarchy

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6873f858ab48832b8ed6717cc45d021f