### PR TITLE
Add simple constant true support test

### DIFF
--- a/test/Pnp2Tests.lean
+++ b/test/Pnp2Tests.lean
@@ -15,6 +15,12 @@ example (n : ℕ) :
     support (fun _ : Point n => false) = (∅ : Finset (Fin n)) := by
   ext i
   simp [support]
+/-- The support of a constantly true function is empty. -/
+example (n : ℕ) :
+    support (fun _ : Point n => true) = (∅ : Finset (Fin n)) := by
+  ext i
+  simp [support]
+
 
 /-- Modifying an irrelevant coordinate leaves the function unchanged. -/
 example (x : Point 2) (b : Bool) :


### PR DESCRIPTION
## Summary
- add a new example in `Pnp2Tests` verifying that the support of a constant
  `true` function is empty

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687eba8e14e0832bbdf4d88960430258