### PR TITLE
Add cover_exists example

### DIFF
--- a/test/Pnp2Tests.lean
+++ b/test/Pnp2Tests.lean
@@ -169,7 +169,17 @@ example {n : ℕ} (t : DecisionTree n) (x : Point n) :
   classical
   simpa using
     DecisionTree.eval_pair_mem_coloredSubcubes (t := t) (x := x)
-
-
+/-- `cover_exists` produces a small cover for the constant true function. -/
+example {n : ℕ} :
+    ∃ Rset : Finset (Subcube n),
+      (∀ R ∈ Rset, Subcube.monochromaticForFamily R ({fun _ : Point n => true} : Family n)) ∧
+      AllOnesCovered ({fun _ : Point n => true} : Family n) Rset ∧
+      Rset.card ≤ mBound n 0 := by
+  classical
+  -- Collision entropy of the constant family is zero.
+  have hH : BoolFunc.H₂ ({fun _ : Point n => true} : Family n) ≤ (0 : ℝ) := by simp
+  obtain ⟨Rset, hmono, hcov, hbound⟩ :=
+    Cover.cover_exists (F := ({fun _ : Point n => true} : Family n)) (h := 0) hH
+  exact ⟨Rset, hmono, hcov, hbound⟩
 
 end Pnp2Tests


### PR DESCRIPTION
## Summary
- add a test showing `cover_exists` works for the constant family

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_687dbba127b4832ba7e869001ec692c5