### PR TITLE
Fix SatCover time lemma duplication

### DIFF
--- a/Pnp2/Algorithms/SatCover.lean
+++ b/Pnp2/Algorithms/SatCover.lean
@@ -69,20 +69,13 @@ lemma satViaCover_time_le_pow (f : BoolFun n) (h : ℕ) :
   classical
   unfold satViaCover_time
   have hle := Finset.card_filter_le (s := Finset.univ)
-                  (p := fun x : Point n => f x = true)
+      (p := fun x : Point n => f x = true)
   have hcard : (Finset.univ : Finset (Point n)).card = 2 ^ n := by
-    classical
     simpa using (Fintype.card_fun (Fin n) Bool)
   simpa [hcard] using hle
 
 lemma satViaCover_time_bound (f : BoolFun n) (h : ℕ) :
-    satViaCover_time (n:=n) f h ≤ 2 ^ n := by
-  classical
-  have hle := Finset.card_filter_le (s := Finset.univ)
-    (p := fun x : Point n => f x = true)
-  have huniv : (Finset.univ : Finset (Point n)).card = 2 ^ n := by
-    classical
-    simpa [Point] using (Finset.card_univ : (Finset.univ : Finset (Point n)).card = Fintype.card (Point n))
-  simpa [satViaCover_time, huniv] using hle
+    satViaCover_time (n:=n) f h ≤ 2 ^ n :=
+  satViaCover_time_le_pow (f := f) (h := h)
 
 end Pnp2.Algorithms


### PR DESCRIPTION
### **User description**
## Summary
- remove redundant proof in `satViaCover_time_bound`
- reuse `satViaCover_time_le_pow` for a shorter lemma

## Testing
- `lake build`
- `lake env lean --run scripts/smoke.lean`


------
https://chatgpt.com/codex/tasks/task_e_68817f540d1c832b93e2866429f7bd66


___

### **PR Type**
Other


___

### **Description**
- Remove redundant proof in `satViaCover_time_bound`

- Reuse existing `satViaCover_time_le_pow` lemma

- Minor formatting improvements to indentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["satViaCover_time_bound"] -- "reuses" --> B["satViaCover_time_le_pow"]
  B --> C["2^n bound proof"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SatCover.lean</strong><dd><code>Deduplicate time bound lemma proof</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Algorithms/SatCover.lean

<ul><li>Removed duplicate proof logic from <code>satViaCover_time_bound</code><br> <li> Changed lemma to directly call <code>satViaCover_time_le_pow</code><br> <li> Fixed indentation in <code>satViaCover_time_le_pow</code><br> <li> Removed redundant <code>classical</code> declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/580/files#diff-0787c19ee93b91a5a758115e134a58975939f1e7a4305db8963438f0482cf70c">+3/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

