### PR TITLE
Add coverage test for RSpread.card_filter_le

### DIFF
--- a/test/CoverExtra.lean
+++ b/test/CoverExtra.lean
@@ -15,6 +15,19 @@ example : RSpread (R := 1) ({∅} : Finset (Finset (Fin 1))) := by
   have hA : ({∅} : Finset (Finset (Fin 1))).Nonempty := by simp
   simpa using RSpread.one_of_nonempty (A := {∅}) (hA := hA)
 
+/-- Bounding the filtered cardinal for a trivial family. -/
+example (S : Finset (Fin 1)) :
+    let A : Finset (Finset (Fin 1)) := {∅}
+    ((A.filter fun T ↦ S ⊆ T).card : ℝ) ≤
+      A.card * Real.rpow (1 : ℝ) (-(S.card : ℝ)) := by
+  intro A
+  classical
+  have hA : A.Nonempty := by simp [A]
+  have hspread : RSpread (R := 1) A :=
+    RSpread.one_of_nonempty (A := A) (hA := hA)
+  simpa [A] using
+    RSpread.card_filter_le (A := A) (h := hspread) (S := S)
+
 
 -- Further cover lemmas are not yet available in the migrated code.
 


### PR DESCRIPTION
## Summary
- add a small test in `CoverExtra` demonstrating `RSpread.card_filter_le`

## Testing
- `lake build Tests`

------
https://chatgpt.com/codex/tasks/task_e_687ee743b010832bac12ef7677c4b8d6