### PR TITLE
Document swap lemma and add test

### DIFF
--- a/Pnp2/BoolFunc.lean
+++ b/Pnp2/BoolFunc.lean
@@ -145,6 +145,21 @@ def Point.update (x : Point n) (i : Fin n) (b : Bool) : Point n :=
   · subst hk; simp [Point.update]
   · simp [Point.update, hk]
 
+/-! ### Additional point update lemmas -/
+
+/-- Updating two different coordinates can be done in either order. -/
+@[simp] lemma Point.update_swap (x : Point n) {i j : Fin n} (h : i ≠ j)
+    (b1 b2 : Bool) :
+    Point.update (Point.update x i b1) j b2 =
+      Point.update (Point.update x j b2) i b1 := by
+  funext k
+  by_cases hk : k = i
+  · subst hk
+    simp [Point.update, h]
+  · by_cases hjk : k = j
+    · subst hjk; simp [Point.update, hk, h]
+    · simp [Point.update, hk, hjk]
+
 /-- **A constant point** with the same Boolean value in every coordinate. -/
 def Point.const (n : ℕ) (b : Bool) : Point n := fun _ => b
 

--- a/test/Pnp2Tests.lean
+++ b/test/Pnp2Tests.lean
@@ -53,6 +53,13 @@ example :
     simp [hempty] at hmem
   exact BoolFunc.exists_true_on_support (f := fun y : Point 1 => y 0) hsupp
 
+/-- `Point.update` operations on distinct coordinates commute. -/
+example (n : ℕ) (x : Point n) (i j : Fin n) (h : i ≠ j) (b₁ b₂ : Bool) :
+    Point.update (Point.update x i b₁) j b₂ =
+      Point.update (Point.update x j b₂) i b₁ := by
+  classical
+  simpa using Point.update_swap (x := x) (i := i) (j := j) h b₁ b₂
+
 /-- A trivial tree has depth zero and one leaf subcube. -/
 example :
     (DecisionTree.leaves_as_subcubes (DecisionTree.leaf true : DecisionTree 1)).card = 0 :=


### PR DESCRIPTION
## Summary
- document the `Point.update_swap` lemma
- add a regression test for swapping coordinate updates

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687a6e22000c832b9428cdb5a92f10c0