### PR TITLE
Update buildCoverCompute documentation

### DIFF
--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -44,8 +44,10 @@ variable {n : ℕ}
 
 /--
 `buildCoverCompute` is a constructive cover enumerator used by the SAT
-procedure.  The current implementation is a placeholder that returns an
-empty list; the full algorithm will mirror `Cover.buildCover`.
+procedure.  The current implementation is a placeholder that simply
+returns the empty list.  The full algorithm will eventually mirror
+`Cover.buildCover` once all intermediate steps become effective.
+-  TODO: replace this stub with the real recursive procedure.
 -/
 def buildCoverCompute (F : Family n) (h : ℕ)
     (hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=


### PR DESCRIPTION
### **User description**
## Summary
- document that `buildCoverCompute` is a stub returning `[]`

## Testing
- `lake build` *(fails: build timed out before completing)*

------
https://chatgpt.com/codex/tasks/task_e_68817f540d1c832b93e2866429f7bd66


___

### **PR Type**
Documentation


___

### **Description**
- Clarify `buildCoverCompute` function documentation

- Add TODO comment for future implementation


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Clarify buildCoverCompute stub documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Enhanced function documentation to clarify it's a placeholder<br> <li> Added TODO comment for future implementation<br> <li> Improved wording about eventual algorithm mirroring</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/581/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

