### PR TITLE
Add base-case bound for buildCover

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -814,7 +814,17 @@ The argument follows the same branch analysis as `buildCover_mono` and repeatedl
 `buildCover_card_bound` bounds the size of the cover returned by
 `buildCover` in terms of the entropy budget `h`.  The detailed induction
 argument is deferred; we expose the expected statement as an axiom for
-now so that the remainder of the development can use it.
+now so that the remainder of the development can use it. -/
+lemma buildCover_card_bound_base (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hfu : firstUncovered F (∅ : Finset (Subcube n)) = none) :
+    (buildCover F h hH).card ≤ mBound n h := by
+  classical
+  have hres : buildCover F h hH = (∅ : Finset (Subcube n)) := by
+    simpa [buildCover, hfu]
+  have : (0 : ℕ) ≤ mBound n h :=
+    (Nat.zero_le _).trans (numeric_bound (n := n) (h := h))
+  simpa [hres] using this
+
 -/
 lemma buildCover_card_bound (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     (buildCover F h hH).card ≤ mBound n h := by


### PR DESCRIPTION
## Summary
- add `buildCover_card_bound_base` lemma covering the trivial case where `firstUncovered` is `none`
- minor comment adjustments

## Testing
- `lake build Pnp2`

------
https://chatgpt.com/codex/tasks/task_e_687bff2513d8832bbcdf0a7d0eea4e42