### PR TITLE
Port lemma for nonempty coordinate slices

### DIFF
--- a/Pnp2/Boolcube.lean
+++ b/Pnp2/Boolcube.lean
@@ -139,6 +139,42 @@ end coordSlice
 
 open coordSlice
 
+/-! If a finite set of points contains at least two distinct elements, then
+some coordinate splits it into nonempty `true` and `false` slices.  This helper
+lemma ports the corresponding result from the legacy `pnp` development. -/
+lemma exists_coord_slice_both_nonempty (S : Finset (Point n))
+    (hS : 1 < S.card) :
+    ∃ i : Fin n,
+      (coordSlice i true S).Nonempty ∧ (coordSlice i false S).Nonempty := by
+  classical
+  -- Pick two distinct points in `S`.
+  obtain ⟨x, y, hx, hy, hxy⟩ := (Finset.one_lt_card_iff).mp hS
+  -- They must differ on some coordinate `i`.
+  have hdiff : ∃ i : Fin n, x i ≠ y i := by
+    by_contra h
+    have hxyeq : x = y := by
+      funext i
+      have hi := (not_exists.mp h) i
+      simpa using hi
+    exact hxy hxyeq
+  obtain ⟨i, hi⟩ := hdiff
+  -- Case split on the values of `x i` and `y i`.
+  cases hx_val : x i <;> cases hy_val : y i
+  case true.true =>
+    -- Impossible: `x i` = `y i` contradicts `hi`.
+    have : x i = y i := by simp [hx_val, hy_val]
+    exact (hi this).elim
+  case true.false =>
+    exact ⟨i, ⟨x, by simp [coordSlice, hx, hx_val]⟩,
+              ⟨y, by simp [coordSlice, hy, hy_val]⟩⟩
+  case false.true =>
+    exact ⟨i, ⟨y, by simp [coordSlice, hy, hy_val]⟩,
+              ⟨x, by simp [coordSlice, hx, hx_val]⟩⟩
+  case false.false =>
+    -- Again `x i = y i` contradicts `hi`.
+    have : x i = y i := by simp [hx_val, hy_val]
+    exact (hi this).elim
+
 lemma exists_coord_card_drop
     (hn : 2 ≤ n)
     {F : Finset (Point n)} (hF : F.Nonempty) :


### PR DESCRIPTION
## Summary
- port `exists_coord_slice_both_nonempty` from the old `pnp` tree

## Testing
- `lake exe cache get`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687b881937b8832b84ac474e654c2bdc