### PR TITLE
Add cover size bound lemma

### DIFF
--- a/pnp/Pnp/CoverSize.lean
+++ b/pnp/Pnp/CoverSize.lean
@@ -1,0 +1,34 @@
+import Pnp.Boolcube
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Finset.Card
+
+open Classical
+open Boolcube
+
+namespace CoverSize
+
+abbrev Cover (n : ℕ) := Finset (Subcube n)
+
+def size {n : ℕ} (c : Cover n) : ℕ := c.card
+
+lemma cover_size_bound {n : ℕ} (c : Cover n) : size c ≤ 3 ^ n := by
+  classical
+  have hsize : size c ≤ Fintype.card (Subcube n) := by
+    simpa [size] using (Finset.card_le_univ (s := c))
+  have hcard : Fintype.card (Subcube n) = 3 ^ n := by
+    classical
+    let e : Subcube n ≃ Fin n → Option Bool :=
+      { toFun := fun C => C.fix,
+        invFun := fun f => ⟨f⟩,
+        left_inv := by intro C; cases C; rfl,
+        right_inv := by intro f; rfl }
+    have h1 := Fintype.card_congr e
+    have h2 := Fintype.card_fun (Fin n) (Option Bool)
+    have h3 : Fintype.card (Fin n → Option Bool) = 3 ^ n := by
+      classical
+      simpa [Fintype.card_fin, Fintype.card_option] using h2
+    simpa [h3] using h1
+  simpa [size, hcard] using hsize
+
+end CoverSize
+


### PR DESCRIPTION
## Summary
- add new module `CoverSize` proving a bound on the number of subcubes in a cover

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68750005bafc832ba5b535b86453b445