### PR TITLE
Add extra tests for Pnp2 subset

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -23,5 +23,5 @@ lean_exe tests where
 @[test_driver]
 lean_lib Tests where
 
-  globs := #[`Basic, `CoverExtra, `Migrated, `Pnp2Legacy]
+  globs := #[`Basic, `CoverExtra, `Migrated, `Pnp2Legacy, `Pnp2Extra]
   srcDir := "test"

--- a/test/Pnp2Extra.lean
+++ b/test/Pnp2Extra.lean
@@ -1,0 +1,21 @@
+import Pnp2.Agreement
+import Pnp2.BoolFunc
+
+open BoolFunc
+open Agreement
+
+namespace Pnp2ExtraTests
+
+/-- The support of a constantly false function is empty. -/
+example (n : ℕ) :
+    support (fun _ : Point n => false) = (∅ : Finset (Fin n)) := by
+  ext i
+  simp [support]
+
+/-- If two points agree on all coordinates of `K`, the second lies in the same subcube. -/
+example {n : ℕ} {K : Finset (Fin n)} {x y : Point n}
+    (h : ∀ i, i ∈ K → x i = y i) :
+    y ∈ₛ Subcube.fromPoint x K := by
+  simpa using Agreement.mem_fromPoint_of_agree (K := K) (x := x) (y := y) h
+
+end Pnp2ExtraTests


### PR DESCRIPTION
## Summary
- extend test driver to include a new `Pnp2Extra` module
- create `test/Pnp2Extra.lean` with small examples over the historical `Pnp2` code

## Testing
- `lake build`
- `lake build Pnp2`
- `lake env lean --run scripts/smoke.lean`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6878442e29d4832b869f58a0e9453601