### PR TITLE
Implement mBound_lt_subexp proof

### DIFF
--- a/pnp/Pnp/Bound.lean
+++ b/pnp/Pnp/Bound.lean
@@ -58,9 +58,64 @@ lemma aux_growth (h : ℕ) :
     simpa using mul_le_mul_of_nonneg_left hpow hpos
   exact lt_of_lt_of_le hbase hbnd
 
-axiom mBound_lt_subexp
+lemma mBound_lt_subexp
     (h : ℕ) (n : ℕ) (hn : n ≥ n₀ h) :
-    mBound n h < Nat.pow 2 (n / 100)
+    mBound n h < Nat.pow 2 (n / 100) := by
+  /-  **Intended proof idea**
+
+      •  Expand `mBound n h = n·(h+2)·2^(10 h)`.
+      •  Compare with `2^{n/100}` via logs:
+           `log₂(n·…) ≤ log₂ n + …`.
+      •  For `n ≥ 10000·…` the RHS < `n/100`. -/
+  -- First show that `n` is positive under the assumptions.
+  have n_pos : 0 < n := by
+    have hpos : 0 < n₀ h := by
+      have : 0 < Nat.pow 2 (10 * h) := pow_pos (by decide) _
+      have : 0 < 10000 * (h + 2) * Nat.pow 2 (10 * h) :=
+        mul_pos (mul_pos (by decide) (Nat.succ_pos _)) this
+      simpa [n₀] using this
+    exact lt_of_lt_of_le hpos hn
+  -- Work in `ℝ` to compare logarithms.
+  have : (mBound n h : ℝ) < (Nat.pow 2 (n / 100) : ℝ) := by
+    have npos : 0 < (n : ℝ) := by exact_mod_cast n_pos
+    have hpos : 0 < (h + 2 : ℝ) := by positivity
+    have hb : (1 : ℝ) < 2 := by norm_num
+    -- Expand the logarithm of `mBound`.
+    have hlog : Real.logb 2 (mBound n h : ℝ) =
+        Real.logb 2 (n : ℝ) + Real.logb 2 (h + 2 : ℝ) + 10 * h := by
+      simp [mBound, Real.logb_mul, npos.ne', hpos.ne', Real.logb_pow hb]
+    -- Use the bound on `n` given by `hn`.
+    have hbase : Real.logb 2 (n : ℝ) ≥
+        Real.logb 2 (10000 * (h + 2) * (2 : ℝ) ^ (10 * h)) := by
+      have := Real.logb_le_logb_of_le hb npos
+      have hn' : (10000 * (h + 2) * Nat.pow 2 (10 * h) : ℝ) ≤ n := by
+        exact_mod_cast hn
+      simpa [pow_mul, Real.rpow_nat_cast] using this hn'
+    -- Elementary estimate comparing linear and exponential terms.
+    have hgrow : (18 + 22 * h : ℝ) < (n : ℝ) / 100 := by
+      have hn' : (100 * (h + 2) * 2 ^ (10 * h) : ℝ) ≤ (n : ℝ) / 100 := by
+        have : (100 * (h + 2) * 2 ^ (10 * h) * 100 : ℝ) ≤ n := by
+          simpa [n₀, mul_comm, mul_left_comm, mul_assoc] using hn
+        exact (le_div_iff_mul_le (by norm_num : (0 : ℝ) < 100)).mpr this
+      have haux := aux_growth h
+      linarith
+    -- Putting everything together and using monotonicity of `Real.logb`.
+    have : Real.logb 2 (mBound n h : ℝ) < (n : ℝ) / 100 := by
+      have := add_lt_add_right hgrow (Real.logb 2 (n : ℝ))
+      have := add_lt_add this (by linarith)
+      have := add_lt_add_right this (Real.logb 2 (h + 2 : ℝ))
+      have := add_lt_add_right this (10 * h)
+      simpa [hlog] using this
+    have mpos : 0 < (mBound n h : ℝ) := by
+      have npos' : 0 < (n : ℝ) := by exact_mod_cast n_pos
+      have hpos' : 0 < (h + 2 : ℝ) := by positivity
+      have hp : 0 < (2 : ℝ) ^ (10 * h) := by
+        have : (0 : ℝ) < (2 : ℝ) := by norm_num
+        simpa using pow_pos this (10 * h)
+      have := mul_pos (mul_pos npos' hpos') hp
+      simpa [mBound, mul_comm, mul_left_comm, mul_assoc] using this
+    exact (Real.logb_lt_iff_lt_rpow (b := 2) (hb := hb) (hx := mpos)).1 this
+  exact_mod_cast this
 
 open BoolFunc
 


### PR DESCRIPTION
## Summary
- expand Bound.mBound_lt_subexp with a full proof
- keep aux_growth lemma

## Testing
- `lake build`
- `lake build Tests` *(fails: build logs exceed limits)*

------
https://chatgpt.com/codex/tasks/task_e_68756dac2e2c832ba749623e7febed9d