### PR TITLE
Clarify sunflower status

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ gradually migrated across.
   `μ(F, h, Rset) = 2 * h + |uncovered F Rset|` remains future work.
   The helper lemma `AllOnesCovered.union` abstracts the union step in
   the coverage proof.
+The sunflower case is still only sketched in comments and the proof falls back to a numeric estimate.
 * `bound.lean` – arithmetic bounds deriving the subexponential size estimate;
   the main inequality `mBound_lt_subexp` is currently stated as an axiom in the
   `Pnp2` namespace.  A complete proof will be added shortly.


### PR DESCRIPTION
## Summary
- update README: note that the sunflower branch of `buildCover_card_bound` is only sketched

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687eeecb03d8832ba31b83a77a265337