### PR TITLE
Add `merge_card_eq_min` lemma

### DIFF
--- a/Pnp2/merge_low_sens.lean
+++ b/Pnp2/merge_low_sens.lean
@@ -69,4 +69,29 @@ lemma merge_correct
   · simpa [merge_cover, h_le] using low_sens_cover.covers
   · simpa [merge_cover, h_le] using entropy_cover.covers
 
+/-!
+`merge_cover` chooses the smaller of the two input covers.  Consequently the
+number of rectangles in the result is the minimum of the two cardinalities.
+This tiny lemma packages the case split so that downstream files can reason
+about the size without repeating the definition.
+-/
+lemma merge_card_eq_min
+    {n : ℕ} {F : Family n} {h : ℕ}
+    (low_sens_cover : FamilyCover F h) (entropy_cover : FamilyCover F h) :
+    (merge_cover low_sens_cover entropy_cover).rects.card =
+      Nat.min low_sens_cover.rects.card entropy_cover.rects.card := by
+  classical
+  unfold merge_cover
+  by_cases h_le : low_sens_cover.rects.card ≤ entropy_cover.rects.card
+  · -- `low_sens_cover` is chosen when its cardinality is smaller.
+    have hmin :
+        Nat.min low_sens_cover.rects.card entropy_cover.rects.card =
+          low_sens_cover.rects.card := Nat.min_eq_left h_le
+    simp [merge_cover, h_le, hmin]
+  · -- Otherwise `entropy_cover` wins and its size is the minimum.
+    have hmin :
+        Nat.min low_sens_cover.rects.card entropy_cover.rects.card =
+          entropy_cover.rects.card := Nat.min_eq_right (le_of_not_le h_le)
+    simp [merge_cover, h_le, hmin]
+
 end Boolcube


### PR DESCRIPTION
## Summary
- add a helper `merge_card_eq_min` to the `merge_low_sens` module
- prove that `merge_cover` returns a cover with cardinality equal to the minimum
  of the two input covers

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687eda332028832b86e5abb633c6b4e4