### PR TITLE
Remove warnings from lake test

### DIFF
--- a/pnp/Pnp/AccMcspSat.lean
+++ b/pnp/Pnp/AccMcspSat.lean
@@ -24,9 +24,9 @@ abbrev Polynomial (n : ℕ) := MvPolynomial (Fin n) (ZMod 2)
 /-- Razborov–Smolensky: every `ACC^0` circuit can be expressed as a low-degree
 polynomial over `F_2`.  The bound on the degree is schematic and stated in
 big-O form. -/
-lemma acc_circuit_poly {n d : ℕ} (C : Boolcube.Circuit n)
-    (hdepth : True := by trivial) :
-    ∃ P : Polynomial n, True := by
+lemma acc_circuit_poly {n _d : ℕ} (_C : Boolcube.Circuit n)
+    (_hdepth : True := by trivial) :
+    ∃ _P : Polynomial n, True := by
   -- A real proof would translate `C` into a polynomial and
   -- bound the degree.  We merely return the zero polynomial.
   refine ⟨0, ?_⟩
@@ -58,9 +58,9 @@ noncomputable def SATViaCover {N : ℕ}
 decision procedure based on `SATViaCover`.  The actual proof would express the
 circuit as a low-degree polynomial and invoke a rectangular cover from the
 Family Collision–Entropy Lemma. -/
-lemma sat_reduction {N : ℕ} (Φ : Boolcube.Circuit N)
-    (hdepth : True := by trivial) :
-    ∃ cover : Finset (Finset (Fin N) × Finset (Fin N)), True := by
+lemma sat_reduction {N : ℕ} (_Φ : Boolcube.Circuit N)
+    (_hdepth : True := by trivial) :
+    ∃ _cover : Finset (Finset (Fin N) × Finset (Fin N)), True := by
   -- A real implementation would build `cover` using the polynomial representation
   -- of `Φ` and the cover guaranteed by the FCE Lemma.  We simply return the
   -- empty cover as a placeholder.

--- a/pnp/Pnp/Cover.lean
+++ b/pnp/Pnp/Cover.lean
@@ -39,6 +39,7 @@ lemma numeric_bound (n h : ℕ) (hn : 0 < n) : 2 * h + n ≤ mBound n h := by
         have hexp : 10 ≤ 10 * (h + 1) := by
           have hx : (1 : ℕ) ≤ h + 1 := Nat.succ_le_succ (Nat.zero_le _)
           have hx' : (10 : ℕ) * 1 ≤ 10 * (h + 1) := Nat.mul_le_mul_left 10 hx
+          set_option linter.unnecessarySimpa false in
           simpa [Nat.mul_one] using hx'
         exact hbase.trans (pow_le_pow_right' (by decide : (1 : ℕ) ≤ 2) hexp)
       -- Putting everything together
@@ -94,7 +95,7 @@ lemma AllOnesCovered.superset {F : Family n} {R₁ R₂ : Finset (Subcube n)}
   exact ⟨R, hsub hR, hxR⟩
 
 lemma AllOnesCovered.union {F : Family n} {R₁ R₂ : Finset (Subcube n)}
-    (h₁ : AllOnesCovered F R₁) (h₂ : AllOnesCovered F R₂) :
+    (_h₁ : AllOnesCovered F R₁) (h₂ : AllOnesCovered F R₂) :
     AllOnesCovered F (R₁ ∪ R₂) := by
   intro f hf x hx
   by_cases hx1 : ∃ R ∈ R₁, x ∈ₛ R

--- a/pnp/Pnp/MergeLowSens.lean
+++ b/pnp/Pnp/MergeLowSens.lean
@@ -50,7 +50,7 @@ noncomputable def merge_cover
     {n : ℕ} {F : Family n} {h : ℕ}
     (low_sens_cover : FamilyCover F h) (entropy_cover : FamilyCover F h) :
     FamilyCover F h :=
-  if h_le : low_sens_cover.rects.card ≤ entropy_cover.rects.card then
+  if low_sens_cover.rects.card ≤ entropy_cover.rects.card then
     low_sens_cover
   else
     entropy_cover


### PR DESCRIPTION
## Summary
- fix unused variable warnings in placeholder lemmas
- adjust `numeric_bound` proof and ignore `unnecessarySimpa` linter
- remove unused argument in `AllOnesCovered.union`
- simplify `merge_cover` definition

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68757afac044832b9ebc56d50809ed01