### PR TITLE
Refine buildCover_card_bound lemma

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -1466,55 +1466,27 @@ lemma buildCover_card_init_mu (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
 lemma buildCover_card_bound (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     (buildCover F h hH).card ≤ mBound n h := by
   classical
-  -- Combine the linear bound with the numeric growth of `mBound`.
-  have hμ := buildCover_card_init_mu (F := F) (h := h) (hH := hH)
-  have hbound := numeric_bound (n := n) (h := h)
-  exact hμ.trans hbound
-
-  -- When both the dimension and entropy budget are large enough we can
-  -- apply the specialised low-sensitivity lemma.  Otherwise we fall back
-  -- to the coarse measure argument used in the placeholder proof.
+  -- When both the dimension and the entropy budget are sufficiently
+  -- large we can analyse the low-sensitivity branch in detail.  In all
+  -- remaining cases we revert to the coarse estimate obtained from the
+  -- initial measure.
   by_cases hh : Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n) ≤ h
   ·
     by_cases hn : 0 < n
-    · -- Use the refined bound that analyses the low-sensitivity branch.
+    · -- Adequate dimension and entropy: invoke the refined lemma.
       simpa using
         buildCover_card_bound_lowSens_or (F := F) (h := h)
           (hH := hH) hh hn
-    · -- Degenerate dimension: revert to the basic measure estimate.
-      have hfu := (by
-        classical
-        -- Check if an uncovered input exists; otherwise we are done.
-        cases hfu : firstUncovered F (∅ : Finset (Subcube n)) with
-        | none =>
-            have hres : buildCover F h hH = (∅ : Finset (Subcube n)) := by
-              simpa [buildCover, hfu]
-            have : (0 : ℕ) ≤ mBound n h :=
-              (Nat.zero_le _).trans (numeric_bound (n := n) (h := h))
-            exact (by simpa [hres] using this)
-        | some _ =>
-            -- Use the numeric placeholder bound.
-            have _hmu := mu_buildCover_le_start (F := F) (h := h) (hH := hH)
-            have _hstart_le := mu_init_bound (F := F) (h := h)
-            have hsize : (buildCover F h hH).card ≤ 2 * h + n := by
-              have := numeric_bound (n := n) (h := h)
-              exact le_trans (Nat.le_of_lt_succ (Nat.lt_succ_self _)) this
-            exact hsize.trans (numeric_bound (n := n) (h := h)))
-      simpa using hfu
+    · -- Dimension `n = 0`.  Fall back to the basic numeric bound.
+      have hinit := buildCover_card_init_mu (F := F) (h := h) (hH := hH)
+      have hnum := numeric_bound (n := n) (h := h)
+      exact hinit.trans hnum
   ·
-    -- Entropy budget too small for the refined argument: reuse the
-    -- original placeholder proof.
-    cases hfu : firstUncovered F (∅ : Finset (Subcube n)) with
-    | none =>
-        simpa [buildCover, hfu] using
-          buildCover_card_bound_base (F := F) (h := h) (hH := hH) hfu
-    | some tup =>
-        have _hmu := mu_buildCover_le_start (F := F) (h := h) (hH := hH)
-        have _hstart_le := mu_init_bound (F := F) (h := h)
-        have hsize : (buildCover F h hH).card ≤ 2 * h + n := by
-          have := numeric_bound (n := n) (h := h)
-          exact le_trans (Nat.le_of_lt_succ (Nat.lt_succ_self _)) this
-        exact hsize.trans (numeric_bound (n := n) (h := h))
+    -- Entropy budget too small for the refined argument: use the
+    -- placeholder measure bound.
+    have hinit := buildCover_card_init_mu (F := F) (h := h) (hH := hH)
+    have hnum := numeric_bound (n := n) (h := h)
+    exact hinit.trans hnum
 
 
 /-! ### Universal bound on the number of rectangles


### PR DESCRIPTION
## Summary
- refine the `buildCover_card_bound` proof
  - use the specialized low-sensitivity bound when the dimension and entropy budget are large enough
  - otherwise fall back to the coarse numeric estimate
- keep tests passing

## Testing
- `lake build`
- `lake test -v`

------
https://chatgpt.com/codex/tasks/task_e_687e8e570ecc832b9819673c48f496af