### PR TITLE
Add index lemmas for decision tree paths

### DIFF
--- a/Pnp2/DecisionTree.lean
+++ b/Pnp2/DecisionTree.lean
@@ -156,6 +156,14 @@ def subcube_of_path : List (Fin n × Bool) → Subcube n
               · exact hj
             exact R.val j hjR }
 
+@[simp] lemma subcube_of_path_nil_idx :
+    (subcube_of_path (n := n) ([] : List (Fin n × Bool))).idx = ({} : Finset (Fin n)) :=
+  rfl
+
+@[simp] lemma subcube_of_path_cons_idx (i : Fin n) (b : Bool) (p : List (Fin n × Bool)) :
+    (subcube_of_path ((i, b) :: p)).idx = insert i (subcube_of_path p).idx :=
+  rfl
+
 end DecisionTree
 
 end BoolFunc

--- a/pnp/Pnp/DecisionTree.lean
+++ b/pnp/Pnp/DecisionTree.lean
@@ -116,6 +116,14 @@ def subcube_of_path : List (Fin n × Bool) → Subcube n
   intro i hi
   exact False.elim (Finset.notMem_empty _ hi)
 
+@[simp] lemma subcube_of_path_nil_idx :
+    (subcube_of_path (n := n) ([] : List (Fin n × Bool))).idx = ({} : Finset (Fin n)) :=
+  rfl
+
+@[simp] lemma subcube_of_path_cons_idx (i : Fin n) (b : Bool) (p : List (Fin n × Bool)) :
+    (subcube_of_path ((i, b) :: p)).idx = insert i (subcube_of_path p).idx :=
+  rfl
+
 /-- The number of leaf subcubes is bounded by `2 ^ depth`. -/
 lemma leaves_as_subcubes_card_le_pow_depth (t : DecisionTree n) :
     (leaves_as_subcubes t).card ≤ 2 ^ depth t := by


### PR DESCRIPTION
## Summary
- add `subcube_of_path_nil_idx` and `subcube_of_path_cons_idx` lemmas
  describing the index set of the subcube obtained from a decision-tree path

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_687a9085db54832b97c1fbb01e34f890