### PR TITLE
Add placeholder theorems for MCSP separation

### DIFF
--- a/pnp/Pnp/NPSeparation.lean
+++ b/pnp/Pnp/NPSeparation.lean
@@ -6,13 +6,58 @@ This file contains axioms relating an MCSP lower bound to standard
 complexity separations.  The actual results are omitted.
 -/
 
-axiom MCSP_lower_bound : ℝ → Prop
+/--
+Lower bound for the minimum circuit size problem (MCSP).
+`MCSP_lower_bound ε` means that MCSP on inputs of size `N` requires
+circuits of size at least `N^{1 + ε}`. Formal details are omitted; see
+Theorem 1.4 of "Hardness Magnification Near State-of-the-Art Lower
+Bounds" (2021).
+-/
+def MCSP_lower_bound (ε : ℝ) : Prop :=
+  sorry
 
-axiom magnification_AC0_MCSP :
-  (∃ ε > 0, MCSP_lower_bound ε) → Prop
+axiom AC0_consequence : Prop
+
+/--
+Magnification for AC0: if MCSP has a lower bound of the form `MCSP_lower_bound ε`
+for some `ε > 0`, then `AC0_consequence` follows.  This is a placeholder for the
+actual hardness magnification statement in AC0 circuits.
+-/
+theorem magnification_AC0_MCSP :
+  (∃ ε > 0, MCSP_lower_bound ε) → AC0_consequence :=
+by
+  intro h
+  -- Proof would invoke hardness magnification results for Gap-MCSP
+  sorry
 
 axiom PH_collapse : Prop
-axiom karp_lipton : (NP ⊆ Ppoly) → PH_collapse
 
-axiom P_ne_NP_of_MCSP_bound :
-  (∃ ε > 0, MCSP_lower_bound ε) → P ≠ NP
+/-- Karp-Lipton theorem: NP ⊆ P/poly implies a collapse of PH. -/
+theorem karp_lipton : (NP ⊆ Ppoly) → PH_collapse := by
+  intro h
+  -- Standard argument using non-uniform advice
+  sorry
+
+/--
+If there exists an ε > 0 with an MCSP lower bound, then P ≠ NP.  The proof
+would combine `magnification_AC0_MCSP` with known implications of MCSP lower
+bounds for circuit complexity.
+-/
+theorem P_ne_NP_of_MCSP_bound :
+  (∃ ε > 0, MCSP_lower_bound ε) → P ≠ NP := by
+  intro h
+  -- Sketch: hardness magnification shows NP ⊄ Circuit[poly]
+  -- Together with standard complexity arguments we conclude P ≠ NP.
+  sorry
+
+section Examples
+example : ¬ (∃ ε > 0, MCSP_lower_bound ε) ∨ P ≠ NP := by
+  -- Either there is no such lower bound or P and NP are separated.
+  sorry
+end Examples
+
+/-!
+References:
+* Hardness Magnification Near State-of-the-Art Lower Bounds (2021):
+  https://theoryofcomputing.org/articles/v017a011/
+-/


### PR DESCRIPTION
## Summary
- elaborate `NPSeparation.lean` with a more detailed definition for the MCSP lower bound
- add placeholder theorem statements for hardness magnification and Karp–Lipton
- include an example section and references

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687446d92f3c832bb996aed9742c7b6e