### PR TITLE
docs: update buildCover_mono status

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ there, but it is no longer built by default.
 * `cover.lean` – experimental cover builder that keeps track of the
   set of uncovered inputs via `firstUncovered`.  The entropy split now
   uses `exists_coord_entropy_drop`, and the sunflower step relies on
-  `sunflower_exists`.  Monochromaticity and size bounds are stated as
-  axioms pending full proofs.  A helper lemma `AllOnesCovered.union`
-  now abstracts the union step in the coverage proof.
+  `sunflower_exists`.  Monochromaticity of the resulting cover is now
+  fully proved via the lemma `buildCover_mono`, while the size bound
+  `buildCover_card_bound` remains axiomatic.  A helper lemma
+  `AllOnesCovered.union` now abstracts the union step in the coverage
+  proof.
 * `bound.lean` – arithmetic bounds deriving the subexponential size estimate;
   the main inequality `mBound_lt_subexp` is currently stated as an axiom in the
   `pnp` namespace.  A complete proof will be added shortly.

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,8 @@ Short list of development tasks reflecting the current repository status.
 - [ ] Port `Bound.mBound_lt_subexp` proof and related lemmas (in progress).
 - [ ] Port halving lemmas `exists_restrict_half_real_aux` and `exists_restrict_half` from `entropy.lean`.
 - [ ] Complete `buildCover` proofs and establish the bound `mBound_lt_subexp`.
-- [ ] Replace axioms `buildCover_mono` and `buildCover_card_bound` with full proofs.
+* [x] Replace the axiom `buildCover_mono` with a complete proof.  The counting
+  lemma `buildCover_card_bound` remains to be formalised.
 - [ ] Integrate the decision-tree implementation with `low_sensitivity_cover`.
 - [ ] Expand numeric bounds in `bound.lean`.
 - [x] Provide more decision-tree utilities (leaf subcubes, path handling).

--- a/docs/E1_roadmap.md
+++ b/docs/E1_roadmap.md
@@ -64,7 +64,9 @@ theory.
 * **Combinatorial block.** Develop the covering method (B‑5) via an “address–data” representation or similar constructions.
   The Lean code now defines `buildCover` in `cover.lean`, tracking uncovered inputs via `firstUncovered` and applying either `sunflower_step` or `exists_coord_entropy_drop`.
   The cardinal lemma `exists_coord_card_drop` is proven and tests for `sunflower_step` verify its behaviour.
-  The statements `buildCover_mono` and `buildCover_card_bound` are currently axioms summarising the recursion invariants.  Completeness proofs and precise counts are still pending.
+  The lemma `buildCover_mono` has now been proved, establishing monochromaticity of
+  the constructed cover.  The size estimate `buildCover_card_bound` remains an
+  axiom, so precise counting is still pending.
 * **Entropy block.**  The new lemma `exists_coord_entropy_drop` in `entropy.lean`
   shows that some coordinate always cuts collision entropy by at least one bit,
   paving the way for a robust splitting strategy.

--- a/docs/b3_b5_details.md
+++ b/docs/b3_b5_details.md
@@ -66,8 +66,9 @@ small-support functions with **distinct supports** remains uncovered,
 while the entropy step now splits on a coordinate whose restriction
 reduces entropy by one bit.  The cardinal lemma `exists_coord_card_drop`
 has been proved, and tests for `sunflower_step` ensure its behaviour.
-The statements `buildCover_mono` and `buildCover_card_bound` are currently
-axioms capturing the intended recursion invariants.  Adapting the remaining
+The lemma `buildCover_mono` now provides a full proof that every rectangle
+inserted by `buildCover` is monochromatic.  The counting lemma
+`buildCover_card_bound` is still axiomatic, so adapting the remaining
 counting arguments to entire families remains an open task.
   Whenever an uncovered pair is found the family must contain at least
   two functions, so the entropy split is well-defined.  The opposite

--- a/docs/master_blueprint.md
+++ b/docs/master_blueprint.md
@@ -58,7 +58,7 @@ maintain a public repository with Lean scripts and accompanying notes.
 Much of the foundational material (Step 0) is available in print but only partly
 formalised.  Steps 1–3 are active research; the key missing piece is proving a
 rectangular cover of `ACC⁰ ∘ MCSP` tables of size at most `2^{N - N^{\delta}}`.
-Recent commits formalise the `coreAgreement` lemma and implement a recursive `buildCover` using `sunflower_step` and `exists_coord_entropy_drop`.  The cardinal drop lemma `exists_coord_card_drop` is now proven.  The lemmas `buildCover_mono` and `buildCover_card_bound` are currently stated as axioms recording the expected invariants.  Lemma statements for `low_sensitivity_cover` are in place, and `acc_mcsp_sat.lean` outlines the SAT reduction. The next steps depend on this breakthrough.
+Recent commits formalise the `coreAgreement` lemma and implement a recursive `buildCover` using `sunflower_step` and `exists_coord_entropy_drop`.  The cardinal drop lemma `exists_coord_card_drop` is now proven.  The lemma `buildCover_mono` has also been established, while the size bound `buildCover_card_bound` remains axiomatic.  Lemma statements for `low_sensitivity_cover` are in place, and `acc_mcsp_sat.lean` outlines the SAT reduction. The next steps depend on this breakthrough.
 A small `DecisionTree` module with evaluation and size utilities now also
 provides path handling via `subcube_of_path` and the lemmas
 `path_to_leaf_length_le_depth` and a leaf-count bound `leaf_count_le_pow_depth`.


### PR DESCRIPTION
## Summary
- note that `buildCover_mono` is now proved in README and docs
- update TODO list accordingly

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6879b3eb8190832b92a3e558212842e1