### PR TITLE
Fix SatCover module for updated Boolcube

### DIFF
--- a/Pnp2.lean
+++ b/Pnp2.lean
@@ -3,6 +3,7 @@ import Pnp2.DecisionTree
 import Pnp2.low_sensitivity_cover
 import Pnp2.cover
 import Pnp2.sat_cover
+import Pnp2.Algorithms.SatCover
 
 /-!
   Entrypoint for the `pnp2` toy development.

--- a/Pnp2/Algorithms/SatCover.lean
+++ b/Pnp2/Algorithms/SatCover.lean
@@ -1,0 +1,212 @@
+import Pnp2.Boolcube
+import Pnp2.Cover.Compute
+import Pnp2.cover
+import Pnp2.CollentropyBasic
+
+open Boolcube
+open Cover
+
+namespace Pnp2.Algorithms
+
+variable {n : ℕ}
+
+/--
+Helper: build the cover list for a single function `f` using the entropy
+bound `h`.  The singleton family `{f}` has collision entropy `0`, so the
+precondition for `buildCoverCompute` is trivially satisfied.
+-/
+noncomputable def buildCoverFor (f : BoolFun n) (h : ℕ) : List (Subcube n) := by
+  classical
+  have hH : BoolFunc.H₂ ({f} : Family n) ≤ (h : ℝ) := by
+    have hx : BoolFunc.H₂ ({f} : Family n) = 0 := by
+      simp [BoolFunc.H₂_card_one]
+    have hx' : (0 : ℝ) ≤ (h : ℝ) := by exact_mod_cast Nat.zero_le h
+    simpa [hx] using hx'
+  exact buildCoverCompute (F := ({f} : Family n)) (h := h) hH
+
+/--
+Evaluate `f` on the representative of each subcube in `l`, returning the first
+point where the function outputs `true`.
+-/
+def satFromList (f : BoolFun n) : List (Subcube n) → Option (Point n)
+  | [] => none
+  | R :: rs =>
+      let x := Subcube.rep (n := n) R
+      if f x then some x else satFromList rs
+  termination_by l => l.length
+  decreasing_by simp
+
+/--
+Main SAT solver: construct a cover for `{f}` and scan the rectangles for a
+satisfying assignment.  Returns `none` if `f` is constantly `false`.
+-/
+noncomputable def satViaCover (f : BoolFun n) (h : ℕ) : Option (Point n) :=
+  satFromList (f := f) (buildCoverFor (f := f) (h := h))
+
+/--
+If some rectangle in `l` evaluates to `true` on its representative, then
+`satFromList` returns such a witness.
+-/
+lemma satFromList_spec {f : BoolFun n} :
+    ∀ {l : List (Subcube n)},
+      (∃ R ∈ l, f (Subcube.rep (n := n) R) = true) →
+        ∃ x, satFromList (n := n) f l = some x ∧ f x = true := by
+  intro l
+  induction l with
+  | nil =>
+      intro h; rcases h with ⟨R, hR, _⟩; cases hR
+  | cons R rs ih =>
+      intro h
+      rcases h with ⟨S, hS, hval⟩
+      cases hS with
+      | head =>
+          subst S
+          dsimp [satFromList]
+          simp [hval]
+      | tail hSrs =>
+          dsimp [satFromList]
+          by_cases hx : f (Subcube.rep (n := n) R)
+          · simp [hx] at hval
+          · have h' : ∃ T ∈ rs, f (Subcube.rep (n := n) T) = true := ⟨S, hSrs, hval⟩
+            have := ih h'
+            rcases this with ⟨x, hxout, hxval⟩
+            simp [hx, hxout, hxval]
+
+/--
+If all representatives evaluate to `false`, `satFromList` returns `none`.
+-/
+lemma satFromList_none {f : BoolFun n} :
+    ∀ {l : List (Subcube n)},
+      (∀ R ∈ l, f (Subcube.rep (n := n) R) = false) →
+        satFromList (n := n) f l = none := by
+  intro l
+  induction l with
+  | nil =>
+      intro _; rfl
+  | cons R rs ih =>
+      intro h
+      have hR := h R (by simp)
+      have hrs := fun S hS => h S (by simp [hS])
+      dsimp [satFromList]
+      simp [hR, ih hrs]
+
+/--
+Correctness of `satViaCover`: if `f` has entropy at most `h`, the algorithm
+returns a witness exactly when one exists.  The witness indeed satisfies `f`.
+-/
+lemma satViaCover_correct (f : BoolFun n) (h : ℕ)
+    (hh : BoolFunc.H₂Fun (n := n) f ≤ h) :
+    (∃ x, satViaCover (n := n) f h = some x ∧ f x = true) ↔
+      ∃ x, f x = true := by
+  classical
+  -- Build the cover list once and recall its specification.
+  let Rlist := buildCoverFor (n := n) (f := f) (h := h)
+  have hspec := buildCoverCompute_spec
+      (F := ({f} : Family n)) (h := h) (by
+        have hx : BoolFunc.H₂ ({f} : Family n) = 0 := by
+          simp [BoolFunc.H₂_card_one]
+        have hx' : (0 : ℝ) ≤ (h : ℝ) := by exact_mod_cast Nat.zero_le h
+        simpa [hx] using hx')
+  constructor
+  · intro hres
+    rcases hres with ⟨x, hxout, hxval⟩
+    exact ⟨x, hxval⟩
+  · intro hx
+    rcases hx with ⟨x, hx⟩
+    -- Use the coverage part of the specification.
+    have hxcov := hspec.1 f (by simp) x hx
+    rcases hxcov with ⟨R, hR, hxR⟩
+    -- `R` occurs in the list and is monochromatic.
+    have hRlist : R ∈ Rlist := List.mem_toFinset.mp hR
+    have hmono := hspec.2.1 R hR
+    rcases hmono with ⟨b, hb⟩
+    have hxcol : f x = b := hb hxR
+    have hbtrue : b = true := by simpa [hx] using hxcol
+    -- Hence the representative also evaluates to `true`.
+    have hrep : f (Subcube.rep (n := n) R) = true := by
+      have := hb (Subcube.rep_mem (n := n) R)
+      simpa [hbtrue] using this
+    have hExists : ∃ S ∈ Rlist, f (Subcube.rep (n := n) S) = true :=
+      ⟨R, hRlist, hrep⟩
+    -- `satFromList` succeeds on this list.
+    have := satFromList_spec (f := f) (l := Rlist) hExists
+    rcases this with ⟨y, hyout, hyval⟩
+    exact ⟨y, by simpa [satViaCover, buildCoverFor] using hyout, hyval⟩
+
+/--
+If `satViaCover` returns `none`, the function is constantly `false`.
+-/
+lemma satViaCover_none (f : BoolFun n) (h : ℕ)
+    (hh : BoolFunc.H₂Fun (n := n) f ≤ h) :
+    satViaCover (n := n) f h = none ↔ ∀ x, f x = false := by
+  classical
+  let Rlist := buildCoverFor (n := n) (f := f) (h := h)
+  have hspec := buildCoverCompute_spec
+      (F := ({f} : Family n)) (h := h) (by
+        have hx : BoolFunc.H₂ ({f} : Family n) = 0 := by
+          simp [BoolFunc.H₂_card_one]
+        have hx' : (0 : ℝ) ≤ (h : ℝ) := by exact_mod_cast Nat.zero_le h
+        simpa [hx] using hx')
+  constructor
+  · intro hnone
+    -- `satFromList` returned none, hence every representative is false.
+    have hfalse : ∀ R ∈ Rlist, f (Subcube.rep (n := n) R) = false := by
+      -- Contraposition via `satFromList_spec`.
+      intro R hR
+      by_contra hpos
+      have hExists : ∃ S ∈ Rlist, f (Subcube.rep (n := n) S) = true := ⟨R, hR, by
+        simpa using hpos⟩
+      have := satFromList_spec (f := f) (l := Rlist) hExists
+      rcases this with ⟨x, hxout, hxval⟩
+      simpa [satViaCover, buildCoverFor, hnone] using hxout
+    -- Any input `x` lies in some rectangle; all are false.
+    intro x
+    have hxcov := hspec.1 f (by simp) x
+    by_cases hxval : f x = true
+    · have := hxcov hxval
+      rcases this with ⟨R, hR, hxR⟩
+      have := hfalse R (List.mem_toFinset.mp hR)
+      have := hspec.2.1 R hR
+      rcases this with ⟨b, hb⟩
+      have hxcol : f x = b := hb hxR
+      have hbfalse : b = false := by simpa [hxval] using hxcol
+      have hrep := hb (Subcube.rep_mem (n := n) R)
+      have hrepFalse : f (Subcube.rep (n := n) R) = false := by simpa [hbfalse] using hrep
+      simpa using hrepFalse
+    · simpa [hxval]
+  · intro hfalse
+    have : ∀ R ∈ Rlist, f (Subcube.rep (n := n) R) = false := by
+      intro R hR
+      have hx := hspec.2.1 R hR
+      rcases hx with ⟨b, hb⟩
+      have hrep := hb (Subcube.rep_mem (n := n) R)
+      have hbfalse : b = false := by
+        have hxpoint := hfalse (Subcube.rep (n := n) R)
+        have hxcol : f (Subcube.rep (n := n) R) = b := hrep
+        simpa [hxpoint] using hxcol.symm
+      simpa [hbfalse] using hrep
+    have := satFromList_none (f := f) (l := Rlist) this
+    simpa [satViaCover, buildCoverFor] using this
+
+/--
+`satViaCover_time` counts how many evaluations of `f` the algorithm performs.
+This equals the length of the constructed cover list.
+-/
+noncomputable def satViaCover_time (f : BoolFun n) (h : ℕ) : ℕ :=
+  (buildCoverFor (f := f) (h := h)).length
+
+lemma satViaCover_time_bound (f : BoolFun n) (h : ℕ)
+    (hh : BoolFunc.H₂Fun (n := n) f ≤ h) :
+    satViaCover_time (n := n) f h ≤ mBound n h := by
+  classical
+  have hH : BoolFunc.H₂ ({f} : Family n) ≤ (h : ℝ) := by
+    have hx : BoolFunc.H₂ ({f} : Family n) = 0 := by
+      simp [BoolFunc.H₂_card_one]
+    have hx' : (0 : ℝ) ≤ (h : ℝ) := by exact_mod_cast Nat.zero_le h
+    simpa [hx] using hx'
+  have hspec := buildCoverCompute_spec
+      (F := ({f} : Family n)) (h := h) hH
+  simpa [satViaCover_time, buildCoverFor, hH] using hspec.2.2
+
+end Pnp2.Algorithms
+

--- a/Pnp2/CollentropyBasic.lean
+++ b/Pnp2/CollentropyBasic.lean
@@ -1,0 +1,80 @@
+import Pnp2.BoolFunc
+import Mathlib.Analysis.SpecialFunctions.Log.Base
+
+open Classical
+open Real
+
+namespace BoolFunc
+
+variable {n : ℕ} [Fintype (Point n)]
+
+/-! ## Collision entropy
+A minimized version providing only what is needed for the SAT solver.
+-/
+
+/-- Collision probability of `f` under the uniform distribution. -/
+@[simp] noncomputable def collProbFun (f : BFunc n) : ℝ :=
+  let p := prob f
+  p * p + (1 - p) * (1 - p)
+
+/-- Collision entropy of a Boolean function in bits. -/
+@[simp] noncomputable def H₂Fun (f : BFunc n) : ℝ :=
+  -Real.logb 2 (collProbFun f)
+
+lemma collProbFun_eq_one_sub (f : BFunc n) :
+    collProbFun f = 1 - 2 * prob f * (1 - prob f) := by
+  classical
+  have : prob f * prob f + (1 - prob f) * (1 - prob f)
+      = 1 - 2 * prob f * (1 - prob f) := by ring
+  simpa [collProbFun] using this
+
+lemma prob_mul_le_quarter (f : BFunc n) :
+    prob f * (1 - prob f) ≤ (1 / 4 : ℝ) := by
+  classical
+  have hsq : 0 ≤ (prob f - 1 / 2 : ℝ) ^ 2 := by positivity
+  have hrepr : prob f * (1 - prob f) = 1 / 4 - (prob f - 1 / 2) ^ 2 := by ring
+  have hx : 1 / 4 - (prob f - 1 / 2) ^ 2 ≤ 1 / 4 := by exact sub_le_self _ hsq
+  simpa [hrepr] using hx
+
+lemma collProbFun_ge_half (f : BFunc n) :
+    (1 / 2 : ℝ) ≤ collProbFun f := by
+  classical
+  have h := prob_mul_le_quarter (f := f)
+  have hrepr := collProbFun_eq_one_sub (f := f)
+  have hx : 2 * prob f * (1 - prob f) ≤ 1 / 2 := by
+    have := mul_le_mul_of_nonneg_left h (by positivity : (0 : ℝ) ≤ 2)
+    simpa [mul_comm, mul_left_comm, mul_assoc] using this
+  have := sub_le_sub_left hx 1
+  simpa [hrepr] using this
+
+lemma collProbFun_le_one (f : BFunc n) :
+    collProbFun f ≤ 1 := by
+  classical
+  have hnonneg : 0 ≤ prob f * (1 - prob f) := by
+    have hp0 := prob_nonneg (f := f)
+    have hp1 := sub_nonneg.mpr (prob_le_one (f := f))
+    exact mul_nonneg hp0 hp1
+  have hrepr := collProbFun_eq_one_sub (f := f)
+  have hx : 1 - 2 * prob f * (1 - prob f) ≤ 1 := by
+    have hx' : -(2 * prob f * (1 - prob f)) ≤ 0 := by
+      have hx'' : (0 : ℝ) ≤ 2 * prob f * (1 - prob f) := by positivity
+      simpa using neg_nonpos.mpr hx''
+    have := add_le_add_left hx' 1
+    simpa [sub_eq_add_neg, add_comm, add_left_comm, add_assoc] using this
+  simpa [hrepr] using hx
+
+lemma H₂Fun_le_one (f : BFunc n) :
+    H₂Fun f ≤ 1 := by
+  classical
+  have hge := collProbFun_ge_half (f := f)
+  have hpos : 0 < collProbFun f :=
+    (lt_of_le_of_lt hge (by norm_num : (1 / 2 : ℝ) < 2))
+  have hlog := Real.logb_le_logb_of_le (b := 2) (by norm_num) hpos hge
+  have hneg := neg_le_neg hlog
+  have hhalf : (-Real.logb 2 (1 / 2 : ℝ)) = (1 : ℝ) := by
+    simp [Real.logb_inv]
+  have h1 : (-Real.logb 2 (collProbFun f)) ≤ (-Real.logb 2 (1 / 2 : ℝ)) := by simpa using hneg
+  simpa [H₂Fun, hhalf] using h1
+
+end BoolFunc
+

--- a/Pnp2/sat_cover.lean
+++ b/Pnp2/sat_cover.lean
@@ -1,27 +1,26 @@
-import Pnp2.BoolFunc
+import Pnp2.Boolcube
 import Pnp2.cover
 import Pnp2.canonical_circuit
 
 open Classical
-open BoolFunc
+open Boolcube
 open Cover
+
+variable {n : ℕ}
+
+notation x " ∈ₛ " R => R.Mem x
+
+def Boolcube.Subcube.monochromaticFor (R : Subcube n) (f : BoolFun n) : Prop :=
+  ∃ b : Bool, ∀ x, x ∈ₛ R → f x = b
 
 namespace SATCover
 
 /-- Choose a canonical point inside a subcube by assigning `false` to all
-free coordinates. -/
-noncomputable def Subcube.somePoint {n : ℕ} (R : Subcube n) : Point n :=
-  fun i => by
-    classical
-    by_cases h : i ∈ R.idx
-    · exact R.val i h
-    · exact false
+free coordinates.  This is the same as `Subcube.sample`. -/
+def Subcube.somePoint {n : ℕ} (R : Subcube n) : Point n := Subcube.sample R
 
-lemma somePoint_mem {n : ℕ} (R : Subcube n) : R.mem (Subcube.somePoint R) := by
-  classical
-  intro i hi
-  dsimp [Subcube.somePoint]
-  simp [hi]
+lemma somePoint_mem {n : ℕ} (R : Subcube n) : R.Mem (Subcube.somePoint R) := by
+  simpa [Subcube.somePoint] using Subcube.sample_mem (n := n) R
 
 /-- Enumerate all rectangles in `cover` and evaluate `Φ` on a witness
 point from each rectangle.  The algorithm succeeds if any evaluation

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -23,5 +23,5 @@ lean_exe tests where
 @[test_driver]
 lean_lib Tests where
 
-  globs := #[`Basic, `CoverExtra, `Migrated, `Pnp2Tests]
+  globs := #[`Basic, `CoverExtra, `Migrated, `Pnp2Tests, `SatCoverTest]
   srcDir := "test"

--- a/test/SatCoverTest.lean
+++ b/test/SatCoverTest.lean
@@ -1,0 +1,45 @@
+import Pnp2.Algorithms.SatCover
+
+open Pnp2.Algorithms
+open Boolcube
+
+namespace SatCoverTest
+
+/-- Simple 3-bit OR function. -/
+def or3 : BoolFun 3 := fun x => x 0 || x 1 || x 2
+
+/-- Simple 3-bit AND function. -/
+def and3 : BoolFun 3 := fun x => x 0 && x 1 && x 2
+
+/-- Constantly false function. -/
+def const0 : BoolFun 3 := fun _ => false
+
+/-- `satViaCover` finds a witness for `or3`. -/
+example : ∃ x, satViaCover (n := 3) or3 1 = some x ∧ or3 x = true := by
+  classical
+  have hx : ∃ x, or3 x = true := by
+    refine ⟨fun _ => true, ?_⟩
+    simp [or3]
+  have hcorrect := (satViaCover_correct (f := or3) (h := 1)
+    (hh := BoolFunc.H₂Fun_le_one (f := or3))).mpr hx
+  exact hcorrect
+
+/-- `satViaCover` finds a witness for `and3`. -/
+example : ∃ x, satViaCover (n := 3) and3 1 = some x ∧ and3 x = true := by
+  classical
+  have hx : ∃ x, and3 x = true := by
+    refine ⟨fun _ => true, ?_⟩
+    simp [and3]
+  have hcorrect := (satViaCover_correct (f := and3) (h := 1)
+    (hh := BoolFunc.H₂Fun_le_one (f := and3))).mpr hx
+  exact hcorrect
+
+/-- The constantly false function yields `none`. -/
+example : satViaCover (n := 3) const0 1 = none := by
+  classical
+  have hnone := (satViaCover_none (f := const0) (h := 1)
+    (hh := BoolFunc.H₂Fun_le_one (f := const0))).mpr (by intro x; simp [const0])
+  simpa using hnone
+
+end SatCoverTest
+


### PR DESCRIPTION
## Summary
- adjust legacy `sat_cover` to import `Boolcube` and use its `Subcube` definitions
- define `monochromaticFor` and canonical sample-based representative for subcubes

## Testing
- `lake build`
- `lake exe tests` *(failed to finish: build interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687f8679824c832bbf51b1ab79b63406