### PR TITLE
Add mBound monotonicity lemma

### DIFF
--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -44,6 +44,10 @@ lemma two_le_mBound (n h : ℕ) (hn : 0 < n) : 2 ≤ mBound n h := by
 
 namespace Cover
 
+lemma mBound_mono_left {n₁ n₂ h : ℕ} (hn : n₁ ≤ n₂) : mBound n₁ h ≤ mBound n₂ h := by
+  have : n₁ * (h + 2) ≤ n₂ * (h + 2) := Nat.mul_le_mul_right _ hn
+  have := Nat.mul_le_mul_right (2 ^ (10 * h)) this
+  simpa [mBound, Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using this
 open BoolFunc
 
 variable {n : ℕ}


### PR DESCRIPTION
### **User description**
## Summary
- document monotonic behaviour of `mBound` with new lemma `mBound_mono_left`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_688252bb05b0832bb35492c038a8045c


___

### **PR Type**
Enhancement


___

### **Description**
- Add monotonicity lemma for `mBound` function

- Prove `mBound n₁ h ≤ mBound n₂ h` when `n₁ ≤ n₂`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mBound function"] --> B["New monotonicity lemma"]
  B --> C["mBound_mono_left proof"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Add monotonicity lemma for mBound</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Add new lemma <code>mBound_mono_left</code> proving monotonicity<br> <li> Implement proof using multiplication monotonicity properties<br> <li> Place lemma in appropriate namespace location</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/607/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

