### PR TITLE
Port a collentropy lemma

### DIFF
--- a/pnp/Pnp/Collentropy.lean
+++ b/pnp/Pnp/Collentropy.lean
@@ -57,6 +57,12 @@ lemma collProbFun_ge_half (f : BFunc n) :
     le_add_of_nonneg_right hx
   exact le_of_le_of_eq hx' h.symm
 
+lemma collProbFun_pos (f : BFunc n) :
+    0 < collProbFun f := by
+  have h := collProbFun_ge_half (f := f)
+  have : (0 : ℝ) < (1 / 2 : ℝ) := by norm_num
+  exact lt_of_lt_of_le this h
+
 end
 
 end BoolFunc

--- a/test/Migrated.lean
+++ b/test/Migrated.lean
@@ -1,6 +1,8 @@
 import Pnp.LowSensitivity
 import Pnp.TableLocality
 import Pnp.NPSeparation
+import Pnp.Entropy
+import Pnp.Collentropy
 
 open Boolcube
 
@@ -27,6 +29,18 @@ example : ∃ k ≤ 1, True := by
 example (h : ∃ ε > 0, MCSP_lower_bound ε) :
     P ≠ NP := by
   exact P_ne_NP_of_MCSP_bound h
+
+-- The halving lemma provides a coordinate that cuts the family size in half.
+example {n : ℕ} (F : BoolFunc.Family n) (hn : 0 < n) (hF : 1 < F.card) :
+    ∃ i : Fin n, ∃ b : Bool,
+      ((F.restrict i b).card : ℝ) ≤ (F.card : ℝ) / 2 := by
+  simpa using
+    BoolFunc.exists_restrict_half_real_aux (F := F) (hn := hn) (hF := hF)
+
+-- Collision probability is always positive.
+example {n : ℕ} (f : BoolFunc.BFunc n) [Fintype (BoolFunc.Point n)] :
+    0 < BoolFunc.collProbFun (n := n) f := by
+  simpa using BoolFunc.collProbFun_pos (f := f)
 
 end MigratedTests
 


### PR DESCRIPTION
## Summary
- port `collProbFun_pos` from `Pnp2` to `pnp` collentropy file
- test the lemma in migrated examples

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6874722d8f0c832bbaf2797fa74032f2