### PR TITLE
Port numeric bound lemma

### DIFF
--- a/pnp/Pnp.lean
+++ b/pnp/Pnp.lean
@@ -12,3 +12,4 @@ import Pnp.ComplexityClasses
 import Pnp.NPSeparation
 import Pnp.Cover
 import Pnp.Bound
+import Pnp.CoverNumeric


### PR DESCRIPTION
## Summary
- re-export `CoverNumeric` from main `Pnp` module

## Testing
- `lake build`
- `lake env lean --run scripts/smoke.lean`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687445c3a6c4832b9baeb04b10476ce3