### PR TITLE
Add Lemma B corollary for circuits

### DIFF
--- a/Pnp2/bound.lean
+++ b/Pnp2/bound.lean
@@ -290,4 +290,36 @@ theorem family_collision_entropy_lemma_table
       Nat.pow_le_pow_of_le_left (by decide : (1 : ℕ) ≤ 2) hpow
   exact ⟨Rset, hmono, hcov, hbound'⟩
 
+/-! ### Specialised corollary for small circuits
+
+The next lemma packages `family_collision_entropy_lemma_table`
+for the concrete family of Boolean functions computed by circuits of
+size at most `n^c`.  This is a convenient formulation of **Lemma B**:
+for sufficiently large `n` the entire circuit class admits a joint
+monochromatic cover of size strictly smaller than `2^{(2^n)/100}`. -/
+
+open Boolcube Circuit
+
+/-- **Lemma B (circuit form).**
+    Let `c` be a fixed exponent and consider all circuits on `n`
+    inputs of size at most `n^c`.  Once `n` exceeds the threshold
+    `n₀ h` (with `h = n^c * (Nat.log n + 1) + 1`), there exists a
+    finite set of subcubes covering every `1`‑input of every such
+    circuit.  Moreover the number of rectangles is bounded by
+    `2^{(2^n)/100}`. -/
+theorem lemmaB_circuit_cover (c n : ℕ)
+    (hn : n ≥ n₀ (n ^ c * (Nat.log n + 1) + 1)) :
+    ∃ Rset : Finset (Subcube n),
+      (∀ R ∈ Rset, Subcube.monochromaticForFamily R (Circuit.family n (n ^ c))) ∧
+      (∀ f ∈ Circuit.family n (n ^ c), ∀ x, f x = true → ∃ R ∈ Rset, x ∈ₛ R) ∧
+      Rset.card ≤ Nat.pow 2 ((Nat.pow 2 n) / 100) := by
+  classical
+  let h := n ^ c * (Nat.log n + 1) + 1
+  have hH : H₂ (Circuit.family n (n ^ c)) ≤ (h : ℝ) := by
+    simpa [h] using Circuit.family_H₂_le (n := n) (m := n ^ c)
+  -- Apply the general entropy-cover lemma specialised to this family.
+  simpa [h] using
+    family_collision_entropy_lemma_table
+      (F := Circuit.family n (n ^ c)) (h := h) (hH := hH) (hn := hn)
+
 end Bound


### PR DESCRIPTION
### **User description**
## Summary
- state a new theorem `lemmaB_circuit_cover` in `bound.lean`
- use the existing entropy bound for `Circuit.family` and the
  `family_collision_entropy_lemma_table` to obtain a cover
  of size `2^(2^n/100)` for circuits of size `n^c`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6881ce8b5af8832b894ca73b7a2bc853


___

### **PR Type**
Enhancement


___

### **Description**
- Add `lemmaB_circuit_cover` theorem for circuit families

- Provide concrete formulation of Lemma B for circuits

- Link entropy bounds to circuit size constraints

- Establish cover size bound of `2^(2^n/100)` for circuits


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Circuit.family n (n^c)"] --> B["entropy bound H₂"]
  B --> C["family_collision_entropy_lemma_table"]
  C --> D["lemmaB_circuit_cover"]
  D --> E["cover size ≤ 2^(2^n/100)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bound.lean</strong><dd><code>Add circuit-specific Lemma B theorem</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/bound.lean

<ul><li>Add <code>lemmaB_circuit_cover</code> theorem linking circuit families to entropy <br>covers<br> <li> Include comprehensive documentation explaining Lemma B for circuits<br> <li> Establish cover size bound using existing entropy lemma<br> <li> Import <code>Boolcube</code> and <code>Circuit</code> namespaces for theorem implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/602/files#diff-99efb12ee336a647c724d856192648e961a1908c1561d5a1c53747610702a065">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

