### PR TITLE
Fix linter warnings in ACCSat example

### DIFF
--- a/pnp/Pnp/AccMcspSat.lean
+++ b/pnp/Pnp/AccMcspSat.lean
@@ -92,8 +92,8 @@ lemma rightBits_mergeBits {k ℓ : ℕ} (xL : Fin k → Bool) (xR : Fin ℓ → 
   have hfin :
       (⟨((Fin.cast (Nat.add_comm ℓ k) (j.addNat k) : Fin (k + ℓ)) : ℕ) - k, hlt⟩ : Fin ℓ) = j := by
     ext; simp [hsub]
-  -- Evaluate the conditional using `hnot` and simplify via `hfin`.
-  simp [hnot, hfin]
+  -- Evaluate the conditional using the derived bounds.
+  simp
 
 
 /-- Schematic meet-in-the-middle SAT algorithm using a rectangular cover of the


### PR DESCRIPTION
## Summary
- update `rightBits_mergeBits` proof in `AccMcspSat.lean`
- remove unused simp arguments

## Testing
- `lake build`
- `lake test` (warnings about simp arguments remain but build succeeds)


------
https://chatgpt.com/codex/tasks/task_e_687ee743b010832bac12ef7677c4b8d6