### PR TITLE
Add lemmas for constant functions

### DIFF
--- a/Pnp2/BoolFunc/Sensitivity.lean
+++ b/Pnp2/BoolFunc/Sensitivity.lean
@@ -141,6 +141,17 @@ lemma exists_family_sensitive_coord (F : Family n) [Fintype (Point n)]
   rcases exists_sensitive_coord (f := f) hpos with ⟨i, x, hx⟩
   exact ⟨i, f, hfF, x, hx⟩
 
+@[simp] lemma sensitivity_const (n : ℕ) (b : Bool) [Fintype (Point n)] :
+    sensitivity (fun _ : Point n => b) = 0 := by
+  classical
+  have hxle : (Finset.univ.sup fun x : Point n => sensitivityAt (fun _ : Point n => b) x) ≤ 0 := by
+    refine Finset.sup_le ?_; intro x hx
+    simp [sensitivityAt]
+  have hxge : 0 ≤ (Finset.univ.sup fun x : Point n => sensitivityAt (fun _ : Point n => b) x) := by
+    exact Nat.zero_le _
+  have hx : (Finset.univ.sup fun x : Point n => sensitivityAt (fun _ : Point n => b) x) = 0 := le_antisymm hxle hxge
+  simpa [sensitivity] using hx
+
 
 end BoolFunc
 

--- a/Pnp2/BoolFunc/Support.lean
+++ b/Pnp2/BoolFunc/Support.lean
@@ -35,10 +35,24 @@ lemma exists_true_on_support {f : BFunc n} (h : support f ≠ ∅) :
   by_cases hfx : f x = true
   · exact ⟨x, hfx⟩
   · have hxne : f (Point.update x i (!x i)) ≠ f x := by simpa using hx.symm
-    cases hupdate : f (Point.update x i (!x i))
-    · have : False := by
-        simp [hfx, hupdate] at hx
-      contradiction
-    · exact ⟨Point.update x i (!x i), by simp [hupdate]⟩
+    cases hupdate : f (Point.update x i (!x i)) with
+    | false =>
+        have : False := by
+          simp [hfx, hupdate] at hxne
+        contradiction
+    | true =>
+        exact ⟨Point.update x i (!x i), by simp [hupdate]⟩
+
+@[simp] lemma support_const_false (n : ℕ) :
+    support (fun _ : Point n => false) = (∅ : Finset (Fin n)) := by
+  classical
+  ext i
+  simp [support]
+
+@[simp] lemma support_const_true (n : ℕ) :
+    support (fun _ : Point n => true) = (∅ : Finset (Fin n)) := by
+  classical
+  ext i
+  simp [support]
 
 end BoolFunc

--- a/test/Pnp2Tests.lean
+++ b/test/Pnp2Tests.lean
@@ -21,6 +21,15 @@ example (n : ℕ) :
   ext i
   simp [support]
 
+/-- Constant functions have zero sensitivity. -/
+example (n : ℕ) [Fintype (Point n)] :
+    BoolFunc.sensitivity (fun _ : Point n => false) = 0 := by
+  simp [BoolFunc.sensitivity_const]
+
+example (n : ℕ) [Fintype (Point n)] :
+    BoolFunc.sensitivity (fun _ : Point n => true) = 0 := by
+  simp [BoolFunc.sensitivity_const]
+
 
 /-- Modifying an irrelevant coordinate leaves the function unchanged. -/
 example (x : Point 2) (b : Bool) :


### PR DESCRIPTION
## Summary
- add support lemmas for constant functions
- prove constant functions have zero sensitivity
- use new lemmas in Pnp2 tests

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_687f7fc67568832b8e239985f6f7e579