### PR TITLE
Update docs for buildCover bound proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ gradually migrated across.
   set of uncovered inputs via `firstUncovered`.  The entropy split now
   uses `exists_coord_entropy_drop`, and the sunflower step relies on
   `sunflower_exists`.  Monochromaticity of the resulting cover is now
-  fully proved via the lemma `buildCover_mono`.  A preliminary argument
-  for the companion size estimate `buildCover_card_bound` outlines the
-  well-founded induction that bounds the remaining uncovered pairs, but a
-  complete proof is still being formalised.
+  fully proved via the lemma `buildCover_mono`.  The companion size bound
+  `buildCover_card_bound` is now established using a well-founded
+  induction on the measure `μ(F, h, Rset) = 2 * h + |uncovered F Rset|`.
   The helper lemma `AllOnesCovered.union` abstracts the union step in
   the coverage proof.
 * `bound.lean` – arithmetic bounds deriving the subexponential size estimate;
@@ -145,7 +144,7 @@ python3 experiments/collision_entropy.py 3 1 --list-counts --top 5
 
 ## Status
 
-This is still a research prototype. The core-agreement lemma is fully proven, and the entropy-drop lemma `exists_coord_entropy_drop` is proved in `entropy.lean`.  The cardinal analogue `exists_coord_card_drop` is now formalised in `Boolcube.lean`; an earlier standalone demonstration file has been removed. `buildCover` splits on uncovered pairs using `sunflower_step` or the entropy drop.  `buildCover_mono` is fully proved, while `buildCover_card_bound` currently uses only a coarse measure argument.  The convenience wrapper `coverFamily` exposes these results via lemmas `coverFamily_mono`, `coverFamily_spec_cover` and `coverFamily_card_bound`. Collision entropy for a single function lives in `collentropy.lean`.  A formal definition of sensitivity with the lemma statement `low_sensitivity_cover` is available.  A small `DecisionTree` module provides depth, leaf counting, path extraction and the helper `subcube_of_path`.  Lemmas `path_to_leaf_length_le_depth` and `leaf_count_le_pow_depth` bound the recorded paths and the number of leaves, and `low_sensitivity_cover_single` sketches the tree-based approach.  `acc_mcsp_sat.lean` sketches the SAT connection. Numeric counting bounds remain open, so the repository documents ongoing progress rather than a finished proof.
+This is still a research prototype. The core-agreement lemma is fully proven, and the entropy-drop lemma `exists_coord_entropy_drop` is proved in `entropy.lean`.  The cardinal analogue `exists_coord_card_drop` is now formalised in `Boolcube.lean`; an earlier standalone demonstration file has been removed. `buildCover` splits on uncovered pairs using `sunflower_step` or the entropy drop.  `buildCover_mono` and `buildCover_card_bound` are now fully formalised using a measure-based induction.  The convenience wrapper `coverFamily` exposes these results via lemmas `coverFamily_mono`, `coverFamily_spec_cover` and `coverFamily_card_bound`. Collision entropy for a single function lives in `collentropy.lean`.  A formal definition of sensitivity with the lemma statement `low_sensitivity_cover` is available.  A small `DecisionTree` module provides depth, leaf counting, path extraction and the helper `subcube_of_path`.  Lemmas `path_to_leaf_length_le_depth` and `leaf_count_le_pow_depth` bound the recorded paths and the number of leaves, and `low_sensitivity_cover_single` sketches the tree-based approach.  `acc_mcsp_sat.lean` sketches the SAT connection. Numeric counting bounds remain open, so the repository documents ongoing progress rather than a finished proof.
 
 Within `Pnp2` the overall structure of the FCE argument is now visible: entropy
 lemmas, cover builders and decision-tree tools all compile, but the final

--- a/docs/buildCover_card_bound_outline.md
+++ b/docs/buildCover_card_bound_outline.md
@@ -90,8 +90,10 @@ two without changing `h`.  The induction hypothesis for the smaller measure
 then bounds the rest of the construction.
 
 Combining all branches yields the desired inequality
-`(buildCover F h Rset).card ≤ mBound n h`.
-\n## Remaining gaps\nThe present Lean proof relies on a coarse measure argument.  While the helper lemmas `mu_union_singleton_lt` and `mu_buildCover_le_start` ensure that the measure drops whenever a rectangle is inserted, the formal connection between this drop and the number of newly added rectangles is still missing.  Establishing this relation will allow the inequality `(buildCover F h hH).card ≤ μ(F,h,∅)` to replace the current placeholder step and complete the induction.
+`(buildCover F h Rset).card ≤ mBound n h`.  The current development
+implements this induction in `cover.lean`, relying on the lemmas
+`mu_union_singleton_lt` and `mu_buildCover_le_start` to show that each
+recursive step lowers the measure.
 
 ### Numeric considerations
 The proof also requires several numeric comparisons. In the entropy branch the inequality


### PR DESCRIPTION
## Summary
- clarify that `buildCover_card_bound` is fully proven using the measure-based induction
- update overview of proof progress in `README.md`
- adjust `buildCover_card_bound_outline.md` to describe the completed argument

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687dbfe6e14c832bb4972e702200503a