### PR TITLE
Add TODO for entropy lemmas

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@ Short list of development tasks reflecting the current repository status.
       tests for the migrated code.
 - [ ] Port missing proofs from `Pnp2` modules (Bound, LowSensitivity, MergeLowSens, CoverNumeric, NPSeparation, AccMcspSat) and add tests.
 - [ ] Port `Bound.mBound_lt_subexp` proof and related lemmas (in progress).
+- [ ] Port halving lemmas `exists_restrict_half_real_aux` and `exists_restrict_half` from `entropy.lean`.
 - [ ] Complete `buildCover` proofs (the bound `mBound_lt_subexp` is now proven).
 - [ ] Replace axioms `buildCover_mono` and `buildCover_card_bound` with full proofs.
 - [ ] Integrate the decision-tree implementation with `low_sensitivity_cover`.


### PR DESCRIPTION
## Summary
- note that the halving lemmas from `entropy.lean` still need to be ported

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6874003d2ccc832ba4c7e90d2ee89c74