### PR TITLE
Improve initial measure bound docs

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -523,6 +523,20 @@ lemma uncovered_init_coarse_bound (F : Family n) :
 -/
 axiom uncovered_init_bound (F : Family n) :
   (uncovered F (∅ : Finset (Subcube n))).toFinset.card ≤ n
+/--
+  A direct numeric variant of `uncovered_init_bound` expressed via the measure
+  `μ`.  Initially we have `μ(F, h, ∅) = 2 * h + (uncovered F ∅).toFinset.card`.
+  Plugging in the bound on the uncovered count yields `μ(F, h, ∅) ≤ 2 * h + n`.
+  This coarse inequality is occasionally convenient when reasoning about the
+  overall recursion measure.
+-/
+lemma mu_init_linear_bound (F : Family n) (h : ℕ) :
+    mu F h (∅ : Finset (Subcube n)) ≤ 2 * h + n := by
+  have hstart :
+      (uncovered F (∅ : Finset (Subcube n))).toFinset.card ≤ n :=
+    uncovered_init_bound (F := F)
+  simpa [mu] using add_le_add_left hstart (2 * h)
+
 
 /-!
 `mu_init_bound` upgrades the initial uncovered bound to the full measure.


### PR DESCRIPTION
## Summary
- document the axiom `uncovered_init_bound` with a helper lemma `mu_init_linear_bound`
- clarify how the uncovered count bounds the initial measure

## Testing
- `lake build`
- `lake exe tests` *(failed: process timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687cdb0fdc48832b8d6d60306bdd27df