### PR TITLE
Partial sorry reduction

### DIFF
--- a/Pnp2/Boolcube.lean
+++ b/Pnp2/Boolcube.lean
@@ -99,8 +99,7 @@ lemma monotonicity {C D : Subcube n}
 @[simp] lemma size_full (n : ℕ) :
     size (n := n) (Subcube.full : Subcube n) = 2 ^ n := by
   classical
-  -- Placeholder proof; direct enumeration is straightforward.
-  sorry
+  simp [size, toFinset]
 
 /-! ### Picking a representative point from a subcube -/
 


### PR DESCRIPTION
## Summary
- prove `size_full` in `Boolcube`

## Testing
- `lake build Pnp2.Boolcube`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68803448458c832b982471845a85f4b3