### PR TITLE
Integrate sunflower step and add entropy filter axiom

### DIFF
--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -574,7 +574,7 @@ partial def buildCover (F : Family n) (h : ℕ)
                 (BoolFunc.H₂_filter_le (F := F)
                     (P := fun g => ¬ ∀ x, x ∈ₛ R → g x = true))
             exact
-              buildCover F_reduced h (by simpa using hH_reduced)
+              buildCover F_reduced h hH_reduced
                 (insert R Rset)
           ·
             exact fallback

--- a/Pnp2/cover.lean
+++ b/Pnp2/cover.lean
@@ -570,9 +570,8 @@ partial def buildCover (F : Family n) (h : ℕ)
             let F_reduced := F.filter fun g => ¬ ∀ x, x ∈ₛ R → g x = true
             have hH_reduced : BoolFunc.H₂ F_reduced ≤ (h : ℝ) := by
               -- Filtering a family cannot increase collision entropy.
-              simpa [F_reduced] using
-                (BoolFunc.H₂_filter_le (F := F)
-                    (P := fun g => ¬ ∀ x, x ∈ₛ R → g x = true))
+              exact le_trans (BoolFunc.H₂_filter_le (F := F)
+                  (P := fun g => ¬ ∀ x, x ∈ₛ R → g x = true)) hH
             exact
               buildCover F_reduced h hH_reduced
                 (insert R Rset)

--- a/Pnp2/entropy.lean
+++ b/Pnp2/entropy.lean
@@ -147,5 +147,14 @@ axiom exists_coord_entropy_drop {n : ℕ} (F : Family n)
     ∃ i : Fin n, ∃ b : Bool,
       H₂ (F.restrict i b) ≤ H₂ F - 1
 
+/--
+Filtering a family cannot increase collision entropy.  We keep this
+statement as an axiom for now so that cover constructions may remove
+functions while staying within the entropy budget.
+-/
+axiom H₂_filter_le {n : ℕ} (F : Family n)
+    (P : BFunc n → Prop) [DecidablePred P] :
+    H₂ (F.filter P) ≤ H₂ F
+
 
 end BoolFunc


### PR DESCRIPTION
### **User description**
## Summary
- adjust `buildCover` to use `sunflower_step` without a reduced family axiom
- introduce new entropy axiom `H₂_filter_le` to bound collision entropy after filtering
- ensure recursion continues with unchanged entropy budget using the new axiom

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68819698fe08832b9acaa97e2a6cfbe9


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor `buildCover` to use `sunflower_step` without reduced family axiom

- Add new entropy filter axiom `H₂_filter_le` for collision entropy bounds

- Maintain entropy budget during function filtering operations

- Replace axiom dependency with direct filtering approach


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sunflower_step"] --> B["filter functions"]
  B --> C["maintain entropy budget"]
  C --> D["continue buildCover recursion"]
  E["H₂_filter_le axiom"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover.lean</strong><dd><code>Refactor sunflower step integration in buildCover</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover.lean

<ul><li>Remove <code>F_reduced</code> parameter from <code>sunflower_step</code> result destructuring<br> <li> Replace axiom-based reduced family with direct filtering of functions<br> <li> Add entropy bound proof using new <code>H₂_filter_le</code> axiom<br> <li> Maintain unchanged entropy budget during recursion</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/587/files#diff-9a24ab7b9cfe4b0d4990c1f89c6b0386965199ee0307066e98b5ccc7b980d446">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>entropy.lean</strong><dd><code>Add entropy filter axiom</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/entropy.lean

<ul><li>Add new axiom <code>H₂_filter_le</code> for collision entropy filtering bounds<br> <li> Provide documentation explaining axiom purpose for cover constructions</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/587/files#diff-c9945293d072d5db339314094c1055ce9e959671dc64f147c5509da4830de9c9">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

