### PR TITLE
Add small DecisionTree test

### DIFF
--- a/test/Pnp2Tests.lean
+++ b/test/Pnp2Tests.lean
@@ -186,6 +186,14 @@ example {n : ℕ} (F : Family n) (p q : List (Fin n × Bool)) :
   simpa using
     BoolFunc.Family.restrictPath_append (F := F) (p := p) (q := q)
 
+/-- The subcube recorded by a two-step path freezes exactly two coordinates. -/
+example :
+    (DecisionTree.subcube_of_path
+        (n := 2) [(⟨0, by decide⟩, true), (⟨1, by decide⟩, false)]).idx.card = 2 :=
+by
+  classical
+  simp [DecisionTree.subcube_of_path]
+
 
 
 end Pnp2Tests


### PR DESCRIPTION
## Summary
- add a new example in `Pnp2Tests` showing how `subcube_of_path` freezes
  coordinates of a decision tree path

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687eda363b84832b90f269a1f4e2dbb2