### PR TITLE
Add TODO note in buildCover_card_bound proof

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -1104,8 +1104,9 @@ lemma buildCover_card_bound (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
         `mBound n h` rectangles before the measure becomes zero.  This
         measure-based induction argument matches the informal proof in the
         project documentation, but the present implementation only sketches
-        the details.  A complete formalisation will replace the placeholder
-        bound used here.
+        the details.  **TODO:** replace this outline with a fully formal
+        proof showing that the recursion yields at most `mBound n h`
+        rectangles.
       -/
       have hsize : (buildCover F h hH).card ≤ 2 * h + n := by
         -- Placeholder reasoning: we simply note that the measure `μ` starts


### PR DESCRIPTION
## Summary
- clarify that the proof of `buildCover_card_bound` is still a sketch
- add a TODO note for the formal measure-based argument

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_687c30180134832b97f1a688a881dc94