### PR TITLE
Prove buildCover_mu lemma

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -1815,9 +1815,8 @@ resulting cover collapses to `2 * h`.
 lemma buildCover_mu (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     mu F h (buildCover F h hH) = 2 * h := by
   classical
-  -- Placeholder: the proof relies on the detailed behaviour of `mu`.
-  -- It is admitted for now to keep the file compiling.
-  sorry
+  have hcov := buildCover_covers (F := F) (h := h) (hH := hH)
+  simpa using mu_of_allCovered (F := F) (Rset := buildCover F h hH) (h := h) hcov
 
 /--
 `buildCover_mono` states that every subcube produced by `buildCover` is


### PR DESCRIPTION
## Summary
- prove `buildCover_mu` using the existing coverage lemma

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68801e3ae6bc832ba894dd880bdce647