### PR TITLE
Refactor duplicate lemma names

### DIFF
--- a/Pnp2/Boolcube.lean
+++ b/Pnp2/Boolcube.lean
@@ -172,15 +172,12 @@ lemma exists_coord_card_drop
   have hcontr := lt_of_lt_of_le this rhs_le
   exact lt_irrefl _ hcontr
 
+
 -- Entropy version.  From the cardinal drop we derive a quantitative decrease of
 -- `H₂`.  Using `log₂ (1 - 1/n) ≤ -1 / (n * ln 2)`.
-lemma exists_coord_entropy_drop
-    (F : Family n) (hn : 0 < n) (hF : 1 < F.card) :
-    ∃ i : Fin n, ∃ b : Bool,
-      H₂ (F.restrict i b) ≤ H₂ F - 1 := by
-  classical
-  simpa using
-    (BoolFunc.exists_coord_entropy_drop (F := F) (hn := hn) (hF := hF))
+-- The actual lemma lives in `entropy.lean` as
+-- `BoolFunc.exists_coord_entropy_drop`.  We omit its duplicate
+-- statement here.
 
 
 /-!  ### 2.  High‑level cover structure and recursive constructor -/

--- a/Pnp2/cover_numeric.lean
+++ b/Pnp2/cover_numeric.lean
@@ -11,7 +11,7 @@ variable {N Nδ : ℕ} (F : Family N)
 -- Placeholder definitions if needed
 -- We assume `minCoverSize` and `buildCover_size_bound` are provided elsewhere.
 
-lemma numeric_bound
+lemma minCoverSize_bound
     (h₀ : H₂ F ≤ N - Nδ) : (minCoverSize F) ≤ 2^(N - Nδ) := by
   simpa using buildCover_size_bound (F := F) h₀
 

--- a/Pnp2/entropy.lean
+++ b/Pnp2/entropy.lean
@@ -77,16 +77,11 @@ noncomputable def H₂ {n : ℕ} (F : Family n) : ℝ :=
     H₂ F = 0 := by simp [H₂, h]
 
 /-!
-`Family.restrict i b` applies `BFunc.restrictCoord` to every function in `F`, fixing the `i`-th input bit to `b`.  This may identify previously distinct functions, so the resulting family can have smaller cardinality.  The next two helper lemmas are straightforward bookkeeping about these cardinalities and need no additional imports.
--/
-
-lemma card_restrict_le {n : ℕ} (F : Family n) (i : Fin n) (b : Bool) :
-    (F.restrict i b).card ≤ F.card := by
-  classical
-  -- `restrict` is implemented via `Finset.image`, hence the cardinality can
-  -- only drop.
-  simpa [Family.restrict] using
-    (Finset.card_image_le (s := F) (f := fun f : BFunc n => f.restrictCoord i b))
+`Family.restrict i b` applies `BFunc.restrictCoord` to every function in `F`,
+fixing the `i`-th input bit to `b`.  This may identify previously distinct
+functions, so the resulting family can only become smaller.  The lemma
+`BoolFunc.card_restrict_le` in `BoolFunc.lean` records this fact.  We do not
+restate it here to avoid duplication. -/
 
 /-- **Existence of a halving restriction (ℝ version)** –
 provides a coordinate `i` and bit `b` such that restricting every


### PR DESCRIPTION
## Summary
- remove duplicate lemma `card_restrict_le` from `entropy.lean`
- drop extra `exists_coord_entropy_drop` in `Boolcube.lean`
- rename `CoverNumeric.numeric_bound` -> `minCoverSize_bound`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687b6d70e4d0832bb89f96d635c49a3e