### PR TITLE
Add colored subcube extraction helpers

### DIFF
--- a/Pnp2/DecisionTree.lean
+++ b/Pnp2/DecisionTree.lean
@@ -169,6 +169,32 @@ def subcube_of_path : List (Fin n × Bool) → Subcube n
     (subcube_of_path ((i, b) :: p)).idx = insert i (subcube_of_path p).idx :=
   rfl
 
+/-!
+Collect all leaf subcubes of a decision tree together with their Boolean labels.
+The helper `coloredSubcubesAux` threads the current path as an accumulator.
+-/
+
+/- Auxiliary recursion accumulating the path to the current node.  The list `p`
+   stores the coordinate decisions made so far. -/
+def coloredSubcubesAux : DecisionTree n → List (Fin n × Bool) →
+    Finset (Bool × Subcube n)
+  | leaf b, p => {⟨b, subcube_of_path p⟩}
+  | node i t0 t1, p =>
+      coloredSubcubesAux t0 ((i, false) :: p) ∪
+        coloredSubcubesAux t1 ((i, true) :: p)
+
+/-- All coloured subcubes of a decision tree. -/
+def coloredSubcubes (t : DecisionTree n) : Finset (Bool × Subcube n) :=
+  coloredSubcubesAux t []
+
+@[simp] lemma coloredSubcubesAux_leaf (b : Bool) (p : List (Fin n × Bool)) :
+    coloredSubcubesAux (n := n) (leaf b) p = {⟨b, subcube_of_path p⟩} := by
+  simp [coloredSubcubesAux]
+
+@[simp] lemma coloredSubcubes_leaf (b : Bool) :
+    coloredSubcubes (n := n) (leaf b) = {⟨b, subcube_of_path (n := n) []⟩} := by
+  simp [coloredSubcubes]
+
 end DecisionTree
 
 end BoolFunc


### PR DESCRIPTION
## Summary
- implement `coloredSubcubesAux` and `coloredSubcubes` in the legacy `Pnp2.DecisionTree` module
- expose lemmas about these functions for later use in decision-tree covers

## Testing
- `lake build`
- `lake build Pnp2`
- `lake env lean --run scripts/smoke.lean`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687ad36e6958832b88fe7d3eef804ab5