### PR TITLE
Update docs on bound lemma status

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ towards a full argument.
   axioms pending full proofs.  A helper lemma `AllOnesCovered.union`
   now abstracts the union step in the coverage proof.
 * `bound.lean` – arithmetic bounds deriving the subexponential size estimate;
-  the main inequality `mBound_lt_subexp` is now fully proven.
+  the main inequality `mBound_lt_subexp` is currently stated as an axiom in the
+  `pnp` namespace.  A complete proof remains available in
+  `Pnp2/bound.lean` and still needs to be ported.
 * `collentropy.lean` – collision entropy of a single Boolean function with
   basic lemmas such as `H₂Fun_le_one`.
 * `family_entropy_cover.lean` – convenience wrapper returning a `FamilyCover`

--- a/fce_lemma_proof.md
+++ b/fce_lemma_proof.md
@@ -117,7 +117,9 @@ The modules above serve as milestones. Our immediate goals are:
 3. ~~Formalise the `CoreAgreement` lemma in `Agreement.lean`.~~
    The file `Agreement.lean` now contains the complete proof of this lemma.
 4. Finalise the recursive covering algorithm in `cover.lean`.  A
-  The inequality `mBound_lt_subexp` is now fully formalised.
+  proof of the inequality `mBound_lt_subexp` exists in the legacy
+  `Pnp2/bound.lean` file, but the new `pnp` version still marks this
+  statement as an axiom awaiting porting.
 
 6. Provide small test instances in `examples.lean`.
 


### PR DESCRIPTION
## Summary
- clarify that `mBound_lt_subexp` is still an axiom in the new code
- mention that the proof lives in `Pnp2/bound.lean`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6874564c2268832b8539aecd2ce0a69b