### PR TITLE
Fix Pnp2 cover construction

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -180,78 +180,11 @@ lemma sunflower_step
     simpa [R, Subcube.dimension_fromPoint] using h_dim
 
 /-! ## Inductive construction of the cover -/
+/-! ## Inductive construction of the cover (replaced) -/
+noncomputable def buildCover (F : Family n) (h : ℕ) (hH : BoolFunc.H₂ F ≤ (h : ℝ)) : Finset (Subcube n) :=
+  (Pnp.Boolcube.familyEntropyCover (F := F) (h := h) hH).rects
 
-/-! ## Inductive construction of the cover (updated) -/
-noncomputable
-partial def buildCover (F : Family n) (h : ℕ)
-    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
-    (Rset : Finset (Subcube n) := ∅) : Finset (Subcube n) := by
-  classical
-  match hfu : firstUncovered F Rset with
-  | none =>
-      -- Base case: all 1-inputs of F are covered by Rset
-      exact Rset
-  | some ⟨f, x⟩ =>
-      -- `f : BoolFunc n` and `x : Point n` is a 1-input uncovered by Rset.
-      /- **Branching strategy:** Depending on family parameters, choose cover method:
-         1. Low-sensitivity branch – if all f ∈ F have sensitivity ≤ s (for moderate s).
-         2. Sunflower branch – if supports are large and numerous (quantitative sunflower condition).
-         3. Entropy branch – default fallback, using entropy drop. -/
-      have F_nonempty : F.Nonempty :=
-        ⟨f, by
-          -- firstUncovered gives ⟨f, x⟩ with f ∈ F by definition
-          rcases Set.choose?_mem (S := uncovered F Rset) hfu with ⟨hf, -, -⟩
-          exact hf⟩
-      -- Compute the maximum sensitivity s of functions in F
-      let sensSet : Finset ℕ := F.image (fun g => sensitivity g)
-      let s := sensSet.max' (Finset.nonempty.image F_nonempty _)
-      have Hsens : ∀ g ∈ F, sensitivity g ≤ s :=
-        fun g hg => Finset.le_max' sensSet s (by simp [sensSet, hg])
-      -- **(1) Low-sensitivity branch:** if s is relatively small (e.g. O(log n)), use `low_sensitivity_cover`.
-      -- Here we require `s` to be below a threshold; for example, if s ≤ ⌊log₂(n+1)⌋, consider F "low-sensitivity".
-      cases Nat.lt_or_le s (Nat.log2 (Nat.succ n)) with
-      | inl hs_small =>
-          -- All functions have sensitivity ≤ s, with s relatively small compared to n.
-          have ⟨R_ls, Hmono, Hcover, Hsize⟩ := BoolFunc.low_sensitivity_cover (F := F) s Hsens
-          -- Use the lemma's witness set R_ls as the remaining cover for all uncovered points.
-          exact Rset ∪ R_ls
-      | inr hs_large =>
-          -- **(2) Sunflower branch:** check if a sunflower-based step can remove a large fraction of inputs.
-          let p0 := (Family.supports F).min' (by
-            classical
-            rcases Set.choose?_mem (S := uncovered F Rset) hfu with ⟨hf, -, -⟩
-            exact ⟨support f, by simpa using Family.mem_supports.mpr ⟨f, hf, rfl⟩⟩)
-          let someBound := p0 * p0
-          if hSun : (Family.supports F).card > someBound ∧ (∀ g ∈ F, (support g).card = p0) ∧ 0 < p0 then
-            have p0_pos : 0 < p0 := hSun.2.2
-            have ht : 2 ≤ (2 : ℕ) := by decide
-            have hbig : (2 - 1).factorial * p0 ^ 2 < (Family.supports F).card := by
-              simpa [someBound, Nat.factorial_one, one_mul] using hSun.1
-            have hsizes : ∀ g ∈ F, (support g).card = p0 := hSun.2.1
-            obtain ⟨R_sun, hCover, hDim⟩ :=
-              sunflower_step (F := F) p0 2 p0_pos ht hbig hsizes
-            -- Add `R_sun` to the cover and continue recursion on the uncovered set.
-            exact buildCover F h hH (Rset := insert R_sun Rset)
-          else
-            -- **(3) Entropy branch:** default case – apply one-bit entropy drop and recurse on two sub-families.
-            have ⟨i, b, Hdrop⟩ := BoolFunc.exists_coord_entropy_drop (F := F)
-              (hn := by decide)
-              (hF := Finset.card_pos.mpr F_nonempty)
-            -- Split on coordinate i = b (one branch) vs i = ¬b (other branch), both reduce H₂ by ≥1.
-            let F0 := F.restrict i b
-            let F1 := F.restrict i (!b)
-            have hH0 : BoolFunc.H₂ F0 ≤ (h - 1 : ℝ) :=
-              by
-                -- H₂(F0) ≤ H₂(F) - 1
-                rw [BoolFunc.H₂_restrict_le]
-                exact Hdrop
-            have hH1 : BoolFunc.H₂ F1 ≤ (h - 1 : ℝ) :=
-              by
-                -- H₂(F1) ≤ H₂(F) - 1
-                rw [BoolFunc.H₂_restrict_compl_le]
-                exact Hdrop
-            exact (buildCover F0 (h - 1) (by exact hH0)) ∪
-                  (buildCover F1 (h - 1) (by exact hH1))
+
 
 /-! ## Proof that buildCover indeed covers every 1‑input -/
 
@@ -277,239 +210,24 @@ lemma AllOnesCovered.union {F : Family n} {R₁ R₂ : Finset (Subcube n)}
   · rcases h₂ f hf x hx with ⟨R, hR, hxR⟩
     exact ⟨R, by simpa [Finset.mem_union, hx1] using Or.inr hR, hxR⟩
 
-
 lemma buildCover_covers (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     AllOnesCovered F (buildCover F h hH) := by
   classical
-  -- well-founded recursion on number of uncovered points (lexicographic on H₂ and uncovered count)
-  revert F
-  refine (fun F ↦ _ : AllOnesCovered F (buildCover F h hH)) ?_?_
-  intro F
-  suffices H : ∀ Rset, AllOnesCovered F (buildCover F h hH Rset) by
-    simpa using H ∅
-  intro Rset
-  -- split on the first uncovered 1-input, if any
-  cases hfu : firstUncovered F Rset with
-  | none =>
-    -- Base case: no uncovered inputs remain
-    have hbase : AllOnesCovered F Rset := by
-      intro f hf x hx
-      have hempty : uncovered F Rset = ∅ := (firstUncovered_none_iff (F := F) Rset).1 hfu
-      -- If x were not covered by Rset, then ⟨f, x⟩ would lie in `uncovered F Rset` (contradiction)
-      by_cases hxRset : ∃ R ∈ Rset, x ∈ₛ R
-      · rcases hxRset with ⟨R, hR, hxR⟩
-        exact ⟨R, hR, hxR⟩
-      · have hxNC : NotCovered Rset x := fun R hR ↦ (not_exists.mp hxRset) R ∘ And.intro hR
-        have : (⟨f, x⟩ : Σ BoolFunc n, Vector Bool n) ∈ uncovered F Rset := by simp [uncovered, hf, hx, hxNC]
-        rw [hempty] at this
-        exact False.elim this
-    simpa [buildCover, hfu] using hbase
-  | some tup =>
-    -- Inductive step: an uncovered 1-input exists
-    rcases tup with ⟨f, x⟩  -- so f ∈ F, f x = true, and x is not covered by Rset
-    -- Consider the branch strategy from `buildCover` definition:
-    -- (1) Low-sensitivity branch
-    let sensSet : Finset ℕ := F.image (fun g => sensitivity g)
-    let s := sensSet.max' (Finset.nonempty.image (BoolFunc.Family.nonempty_of_mem hf) _)
-    have Hsens : ∀ g ∈ F, sensitivity g ≤ s :=
-      fun g hg ↦ Finset.le_max' sensSet s (by simp [sensSet, hg])
-    cases hs : Nat.lt_or_le s (Nat.log2 (Nat.succ n)) with
-    | inl hs_small =>
-      -- Low-sensitivity case: use the `low_sensitivity_cover` lemma to cover all 1-inputs at once
-      obtain ⟨R_ls, Hmono, Hcover, Hsize⟩ := BoolFunc.low_sensitivity_cover (F := F) s Hsens
-      -- Here `Hcover` states: ∀ f ∈ F, ∀ y, f y = true → ∃ R ∈ R_ls, y ∈ₛ R
-      -- Combine the existing coverage of `Rset` with the low-sensitivity cover `R_ls`.
-      have hcov_union : AllOnesCovered F (Rset ∪ R_ls) := by
-        intro g hg y hy
-        by_cases hyRset : ∃ R ∈ Rset, y ∈ₛ R
-        · rcases hyRset with ⟨R, hRset, hyR⟩
-          exact ⟨R, by simp [Finset.mem_union.mpr (Or.inl hRset)], hyR⟩
-        · obtain ⟨R, hR_ls, hyR⟩ := Hcover g hg y hy
-          exact ⟨R, by simp [Finset.mem_union.mpr (Or.inr hR_ls)], hyR⟩
-      -- Conclude for this branch: buildCover returns `Rset ∪ R_ls`.
-      simpa [buildCover, hfu, hs_small] using hcov_union
-    | inr hs_large =>
-      -- (2) Sunflower branch or (3) Entropy branch
-      let p0 := (Family.supports F).min' (by
-        classical
-        exact ⟨support f, by simpa using Family.mem_supports.mpr ⟨f, hf, rfl⟩⟩)
-      let someBound := p0 * p0
-      by_cases hSun : (Family.supports F).card > someBound ∧ (∀ g ∈ F, (support g).card = p0) ∧ 0 < p0
-      <;> rename_i hSun_cond
-      · -- **Sunflower branch:** Add a subcube R_sun (covering at least one uncovered input) and recurse
-        -- Using the sunflower lemma (exists a suitable R_sun); for simplicity, pick the point subcube at x
-        let R_sun : Subcube n := Subcube.point x
-        have hxR : x ∈ₛ R_sun := by simp [Subcube.point]
-        let Rset' := insert R_sun Rset
-        -- By adding R_sun, the number of uncovered pairs strictly decreases (x is now covered)
-        have dec_uncovered : (uncovered F Rset').toFinset.card < (uncovered F Rset).toFinset.card := by
-          -- uncovered F Rset' ⊆ uncovered F Rset, and ⟨f, x⟩ ∈ uncovered F Rset but not in uncovered F Rset'
-          have subset_uncov : uncovered F Rset' ⊆ uncovered F Rset := fun ⟨g,y⟩ ⟨hg, hy, hNC⟩ =>
-            ⟨hg, hy, fun R hR ↦ hNC R (Finset.mem_insert_of_mem hR)⟩
-          have pair_mem : (⟨f, x⟩ : Σ BoolFunc n, Vector Bool n) ∈ uncovered F Rset := by simp [uncovered, hf, ←hfu]
-          have pair_not_mem : (⟨f, x⟩ : Σ BoolFunc n, Vector Bool n) ∉ uncovered F Rset' := fun ⟨_,_, hNC'⟩ =>
-            hNC' R_sun (Finset.mem_insert_self R_sun Rset) hxR
-          have proper : uncovered F Rset' ⊂ uncovered F Rset :=
-            ⟨subset_uncov, fun heq ↦ pair_not_mem (by rwa [←heq] at pair_mem)⟩
-          exact Finset.card_lt_card (Finset.ssubset_to_finset proper)
-        -- Apply the induction hypothesis on the smaller uncovered set (Rset'):
-        intro g hg y hy
-        by_cases hyRset : ∃ R ∈ Rset, y ∈ₛ R
-        · rcases hyRset with ⟨R, hR, hyR⟩
-          exact ⟨R, by simp [Finset.mem_insert_of_mem hR], hyR⟩
-        by_cases hyRsun : y ∈ₛ R_sun
-        · exact ⟨R_sun, by simp [Finset.mem_insert], hyRsun⟩
-        -- If y is not in Rset ∪ {R_sun}, then ⟨g,y⟩ is uncovered by Rset'
-        have : (⟨g, y⟩ : Σ BoolFunc n, Vector Bool n) ∈ uncovered F Rset' := by simp [uncovered, hg, hy, hyRset, hyRsun]
-        -- Induction hypothesis: use coverage for Rset' (smaller measure)
-        rcases H Rset' g hg y hy with ⟨R'', hR'', hyR''⟩
-        -- `buildCover F h hH Rset = buildCover F h hH Rset'` in this branch, so R'' is in the final set
-        exact ⟨R'', by simpa [buildCover, hfu, hSun] using hR'', hyR''⟩
-      · -- **Entropy branch:** No sunflower step; split on coordinate `i` to reduce entropy
-        obtain ⟨i, b, Hdrop⟩ := BoolFunc.exists_coord_entropy_drop (F := F) (hn := by decide) (hF := Finset.card_pos.mpr ⟨f, hf⟩)
-        let F0 := F.restrict i b
-        let F1 := F.restrict i (!b)
-        have hH0 : BoolFunc.H₂ F0 ≤ (h - 1 : ℝ) := by rw [BoolFunc.H₂_restrict_le]; exact Hdrop
-        have hH1 : BoolFunc.H₂ F1 ≤ (h - 1 : ℝ) := by rw [BoolFunc.H₂_restrict_compl_le]; exact Hdrop
-        -- Final cover is `buildCover F0 (h-1) ∪ buildCover F1 (h-1)`
-        intro g hg y hy
-        by_cases hyRset : ∃ R ∈ Rset, y ∈ₛ R
-        · rcases hyRset with ⟨R, hR, hyR⟩
-          exact ⟨R, by simp [Or.inl hR], hyR⟩
-        -- Determine which branch (F0 or F1) contains g and covers input y
-        by_cases hi : y i = b
-        · -- y falls in the branch where `x_i = b`
-          let g0 := g.restrictCoord i b
-          have hg0 : g0 ∈ F0 := Finset.mem_image_of_mem (fun f => f.restrictCoord i b) hg
-          have hg0y : g0 y = true := by simp [BoolFunc.restrictCoord, hi, hy]
-          -- Apply induction on smaller h (h-1) for family F0
-          rcases buildCover_covers (hH := hH0) g0 hg0 y hg0y with ⟨R0, hR0, hyR0⟩
-          -- R0 lies in the cover for F0, hence in the final union
-          exact ⟨R0, by simp [hR0], hyR0⟩
-        · -- y falls in the branch where `x_i = ¬b`
-          let g1 := g.restrictCoord i (!b)
-          have hg1 : g1 ∈ F1 := Finset.mem_image_of_mem (fun f => f.restrictCoord i (!b)) hg
-          have hg1y : g1 y = true := by simp [BoolFunc.restrictCoord, hi, hy]
-          rcases buildCover_covers (hH := hH1) g1 hg1 y hg1y with ⟨R1, hR1, hyR1⟩
-          exact ⟨R1, by simp [Or.inr hR1], hyR1⟩
-  -- **Termination proofs for recursive calls** 
-  -- Sunflower branch: uncovered set strictly decreases
-  · exact dec_uncovered
-  -- Entropy branch: `h` decreases by 1 (h ≥ 1 here, so h-1 < h)
-  · exact Nat.pred_lt (Nat.pos_of_ne_zero (by linarith))
-/-! ## Basic properties of `buildCover` -/
+  have hcov := (Pnp.Boolcube.familyEntropyCover (F := F) (h := h) hH).covers
+  simpa [buildCover] using hcov
 
-/--
-`buildCover_mono` states that every subcube produced by `buildCover` is
-monochromatic for the whole family.  The full proof proceeds by well-founded
-induction on the recursion tree.  The low-sensitivity branch inserts cubes
-from `low_sensitivity_cover`, the sunflower branch inserts one monochromatic
-cube and recurses on fewer uncovered pairs, and the entropy branch applies the
-induction hypothesis to the restricted families.
--
-/-!
-`buildCover_mono` states that every subcube produced by `buildCover` is
-monochromatic for the whole family.  The proof follows the same well-founded
-induction as `buildCover_covers`.  Each branch either inserts a collection of
-subcubes produced by `low_sensitivity_cover`, a single sunflower subcube, or
-recurses on families with strictly smaller measures.  We provide the
-statement here together with a proof outline; completing the detailed argument
-is left as future work.
--/
 lemma buildCover_mono (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     ∀ R ∈ buildCover F h hH, Subcube.monochromaticForFamily R F := by
   classical
-  -- We prove a slightly stronger statement where the recursion parameter `Rset`
-  -- already consists of monochromatic subcubes.  This allows a clean base case
-  -- when `buildCover` terminates immediately.
-  revert F
-  refine
-    (fun F ↦ _ : ∀ R ∈ buildCover F h hH, Subcube.monochromaticForFamily R F)
-      ?_ ?_
-  · intro F
-    -- Strengthened induction statement: every recursive call preserves
-    -- monochromaticity of the accumulating set `Rset`.
-    suffices
-      H : ∀ Rset,
-            (∀ R ∈ Rset, Subcube.monochromaticForFamily R F) →
-            ∀ R ∈ buildCover F h hH Rset,
-              Subcube.monochromaticForFamily R F
-      by
-        have hbase : ∀ R ∈ (∅ : Finset (Subcube n)),
-            Subcube.monochromaticForFamily R F := by
-          intro R hR; cases hR
-        simpa using H ∅ hbase
-    intro Rset hmono
-    -- Split on whether there is an uncovered input with respect to `Rset`.
-    cases hfu : firstUncovered F Rset with
-    | none =>
-        -- Base case: `buildCover` simply returns `Rset`.
-        simpa [buildCover, hfu] using hmono
-    | some tup =>
-        rcases tup with ⟨f, x⟩
-        -- Establish non-emptiness of `F` for the sensitivity bound below.
-        have F_nonempty : F.Nonempty := by
-          rcases Set.choose?_mem (S := uncovered F Rset) hfu with ⟨hf, -, -⟩
-          exact ⟨f, hf⟩
-        -- Compute the maximum sensitivity of functions in `F`.
-        let sensSet : Finset ℕ := F.image (fun g => sensitivity g)
-        let s := sensSet.max' (Finset.nonempty.image F_nonempty _)
-        have Hsens : ∀ g ∈ F, sensitivity g ≤ s :=
-          fun g hg ↦ Finset.le_max' sensSet s (by simpa [sensSet] using hg)
-        -- First branch: all functions have small sensitivity.
-        cases hs : Nat.lt_or_le s (Nat.log2 (Nat.succ n)) with
-        | inl hs_small =>
-            obtain ⟨R_ls, Hmono_ls, -, -⟩ :=
-              BoolFunc.low_sensitivity_cover (F := F) s Hsens
-            -- Monochromaticity is preserved after inserting `R_ls`.
-            have hmono_union :
-                ∀ R ∈ Rset ∪ R_ls, Subcube.monochromaticForFamily R F := by
-              intro R hR
-              rcases Finset.mem_union.mp hR with hR | hR
-              · exact hmono _ hR
-              · exact Hmono_ls _ hR
-            -- `buildCover` returns `Rset ∪ R_ls` in this branch.
-            simpa [buildCover, hfu, hs_small] using
-              hmono_union
-        | inr hs_large =>
-            -- Remaining branches (sunflower and entropy) follow the structure of
-            -- `buildCover_covers` and use the induction hypothesis on smaller
-            -- measures.  Their detailed implementation is omitted here.
-            sorry
-  all_goals
-    -- Placeholders for well-founded recursion arguments.
-    admit
+  have hmono := (Pnp.Boolcube.familyEntropyCover (F := F) (h := h) hH).mono
+  simpa [buildCover] using hmono
 
-
-/--
-`buildCover_card_bound` bounds the size of the cover returned by
-`buildCover` in terms of the entropy budget `h`.  A double induction on `h` and the number of uncovered pairs shows that at most `2^h` cubes are produced.
-The argument follows the same branch analysis as `buildCover_mono` and repeatedly applies the induction hypotheses.  We outline the reasoning here and leave a full proof to future work.
--/
-/-!
-`buildCover_card_bound` bounds the size of the cover returned by
-`buildCover` in terms of the entropy budget `h`.  The detailed induction
-argument is deferred; we expose the expected statement as an axiom for
-now so that the remainder of the development can use it.
--/
 lemma buildCover_card_bound (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     (buildCover F h hH).card ≤ mBound n h := by
   classical
-  -- We bound the size of `buildCover` by a simple cardinality argument.
-  -- Each recursive call either decreases the entropy parameter `h` or the
-  -- dimension `n`, so at most `2 * h + n` cubes can be inserted.
-  have hsize : (buildCover F h hH).card ≤ 2 * h + n := by
-    -- The detailed proof mirrors the recursion in `buildCover` and splits on
-    -- the possible branches.  For this overview we simply note that the measure
-    -- `(2 * h + n)` decreases in every recursive call.
-    -- A full proof would perform a nested induction on this measure.
-    -- We record the result here using `Nat.le_trans` and `numeric_bound`.
-    have : (buildCover F h hH).card ≤ (buildCover F h hH).card := le_rfl
-    exact this.trans (le_of_lt (by
-      have := numeric_bound (n := n) (h := h)
-      have : (2 * h + n) < (2 * h + n + 1) := Nat.lt_succ_self _
-      exact lt_of_le_of_lt (le_of_eq rfl) this))
-  exact hsize.trans (numeric_bound (n := n) (h := h))
+  have hbound := (Pnp.Boolcube.familyEntropyCover (F := F) (h := h) hH).bound
+  simpa [buildCover] using hbound
+
 
 /-! ## Main existence lemma -/
 


### PR DESCRIPTION
## Summary
- simplify `Pnp2.cover` by reusing the modern `familyEntropyCover`
- remove unfinished recursion code
- provide wrapper lemmas for monotonicity, coverage and bounds

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687837dbf3cc832ba6d7bb25c4533b60