### PR TITLE
Add measure drop lemma for singleton union

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -657,6 +657,21 @@ lemma mu_union_singleton_lt {F : Family n} {Rset : Finset (Subcube n)}
   -- Add `2*h` to both sides.
   simpa [mu] using Nat.add_lt_add_left hcard (2 * h)
 
+/-!
+Adding a rectangle that covers at least one previously uncovered
+pair decreases the measure `μ` by at least one.
+This quantified version of `mu_union_singleton_lt` is occasionally
+convenient when reasoning about numeric bounds.
+-/
+lemma mu_union_singleton_succ_le {F : Family n} {Rset : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    (hx : ∃ p ∈ uncovered F Rset, p.2 ∈ₛ R) :
+    mu F h (Rset ∪ {R}) + 1 ≤ mu F h Rset := by
+  classical
+  have hlt :=
+    mu_union_singleton_lt (F := F) (Rset := Rset) (R := R) (h := h) hx
+  exact Nat.succ_le_of_lt hlt
+
 lemma mu_union_le {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ} :
     mu F h (R₁ ∪ R₂) ≤ mu F h R₁ := by
   classical


### PR DESCRIPTION
## Summary
- prove `mu_union_singleton_succ_le` showing the measure decreases by at least one when a new rectangle covers an uncovered point
- document the lemma with comments

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_687e95c481d8832baf5f07925b11c68b