### PR TITLE
Prove halving restriction lemma

### DIFF
--- a/pnp/Pnp/Entropy.lean
+++ b/pnp/Pnp/Entropy.lean
@@ -110,9 +110,19 @@ lemma exists_restrict_half {n : ℕ} (F : Family n) (hn : 0 < n) (hF : 1 < F.car
 
 /-- **Existence of a halving restriction (ℝ version)** – deduced from the
 integer statement. -/
-axiom exists_restrict_half_real {n : ℕ} (F : Family n) (hn : 0 < n)
+lemma exists_restrict_half_real {n : ℕ} (F : Family n) (hn : 0 < n)
     (hF : 1 < F.card) : ∃ i : Fin n, ∃ b : Bool,
-    ((F.restrict i b).card : ℝ) ≤ (F.card : ℝ) / 2
+    ((F.restrict i b).card : ℝ) ≤ (F.card : ℝ) / 2 := by
+  classical
+  obtain ⟨i, b, hle⟩ :=
+    exists_restrict_half (F := F) (hn := hn) (hF := hF)
+  have hmul_nat : (F.restrict i b).card * 2 ≤ F.card :=
+    (Nat.le_div_iff_mul_le (by decide : 0 < 2)).1 hle
+  have hmul_real : ((F.restrict i b).card : ℝ) * 2 ≤ (F.card : ℝ) := by
+    exact_mod_cast hmul_nat
+  have hle_real : ((F.restrict i b).card : ℝ) ≤ (F.card : ℝ) / 2 :=
+    (le_div_iff₀ (by positivity : (0 : ℝ) < 2)).2 hmul_real
+  exact ⟨i, b, hle_real⟩
 
 /-- **Entropy‑Drop Lemma.**  There exists a coordinate whose restriction lowers
 collision entropy by at least one bit. -/


### PR DESCRIPTION
## Summary
- remove `exists_restrict_half_real` axiom and give a proof
- adapt the proof using `Nat.le_div_iff_mul_le` and `le_div_iff₀`

## Testing
- `lake -Kenv=dev build Pnp.Entropy`
- `lake -Kenv=dev test`

------
https://chatgpt.com/codex/tasks/task_e_6874f01fdd6c832ba487a27d9d6d833f