### PR TITLE
Implement SAT search using rectangle cover

### DIFF
--- a/Pnp2/Boolcube.lean
+++ b/Pnp2/Boolcube.lean
@@ -113,6 +113,21 @@ lemma monotonicity {C D : Subcube n}
   -- Hence the cardinality equals the size of the entire cube.
   simp [size, hfin]
 
+/-! ### Picking a representative point from a subcube -/
+
+/-
+`sample` assigns the fixed coordinates of a subcube and fills all
+remaining bits with `false`.  This deterministic choice is handy for
+searching a cover: evaluating a Boolean function on `sample C` reveals
+the constant colour of `C` when `C` is known to be monochromatic. -/
+def sample (C : Subcube n) : Point n :=
+  fun i => (C.fix i).getD false
+
+@[simp] lemma sample_mem (C : Subcube n) : C.Mem (sample C) := by
+  intro i
+  cases h : C.fix i <;> simp [sample, h]
+
+
 /-!  A single-point subcube has size `1`. -/
 @[simp] lemma size_point (x : Point n) :
     size (n := n) (Subcube.point (n := n) x) = 1 := by

--- a/Pnp2/acc_mcsp_sat.lean
+++ b/Pnp2/acc_mcsp_sat.lean
@@ -120,6 +120,34 @@ lemma mergeBits_left_right {k ℓ : ℕ} (x : Fin (k + ℓ) → Bool) :
     simp [h, hcast, hle]
 
 
+/-! ## SAT search via rectangle covers
+
+`satSearchList` iterates over a list of subcubes and evaluates a Boolean
+function on the canonical `sample` point of each cube.  If any evaluation
+returns `true`, that witness is returned.  The wrapper `satSearch` applies
+this procedure to a `Finset` of rectangles.  When the rectangles form a
+monochromatic cover, this realises the shortened brute‑force SAT search
+from the project overview. -/
+
+open Boolcube
+
+def satSearchList {n : ℕ} (f : BoolFun n) :
+    List (Subcube n) → Option (Point n)
+  | [] => none
+  | R :: Rs =>
+      if f (Subcube.sample R) then
+        some (Subcube.sample R)
+      else
+        satSearchList Rs
+
+/-- Search for a satisfying assignment using a rectangular cover.  The
+    cubes are examined in an arbitrary order until a `true` evaluation is
+    found.  Returns `none` if no sampled point satisfies `f`. -/
+def satSearch {n : ℕ} (f : BoolFun n) (cover : Finset (Subcube n)) :
+    Option (Point n) :=
+  satSearchList f cover.toList
+
+
 
 /-- Schematic definition of the meet‑in‑the‑middle SAT algorithm using
     a rectangular cover of the MCSP truth tables.  The algorithm loops


### PR DESCRIPTION
## Summary
- add a helper `Subcube.sample` to choose a deterministic point from a subcube
- provide `satSearchList` and `satSearch` utilities to scan rectangle covers
- these functions outline how to find a satisfying assignment from a cover

## Testing
- `lake build`
- `lake env lean --run scripts/smoke.lean`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_687f1db7afcc832bbfbadf5d865a9901