### PR TITLE
Port missing notCovered lemmas

### DIFF
--- a/Pnp2/BoolFunc.lean
+++ b/Pnp2/BoolFunc.lean
@@ -145,6 +145,20 @@ def Point.update (x : Point n) (i : Fin n) (b : Bool) : Point n :=
   · subst hk; simp [Point.update]
   · simp [Point.update, hk]
 
+/-! ### Additional point update lemmas -/
+
+@[simp] lemma Point.update_swap (x : Point n) {i j : Fin n} (h : i ≠ j)
+    (b1 b2 : Bool) :
+    Point.update (Point.update x i b1) j b2 =
+      Point.update (Point.update x j b2) i b1 := by
+  funext k
+  by_cases hk : k = i
+  · subst hk
+    simp [Point.update, h]
+  · by_cases hjk : k = j
+    · subst hjk; simp [Point.update, hk, h]
+    · simp [Point.update, hk, hjk]
+
 /-- **A constant point** with the same Boolean value in every coordinate. -/
 def Point.const (n : ℕ) (b : Bool) : Point n := fun _ => b
 

--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -92,6 +92,18 @@ variable {n h : ℕ} (F : Family n)
 def NotCovered (Rset : Finset (Subcube n)) (x : Vector Bool n) : Prop :=
   ∀ R ∈ Rset, x ∉ₛ R
 
+@[simp] lemma notCovered_empty (x : Vector Bool n) :
+    NotCovered (Rset := (∅ : Finset (Subcube n))) x := by
+  intro R hR
+  -- `hR` is impossible since the set is empty
+  exact False.elim (by simpa using hR)
+
+lemma NotCovered.monotone {R₁ R₂ : Finset (Subcube n)} (hsub : R₁ ⊆ R₂)
+    {x : Vector Bool n} (hx : NotCovered (Rset := R₂) x) :
+    NotCovered (Rset := R₁) x := by
+  intro R hR
+  exact hx R (hsub hR)
+
 /-- The set of all uncovered 1-inputs (together with their functions). -/
 @[simp]
 def uncovered (F : Family n) (Rset : Finset (Subcube n)) : Set (Σ f : BoolFunc n, Vector Bool n) :=


### PR DESCRIPTION
## Summary
- add `notCovered_empty` and monotonicity lemmas for `NotCovered` in `cover.lean`
- ported from the modern `pnp` library

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687a6e22000c832b9428cdb5a92f10c0