### PR TITLE
Add lemmas for monochromatic union

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -289,6 +289,21 @@ lemma AllOnesCovered.union {F : Family n} {R₁ R₂ : Finset (Subcube n)}
   · rcases h₂ f hf x hx with ⟨R, hR, hxR⟩
     exact ⟨R, by simpa [Finset.mem_union, hx1] using Or.inr hR, hxR⟩
 
+lemma mono_subset {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    (h₁ : ∀ R ∈ R₁, Subcube.monochromaticForFamily R F) (hsub : R₂ ⊆ R₁) :
+    ∀ R ∈ R₂, Subcube.monochromaticForFamily R F := by
+  intro R hR
+  exact h₁ R (hsub hR)
+
+lemma mono_union {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    (h₁ : ∀ R ∈ R₁, Subcube.monochromaticForFamily R F)
+    (h₂ : ∀ R ∈ R₂, Subcube.monochromaticForFamily R F) :
+    ∀ R ∈ R₁ ∪ R₂, Subcube.monochromaticForFamily R F := by
+  intro R hR
+  rcases Finset.mem_union.mp hR with h | h
+  · exact h₁ R h
+  · exact h₂ R h
+
 /-! ### Lifting monochromaticity from restricted families
 
 If a subcube `R` fixes the `i`-th coordinate to `b`, then a family that is

--- a/pnp/Pnp/Cover.lean
+++ b/pnp/Pnp/Cover.lean
@@ -115,6 +115,21 @@ lemma AllOnesCovered.union {F : Family n} {R₁ R₂ : Finset (Subcube n)}
   · rcases h₂ f hf x hx with ⟨R, hR, hxR⟩
     exact ⟨R, by simpa [Finset.mem_union, hx1] using Or.inr hR, hxR⟩
 
+lemma mono_subset {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    (h₁ : ∀ R ∈ R₁, Subcube.monochromaticForFamily R F) (hsub : R₂ ⊆ R₁) :
+    ∀ R ∈ R₂, Subcube.monochromaticForFamily R F := by
+  intro R hR
+  exact h₁ R (hsub hR)
+
+lemma mono_union {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    (h₁ : ∀ R ∈ R₁, Subcube.monochromaticForFamily R F)
+    (h₂ : ∀ R ∈ R₂, Subcube.monochromaticForFamily R F) :
+    ∀ R ∈ R₁ ∪ R₂, Subcube.monochromaticForFamily R F := by
+  intro R hR
+  rcases Finset.mem_union.mp hR with h | h
+  · exact h₁ R h
+  · exact h₂ R h
+
 @[simp] lemma AllOnesCovered.empty {F : Family n} :
     AllOnesCovered (F := F) (∅ : Finset (Subcube n)) ↔
       ∀ f ∈ F, ∀ x, f x = true → False := by


### PR DESCRIPTION
## Summary
- add helper lemmas `mono_subset` and `mono_union` in `Cover` modules
- these lemmas help show unions of monochromatic rectangles remain monochromatic

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68795c224ef0832ba0f482c7571f42f2