### PR TITLE
Add SAT cover search

### DIFF
--- a/Pnp2.lean
+++ b/Pnp2.lean
@@ -2,6 +2,7 @@ import Pnp2.BoolFunc.Sensitivity
 import Pnp2.DecisionTree
 import Pnp2.low_sensitivity_cover
 import Pnp2.cover
+import Pnp2.sat_cover
 
 /-!
   Entrypoint for the `pnp2` toy development.

--- a/Pnp2/Boolcube.lean
+++ b/Pnp2/Boolcube.lean
@@ -75,7 +75,7 @@ namespace Subcube
     · simp [Subcube.fixOne, hj]
   -- Hence the cardinality of the support is one.
   have hcard : ((Subcube.fixOne (n := n) i b).support).card = 1 := by
-    simpa [hsup]
+    simpa [hsup] using (Finset.card_singleton i)
   -- The dimension subtracts this cardinality from `n`.
   simpa [Subcube.dim, hcard]
 
@@ -111,7 +111,9 @@ lemma monotonicity {C D : Subcube n}
   have hfin : toFinset (n := n) (Subcube.full : Subcube n) = Finset.univ := by
     ext x; simp [toFinset]
   -- Hence the cardinality equals the size of the entire cube.
-  simp [size, hfin]
+  have hcard : (Finset.univ : Finset (Point n)).card = 2 ^ n := by
+    simpa using (Fintype.card_fun (α := Fin n) (β := fun _ => Bool))
+  simpa [size, hfin] using hcard
 
 /-!  A single-point subcube has size `1`. -/
 @[simp] lemma size_point (x : Point n) :
@@ -119,11 +121,7 @@ lemma monotonicity {C D : Subcube n}
   classical
   -- Only the point `x` satisfies the membership predicate.
   have hfin : toFinset (n := n) (Subcube.point (n := n) x) = {x} := by
-    ext y; constructor <;> intro hy
-    · have := (mem_toFinset (C := Subcube.point (n := n) x) (x := y)).1 hy
-      simpa [Subcube.point] using this
-    · have hy' : y = x := by simpa using hy
-      simpa [hy', Subcube.point] using Finset.mem_singleton.mpr rfl
+    ext y; simp [toFinset, Subcube.mem_point_iff]
   simp [size, hfin]
 
 

--- a/Pnp2/sat_cover.lean
+++ b/Pnp2/sat_cover.lean
@@ -1,0 +1,63 @@
+import Pnp2.BoolFunc
+import Pnp2.cover
+import Pnp2.canonical_circuit
+
+open Classical
+open BoolFunc
+open Cover
+
+namespace SATCover
+
+/-- Choose a canonical point inside a subcube by assigning `false` to all
+free coordinates. -/
+noncomputable def Subcube.somePoint {n : ℕ} (R : Subcube n) : Point n :=
+  fun i => by
+    classical
+    by_cases h : i ∈ R.idx
+    · exact R.val i h
+    · exact false
+
+lemma somePoint_mem {n : ℕ} (R : Subcube n) : R.mem (Subcube.somePoint R) := by
+  classical
+  intro i hi
+  dsimp [Subcube.somePoint]
+  simp [hi]
+
+/-- Enumerate all rectangles in `cover` and evaluate `Φ` on a witness
+point from each rectangle.  The algorithm succeeds if any evaluation
+returns `true`. -/
+noncomputable def satByCover {n : ℕ}
+    (Φ : Circuit n) (cover : Finset (Subcube n)) : Bool :=
+  decide (∃ R ∈ cover, Circuit.eval Φ (Subcube.somePoint R) = true)
+
+lemma satByCover_true_of_sat {n : ℕ} {Φ : Circuit n} {cover : Finset (Subcube n)}
+    (hmono : ∀ R ∈ cover, Subcube.monochromaticFor R (Circuit.eval Φ))
+    (hcov : ∀ x, Circuit.eval Φ x = true → ∃ R ∈ cover, x ∈ₛ R) :
+    (∃ x, Circuit.eval Φ x = true) → satByCover Φ cover = true := by
+  classical
+  intro hx
+  rcases hx with ⟨x, hx⟩
+  rcases hcov x hx with ⟨R, hR, hxR⟩
+  rcases hmono R hR with ⟨b, hb⟩
+  have hxcol : Circuit.eval Φ x = b := hb hxR
+  have hbtrue : b = true := by
+    calc
+      b = Circuit.eval Φ x := by simpa using hxcol.symm
+      _ = true := hx
+  have hpoint : Circuit.eval Φ (Subcube.somePoint R) = b := hb (somePoint_mem R)
+  have hpoint_true : Circuit.eval Φ (Subcube.somePoint R) = true := by simpa [hbtrue] using hpoint
+  have hExists : ∃ R ∈ cover, Circuit.eval Φ (Subcube.somePoint R) = true :=
+    ⟨R, hR, hpoint_true⟩
+  simpa [satByCover, hExists]
+
+lemma satByCover_complete {n : ℕ} {Φ : Circuit n} {cover : Finset (Subcube n)} :
+    satByCover Φ cover = true → ∃ x, Circuit.eval Φ x = true := by
+  classical
+  intro h
+  dsimp [satByCover] at h
+  have hExists : ∃ R ∈ cover, Circuit.eval Φ (Subcube.somePoint R) = true :=
+    of_decide_eq_true h
+  rcases hExists with ⟨R, _, hval⟩
+  exact ⟨Subcube.somePoint R, hval⟩
+
+end SATCover


### PR DESCRIPTION
## Summary
- implement `sat_cover` module with a simple cover-based SAT algorithm
- expose the algorithm through `Pnp2.lean`
- fix cardinality proofs in `Boolcube` needed by the build

## Testing
- `bash scripts/check.sh` *(fails: build error in Pnp2.Boolcube)*

------
https://chatgpt.com/codex/tasks/task_e_687f1db7afcc832bbfbadf5d865a9901