### PR TITLE
Fix doc build instructions

### DIFF
--- a/docs/collision_entropy_solution.md
+++ b/docs/collision_entropy_solution.md
@@ -66,7 +66,7 @@ These facts provide the basic groundwork for further entropy arguments.
 To compile the `collentropy` module run:
 ```bash
 lake exe cache get
-lake build Pnp.Collentropy
+lake build Pnp2.collentropy
 ```
 The first command downloads pre-built Mathlib binaries. If the download fails or is skipped, the build step may take a long time as it compiles Mathlib from source.
 


### PR DESCRIPTION
## Summary
- correct the module name in the collision entropy note

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6881aae561c0832bbd5be379c2eb39ea