### PR TITLE
Add universal bound lemma for buildCover

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -1073,6 +1073,21 @@ lemma buildCover_card_bound (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
       -- `2 * h + n` used above.
       exact hsize.trans (numeric_bound (n := n) (h := h))
 
+/-! ### Universal bound on the number of rectangles
+
+Even without the detailed recursion argument we can still bound the
+size of the cover produced by `buildCover` by the number of all
+subcubes.  This very weak estimate is occasionally useful as a
+fallback. -/
+
+lemma buildCover_card_univ_bound (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (buildCover F h hH).card ≤ bound_function n := by
+  classical
+  -- `size_bounds` provides a universal bound for any finite set of
+  -- subcubes.  We instantiate it with the set returned by `buildCover`.
+  have := size_bounds (n := n) (Rset := buildCover F h hH)
+  simpa [size, bound_function] using this
+
 /-! ## Main existence lemma -/
 
 lemma cover_exists (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :


### PR DESCRIPTION
## Summary
- add `buildCover_card_univ_bound` giving a simple bound using the full set of subcubes

## Testing
- `lake build`
- `lake env lean --run scripts/smoke.lean`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687c26de42f0832baa190fab1a622386