### PR TITLE
Enable building legacy Pnp2 code

### DIFF
--- a/Pnp2/Pnp2.lean
+++ b/Pnp2/Pnp2.lean
@@ -1,0 +1,3 @@
+import Pnp2.BoolFunc.Sensitivity
+import Pnp2.DecisionTree
+import Pnp2.low_sensitivity_cover

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,6 +9,12 @@ require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v
 lean_lib Pnp where
   srcDir := "pnp"
 
+/-- Legacy Pnp2 code base preserved for reference.  We build it as a separate
+    library so that historical proofs continue to compile. -/
+lean_lib Pnp2 where
+  srcDir := "."
+  roots := #[`Pnp2]
+
 lean_exe tests where
   root := `Main
   srcDir := "test"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -3,5 +3,6 @@
 set -euo pipefail
 
 lake build
+lake build Pnp2
 lake env lean --run scripts/smoke.lean
 lake test


### PR DESCRIPTION
## Summary
- compile the historical Pnp2 modules as a secondary library
- ensure the check script also builds Pnp2

## Testing
- `lake build`
- `lake build Pnp2`
- `lake test`
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6878286a6404832bae611f2a66590c4d