### PR TITLE
Enhance Pnp2 proofs and tests

### DIFF
--- a/Pnp2/Agreement.lean
+++ b/Pnp2/Agreement.lean
@@ -44,7 +44,7 @@ on some point `x` must output `true` on all points `y` within Hamming
 distance `ℓ` of `x`. -/
 class CoreClosed (ℓ : ℕ) (F : Family n) : Prop where
   closed_under_ball :
-    ∀ {f : BFunc n} (hf : f ∈ F) {x y : Point n},
+    ∀ {f : BFunc n} (_hf : f ∈ F) {x y : Point n},
       f x = true → hammingDist x y ≤ ℓ → f y = true
 
 /-! ### A convenience constructor for subcubes fixed by a point -/
@@ -53,7 +53,7 @@ class CoreClosed (ℓ : ℕ) (F : Family n) : Prop where
 `I ⊆ Fin n` to the values they take in the point `x`. -/
 def Subcube.fromPoint (x : Point n) (I : Finset (Fin n)) : Subcube n where
   idx := I
-  val := fun i h => x i
+  val := fun i _ => x i
 
 @[simp] lemma fromPoint_mem
     {x : Point n} {I : Finset (Fin n)} {y : Point n} :
@@ -65,6 +65,20 @@ def Subcube.fromPoint (x : Point n) (I : Finset (Fin n)) : Subcube n where
     {x : Point n} {I : Finset (Fin n)} :
     (Subcube.fromPoint x I).dimension = n - I.card := by
   rfl
+
+@[simp] lemma Subcube.monochromatic_point
+    {x : Point n} {f : BFunc n} :
+    (Subcube.fromPoint x (Finset.univ : Finset (Fin n))).monochromaticFor f := by
+  classical
+  refine ⟨f x, ?_⟩
+  intro y hy
+  have hy_eq : y = x := by
+    ext i
+    have h :=
+      (fromPoint_mem (x := x) (I := (Finset.univ : Finset (Fin n))) (y := y)).1
+        hy i (by simp)
+    simpa using h
+  simp [hy_eq]
 
 /-! ### Core‑agreement lemma with CoreClosed assumption -/
 
@@ -127,9 +141,9 @@ This is exactly Lemma 4.3 of the formal specification. -/
 lemma coreAgreement
     {x₁ x₂ : Point n} (I : Finset (Fin n))
     (h_size  : n - ℓ ≤ I.card)
-    (h_agree : ∀ i : Fin n, i ∈ I → x₁ i = x₂ i)
+    (_h_agree : ∀ i : Fin n, i ∈ I → x₁ i = x₂ i)
     (h_val1  : ∀ f, f ∈ F → f x₁ = true)
-    (h_val2  : ∀ f, f ∈ F → f x₂ = true)
+    (_h_val2 : ∀ f, f ∈ F → f x₂ = true)
     [CoreClosed ℓ F] :
     (Subcube.fromPoint x₁ I).monochromaticForFamily F := by
   classical
@@ -139,7 +153,7 @@ lemma coreAgreement
   have hdist : hammingDist x₁ y ≤ ℓ :=
     dist_le_of_compl_subset (n := n) (ℓ := ℓ) (x := x₁) (y := y)
       (I := I) h_size hy
-  exact CoreClosed.closed_under_ball (f := f) (hf := hf) hx₁ hdist
+  exact CoreClosed.closed_under_ball (f := f) hf hx₁ hdist
 
 open Finset
 
@@ -160,11 +174,11 @@ lemma Subcube.point_eq_core {n : ℕ} {K : Finset (Fin n)} {x₀ x : Point n}
     (h : ∀ i, i ∈ K → x i = x₀ i) :
     Subcube.fromPoint x K = Subcube.fromPoint x₀ K := by
   have hval : (fun i (hi : i ∈ K) => x i) = (fun i (hi : i ∈ K) => x₀ i) := by
-    funext i hi; simpa [h i hi]
+    funext i hi; simp [h i hi]
   simp [Subcube.fromPoint, hval]
 
 end Agreement
 
 lemma agree_on_refl {α β : Type _} (f : α → β) (s : Set α) : Set.EqOn f f s :=
-  fun x hx => rfl
+  fun _ _ => rfl
 

--- a/test/Pnp2Tests.lean
+++ b/test/Pnp2Tests.lean
@@ -79,6 +79,52 @@ example (n s C : ℕ) (f : BFunc n) [Fintype (Point n)]
     BoolFunc.low_sensitivity_cover_single
       (n := n) (s := s) (C := C) (f := f) Hs
 
+/-- Dimension of a subcube freezes exactly the chosen coordinates. -/
+example {n : ℕ} (x : Point n) (I : Finset (Fin n)) :
+    (Agreement.Subcube.fromPoint (n := n) x I).dimension = n - I.card := by
+  simpa using Agreement.dimension_fromPoint (x := x) (I := I)
+
+/-- A full subcube is monochromatic for any function. -/
+example {n : ℕ} (x : Point n) (f : BFunc n) :
+    (Agreement.Subcube.fromPoint (n := n) x Finset.univ).monochromaticFor f := by
+  classical
+  simpa using Agreement.Subcube.monochromatic_point (x := x) (f := f)
+
+/-- Freezing the same coordinates according to matching points yields the same subcube. -/
+example {n : ℕ} {K : Finset (Fin n)} {x₀ x : Point n}
+    (h : ∀ i, i ∈ K → x i = x₀ i) :
+    Agreement.Subcube.fromPoint (n := n) x K =
+      Agreement.Subcube.fromPoint (n := n) x₀ K := by
+  simpa using Agreement.Subcube.point_eq_core (K := K) (x₀ := x₀) (x := x) h
+
+/-- Core-agreement for the trivial family containing only the constantly true function. -/
+example {n ℓ : ℕ} (x : Point n) :
+    Agreement.Subcube.fromPoint (n := n) x Finset.univ |>.monochromaticForFamily
+      ({fun _ : Point n => true} : Family n) := by
+  classical
+  haveI : Agreement.CoreClosed ℓ ({fun _ : Point n => true} : Family n) :=
+    { closed_under_ball := by
+        intro f hf x y hx hy
+        have hf' : f = (fun _ => true) := by
+          simpa [Finset.mem_singleton] using hf
+        simpa [hf', hx] }
+  simpa using
+    Agreement.coreAgreement (n := n) (ℓ := ℓ)
+      (F := ({fun _ : Point n => true} : Family n))
+      (x₁ := x) (x₂ := x) (I := Finset.univ)
+      (h_size := by simp)
+      (_h_agree := by intro i hi; rfl)
+      (h_val1 := by
+        intro f hf
+        have hf' : f = (fun _ => true) := by
+          simpa [Finset.mem_singleton] using hf
+        simp [hf'] )
+      (_h_val2 := by
+        intro f hf
+        have hf' : f = (fun _ => true) := by
+          simpa [Finset.mem_singleton] using hf
+        simp [hf'] )
+
 
 
 end Pnp2Tests


### PR DESCRIPTION
## Summary
- remove warning-producing variables in `Pnp2/Agreement.lean`
- add missing lemma `Subcube.monochromatic_point`
- tweak equality proof using `simp`
- extend `Pnp2Tests` with additional examples and a check for `coreAgreement`

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68786898f0f4832b8f38a799d4fab30f