### PR TITLE
Add colored subcube collection for decision trees

### DIFF
--- a/pnp/Pnp/DecisionTree.lean
+++ b/pnp/Pnp/DecisionTree.lean
@@ -160,6 +160,33 @@ lemma tree_depth_bound (t : DecisionTree n) :
     (leaves_as_subcubes t).card ≤ 2 ^ depth t :=
   leaves_as_subcubes_card_le_pow_depth (t := t)
 
+/-!
+The following helper collects the subcube associated with each leaf together
+with its Boolean label.  This will be used when transforming a decision tree
+into an explicit rectangle cover.
+-/
+
+/-- Auxiliary recursion accumulating the path to the current node.  The list `p`
+stores the coordinate decisions made so far. -/
+def coloredSubcubesAux : DecisionTree n → List (Fin n × Bool) →
+    Finset (Bool × Subcube n)
+  | leaf b, p => {⟨b, subcube_of_path p⟩}
+  | node i t0 t1, p =>
+      coloredSubcubesAux t0 ((i, false) :: p) ∪
+        coloredSubcubesAux t1 ((i, true) :: p)
+
+/-- All coloured subcubes of a decision tree. -/
+def coloredSubcubes (t : DecisionTree n) : Finset (Bool × Subcube n) :=
+  coloredSubcubesAux t []
+
+@[simp] lemma coloredSubcubesAux_leaf (b : Bool) (p : List (Fin n × Bool)) :
+    coloredSubcubesAux (n := n) (leaf b) p = {⟨b, subcube_of_path p⟩} := by
+  simp [coloredSubcubesAux]
+
+@[simp] lemma coloredSubcubes_leaf (b : Bool) :
+    coloredSubcubes (n := n) (leaf b) = {⟨b, subcube_of_path (n := n) []⟩} := by
+  simp [coloredSubcubes]
+
 end DecisionTree
 
 end BoolFunc


### PR DESCRIPTION
## Summary
- extend `DecisionTree` with a helper `coloredSubcubesAux` that collects subcubes for all leaves along with their colours
- expose `coloredSubcubes` and simp lemmas for leaves

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687ac2a00e88832b99c910d4f2f75d90