### PR TITLE
Add basic NotCovered lemmas

### DIFF
--- a/pnp/Pnp/Cover.lean
+++ b/pnp/Pnp/Cover.lean
@@ -62,6 +62,17 @@ variable {n : ℕ} (F : Family n)
 def NotCovered (Rset : Finset (Subcube n)) (x : Point n) : Prop :=
   ∀ R ∈ Rset, ¬ x ∈ₛ R
 
+@[simp] lemma notCovered_empty (x : Point n) :
+    NotCovered (Rset := (∅ : Finset (Subcube n))) x := by
+  intro R hR
+  simpa using hR
+
+lemma NotCovered.monotone {R₁ R₂ : Finset (Subcube n)} (hsub : R₁ ⊆ R₂)
+    {x : Point n} (hx : NotCovered (Rset := R₂) x) :
+    NotCovered (Rset := R₁) x := by
+  intro R hR
+  exact hx R (hsub hR)
+
 /-- The set of all uncovered 1-inputs (together with their functions). -/
 @[simp]
 def uncovered (F : Family n) (Rset : Finset (Subcube n)) : Set ((BFunc n) × Point n) :=


### PR DESCRIPTION
## Summary
- add `notCovered_empty` and monotonicity lemma for `NotCovered`
- regenerate build & test

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687954defd18832b8bef1bf48567c80c