### PR TITLE
Add trivial mBound zero lemma

### DIFF
--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -19,6 +19,10 @@ lemma mBound_pos (n h : ℕ) (hn : 0 < n) : 0 < mBound n h := by
     exact Nat.mul_pos hn hpos
   exact Nat.mul_pos hmul1 hpow
 
+/-- `mBound` vanishes when there are no variables. -/
+@[simp] lemma mBound_zero (h : ℕ) : mBound 0 h = 0 := by
+  simp [mBound]
+
 /-!  `mBound` is at least `2` whenever the dimension `n` is positive.  This
 simple numeric bound mirrors the analogous lemma in the full cover
 development and is occasionally convenient for toy proofs. -/


### PR DESCRIPTION
### **User description**
## Summary
- define `mBound_zero` lemma in `Cover/Compute.lean`

## Testing
- `lake build`
- `./scripts/check.sh`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68817f540d1c832b93e2866429f7bd66


___

### **PR Type**
Enhancement


___

### **Description**
- Add `mBound_zero` lemma for zero variables case

- Provides simplification rule for `mBound 0 h = 0`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mBound function"] --> B["Add mBound_zero lemma"]
  B --> C["Simplifies mBound 0 h = 0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Add mBound_zero simplification lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Add <code>mBound_zero</code> lemma with <code>@[simp]</code> attribute<br> <li> Proves that <code>mBound 0 h = 0</code> for any <code>h</code><br> <li> Includes documentation comment explaining the lemma purpose</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/582/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

