### PR TITLE
Port update_swap lemma to Pnp2

### DIFF
--- a/Pnp2/BoolFunc.lean
+++ b/Pnp2/BoolFunc.lean
@@ -145,6 +145,20 @@ def Point.update (x : Point n) (i : Fin n) (b : Bool) : Point n :=
   · subst hk; simp [Point.update]
   · simp [Point.update, hk]
 
+/-! ### Additional point update lemmas -/
+
+@[simp] lemma Point.update_swap (x : Point n) {i j : Fin n} (h : i ≠ j)
+    (b1 b2 : Bool) :
+    Point.update (Point.update x i b1) j b2 =
+      Point.update (Point.update x j b2) i b1 := by
+  funext k
+  by_cases hk : k = i
+  · subst hk
+    simp [Point.update, h]
+  · by_cases hjk : k = j
+    · subst hjk; simp [Point.update, hk, h]
+    · simp [Point.update, hk, hjk]
+
 /-- **A constant point** with the same Boolean value in every coordinate. -/
 def Point.const (n : ℕ) (b : Bool) : Point n := fun _ => b
 

--- a/Pnp2/BoolFunc/Sensitivity.lean
+++ b/Pnp2/BoolFunc/Sensitivity.lean
@@ -26,5 +26,55 @@ lemma sensitivityAt_le (f : BFunc n) (x : Point n) :
     have hx : x ∈ (Finset.univ : Finset (Point n)) := by simp
     exact Finset.le_sup (s := Finset.univ) hx
 
+/-! ### Sensitivity and restrictions -/
+
+@[simp] lemma sensitivityAt_restrict_le (f : BFunc n) (j : Fin n)
+    (b : Bool) (x : Point n) :
+    sensitivityAt (f.restrictCoord j b) x ≤
+      sensitivityAt f (Point.update x j b) := by
+  classical
+  -- Unfold both `sensitivityAt` sets.
+  simp [sensitivityAt, BFunc.restrictCoord] at *
+  -- Define the original and restricted index sets.
+  set z := Point.update x j b with hz
+  have hz_i (i : Fin n) (hij : i ≠ j) :
+      Point.update (Point.update x i (!x i)) j b =
+        Point.update z i (!z i) := by
+    have := Point.update_swap (x := x) hij (!x i) b
+    simpa [hz, hij] using this
+  have hsubset :
+      (Finset.univ.filter fun i =>
+          f (Point.update (Point.update x i (!x i)) j b) ≠ f z) ⊆
+        Finset.univ.filter fun i => f (Point.update z i (!z i)) ≠ f z := by
+    intro i hi
+    rcases Finset.mem_filter.mp hi with ⟨hiu, hi⟩
+    by_cases hij : i = j
+    · -- Updates on the fixed coordinate `j` cancel out and cannot contribute.
+      subst hij
+      have hpoint : Point.update (Point.update x i (!x i)) i b = Point.update x i b := by
+        funext k
+        by_cases hk : k = i
+        · subst hk; simp [Point.update]
+        · simp [Point.update, hk]
+      have hcontr : f (Point.update x i b) ≠ f (Point.update x i b) := by
+        simpa [hz, hpoint] using hi
+      exact (hcontr rfl).elim
+    · -- For `i ≠ j` we use the swap lemma to rewrite the update order.
+      have hi' : f (Point.update z i (!z i)) ≠ f z := by
+        simpa [hz_i i hij, hz, hij] using hi
+      exact Finset.mem_filter.mpr ⟨by simpa, hi'⟩
+  -- The subset relation yields the desired card inequality.
+  have hcard := Finset.card_le_card hsubset
+  simpa [hz] using hcard
+
+lemma sensitivity_restrictCoord_le (f : BFunc n) (j : Fin n) (b : Bool) :
+    sensitivity (f.restrictCoord j b) ≤ sensitivity f := by
+  classical
+  unfold sensitivity
+  refine Finset.sup_le ?_
+  intro x hx
+  have hx' := sensitivityAt_le (f := f) (x := Point.update x j b)
+  exact le_trans (sensitivityAt_restrict_le (f := f) (j := j) (b := b) (x := x)) hx'
+
 end BoolFunc
 


### PR DESCRIPTION
## Summary
- add `Point.update_swap` lemma to `Pnp2/BoolFunc.lean`
- show that restricting a coordinate does not increase sensitivity

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687a6e22000c832b9428cdb5a92f10c0