### PR TITLE
docs: clarify lemma B variant

### DIFF
--- a/docs/lemma_B_plan.md
+++ b/docs/lemma_B_plan.md
@@ -35,3 +35,9 @@ What remains open is a **computable** enumeration of these rectangles
 via `Cover.buildCoverCompute`.  The current stub always returns an
 empty list, so the algorithmic applications are still hypothetical.
 
+An alternative presentation is given by the lemma
+`Bound.lemmaB_circuit_cover_delta`.  It reformulates the subexponential
+bound as `|Rset| ≤ 2^{2^n - 2^{n/2}}`, matching the usual
+`2^{N - N^δ}` notation with `δ = 1/2`.  This version follows from the
+basic bound by a straightforward numeric comparison.
+


### PR DESCRIPTION
### **User description**
## Summary
- clarify documentation of Lemma B by referencing the variant `lemmaB_circuit_cover_delta`

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_688435eaf2cc832bb14da3f1a6f9223e


___

### **PR Type**
Documentation


___

### **Description**
- Add clarification about alternative lemma B presentation

- Reference `lemmaB_circuit_cover_delta` variant with delta notation

- Explain relationship between basic and alternative bounds


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lemma_B_plan.md</strong><dd><code>Add alternative lemma B variant documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/lemma_B_plan.md

<ul><li>Add section explaining alternative lemma B presentation<br> <li> Reference <code>lemmaB_circuit_cover_delta</code> with delta=1/2 notation<br> <li> Clarify relationship to basic bound via numeric comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/617/files#diff-e9d0bd6d17194563d60193cd801d91945277c1aec3c0054e3ce161f9b8b60c57">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

