### PR TITLE
Add DecisionTree path lemmas

### DIFF
--- a/pnp/Pnp/DecisionTree.lean
+++ b/pnp/Pnp/DecisionTree.lean
@@ -187,6 +187,50 @@ def coloredSubcubes (t : DecisionTree n) : Finset (Bool × Subcube n) :=
     coloredSubcubes (n := n) (leaf b) = {⟨b, subcube_of_path (n := n) []⟩} := by
   simp [coloredSubcubes]
 
+/-- Evaluate a leaf. Convenience lemma for rewriting. -/
+@[simp] lemma eval_tree_leaf (b : Bool) (x : Point n) :
+    eval_tree (leaf b) x = b := rfl
+
+/-- Evaluate a node. The result depends on the queried bit. -/
+@[simp] lemma eval_tree_node (i : Fin n) (t0 t1 : DecisionTree n) (x : Point n) :
+    eval_tree (node i t0 t1) x = (if x i then eval_tree t1 x else eval_tree t0 x) := by
+  by_cases h : x i
+  · simp [eval_tree, h]
+  · simp [eval_tree, h]
+
+/-- If `x` lies in the subcube described by a path, it also lies in the extended
+path obtained by fixing one additional coordinate. -/
+lemma mem_subcube_of_path_cons_of_mem (x : Point n) (p : List (Fin n × Bool))
+    (i : Fin n) (b : Bool)
+    (hx : (subcube_of_path p).mem x) (hxi : x i = b) :
+    (subcube_of_path ((i, b) :: p)).mem x := by
+  intro j hj
+  rcases Finset.mem_insert.mp hj with hj | hj
+  · subst hj; simpa [subcube_of_path, hxi]
+  · have hxj := hx j hj
+    by_cases hji : j = i
+    · subst hji; simpa [subcube_of_path, hxi] using hxi
+    · simp [subcube_of_path, hj, hji, hxj]
+
+/-- Any input lies in the subcube corresponding to the path it takes to reach a
+leaf. -/
+lemma mem_subcube_of_path_path_to_leaf (t : DecisionTree n) (x : Point n) :
+    (subcube_of_path (path_to_leaf t x)).mem x := by
+  induction t generalizing x with
+  | leaf b =>
+      simpa [path_to_leaf, subcube_of_path] using
+        (mem_subcube_of_path_nil (n := n) (x := x))
+  | node i t0 t1 ih0 ih1 =>
+      by_cases h : x i
+      · have h' := ih1 x
+        simpa [path_to_leaf, h] using
+          mem_subcube_of_path_cons_of_mem (x := x) (p := path_to_leaf t1 x)
+            (i := i) (b := true) h' (by simpa [h])
+      · have h' := ih0 x
+        simpa [path_to_leaf, h] using
+          mem_subcube_of_path_cons_of_mem (x := x) (p := path_to_leaf t0 x)
+            (i := i) (b := false) h' (by simpa [h])
+
 end DecisionTree
 
 end BoolFunc


### PR DESCRIPTION
## Summary
- add evaluation lemmas for `DecisionTree` leaves and nodes
- show how to extend membership in a path-defined subcube
- prove that any point lies in the subcube determined by `path_to_leaf`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687ad84615a0832b89af4a656b4d0c76