### PR TITLE
Add lemma for empty decision tree path

### DIFF
--- a/pnp/Pnp/BoolFunc.lean
+++ b/pnp/Pnp/BoolFunc.lean
@@ -145,6 +145,20 @@ def Point.update (x : Point n) (i : Fin n) (b : Bool) : Point n :=
   · subst hk; simp [Point.update]
   · simp [Point.update, hk]
 
+/-! ### Additional point update lemmas -/
+
+@[simp] lemma Point.update_swap (x : Point n) {i j : Fin n} (h : i ≠ j)
+    (b1 b2 : Bool) :
+    Point.update (Point.update x i b1) j b2 =
+      Point.update (Point.update x j b2) i b1 := by
+  funext k
+  by_cases hk : k = i
+  · subst hk
+    simp [Point.update, h]
+  · by_cases hjk : k = j
+    · subst hjk; simp [Point.update, hk, h]
+    · simp [Point.update, hk, hjk]
+
 /-- **A constant point** with the same Boolean value in every coordinate. -/
 def Point.const (n : ℕ) (b : Bool) : Point n := fun _ => b
 

--- a/pnp/Pnp/DecisionTree.lean
+++ b/pnp/Pnp/DecisionTree.lean
@@ -109,6 +109,13 @@ def subcube_of_path : List (Fin n × Bool) → Subcube n
               · exact hj
             exact R.val j hjR }
 
+/-! ### Basic lemmas about `subcube_of_path` -/
+
+@[simp] lemma mem_subcube_of_path_nil (x : Point n) :
+    (subcube_of_path (n := n) []).mem x := by
+  intro i hi
+  exact False.elim (Finset.notMem_empty _ hi)
+
 /-- The number of leaf subcubes is bounded by `2 ^ depth`. -/
 lemma leaves_as_subcubes_card_le_pow_depth (t : DecisionTree n) :
     (leaves_as_subcubes t).card ≤ 2 ^ depth t := by


### PR DESCRIPTION
## Summary
- extend decision tree utilities with `mem_subcube_of_path_nil`
- include point update swapping lemma

## Testing
- `lake build`
- `lake env lean --run scripts/smoke.lean`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687a5e248bb0832bb454a720e1483baf