### PR TITLE
Fix warnings and clean definitions

### DIFF
--- a/Pnp2/Algorithms/SatCover.lean
+++ b/Pnp2/Algorithms/SatCover.lean
@@ -16,35 +16,35 @@ implementation simply returns an arbitrary witness using classical
 choice whenever one exists.  The parameter `h` is reserved for future
 complexity bounds and is presently ignored.
 -/
-noncomputable def satViaCover (f : BoolFun n) (h : ℕ) : Option (Point n) :=
+noncomputable def satViaCover (f : BoolFun n) (_h : ℕ) : Option (Point n) :=
   if hx : ∃ x, f x = true then
     some (Classical.choose hx)
   else
     none
 
-lemma satViaCover_correct (f : BoolFun n) (h : ℕ) :
-    (∃ x, satViaCover (n:=n) f h = some x ∧ f x = true) ↔ ∃ x, f x = true := by
+lemma satViaCover_correct (f : BoolFun n) (_h : ℕ) :
+    (∃ x, satViaCover (n:=n) f _h = some x ∧ f x = true) ↔ ∃ x, f x = true := by
   classical
   unfold satViaCover
   by_cases hx : ∃ x, f x = true
-  · have hxval := Classical.choose_spec hx
+  · have _ := Classical.choose_spec hx
     constructor
     · intro hres
       rcases hres with ⟨x, _, hxtrue⟩
       exact ⟨x, hxtrue⟩
     · intro _
-      refine ⟨Classical.choose hx, ?_, hxval⟩
-      simp [satViaCover, hx, hxval]
+      refine ⟨Classical.choose hx, ?_, (Classical.choose_spec hx)⟩
+      simp [hx]
   · constructor
     · intro hres
       rcases hres with ⟨x, hxres, _⟩
-      simp [satViaCover, hx] at hxres
+      simp [hx] at hxres
     · intro h
       rcases h with ⟨x, hxtrue⟩
       exact False.elim (hx ⟨x, hxtrue⟩)
 
-lemma satViaCover_none (f : BoolFun n) (h : ℕ) :
-    satViaCover (n:=n) f h = none ↔ ∀ x, f x = false := by
+lemma satViaCover_none (f : BoolFun n) (_h : ℕ) :
+    satViaCover (n:=n) f _h = none ↔ ∀ x, f x = false := by
   classical
   unfold satViaCover
   by_cases hx : ∃ x, f x = true
@@ -53,19 +53,20 @@ lemma satViaCover_none (f : BoolFun n) (h : ℕ) :
       intro h'
       have := h' x
       simp [hxtrue] at this
-    have hxval := Classical.choose_spec hx
-    simp [satViaCover, hx, hxval, hxfalse]
+    -- explicit witness for readability, though unused below
+    have _ := Classical.choose_spec hx
+    simp [hx, hxfalse]
   · have hxforall : ∀ x, f x = false := by
       intro x
       by_contra hxtrue
       exact hx ⟨x, by simpa using hxtrue⟩
-    simp [satViaCover, hx, hxforall]
+    simp [hxforall]
 
-noncomputable def satViaCover_time (f : BoolFun n) (h : ℕ) : ℕ :=
+noncomputable def satViaCover_time (f : BoolFun n) (_h : ℕ) : ℕ :=
   (Finset.univ.filter fun x : Point n => f x = true).card
 
-lemma satViaCover_time_le_pow (f : BoolFun n) (h : ℕ) :
-    satViaCover_time (n:=n) f h ≤ 2 ^ n := by
+lemma satViaCover_time_le_pow (f : BoolFun n) (_h : ℕ) :
+    satViaCover_time (n:=n) f _h ≤ 2 ^ n := by
   classical
   unfold satViaCover_time
   have hle := Finset.card_filter_le (s := Finset.univ)
@@ -74,8 +75,8 @@ lemma satViaCover_time_le_pow (f : BoolFun n) (h : ℕ) :
     simpa using (Fintype.card_fun (Fin n) Bool)
   simpa [hcard] using hle
 
-lemma satViaCover_time_bound (f : BoolFun n) (h : ℕ) :
-    satViaCover_time (n:=n) f h ≤ 2 ^ n :=
-  satViaCover_time_le_pow (f := f) (h := h)
+lemma satViaCover_time_bound (f : BoolFun n) (_h : ℕ) :
+    satViaCover_time (n:=n) f _h ≤ 2 ^ n :=
+  satViaCover_time_le_pow (f := f) (_h := _h)
 
 end Pnp2.Algorithms

--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -56,21 +56,21 @@ variable {n : ℕ}
 It enumerates the rectangles produced by `Cover.coverFamily`, turning the finite set into an explicit list.
 -/
 def buildCoverCompute (F : Family n) (h : ℕ)
-    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=
   []
 @[simp] lemma buildCoverCompute_empty (h : ℕ)
-    (hH : BoolFunc.H₂ (∅ : Family n) ≤ (h : ℝ)) :
-    buildCoverCompute (F := (∅ : Family n)) (h := h) hH = [] :=
+    (_hH : BoolFunc.H₂ (∅ : Family n) ≤ (h : ℝ)) :
+    buildCoverCompute (F := (∅ : Family n)) (h := h) _hH = [] :=
   rfl
 /--
 Basic specification for `buildCoverCompute`. It simply expands `Cover.coverFamily` into a list,
 so the rectangles remain monochromatic and the length bound follows from `coverFamily_card_bound`.
 -/
 lemma buildCoverCompute_spec (F : Family n) (h : ℕ)
-    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
-    (∀ R ∈ (buildCoverCompute (F := F) (h := h) hH).toFinset,
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (∀ R ∈ (buildCoverCompute (F := F) (h := h) _hH).toFinset,
         Subcube.monochromaticForFamily R F) ∧
-    (buildCoverCompute (F := F) (h := h) hH).length ≤ mBound n h := by
+    (buildCoverCompute (F := F) (h := h) _hH).length ≤ mBound n h := by
   classical
   constructor
   · intro R hR; cases hR

--- a/Pnp2/entropy.lean
+++ b/Pnp2/entropy.lean
@@ -22,12 +22,12 @@ namespace BoolFunc
 We work in `ℝ` because later analytic lemmas (`log` monotonicity, etc.) live
 in `ℝ`. -/
 noncomputable
- def collProb {n : ℕ} (F : Family n) : ℝ :=
-  if h : (F.card = 0) then 0 else (F.card : ℝ)⁻¹
+def collProb {n : ℕ} (F : Family n) : ℝ :=
+  if F.card = 0 then 0 else (F.card : ℝ)⁻¹
 
 @[simp] lemma collProb_pos {n : ℕ} {F : Family n} (h : 0 < F.card) :
     collProb F = (F.card : ℝ)⁻¹ := by
-  simp [collProb, h.ne', h]
+  simp [collProb, Nat.ne_of_gt h]
 
 @[simp] lemma collProb_zero {n : ℕ} {F : Family n} (h : F.card = 0) :
     collProb F = 0 := by simp [collProb, h]
@@ -199,7 +199,7 @@ lemma H₂_filter_le {n : ℕ} (F : Family n)
   · -- The filtered family is empty, so the entropy is zero.
     have hF_ge : 0 ≤ H₂ F := by
       by_cases hF0 : F.card = 0
-      · simpa [H₂, hF0] using (le_of_eq rfl : (0 : ℝ) ≤ 0)
+      · simp [H₂, hF0]
       ·
         have hx : 1 ≤ (F.card : ℝ) := by
           have hpos : 0 < F.card := Nat.pos_of_ne_zero hF0


### PR DESCRIPTION
### **User description**
## Summary
- remove unused parameter in `collProb` and simplify proof lemmas
- mark unused parameters in `Cover/Compute` and `SatCover`
- clean up `SatCover` proofs to avoid simp warnings

## Testing
- `./scripts/check.sh`
- `lake build`


------
https://chatgpt.com/codex/tasks/task_e_68843e241c04832b9c67feeb9900446c


___

### **PR Type**
Other


___

### **Description**
- Mark unused parameters with underscore prefix

- Remove unused variables and simplify proof lemmas

- Clean up simp warnings in proofs

- Simplify conditional logic in collision probability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Unused parameters"] --> B["Mark with underscore"]
  C["Unused variables"] --> D["Remove or simplify"]
  E["Simp warnings"] --> F["Clean up proofs"]
  G["Conditional logic"] --> H["Simplify expressions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SatCover.lean</strong><dd><code>Mark unused parameters and clean proof warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Algorithms/SatCover.lean

<ul><li>Mark unused parameter <code>h</code> as <code>_h</code> in function signatures<br> <li> Remove unused variables like <code>hxval</code> in proofs<br> <li> Simplify simp calls to avoid warnings<br> <li> Add explanatory comments for unused witnesses</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/619/files#diff-0787c19ee93b91a5a758115e134a58975939f1e7a4305db8963438f0482cf70c">+19/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Mark unused entropy bound parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Mark unused parameter <code>hH</code> as <code>_hH</code> in function signatures<br> <li> Update function calls to use renamed parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/619/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>entropy.lean</strong><dd><code>Simplify collision probability and entropy proofs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/entropy.lean

<ul><li>Remove unused variable <code>h</code> from if condition in <code>collProb</code><br> <li> Simplify proof logic using <code>Nat.ne_of_gt</code> instead of manual checks<br> <li> Remove redundant equality check in H₂ filter lemma</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/619/files#diff-c9945293d072d5db339314094c1055ce9e959671dc64f147c5509da4830de9c9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

