### PR TITLE
feat: begin port of numeric bound proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ there, but it is no longer built by default.
   now abstracts the union step in the coverage proof.
 * `bound.lean` – arithmetic bounds deriving the subexponential size estimate;
   the main inequality `mBound_lt_subexp` is currently stated as an axiom in the
-  `pnp` namespace.  A complete proof remains available in
-  `Pnp2/bound.lean` and still needs to be ported.
+  `pnp` namespace.  A complete proof will be added shortly.
 * `collentropy.lean` – collision entropy of a single Boolean function with
   basic lemmas such as `H₂Fun_le_one`.
 * `family_entropy_cover.lean` – convenience wrapper returning a `FamilyCover`
@@ -173,4 +172,4 @@ tasks are:
    codebase.
 Once these are done the lemma `FCE_lemma` will follow.
 
-Added note about `numeric_bound` proof origin from `Pnp2.cover_numeric`.
+Proofs for the numeric bounds are being ported and will appear in the next update.

--- a/TODO.md
+++ b/TODO.md
@@ -22,3 +22,21 @@ Short list of development tasks reflecting the current repository status.
 - [x] Add `AllOnesCovered.union` helper lemma to simplify coverage proofs.
 - [ ] Use `collentropy.lean` and `family_entropy_cover.lean` across modules.
 - [x] Remove outdated standalone file `src/entropy_drop.lean` (lemma now lives in `Boolcube.lean`).
+
+## Remaining axioms (as of 2025-07-16)
+- `Bound.mBound_lt_subexp`
+- `LowSensitivityCover.decisionTree_cover` (external)
+- `CoverNumeric.minCoverSize`
+- `CoverNumeric.buildCover_size_bound`
+- `CoverNumeric.buildCover_card`
+- `CoverNumeric.buildCover_card_bigO`
+- `ComplexityClasses.P_subset_Ppoly` (external)
+- `NPSeparation.MCSP_lower_bound` (external)
+- `NPSeparation.magnification_AC0_MCSP` (external)
+- `NPSeparation.PH_collapse` (external)
+- `NPSeparation.karp_lipton` (external)
+- `NPSeparation.FCE_implies_MCSP`
+- `Entropy.exists_restrict_half_real_aux`
+
+The complexity-theoretic axioms are expected to remain long‑term.
+The numeric bounds and halving lemma will be replaced by actual proofs in future commits.

--- a/migration.md
+++ b/migration.md
@@ -37,14 +37,14 @@ The implementations from `Pnp2` still contain complete statements and proofs
 that have been replaced by placeholders in `pnp`.  The following parts are
 missing and should be ported:
 
-- the proofs of `aux_growth` and `mBound_lt_subexp` in `Bound.lean`
+- the proofs of `aux_growth` and `mBound_lt_subexp` in `Bound.lean` (proof incoming in next commit)
 - the full definition of `mergeLowSensitivityCover` in `MergeLowSens.lean`
 - the `low_sensitivity_cover` construction and helper lemmas from
   `LowSensitivity.lean`
 - the example-driven code in `Examples.lean`
 - the SAT outline in `AccMcspSat.lean`
 - the separation lemma `P_ne_NP_of_MCSP_bound` from `NPSeparation.lean`
-- numeric cover bounds in `CoverNumeric.lean`
+- numeric cover bounds in `CoverNumeric.lean` (proof incoming in next commit)
 - tests exercising these modules
 
 Once these proofs and tests have been migrated, the `Pnp2` directory can be

--- a/pnp/Pnp/Bound.lean
+++ b/pnp/Pnp/Bound.lean
@@ -63,11 +63,10 @@ lemma aux_growth (h : ℕ) :
 /--
 `mBound_lt_subexp` is the numeric heart of the argument.  It bounds the
 explicit counting estimate `mBound n h = n * (h + 2) * 2 ^ (10 * h)` by the
-sub‑exponential quantity `2^{n / 100}` once `n ≥ n₀ h`.  The full proof is
-ported to `Pnp2/bound.lean`; it proceeds by taking base‑2 logarithms,
-comparing terms using `aux_growth`, and exploiting the fast growth of the
-exponential factor.  The present file keeps the statement as an axiom to
-avoid duplicating lengthy arithmetic calculations.
+sub‑exponential quantity `2^{n / 100}` once `n ≥ n₀ h`.  The full proof will
+be restored from the historical development in a future commit.  The present
+file keeps the statement as an axiom to avoid duplicating lengthy arithmetic
+calculations.  -- TODO: port numeric proof (plan step 2).
 -/
 axiom mBound_lt_subexp
     (h : ℕ) (n : ℕ) (hn : n ≥ n₀ h) :

--- a/pnp/Pnp/BoundPorting.lean
+++ b/pnp/Pnp/BoundPorting.lean
@@ -1,0 +1,171 @@
+/-
+bound.lean
+===========
+
+Pure *arithmetic* lemmas that translate the explicit counting bound  
+`|𝓡| ≤ n·(h+2)·2^(10 h)` (proved in `cover.lean`) into the convenient
+*sub‑exponential* tail bound that appears in every prose version of the
+Family Collision‑Entropy Lemma:
+
+> for sufficiently large `n` we have  
+> `n·(h+2)·2^(10 h) < 2^{n / 100}`.
+
+The file is intentionally **isolated** from the combinatorial logic:
+its only imports are earlier modules for the *definitions* of `mBound`
+and `coverFamily`.  The numeric arguments are nontrivial and currently
+sketched at the end of this file, but the statements are final and can be
+used by subsequent documentation or tests.
+-/
+
+import Mathlib.Tactic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Pnp.Entropy
+import Pnp.FamilyEntropyCover
+import Pnp.Cover
+
+set_option maxHeartbeats 400000
+
+open Classical
+open Cover
+open Boolcube
+
+namespace Bound
+
+/-! ## Elementary growth estimates -/
+
+/-- A *convenience constant* `n₀(h)` such that  
+    for all `n ≥ n₀(h)` we have  
+    `n·(h+2)·2^(10 h) < 2^{n/100}`.  
+
+    The closed‑form we pick (far from optimal) is  
+    `n₀(h) = 10 000 · (h + 2) · 2^(10 h)`.  -/
+def n₀ (h : ℕ) : ℕ :=
+  10000 * (h + 2) * Nat.pow 2 (10 * h)
+
+/-!  A crude growth estimate used in the proof of `mBound_lt_subexp`.
+    It simply bounds a linear expression in `h` by the dominating
+    exponential term appearing in `n₀`.  The statement is far from sharp
+    but suffices for our purposes.  -/
+lemma aux_growth (h : ℕ) :
+    (18 + 22 * h : ℝ) < 100 * (h + 2) * 2 ^ (10 * h) := by
+  -- First bound `(18 + 22 * h)` by a simpler linear expression.
+  have hbase : (18 + 22 * h : ℝ) < 100 * (h + 2) := by
+    nlinarith
+  -- Note that `2 ^ (10 * h) ≥ 1` for all `h`.
+  have hpow : (1 : ℝ) ≤ (2 : ℝ) ^ (10 * h) := by
+    simpa using (one_le_pow₀ (n := 10 * h) (a := (2 : ℝ)) (by norm_num : (1 : ℝ) ≤ 2))
+  -- Multiplying the linear bound by the positive factor `2 ^ (10 * h)`
+  -- yields the desired inequality.
+  have hbnd : 100 * (h + 2) ≤ 100 * (h + 2) * (2 : ℝ) ^ (10 * h) := by
+    have hpos : (0 : ℝ) ≤ 100 * (h + 2) := by positivity
+    simpa using mul_le_mul_of_nonneg_left hpow hpos
+  exact lt_of_lt_of_le hbase hbnd
+
+/-- Main numeric inequality: the explicit bound *is* sub‑exponential. -/
+lemma mBound_lt_subexp
+    (h : ℕ) (n : ℕ) (hn : n ≥ n₀ h) :
+    mBound n h < Nat.pow 2 (n / 100) := by
+  -- Sketch of the numeric argument:
+  -- Taking binary logarithms reduces the inequality to
+  -- `logb 2 (mBound n h)` < `n / 100`, which follows from
+  -- the assumption `hn` after bounding linear terms via `aux_growth`.
+  -- A full formal argument requires some tedious growth estimates.
+  -- We sketch most of the argument, delegating the last numeric step
+  -- to `aux_growth` proved above.
+  have n_pos : 0 < n := by
+    have hpos : 0 < n₀ h := by
+      have : 0 < Nat.pow 2 (10 * h) := pow_pos (by decide) _
+      have : 0 < 10000 * (h + 2) * Nat.pow 2 (10 * h) :=
+        mul_pos (mul_pos (by decide) (Nat.succ_pos _)) this
+      simpa [n₀] using this
+    exact lt_of_lt_of_le hpos hn
+  -- Casting everything to `ℝ` allows us to compare logarithms.
+  have : (mBound n h : ℝ) < (Nat.pow 2 (n / 100) : ℝ) := by
+    have npos : 0 < (n : ℝ) := by exact_mod_cast n_pos
+    have hpos : 0 < (h + 2 : ℝ) := by positivity
+    have hb : (1 : ℝ) < 2 := by norm_num
+    -- Expand the logarithm of `mBound`.
+    have hlog : Real.logb 2 (mBound n h : ℝ) =
+        Real.logb 2 (n : ℝ) + Real.logb 2 (h + 2 : ℝ) + 10 * h := by
+      simp [Cover.mBound, Real.logb_mul, npos.ne', hpos.ne',
+        Real.logb_pow hb]
+    -- Use the bound on `n` given by `hn`.
+    have hbase : Real.logb 2 (n : ℝ) ≥
+        Real.logb 2 (10000 * (h + 2) * (2 : ℝ) ^ (10 * h)) := by
+      have := (Real.logb_le_logb_of_le hb npos)
+      have hn' : (10000 * (h + 2) * Nat.pow 2 (10 * h) : ℝ) ≤ n := by
+        exact_mod_cast hn
+      simpa [pow_mul, Real.rpow_nat_cast] using this hn'
+    -- Elementary estimate comparing linear and exponential terms.
+    have hgrow : (18 + 22 * h : ℝ) < (n : ℝ) / 100 := by
+      have hn' : (100 * (h + 2) * 2 ^ (10 * h) : ℝ) ≤ (n : ℝ) / 100 := by
+        have : (100 * (h + 2) * 2 ^ (10 * h) * 100 : ℝ) ≤ n := by
+          simpa [n₀, mul_comm, mul_left_comm, mul_assoc] using hn
+        exact (le_div_iff_mul_le (by norm_num : (0 : ℝ) < 100)).mpr this
+      have haux := aux_growth h
+      linarith
+    -- Putting everything together and using monotonicity of `Real.logb`.
+    have : Real.logb 2 (mBound n h : ℝ) < (n : ℝ) / 100 := by
+      have := add_lt_add_right hgrow (Real.logb 2 (n : ℝ))
+      have := add_lt_add this (by linarith)
+      -- numeric constants are small enough for `linarith` to solve the goal
+      have := add_lt_add_right this (Real.logb 2 (h + 2 : ℝ))
+      have := add_lt_add_right this (10 * h)
+      simpa [hlog] using this
+    have hb' : (1 : ℝ) < 2 := by norm_num
+    have hpow : (mBound n h : ℝ) < (2 : ℝ) ^ (n / 100) :=
+      (Real.logb_lt_iff_lt_rpow hb').1 this
+    exact hpow
+  exact_mod_cast this
+
+/-! ## Final packaging: the full FCE‑lemma statement -/
+
+open BoolFunc
+
+variable {n h : ℕ} (F : BoolFunc.Family n)
+
+/--
+**Family Collision‑Entropy Lemma (β‑version).**
+
+Under the entropy assumption `H₂(F) ≤ h`,
+the `coverFamily` constructed in `cover.lean`:
+
+1.  is jointly **monochromatic** on each rectangle;
+2.  **covers** every `1`‑input of every `f ∈ F`;
+3.  satisfies the **sub‑exponential** bound  
+    `|coverFamily| < 2^{n/100}` once `n ≥ n₀(h)`.
+-/
+theorem FCE_lemma
+    (hH : H₂ F ≤ (h : ℝ))
+    (hn : n ≥ n₀ h) :
+    (Boolcube.familyEntropyCover (F := F) (h := h) hH).rects.card <
+      Nat.pow 2 (n / 100) := by
+  have h1 :=
+    (Boolcube.familyEntropyCover (F := F) (h := h) hH).bound
+  have h2 :=
+    mBound_lt_subexp (h := h) (n := n) hn
+  exact lt_of_le_of_lt h1 h2
+
+/--
+**Family Collision‑Entropy Lemma.**
+
+Assuming `H₂(F) ≤ h` and `n ≥ n₀(h)`, there exists a finite set of
+subcubes that is jointly monochromatic for the entire family and covers
+all `1`‑inputs of every `f ∈ F`.  The construction is the
+`familyEntropyCover` from `family_entropy_cover.lean`, and the numeric
+bound below shows that the cover has at most `2^{n/100}` rectangles. -/
+theorem family_collision_entropy_lemma
+    (hH : H₂ F ≤ (h : ℝ))
+    (hn : n ≥ n₀ h) :
+    ∃ Rset : Finset (BoolFunc.Subcube n),
+      (∀ R ∈ Rset, BoolFunc.Subcube.monochromaticForFamily R F) ∧
+      (∀ f ∈ F, ∀ x, f x = true → ∃ R ∈ Rset, x ∈ₛ R) ∧
+      Rset.card ≤ Nat.pow 2 (n / 100) := by
+  classical
+  let FC := Boolcube.familyEntropyCover (F := F) (h := h) hH
+  have hlt : FC.rects.card < Nat.pow 2 (n / 100) :=
+    lt_of_le_of_lt FC.bound (mBound_lt_subexp (h := h) (n := n) hn)
+  have hle : FC.rects.card ≤ Nat.pow 2 (n / 100) := Nat.le_of_lt hlt
+  refine ⟨FC.rects, FC.mono, FC.covers, hle⟩
+
+end Bound

--- a/pnp/Pnp/CoverNumeric.lean
+++ b/pnp/Pnp/CoverNumeric.lean
@@ -10,9 +10,11 @@ namespace CoverNumeric
 variable {N Nδ : ℕ} (F : Family N)
 
 /-- Minimal size of a cover for `F`. Placeholder for the actual definition. -/
+-- TODO: port the real definition from the numeric development.
 axiom minCoverSize (F : Family N) : ℕ
 
 /-- Entropy-based size bound for a family cover. Placeholder theorem. -/
+-- TODO: prove using the entropy argument.
 axiom buildCover_size_bound
     (h₀ : BoolFunc.H₂ F ≤ N - Nδ) :
     minCoverSize F ≤ 2 ^ (N - Nδ)
@@ -26,10 +28,12 @@ experimental algorithm on families of dimension `n`.  The precise
 definition is irrelevant for this file; we only record the asymptotic
 bound used elsewhere. -/
 
+-- TODO: implement the experimental cover algorithm and remove this axiom.
 axiom buildCover_card (n : ℕ) : ℕ
 
 /--  The cover size grows at most like `(2 / √3)^n`.
     This wraps the analytic estimate in `big-O` notation.  -/
+-- TODO: port the analytic estimate of the algorithmic cover size.
 axiom buildCover_card_bigO :
   (fun n ↦ (buildCover_card n : ℝ)) =O[atTop] fun n ↦ (2 / Real.sqrt 3) ^ n
 

--- a/pnp/Pnp/Entropy.lean
+++ b/pnp/Pnp/Entropy.lean
@@ -80,6 +80,7 @@ lemma card_restrict_le {n : ℕ} (F : Family n) (i : Fin n) (b : Bool) :
 /-- **Existence of a halving restriction (ℝ version)**.  There exists a
 coordinate `i` and bit `b` such that restricting every function in the family to
 `i = b` cuts its cardinality by at least half (real version). -/
+-- TODO: port the analytic halving lemma from the original development.
 axiom exists_restrict_half_real_aux {n : ℕ} (F : Family n) (hn : 0 < n)
     (hF : 1 < F.card) : ∃ i : Fin n, ∃ b : Bool,
     ((F.restrict i b).card : ℝ) ≤ (F.card : ℝ) / 2

--- a/pnp/Pnp/LowSensitivityCover.lean
+++ b/pnp/Pnp/LowSensitivityCover.lean
@@ -17,6 +17,7 @@ variable {n : ℕ}
 -- number of such subcubes is therefore at most an exponential in
 -- `s * log₂ (n + 1)`.  We keep the statement as an axiom here and rely on
 -- the external combinatorial argument.
+-- TODO: replace this axiom with the formal decision-tree construction.
 axiom decisionTree_cover
   {n : Nat} (F : Family n) (s C : Nat) [Fintype (Point n)]
     (Hsens : ∀ f ∈ F, sensitivity f ≤ s) :

--- a/pnp/Pnp/NPSeparation.lean
+++ b/pnp/Pnp/NPSeparation.lean
@@ -13,15 +13,19 @@ circuits of size at least `N^{1 + ε}`. Formal details are omitted; see
 Theorem 1.4 of "Hardness Magnification Near State-of-the-Art Lower
 Bounds" (2021).
 -/
+-- TODO: keep as external assumption until the magnification result is formalised.
 axiom MCSP_lower_bound : ℝ → Prop
 
+-- TODO: this magnification result remains as an external axiom.
 axiom magnification_AC0_MCSP :
   (∃ ε > 0, MCSP_lower_bound ε) → ¬ NP ⊆ Ppoly
 
+-- TODO: external complexity-theoretic result.
 axiom PH_collapse : Prop
 
 /-- Karp-Lipton theorem: `NP ⊆ P/poly` implies a collapse of the polynomial
 hierarchy.  The proof is assumed as an axiom in this development. -/
+-- TODO: replace with a formal proof of Karp-Lipton.
 axiom karp_lipton : (NP ⊆ Ppoly) → PH_collapse
 
 /--
@@ -64,6 +68,7 @@ References:
 Bridge from the constructive cover (FCE-Lemma) to the MCSP lower bound.
 In the current blueprint this implication is assumed as an axiom.
 -/
+-- TODO: bridge from the constructive lemma to MCSP lower bounds.
 axiom FCE_implies_MCSP : ∃ ε > 0, MCSP_lower_bound ε
 
 /--


### PR DESCRIPTION
## Summary
- start porting arithmetic proof into `BoundPorting` parallel file
- tweak imports and numeric proof implementation

## Testing
- `lake build Pnp.BoundPorting` *(fails: build requires mathlib; long compilation not completed)*

------
https://chatgpt.com/codex/tasks/task_e_6877e8de7bc0832b9a323cf5ddf85cce