### PR TITLE
Add family path restriction utilities

### DIFF
--- a/Pnp2/DecisionTree.lean
+++ b/Pnp2/DecisionTree.lean
@@ -1,4 +1,5 @@
 import Pnp2.BoolFunc
+import Pnp2.BoolFunc.Sensitivity
 import Mathlib.Algebra.Order.Monoid.Unbundled.Pow
 
 namespace BoolFunc
@@ -315,5 +316,46 @@ lemma path_to_leaf_idx_card_le_depth (t : DecisionTree n) (x : Point n) :
   exact le_trans this hlen
 
 end DecisionTree
+
+/-! ### Path-based family restrictions -/
+
+namespace Family
+
+variable {n : ℕ}
+
+/--
+Restrict every function in a family according to a path of fixed coordinates.
+Each pair `(i, b)` in the list records that coordinate `i` is set to `b`.
+Later occurrences in the path override earlier ones, mirroring
+`DecisionTree.subcube_of_path` behaviour. -/
+noncomputable def restrictPath (F : Family n) : List (Fin n × Bool) → Family n
+  | []        => F
+  | (i, b) :: p => (restrictPath F p).restrict i b
+
+@[simp] lemma restrictPath_nil (F : Family n) :
+    restrictPath F [] = F := rfl
+
+@[simp] lemma restrictPath_cons (F : Family n) (i : Fin n) (b : Bool)
+    (p : List (Fin n × Bool)) :
+    restrictPath F ((i, b) :: p) = (restrictPath F p).restrict i b := rfl
+
+/-- Restricting along a path does not increase sensitivity.  This follows by
+iterating `sensitivity_family_restrict_le`. -/
+lemma sensitivity_restrictPath_le (F : Family n) (p : List (Fin n × Bool))
+    {s : ℕ} [Fintype (Point n)] (Hs : ∀ f ∈ F, sensitivity f ≤ s) :
+    ∀ g ∈ restrictPath F p, sensitivity g ≤ s := by
+  induction p with
+  | nil =>
+      simpa using Hs
+  | cons q p ih =>
+      cases q with
+      | mk i b =>
+          intro g hg
+          have hg' : g ∈ (restrictPath F p).restrict i b := by simpa using hg
+          have htail := sensitivity_family_restrict_le
+            (F := restrictPath F p) (i := i) (b := b) (s := s) (hF := ih)
+          exact htail g hg'
+
+end Family
 
 end BoolFunc


### PR DESCRIPTION
## Summary
- extend `DecisionTree` utilities with `Family.restrictPath`
- show sensitivity is preserved along restricted paths

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687b1fa48998832bb25922ba5a5e806a