### PR TITLE
Add example for strengthened Lemma B

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -340,5 +340,18 @@ example (c n : ℕ)
   classical
   simpa using Bound.lemmaB_circuit_cover (c := c) (n := n) hn
 
+-- A variant of Lemma B with an explicit exponential tail `δ = 1/2`.
+example (c n : ℕ)
+    (hn : n ≥ Bound.n₀ (n ^ c * (Nat.log n + 1) + 1)) (hnpos : 0 < n) :
+    ∃ Rset : Finset (Boolcube.Subcube n),
+      (∀ R ∈ Rset,
+          Subcube.monochromaticForFamily R (Boolcube.Circuit.family n (n ^ c))) ∧
+      (∀ f ∈ Boolcube.Circuit.family n (n ^ c),
+          ∀ x, f x = true → ∃ R ∈ Rset, x ∈ₛ R) ∧
+      Rset.card ≤ Nat.pow 2 (Nat.pow 2 n - Nat.pow 2 (n / 2)) := by
+  classical
+  simpa using
+    Bound.lemmaB_circuit_cover_delta (c := c) (n := n) hn hnpos
+
 
 end BasicTests


### PR DESCRIPTION
### **User description**
## Summary
- extend `Basic.lean` with an example using `lemmaB_circuit_cover_delta`

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_688435eaf2cc832bb14da3f1a6f9223e


___

### **PR Type**
Tests


___

### **Description**
- Add example demonstrating strengthened Lemma B with explicit exponential tail

- Introduce variant using `lemmaB_circuit_cover_delta` with δ = 1/2

- Extend test coverage for circuit covering bounds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original Lemma B example"] --> B["New strengthened variant"]
  B --> C["Explicit δ = 1/2 parameter"]
  C --> D["Enhanced bound calculation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Basic.lean</strong><dd><code>Add strengthened Lemma B example with explicit delta</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Basic.lean

<ul><li>Add new example using <code>lemmaB_circuit_cover_delta</code> function<br> <li> Include explicit exponential tail parameter δ = 1/2<br> <li> Add positive integer constraint <code>hnpos : 0 < n</code><br> <li> Demonstrate enhanced bound with <code>Nat.pow 2 (Nat.pow 2 n - Nat.pow 2 (n </code><br><code>/ 2))</code></ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/618/files#diff-fbce6bd3531ab84591373af266126062c709cd0ae19cbe7688fce16a26bb1f1b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

