### PR TITLE
Remove an easy sorry

### DIFF
--- a/pnp/Pnp/NPSeparation.lean
+++ b/pnp/Pnp/NPSeparation.lean
@@ -46,8 +46,12 @@ theorem P_ne_NP_of_MCSP_bound :
 
 section Examples
 example : ¬ (∃ ε > 0, MCSP_lower_bound ε) ∨ P ≠ NP := by
-  -- Either there is no such lower bound or P and NP are separated.
-  sorry
+  classical
+  by_cases h : ∃ ε > 0, MCSP_lower_bound ε
+  · right
+    exact P_ne_NP_of_MCSP_bound h
+  · left
+    exact h
 end Examples
 
 /-!


### PR DESCRIPTION
## Summary
- prove the example in `NPSeparation` rather than relying on a placeholder

## Testing
- `lake -Kenv=dev build`
- `lake -Kenv=dev test`


------
https://chatgpt.com/codex/tasks/task_e_6874f78873d8832b8cc9503bad2bde1c