### PR TITLE
Fix NP separation proof with P ⊆ P/poly axiom

### DIFF
--- a/pnp/Pnp/ComplexityClasses.lean
+++ b/pnp/Pnp/ComplexityClasses.lean
@@ -55,3 +55,4 @@ structure InPpoly (L : Language) where
 /-- The non-uniform class `P/poly`. -/
 def Ppoly : Set Language := { L | ∃ _ : InPpoly L, True }
 
+axiom P_subset_Ppoly : P ⊆ Ppoly

--- a/pnp/Pnp/NPSeparation.lean
+++ b/pnp/Pnp/NPSeparation.lean
@@ -36,9 +36,11 @@ theorem P_ne_NP_of_MCSP_bound :
   -- If `P = NP`, then `NP ⊆ Ppoly` trivially, contradicting `h₁`.
   by_contra hPNP
   have : NP ⊆ Ppoly := by
-    -- Placeholder: a standard argument uses `hPNP` to derive this inclusion.
-    -- The details are omitted here.
-    sorry
+    -- From `hPNP : P = NP` we obtain `NP ⊆ P` by rewriting,
+    -- and `P ⊆ Ppoly` is available as the axiom `P_subset_Ppoly`.
+    intro L hL
+    have hL_P : L ∈ P := by simpa [hPNP] using hL
+    exact P_subset_Ppoly hL_P
   have := h₁ this
   contradiction
 


### PR DESCRIPTION
## Summary
- add an axiom stating `P ⊆ Ppoly`
- complete `P_ne_NP_of_MCSP_bound` using the new axiom

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68755da5bbf8832bad53c4cc85344058