### PR TITLE
Add strict measure lemma for rectangle union

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -805,6 +805,22 @@ lemma mu_union_singleton_double_succ_le {F : Family n} {Rset : Finset (Subcube n
   -- Rewrite everything in terms of `μ`.
   simpa [mu, S, T, add_comm, add_left_comm, add_assoc] using this
 
+/-!  A convenient corollary of `mu_union_singleton_double_succ_le`: if a
+rectangle covers two distinct uncovered pairs, the measure strictly decreases
+after inserting this rectangle.  The proof reuses the single-pair inequality
+`mu_union_singleton_lt` on one of the witnesses.-/
+lemma mu_union_singleton_double_lt {F : Family n} {Rset : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    {p₁ p₂ : Σ f : BoolFunc n, Vector Bool n}
+    (hp₁ : p₁ ∈ uncovered F Rset) (hp₂ : p₂ ∈ uncovered F Rset)
+    (hp₁R : p₁.2 ∈ₛ R) (hp₂R : p₂.2 ∈ₛ R) (hne : p₁ ≠ p₂) :
+    mu F h (Rset ∪ {R}) < mu F h Rset := by
+  classical
+  -- Covering even a single uncovered pair suffices for a strict drop.
+  have hx : ∃ p ∈ uncovered F Rset, p.2 ∈ₛ R := ⟨p₁, hp₁, hp₁R⟩
+  -- Apply the basic inequality for one newly covered pair.
+  exact mu_union_singleton_lt (F := F) (Rset := Rset) (R := R) (h := h) hx
+
 lemma mu_union_le {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ} :
     mu F h (R₁ ∪ R₂) ≤ mu F h R₁ := by
   classical


### PR DESCRIPTION
## Summary
- add `mu_union_singleton_double_lt` lemma to strengthen measure decrease when a rectangle covers two uncovered pairs
- no test changes needed; `lake test` remains clean

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687eba854394832bb229c2b6e907b185