### PR TITLE
Fix: ensure BigOperators scope

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -166,7 +166,7 @@ example :
   simpa using
     BoolFunc.exists_restrict_half
       (F := {(fun x : Point 1 => x 0), (fun x : Point 1 => !x 0)})
-      hn hF hconst
+      hn hF
 -/
 
 -- Evaluate a simple Boolean circuit.

--- a/test/Migrated.lean
+++ b/test/Migrated.lean
@@ -31,14 +31,11 @@ example (h : ∃ ε > 0, MCSP_lower_bound ε) :
   exact P_ne_NP_of_MCSP_bound h
 
 -- The halving lemma provides a coordinate that cuts the family size in half.
-example {n : ℕ} (F : BoolFunc.Family n) (hn : 0 < n) (hF : 1 < F.card)
-    (hconst : ¬ ∃ b, ((fun _ : BoolFunc.Point n ↦ b) ∈ F ∧
-                      (fun _ : BoolFunc.Point n ↦ !b) ∈ F)) :
+example {n : ℕ} (F : BoolFunc.Family n) (hn : 0 < n) (hF : 1 < F.card) :
     ∃ i : Fin n, ∃ b : Bool,
       ((F.restrict i b).card : ℝ) ≤ (F.card : ℝ) / 2 := by
   simpa using
     BoolFunc.exists_restrict_half_real_aux (F := F) (hn := hn) (hF := hF)
-      (hconst := hconst)
 
 -- Collision probability is always positive.
 example {n : ℕ} (f : BoolFunc.BFunc n) [Fintype (BoolFunc.Point n)] :


### PR DESCRIPTION
## Summary
- refactor halving lemma proof and remove the last `sorry`
- drop unused `hconst` parameter from wrapper lemmas
- adjust unit tests accordingly

## Testing
- `lake build` *(succeeds)*
- `lake test` *(attempted but long build; partial logs show progress)*

------
https://chatgpt.com/codex/tasks/task_e_6877210860ac832baa2e098c3b762fb3