### PR TITLE
Add restrictPath_append lemma

### DIFF
--- a/Pnp2/DecisionTree.lean
+++ b/Pnp2/DecisionTree.lean
@@ -429,6 +429,20 @@ noncomputable def restrictPath (F : Family n) : List (Fin n × Bool) → Family 
     (p : List (Fin n × Bool)) :
     restrictPath F ((i, b) :: p) = (restrictPath F p).restrict i b := rfl
 
+/-!  Concatenating paths corresponds to sequentially applying the
+    restrictions.  This helper lemma unfolds the recursion and shows
+    that processing `p ++ q` is the same as first restricting by `q`
+    and then by `p`. -/
+lemma restrictPath_append (F : Family n) (p q : List (Fin n × Bool)) :
+    restrictPath F (p ++ q) = restrictPath (restrictPath F q) p := by
+  induction p with
+  | nil =>
+      simp [restrictPath]
+  | cons hd tl ih =>
+      cases hd with
+      | mk i b =>
+          simp [List.cons_append, restrictPath, ih]
+
 /-- Restricting along a path does not increase sensitivity.  This follows by
 iterating `sensitivity_family_restrict_le`. -/
 lemma sensitivity_restrictPath_le (F : Family n) (p : List (Fin n × Bool))

--- a/test/Pnp2Tests.lean
+++ b/test/Pnp2Tests.lean
@@ -170,6 +170,16 @@ example {n : ℕ} (t : DecisionTree n) (x : Point n) :
   simpa using
     DecisionTree.eval_pair_mem_coloredSubcubes (t := t) (x := x)
 
+/-- Restricting along a concatenated path is equivalent to
+    applying the restrictions sequentially. -/
+example {n : ℕ} (F : Family n) (p q : List (Fin n × Bool)) :
+    BoolFunc.Family.restrictPath (n := n) (F := F) (p ++ q) =
+      BoolFunc.Family.restrictPath (n := n)
+        (F := BoolFunc.Family.restrictPath (n := n) (F := F) q) p := by
+  classical
+  simpa using
+    BoolFunc.Family.restrictPath_append (F := F) (p := p) (q := q)
+
 
 
 end Pnp2Tests


### PR DESCRIPTION
## Summary
- add `restrictPath_append` to `DecisionTree`
- test that concatenated path restriction matches sequential restriction

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_687dceddbfbc832b820515af1e2ff27d