### PR TITLE
Add equivalence lemma for familyEntropyCover

### DIFF
--- a/Pnp2/family_entropy_cover.lean
+++ b/Pnp2/family_entropy_cover.lean
@@ -51,4 +51,19 @@ noncomputable def familyEntropyCover
   rcases hcov f hf x hx with ⟨C, hC, hxC⟩
   exact ⟨C, hC, hxC⟩
 
+/-!
+`familyEntropyCover` is defined using `cover_exists`, just like
+`Cover.coverFamily`.  The following lemma exposes this relationship by
+identifying the set of rectangles produced by both constructions.
+This convenience result simplifies linking the wrapper record with the
+underlying cover used elsewhere in the development.
+-/
+@[simp] lemma familyEntropyCover_rects_eq_coverFamily
+    {n : ℕ} (F : Family n) {h : ℕ} (hH : H₂ F ≤ (h : ℝ)) :
+    (familyEntropyCover (F := F) (h := h) hH).rects
+      = Cover.coverFamily (F := F) (h := h) hH := by
+  classical
+  -- Unfold both constructions and simplify using `cover_exists`.
+  simp [familyEntropyCover, Cover.coverFamily, Cover.cover_exists]
+
 end Boolcube


### PR DESCRIPTION
## Summary
- expose `familyEntropyCover_rects_eq_coverFamily` connecting the wrapper record to `coverFamily`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687eba854394832bb229c2b6e907b185