### PR TITLE
Add decision tree leaf bound lemmas

### DIFF
--- a/pnp/Pnp/DecisionTree.lean
+++ b/pnp/Pnp/DecisionTree.lean
@@ -109,6 +109,42 @@ def subcube_of_path : List (Fin n × Bool) → Subcube n
               · exact hj
             exact R.val j hjR }
 
+/-- The number of leaf subcubes is bounded by `2 ^ depth`. -/
+lemma leaves_as_subcubes_card_le_pow_depth (t : DecisionTree n) :
+    (leaves_as_subcubes t).card ≤ 2 ^ depth t := by
+  induction t with
+  | leaf b =>
+      simp [leaves_as_subcubes, depth]
+  | node i t0 t1 ih0 ih1 =>
+      have hunion :
+          (leaves_as_subcubes t0 ∪ leaves_as_subcubes t1).card ≤
+            (leaves_as_subcubes t0).card + (leaves_as_subcubes t1).card := by
+        simpa using
+          (Finset.card_union_le (s := leaves_as_subcubes t0)
+            (t := leaves_as_subcubes t1))
+      have hsum : (leaves_as_subcubes t0).card + (leaves_as_subcubes t1).card ≤
+          2 ^ depth t0 + 2 ^ depth t1 := Nat.add_le_add ih0 ih1
+      have h0 : 2 ^ depth t0 ≤ 2 ^ max (depth t0) (depth t1) := by
+        have : depth t0 ≤ max (depth t0) (depth t1) := le_max_left _ _
+        exact pow_le_pow_right' (by decide : (1 : ℕ) ≤ 2) this
+      have h1 : 2 ^ depth t1 ≤ 2 ^ max (depth t0) (depth t1) := by
+        have : depth t1 ≤ max (depth t0) (depth t1) := le_max_right _ _
+        exact pow_le_pow_right' (by decide : (1 : ℕ) ≤ 2) this
+      have hsum2 : 2 ^ depth t0 + 2 ^ depth t1 ≤ 2 * 2 ^ max (depth t0) (depth t1) := by
+        have := Nat.add_le_add h0 h1
+        simpa [two_mul] using this
+      have h : (leaves_as_subcubes t0 ∪ leaves_as_subcubes t1).card ≤ 2 * 2 ^ max (depth t0) (depth t1) :=
+        le_trans hunion (le_trans hsum hsum2)
+      have hpow : 2 * 2 ^ max (depth t0) (depth t1) =
+          2 ^ (Nat.succ (max (depth t0) (depth t1))) := by
+        simp [Nat.pow_succ, Nat.mul_comm]
+      simpa [leaves_as_subcubes, depth, hpow] using h
+
+/-- A convenient alias for `leaves_as_subcubes_card_le_pow_depth`. -/
+lemma tree_depth_bound (t : DecisionTree n) :
+    (leaves_as_subcubes t).card ≤ 2 ^ depth t :=
+  leaves_as_subcubes_card_le_pow_depth (t := t)
+
 end DecisionTree
 
 end BoolFunc

--- a/pnp/Pnp/LowSensitivityCover.lean
+++ b/pnp/Pnp/LowSensitivityCover.lean
@@ -29,6 +29,11 @@ lemma monochromaticFor_of_family_singleton {R : Subcube n} {f : BFunc n} :
   have := hb f (by simp) hx
   simpa using this
 
+/-- A decision tree with depth `d` has at most `2 ^ d` leaf subcubes. -/
+lemma tree_depth_bound (t : DecisionTree n) :
+    (DecisionTree.leaves_as_subcubes t).card ≤ 2 ^ DecisionTree.depth t := by
+  simpa using DecisionTree.leaves_as_subcubes_card_le_pow_depth (t := t)
+
 /-- **Low-sensitivity cover** (statement only).  If every function in the
     family has sensitivity at most `s`, then there exists a small set of
     subcubes covering all ones of the family.  The proof will use decision


### PR DESCRIPTION
## Summary
- bound the number of leaf subcubes by the depth of a decision tree
- expose this bound in `LowSensitivityCover`

## Testing
- `lake build Pnp.DecisionTree`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68756c97c534832bbb488a6825dff531