### PR TITLE
Add update-swap test

### DIFF
--- a/pnp/Pnp/BoolFunc.lean
+++ b/pnp/Pnp/BoolFunc.lean
@@ -145,6 +145,20 @@ def Point.update (x : Point n) (i : Fin n) (b : Bool) : Point n :=
   · subst hk; simp [Point.update]
   · simp [Point.update, hk]
 
+/-! ### Additional point update lemmas -/
+
+@[simp] lemma Point.update_swap (x : Point n) {i j : Fin n} (h : i ≠ j)
+    (b1 b2 : Bool) :
+    Point.update (Point.update x i b1) j b2 =
+      Point.update (Point.update x j b2) i b1 := by
+  funext k
+  by_cases hk : k = i
+  · subst hk
+    simp [Point.update, h]
+  · by_cases hjk : k = j
+    · subst hjk; simp [Point.update, hk, h]
+    · simp [Point.update, hk, hjk]
+
 /-- **A constant point** with the same Boolean value in every coordinate. -/
 def Point.const (n : ℕ) (b : Bool) : Point n := fun _ => b
 

--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -79,6 +79,14 @@ example :
     simp [hempty] at hmem
   exact BoolFunc.exists_true_on_support (f := fun y : Point 1 => y 0) hsupp
 
+-- Swapping updates to two different coordinates yields the same result.
+example (x : Point 3) :
+    Point.update (Point.update x 0 true) 1 false =
+      Point.update (Point.update x 1 false) 0 true := by
+  have h : (0 : Fin 3) ≠ 1 := by decide
+  simpa using Point.update_swap (x := x) (i := (0 : Fin 3)) (j := (1 : Fin 3)) h
+      true false
+
 
 -- Basic lemmas from `Boolcube`
 example (n : ℕ) :


### PR DESCRIPTION
## Summary
- extend unit tests with an example exercising `Point.update_swap`

## Testing
- `lake build`
- `lake env lean --run scripts/smoke.lean`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687a5e248bb0832bb454a720e1483baf