### PR TITLE
Update docs on buildCover_card_bound progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ gradually migrated across.
   set of uncovered inputs via `firstUncovered`.  The entropy split now
   uses `exists_coord_entropy_drop`, and the sunflower step relies on
   `sunflower_exists`.  Monochromaticity of the resulting cover is now
-  fully proved via the lemma `buildCover_mono`.  The companion size
-  estimate `buildCover_card_bound` is established via a well-founded
-  induction on a simple measure tracking the remaining uncovered pairs.
+  fully proved via the lemma `buildCover_mono`.  A preliminary argument
+  for the companion size estimate `buildCover_card_bound` outlines the
+  well-founded induction that bounds the remaining uncovered pairs, but a
+  complete proof is still being formalised.
   The helper lemma `AllOnesCovered.union` abstracts the union step in
   the coverage proof.
 * `bound.lean` – arithmetic bounds deriving the subexponential size estimate;
@@ -144,7 +145,7 @@ python3 experiments/collision_entropy.py 3 1 --list-counts --top 5
 
 ## Status
 
-This is still a research prototype. The core-agreement lemma is fully proven, and the entropy-drop lemma `exists_coord_entropy_drop` is proved in `entropy.lean`.  The cardinal analogue `exists_coord_card_drop` is now formalised in `Boolcube.lean`; an earlier standalone demonstration file has been removed. `buildCover` splits on uncovered pairs using `sunflower_step` or the entropy drop, and preliminary proofs of its properties (`buildCover_mono` and `buildCover_card_bound`) have been added. The convenience wrapper `coverFamily` exposes these results via lemmas `coverFamily_mono`, `coverFamily_spec_cover` and `coverFamily_card_bound`. Collision entropy for a single function lives in `collentropy.lean`.  A formal definition of sensitivity with the lemma statement `low_sensitivity_cover` is available.  A small `DecisionTree` module provides depth, leaf counting, path extraction and the helper `subcube_of_path`.  Lemmas `path_to_leaf_length_le_depth` and `leaf_count_le_pow_depth` bound the recorded paths and the number of leaves, and `low_sensitivity_cover_single` sketches the tree-based approach.  `acc_mcsp_sat.lean` sketches the SAT connection. Numeric counting bounds remain open, so the repository documents ongoing progress rather than a finished proof.
+This is still a research prototype. The core-agreement lemma is fully proven, and the entropy-drop lemma `exists_coord_entropy_drop` is proved in `entropy.lean`.  The cardinal analogue `exists_coord_card_drop` is now formalised in `Boolcube.lean`; an earlier standalone demonstration file has been removed. `buildCover` splits on uncovered pairs using `sunflower_step` or the entropy drop.  `buildCover_mono` is fully proved, while `buildCover_card_bound` currently uses only a coarse measure argument.  The convenience wrapper `coverFamily` exposes these results via lemmas `coverFamily_mono`, `coverFamily_spec_cover` and `coverFamily_card_bound`. Collision entropy for a single function lives in `collentropy.lean`.  A formal definition of sensitivity with the lemma statement `low_sensitivity_cover` is available.  A small `DecisionTree` module provides depth, leaf counting, path extraction and the helper `subcube_of_path`.  Lemmas `path_to_leaf_length_le_depth` and `leaf_count_le_pow_depth` bound the recorded paths and the number of leaves, and `low_sensitivity_cover_single` sketches the tree-based approach.  `acc_mcsp_sat.lean` sketches the SAT connection. Numeric counting bounds remain open, so the repository documents ongoing progress rather than a finished proof.
 
 Within `Pnp2` the overall structure of the FCE argument is now visible: entropy
 lemmas, cover builders and decision-tree tools all compile, but the final

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,8 @@ Short list of development tasks reflecting the current repository status.
 - [x] Port halving lemmas `exists_restrict_half_real_aux` and `exists_restrict_half` from `entropy.lean`.
 - [ ] Complete `buildCover` proofs and establish the bound `mBound_lt_subexp`.
 * [x] Replace the axiom `buildCover_mono` with a complete proof.  The counting
-  lemma `buildCover_card_bound` remains to be formalised.
+  lemma `buildCover_card_bound` now has a placeholder proof using a coarse
+  measure bound.  Formalising the full induction is still on the to-do list.
 - [ ] Integrate the decision-tree implementation with `low_sensitivity_cover`.
 - [ ] Expand numeric bounds in `bound.lean`.
 - [x] Provide more decision-tree utilities (leaf subcubes, path handling).

--- a/docs/E1_roadmap.md
+++ b/docs/E1_roadmap.md
@@ -65,8 +65,9 @@ theory.
   The Lean code now defines `buildCover` in `cover.lean`, tracking uncovered inputs via `firstUncovered` and applying either `sunflower_step` or `exists_coord_entropy_drop`.
   The cardinal lemma `exists_coord_card_drop` is proven and tests for `sunflower_step` verify its behaviour.
   The lemma `buildCover_mono` has now been proved, establishing monochromaticity of
-  the constructed cover.  The size estimate `buildCover_card_bound` remains an
-  axiom, so precise counting is still pending.
+  the constructed cover.  The companion size estimate `buildCover_card_bound`
+  currently relies on a coarse measure argument; completing the formal
+  induction is work in progress.
 * **Entropy block.**  The new lemma `exists_coord_entropy_drop` in `entropy.lean`
   shows that some coordinate always cuts collision entropy by at least one bit,
   paving the way for a robust splitting strategy.

--- a/docs/b3_b5_details.md
+++ b/docs/b3_b5_details.md
@@ -67,9 +67,9 @@ while the entropy step now splits on a coordinate whose restriction
 reduces entropy by one bit.  The cardinal lemma `exists_coord_card_drop`
 has been proved, and tests for `sunflower_step` ensure its behaviour.
 The lemma `buildCover_mono` now provides a full proof that every rectangle
-inserted by `buildCover` is monochromatic.  The counting lemma
-`buildCover_card_bound` is still axiomatic, so adapting the remaining
-counting arguments to entire families remains an open task.
+inserted by `buildCover` is monochromatic.  A first version of the counting
+lemma `buildCover_card_bound` has been implemented using a rough measure
+bound, but the detailed induction argument is not yet complete.
   Whenever an uncovered pair is found the family must contain at least
   two functions, so the entropy split is well-defined.  The opposite
   branch of the split also satisfies the same entropy bound because

--- a/docs/buildCover_card_bound_outline.md
+++ b/docs/buildCover_card_bound_outline.md
@@ -46,5 +46,6 @@ recursion stops.  Because `mBound` dominates this initial measure we obtain
 `(buildCover F h hH).card ≤ mBound n h`.
 
 The current Lean development provides most helper lemmas described above.
-Formalising the complete induction is work in progress, but the outline here
-records the intended argument.
+Formalising the complete induction is work in progress.  The current
+implementation in `cover.lean` includes a coarse bound following this
+strategy, and future updates will replace it with the full argument.


### PR DESCRIPTION
## Summary
- clarify that `buildCover_card_bound` only has a coarse measure proof so far
- update roadmap and design notes to reflect partial progress
- mention placeholder status in TODO

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687c3aaf7b38832bb3adee547d2f3aeb