### PR TITLE
Minor simplification in ACC-SAT helpers

### DIFF
--- a/pnp/Pnp/AccMcspSat.lean
+++ b/pnp/Pnp/AccMcspSat.lean
@@ -88,7 +88,12 @@ lemma rightBits_mergeBits {k ℓ : ℕ} (xL : Fin k → Bool) (xR : Fin ℓ → 
   have hlt :
       ((Fin.cast (Nat.add_comm ℓ k) (j.addNat k) : Fin (k + ℓ)) : ℕ) - k < ℓ :=
     by simpa [hsub] using j.is_lt
-  simp [hnot, hsub, hlt]
+  -- Show that the index produced by `mergeBits` coincides with `j`.
+  have hfin :
+      (⟨((Fin.cast (Nat.add_comm ℓ k) (j.addNat k) : Fin (k + ℓ)) : ℕ) - k, hlt⟩ : Fin ℓ) = j := by
+    ext; simp [hsub]
+  -- Evaluate the conditional using `hnot` and simplify via `hfin`.
+  simp [hnot, hfin]
 
 
 /-- Schematic meet-in-the-middle SAT algorithm using a rectangular cover of the


### PR DESCRIPTION
## Summary
- tweak `rightBits_mergeBits` proof
- keep overall tests passing

## Testing
- `lake build Pnp.AccMcspSat`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687ed19d79dc832bb99532b3d0b22627