### PR TITLE
Add AllOnesCovered.empty lemma

### DIFF
--- a/pnp/Pnp/Cover.lean
+++ b/pnp/Pnp/Cover.lean
@@ -104,4 +104,15 @@ lemma AllOnesCovered.union {F : Family n} {R₁ R₂ : Finset (Subcube n)}
   · rcases h₂ f hf x hx with ⟨R, hR, hxR⟩
     exact ⟨R, by simpa [Finset.mem_union, hx1] using Or.inr hR, hxR⟩
 
+@[simp] lemma AllOnesCovered.empty {F : Family n} :
+    AllOnesCovered (F := F) (∅ : Finset (Subcube n)) ↔
+      ∀ f ∈ F, ∀ x, f x = true → False := by
+  classical
+  constructor
+  · intro h f hf x hx
+    rcases h f hf x hx with ⟨R, hR, _hxR⟩
+    simp at hR
+  · intro h f hf x hx
+    exact False.elim (h f hf x hx)
+
 end Cover


### PR DESCRIPTION
## Summary
- add `AllOnesCovered.empty` lemma in `Cover`
- minor linter cleanup

## Testing
- `lake build Pnp.Cover`


------
https://chatgpt.com/codex/tasks/task_e_687954defd18832b8bef1bf48567c80c