### PR TITLE
Replace halving axiom with proof

### DIFF
--- a/pnp/Pnp/Entropy.lean
+++ b/pnp/Pnp/Entropy.lean
@@ -110,9 +110,19 @@ lemma exists_restrict_half {n : ℕ} (F : Family n) (hn : 0 < n) (hF : 1 < F.car
 
 /-- **Existence of a halving restriction (ℝ version)** – deduced from the
 integer statement. -/
-axiom exists_restrict_half_real {n : ℕ} (F : Family n) (hn : 0 < n)
+lemma exists_restrict_half_real {n : ℕ} (F : Family n) (hn : 0 < n)
     (hF : 1 < F.card) : ∃ i : Fin n, ∃ b : Bool,
-    ((F.restrict i b).card : ℝ) ≤ (F.card : ℝ) / 2
+    ((F.restrict i b).card : ℝ) ≤ (F.card : ℝ) / 2 := by
+  classical
+  obtain ⟨i, b, hle⟩ := exists_restrict_half (F := F) (hn := hn) (hF := hF)
+  have hle_real' : ((F.restrict i b).card : ℝ) ≤ ((F.card / 2 : ℕ) : ℝ) := by
+    exact_mod_cast hle
+  have hle_cast_div : ((F.card / 2 : ℕ) : ℝ) ≤ (F.card : ℝ) / 2 := by
+    simpa using (Nat.cast_div_le (m := F.card) (n := 2) :
+      ((F.card / 2 : ℕ) : ℝ) ≤ (F.card : ℝ) / 2)
+  have hle_real : ((F.restrict i b).card : ℝ) ≤ (F.card : ℝ) / 2 :=
+    hle_real'.trans hle_cast_div
+  exact ⟨i, b, hle_real⟩
 
 /-- **Entropy‑Drop Lemma.**  There exists a coordinate whose restriction lowers
 collision entropy by at least one bit. -/


### PR DESCRIPTION
## Summary
- fill in the statement `exists_restrict_half_real` using the integer version
- use `Nat.cast_div_le` to relate natural and real division

## Testing
- `lake build Pnp.Entropy`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6874f01e218c832b92d5dccf09b0c355