### PR TITLE
Add bound for low-sensitivity cover with existing rectangles

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -1236,6 +1236,48 @@ lemma buildCover_card_bound_lowSens (hH : BoolFunc.H₂ F ≤ (h : ℝ))
   simpa using hbound
 
 /-!
+  `buildCover_card_bound_lowSens_with` upgrades `buildCover_card_lowSens_with`
+  to the standard bound `mBound`.  The lemma allows an existing collection
+  of rectangles `Rset` as starting point and shows that after inserting the
+  low‑sensitivity cover the total size is still controlled by the next
+  entropy budget `h + 1`.
+
+  The numeric hypothesis `hh` ensures that the intermediate exponential bound
+  fits into `mBound n h`.  This lets us combine the sizes via
+  `two_mul_mBound_le_succ`.
+-/
+lemma buildCover_card_bound_lowSens_with (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hs : ∀ f ∈ F, sensitivity f < Nat.log2 (Nat.succ n))
+    (hh : Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n) ≤ h)
+    (hn : 0 < n) (Rset : Finset (Subcube n))
+    (hcard : Rset.card ≤ mBound n h) :
+    (buildCover F h hH Rset).card ≤ mBound n (h + 1) := by
+  classical
+  -- Cardinality bound from the low-sensitivity cover.
+  have hsize :=
+    buildCover_card_lowSens_with (F := F) (h := h) (hH := hH) hs
+      (Rset := Rset)
+  -- Estimate the additional rectangles using `mBound`.
+  have hexp_mul : 10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)
+      ≤ 10 * h := by
+    have := Nat.mul_le_mul_left 10 hh
+    simpa [Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using this
+  have hpow :
+      Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n))
+        ≤ mBound n h :=
+    le_trans
+      (Nat.pow_le_pow_of_le_left (by decide : 1 ≤ (2 : ℕ)) hexp_mul)
+      (pow_le_mBound (n := n) (h := h) hn)
+  -- Combine with the existing rectangles.
+  have hsum : (buildCover F h hH Rset).card ≤ Rset.card + mBound n h :=
+    hsize.trans <| Nat.add_le_add_left hpow _
+  have hdouble : Rset.card + mBound n h ≤ 2 * mBound n h := by
+    have := add_le_add hcard (le_rfl : mBound n h ≤ mBound n h)
+    simpa [two_mul] using this
+  have hstep := two_mul_mBound_le_succ (n := n) (h := h)
+  exact hsum.trans (hdouble.trans hstep)
+
+/-!
   `buildCover_card_bound_lowSens_or` partially bridges the gap towards the
   full counting lemma `buildCover_card_bound`.  When the maximum sensitivity of
   functions in the family falls below the logarithmic threshold we invoke the


### PR DESCRIPTION
## Summary
- add `buildCover_card_bound_lowSens_with` lemma
- show that adding a low-sensitivity cover on top of a bounded set of rectangles still fits in the next entropy budget
- proof uses existing numeric bounds

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687e95c876d0832b97b20d93014d7a39