### PR TITLE
Port acc_circuit_poly

### DIFF
--- a/pnp/Pnp/AccMcspSat.lean
+++ b/pnp/Pnp/AccMcspSat.lean
@@ -1,38 +1,47 @@
 -- acc_mcsp_sat.lean
 -- ==================
+--
 -- Outline of the meet-in-the-middle SAT algorithm for `ACC^0 ∘ MCSP`.
--- The statements are placeholders and proofs are omitted.
-
+-- This module gathers a few definitions and lemma stubs that would
+-- connect the cover from the Family Collision–Entropy Lemma
+-- (Lemma B) with a subexponential SAT algorithm.
+-- All statements are currently placeholders and the proofs are omitted.
 import Pnp.BoolFunc
 import Pnp.CanonicalCircuit
+import Mathlib.Algebra.MvPolynomial.Basic
+import Mathlib.Data.ZMod.Basic
 
 open Classical
 
 namespace ACCSAT
 
-/-! Placeholder type for polynomials over `F_2` in `n` variables. -/
-def AccPolynomial (_n : ℕ) : Type := Unit
-def polyDefault {n : ℕ} : AccPolynomial n := ()
+/-! Placeholder type for polynomials over `𝔽₂` in `n` variables.  We use
+`MvPolynomial` over `ZMod 2` for a minimal setup. -/
+abbrev Polynomial (n : ℕ) := MvPolynomial (Fin n) (ZMod 2)
 
 /-- Razborov–Smolensky: every `ACC^0` circuit can be expressed as a low-degree
 polynomial over `F_2`.  The bound on the degree is schematic and stated in
 big-O form. -/
-lemma acc_circuit_poly {n _d : ℕ} (_C : Boolcube.Circuit n)
-    (_hdepth : True := by trivial) :
-    ∃ _ : AccPolynomial n, True :=
-  ⟨polyDefault, trivial⟩
+lemma acc_circuit_poly {n d : ℕ} (C : Boolcube.Circuit n)
+    (hdepth : True := by trivial) :
+    ∃ P : Polynomial n, True := by
+  -- A real proof would translate `C` into a polynomial and
+  -- bound the degree.  We merely return the zero polynomial.
+  refine ⟨0, ?_⟩
+  trivial
 
 /-- Split an `N`-bit vector into `k` left bits and `ℓ` right bits
 (`N = k + ℓ`).  The helper functions project the appropriate coordinates. -/
 def leftBits (N k ℓ : ℕ) (h : N = k + ℓ)
     (x : Fin N → Bool) : Fin k → Bool := by
   subst h
-  exact fun i => x (Fin.castAdd ℓ i)
+  exact fun i => x (Fin.cast rfl (Fin.castAdd ℓ i))
 
 def rightBits (N k ℓ : ℕ) (h : N = k + ℓ)
     (x : Fin N → Bool) : Fin ℓ → Bool := by
   subst h
-  exact fun j => x (Fin.cast (Nat.add_comm ℓ k) (Fin.addNat j k))
+  have hcomm : ℓ + k = k + ℓ := Nat.add_comm _ _
+  exact fun j => x (Fin.cast hcomm (j.addNat k))
 
 /-- Schematic meet-in-the-middle SAT algorithm using a rectangular cover of the
 MCSP truth tables. The algorithm loops over the rectangles and computes partial


### PR DESCRIPTION
## Summary
- port the `acc_circuit_poly` lemma from the old namespace
- use `MvPolynomial` over `ZMod 2` as the polynomial type
- fix `leftBits` and `rightBits` to coerce coordinates

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6875516d220c832b9b8e1cacbeca1e13