### PR TITLE
Add Lemma B circuit cover test

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -327,5 +327,18 @@ example :
     simp [Bound.n₀]
   exact Bound.mBound_lt_subexp (h := 1) (n := 30720000) h0
 
+-- The circuit form of **Lemma B** ensures a joint cover of size
+-- `2^{(2^n)/100}` once `n` exceeds the threshold `n₀`.
+example (c n : ℕ)
+    (hn : n ≥ Bound.n₀ (n ^ c * (Nat.log n + 1) + 1)) :
+    ∃ Rset : Finset (Boolcube.Subcube n),
+      (∀ R ∈ Rset,
+          Subcube.monochromaticForFamily R (Boolcube.Circuit.family n (n ^ c))) ∧
+      (∀ f ∈ Boolcube.Circuit.family n (n ^ c),
+          ∀ x, f x = true → ∃ R ∈ Rset, x ∈ₛ R) ∧
+      Rset.card ≤ Nat.pow 2 ((Nat.pow 2 n) / 100) := by
+  classical
+  simpa using Bound.lemmaB_circuit_cover (c := c) (n := n) hn
+
 
 end BasicTests


### PR DESCRIPTION
### **User description**
## Summary
- add regression test exercising `lemmaB_circuit_cover`

## Testing
- `lake build Tests`

------
https://chatgpt.com/codex/tasks/task_e_68842a2c457c832b944fc5a32bc03d93


___

### **PR Type**
Tests


___

### **Description**
- Add regression test for `lemmaB_circuit_cover` function

- Test validates circuit cover size bounds for Lemma B

- Ensures joint cover size ≤ 2^(2^n/100) when n exceeds threshold


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Test Input: n, c parameters"] --> B["Check n ≥ threshold n₀"]
  B --> C["Apply lemmaB_circuit_cover"]
  C --> D["Verify cover properties"]
  D --> E["Validate size bound ≤ 2^(2^n/100)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Basic.lean</strong><dd><code>Add circuit cover test example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Basic.lean

<ul><li>Add new test example for <code>lemmaB_circuit_cover</code> function<br> <li> Test validates circuit cover existence and size bounds<br> <li> Uses classical logic and <code>simpa</code> tactic for proof</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/615/files#diff-fbce6bd3531ab84591373af266126062c709cd0ae19cbe7688fce16a26bb1f1b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

