### PR TITLE
Add contrib helper lemma

### DIFF
--- a/pnp/Pnp/Entropy.lean
+++ b/pnp/Pnp/Entropy.lean
@@ -77,6 +77,32 @@ lemma card_restrict_le {n : ℕ} (F : Family n) (i : Fin n) (b : Bool) :
   simpa [Family.restrict] using
     (Finset.card_image_le (s := F) (f := fun f : BFunc n => f.restrictCoord i b))
 
+/-!  ## Вспомогательные определения для halving‑леммы -/
+
+open Finset
+
+/-- Вклад функции `f` в координату `i`:
+* `2`, если `f` одинаковa на парах `x, x ⟪i := !x i⟫`
+  (то есть от `i` не зависит);
+* `1` — в противном случае. -/
+private def contrib {n : ℕ} (f : BFunc n) (i : Fin n) : ℕ :=
+  1 + if h : ∀ x, f x = f (Point.update x i (!x i)) then 1 else 0
+
+/-- Явное неравенство `contrib ≤ 2`, нужное для последующих оценок. -/
+private lemma contrib_le_two {n : ℕ} (f : BFunc n) (i : Fin n) :
+    contrib f i ≤ 2 := by
+  unfold contrib; split <;> simp
+
+/-- Сумма вкладов одной функции по всем координатам раскладывается
+на `n` постоянных единиц и отдельный счёт координат, на которых
+функция константна. -/
+private lemma sum_contrib {n : ℕ} (f : BFunc n) :
+    (∑ i : Fin n, contrib f i) =
+      n + ∑ i : Fin n,
+        (if h : ∀ x, f x = f (Point.update x i (!x i)) then 1 else 0) := by
+  classical
+  -- разложим сумму через определение `contrib`
+  simp [contrib, sum_add_distrib, card_fin]
 /-- **Existence of a halving restriction (ℝ version)**.  There exists a
 coordinate `i` and bit `b` such that restricting every function in the family to
 `i = b` cuts its cardinality by at least half (real version). -/


### PR DESCRIPTION
## Summary
- introduce `contrib` helper to measure the effect of a coordinate on a Boolean function
- prove a simple bound `contrib_le_two`
- add lemma `sum_contrib` used for the future halving lemma

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6876ecf3f7d0832bbb2255642c250432