### PR TITLE
Port axiom on P/poly inclusion

### DIFF
--- a/Pnp2/ComplexityClasses.lean
+++ b/Pnp2/ComplexityClasses.lean
@@ -81,3 +81,12 @@ structure InPpoly (L : Language) where
 
 /-- The non-uniform class `P/poly`. -/
 def Ppoly : Set Language := { L | ∃ h : InPpoly L, True }
+
+/-!
+`P ⊆ Ppoly` is a classical counting argument: every polytime Turing
+machine can be translated into a polynomial-size circuit family.  We
+keep this implication as an axiom so that later developments can rely
+on the standard complexity-theoretic fact without redoing the
+construction here.
+-/
+axiom P_subset_Ppoly : P ⊆ Ppoly


### PR DESCRIPTION
## Summary
- add missing `P_subset_Ppoly` axiom

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687b8d028240832bbacb4332b34b854a