### PR TITLE
Implement merge_cover

### DIFF
--- a/pnp/Pnp/MergeLowSens.lean
+++ b/pnp/Pnp/MergeLowSens.lean
@@ -45,4 +45,24 @@ lemma mergeLowSensitivityCover_bound
   have := (familyEntropyCover (F := F) (h := h) hH).bound
   simpa [mergeLowSensitivityCover] using this
 
+/-- Choose the smaller of a low-sensitivity cover and an entropy-based cover. -/
+noncomputable def merge_cover
+    {n : ℕ} {F : Family n} {h : ℕ}
+    (low_sens_cover : FamilyCover F h) (entropy_cover : FamilyCover F h) :
+    FamilyCover F h :=
+  if h_le : low_sens_cover.rects.card ≤ entropy_cover.rects.card then
+    low_sens_cover
+  else
+    entropy_cover
+
+lemma merge_correct
+    {n : ℕ} {F : Family n} {h : ℕ}
+    (low_sens_cover : FamilyCover F h) (entropy_cover : FamilyCover F h) :
+    AllOnesCovered F (merge_cover low_sens_cover entropy_cover).rects := by
+  classical
+  unfold merge_cover
+  by_cases h_le : low_sens_cover.rects.card ≤ entropy_cover.rects.card
+  · simpa [merge_cover, h_le] using low_sens_cover.covers
+  · simpa [merge_cover, h_le] using entropy_cover.covers
+
 end Boolcube


### PR DESCRIPTION
## Summary
- add `merge_cover` to `MergeLowSens`
- choose the cover with fewer rectangles
- prove coverage for the selected cover

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68756c85e314832b80268c427844e8ef