### PR TITLE
Add simple bound lemma for mBound

### DIFF
--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -19,6 +19,23 @@ lemma mBound_pos (n h : ℕ) (hn : 0 < n) : 0 < mBound n h := by
     exact Nat.mul_pos hn hpos
   exact Nat.mul_pos hmul1 hpow
 
+/-!  `mBound` is at least `2` whenever the dimension `n` is positive.  This
+simple numeric bound mirrors the analogous lemma in the full cover
+development and is occasionally convenient for toy proofs. -/
+lemma two_le_mBound (n h : ℕ) (hn : 0 < n) : 2 ≤ mBound n h := by
+  have hn1 : 1 ≤ n := Nat.succ_le_of_lt hn
+  have hh2 : 2 ≤ h + 2 := by
+    have := Nat.zero_le h
+    exact Nat.succ_le_succ (Nat.succ_le_succ this)
+  have hfactor : 2 ≤ n * (h + 2) := by
+    have := Nat.mul_le_mul hn1 hh2
+    simpa [one_mul] using this
+  have hpow : 1 ≤ 2 ^ (10 * h) := by
+    have hpos : 0 < 2 ^ (10 * h) := pow_pos (by decide) _
+    exact Nat.succ_le_of_lt hpos
+  have := Nat.mul_le_mul hfactor hpow
+  simpa [mBound, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using this
+
 namespace Cover
 
 open BoolFunc


### PR DESCRIPTION
### **User description**
## Summary
- add `two_le_mBound` lemma in `Cover/Compute.lean`
- provide a short numeric proof that `mBound` is at least 2 when dimension is positive

## Testing
- `lake build`
- `lake exe tests`


------
https://chatgpt.com/codex/tasks/task_e_6881707a065c832b98de8ae6f26e39c0


___

### **PR Type**
Enhancement


___

### **Description**
- Add `two_le_mBound` lemma proving mBound ≥ 2

- Provide numeric bound for positive dimension cases

- Include documentation explaining lemma purpose and usage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mBound function"] --> B["two_le_mBound lemma"]
  B --> C["Proves mBound ≥ 2"]
  C --> D["When dimension n > 0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Add numeric bound lemma for mBound</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Add <code>two_le_mBound</code> lemma with proof that <code>mBound n h ≥ 2</code> when <code>n > 0</code><br> <li> Include detailed documentation explaining the lemma's purpose<br> <li> Use step-by-step proof approach with intermediate bounds</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/578/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

