### PR TITLE
Add empty-family lemma for low-sensitivity cover

### DIFF
--- a/Pnp2/low_sensitivity_cover.lean
+++ b/Pnp2/low_sensitivity_cover.lean
@@ -139,5 +139,18 @@ lemma low_sensitivity_cover_single
   · intro x hx
     simpa using hcov f (by simp) x hx
 
-end BoolFunc
 
+
+/-- Specialized version of `low_sensitivity_cover` for the empty family.
+    This is a small convenience wrapper around `decisionTree_cover_empty`. -/
+lemma low_sensitivity_cover_empty (n s C : ℕ)
+    [Fintype (Point n)] :
+  ∃ Rset : Finset (Subcube n),
+    (∀ R ∈ Rset, Subcube.monochromaticForFamily R (∅ : Family n)) ∧
+    (∀ f ∈ (∅ : Family n), ∀ x, f x = true → ∃ R ∈ Rset, x ∈ₛ R) ∧
+    Rset.card ≤ Nat.pow 2 (C * s * Nat.log2 (Nat.succ n)) := by
+  classical
+  simpa using
+    (decisionTree_cover_empty (n := n) (s := s) (C := C))
+
+end BoolFunc


### PR DESCRIPTION
## Summary
- provide a version of `low_sensitivity_cover` specialised to the empty family
- reuse `decisionTree_cover_empty` for the proof

## Testing
- `lake build Pnp2`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687b1a7b10b4832bbb85d60a8e4ef995