### PR TITLE
Add lemma for colored subcube count

### DIFF
--- a/Pnp2/DecisionTree.lean
+++ b/Pnp2/DecisionTree.lean
@@ -195,6 +195,11 @@ def coloredSubcubes (t : DecisionTree n) : Finset (Bool × Subcube n) :=
     coloredSubcubes (n := n) (leaf b) = {⟨b, subcube_of_path (n := n) []⟩} := by
   simp [coloredSubcubes]
 
+/-! A leaf contributes exactly one coloured subcube. -/
+@[simp] lemma coloredSubcubes_leaf_card (b : Bool) :
+    (coloredSubcubes (n := n) (leaf b)).card = 1 := by
+  simp
+
 end DecisionTree
 
 end BoolFunc


### PR DESCRIPTION
## Summary
- prove a small helper lemma `coloredSubcubes_leaf_card`
- this lemma states that a `leaf` decision tree contributes exactly one coloured subcube

## Testing
- `lake build`
- `lake build Tests`

------
https://chatgpt.com/codex/tasks/task_e_687ad847d154832b830817b0ba57a08b