### PR TITLE
Add subcube representative and cover list

### DIFF
--- a/Pnp2/Boolcube.lean
+++ b/Pnp2/Boolcube.lean
@@ -124,6 +124,23 @@ lemma monotonicity {C D : Subcube n}
     ext y; simp [toFinset, Subcube.mem_point_iff]
   simp [size, hfin]
 
+/-! ### A representative point of a subcube -/
+
+-- |`Subcube.rep R`| picks an arbitrary point inside `R` by assigning
+-- `false` to all free coordinates.  This choice is convenient for
+-- constructive algorithms that need a concrete witness from each
+-- subcube.
+@[simp] def Subcube.rep (R : Subcube n) : Point n :=
+  fun i => (R.fix i).getD false
+
+lemma Subcube.rep_mem (R : Subcube n) : R.Mem (Subcube.rep (n := n) R) := by
+  intro i
+  cases h : R.fix i with
+  | none =>
+      simp [Subcube.rep, Mem, h]
+  | some b =>
+      simp [Subcube.rep, Mem, h]
+
 
 end Subcube
 

--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -1,0 +1,58 @@
+import Pnp2.cover
+
+namespace Cover
+
+open BoolFunc
+
+variable {n : ℕ}
+
+/-!
+`buildCoverCompute` is a convenience wrapper around `Cover.buildCover`
+that returns the resulting rectangles as a `List`.  The underlying
+construction is identical to `buildCover`, so all previously proved
+properties carry over to the list representation.
+-/
+noncomputable
+partial def buildCoverCompute (F : Family n) (h : ℕ)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=
+  (buildCover (F := F) (h := h) hH).toList
+
+/-- Specification of `buildCoverCompute`.  The list of rectangles covers
+all `1`-inputs of every function in `F`, each rectangle is jointly
+monochromatic, and the length of the list is bounded by `mBound`. -/
+lemma buildCoverCompute_spec (F : Family n) (h : ℕ)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (∀ f ∈ F, ∀ x, f x = true →
+        ∃ R ∈ (buildCoverCompute (F := F) (h := h) hH).toFinset, x ∈ₛ R) ∧
+    (∀ R ∈ (buildCoverCompute (F := F) (h := h) hH).toFinset,
+        Subcube.monochromaticForFamily R F) ∧
+    (buildCoverCompute (F := F) (h := h) hH).length ≤ mBound n h := by
+  classical
+  have hcov := buildCover_covers (F := F) (h := h) hH
+  have hmono := buildCover_mono (F := F) (h := h) (hH := hH)
+  have hcard := buildCover_card_bound (F := F) (h := h) (hH := hH)
+  have hset :
+      (buildCoverCompute (F := F) (h := h) hH).toFinset =
+        buildCover (F := F) (h := h) hH := by
+    simpa [buildCoverCompute] using
+      (Finset.toList_toFinset (buildCover (F := F) (h := h) hH))
+  have hlen :
+      (buildCoverCompute (F := F) (h := h) hH).length =
+        (buildCover (F := F) (h := h) hH).card := by
+    simpa [buildCoverCompute] using
+      (Finset.length_toList (buildCover (F := F) (h := h) hH))
+  constructor
+  · intro f hf x hx
+    have := hcov f hf x hx
+    rcases this with ⟨R, hR, hxR⟩
+    refine ⟨R, ?_, hxR⟩
+    simpa [hset] using hR
+  constructor
+  · intro R hR
+    have hR' : R ∈ buildCover (F := F) (h := h) hH := by
+      simpa [hset] using hR
+    exact hmono R hR'
+  · have := hcard
+    simpa [hlen] using this
+
+end Cover


### PR DESCRIPTION
## Summary
- implement `Subcube.rep` to pick a canonical point inside a subcube
- expose `buildCoverCompute` that returns the cover as a list
- prove a specification lemma for `buildCoverCompute`

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687f7fb24fc0832ba1579f63780da9e9