### PR TITLE
Add simple mBound positivity test

### DIFF
--- a/test/CoverComputeTest.lean
+++ b/test/CoverComputeTest.lean
@@ -10,6 +10,11 @@ namespace CoverComputeTest
 example : mBound 1 0 = 2 := by
   simp [mBound]
 
+/-- `mBound` is positive whenever `n > 0`. -/
+example : 0 < mBound 1 0 := by
+  have : 0 < (1 : ℕ) := by decide
+  simpa [mBound] using mBound_pos (n := 1) (h := 0) this
+
 /-- `buildCoverCompute` returns the empty list for a trivial function. -/
 def trivialFun : BoolFun 1 := fun _ => false
 


### PR DESCRIPTION
## Summary
- extend `CoverComputeTest` to assert `mBound` is positive when `n > 0`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6881607ea3e4832b86ec0b426f5a7403