### PR TITLE
Fix warnings in entropy and algorithms

### DIFF
--- a/Pnp2/Algorithms/SatCover.lean
+++ b/Pnp2/Algorithms/SatCover.lean
@@ -16,14 +16,14 @@ implementation simply returns an arbitrary witness using classical
 choice whenever one exists.  The parameter `h` is reserved for future
 complexity bounds and is presently ignored.
 -/
-noncomputable def satViaCover (f : BoolFun n) (h : ℕ) : Option (Point n) :=
+noncomputable def satViaCover (f : BoolFun n) (_h : ℕ) : Option (Point n) :=
   if hx : ∃ x, f x = true then
     some (Classical.choose hx)
   else
     none
 
-lemma satViaCover_correct (f : BoolFun n) (h : ℕ) :
-    (∃ x, satViaCover (n:=n) f h = some x ∧ f x = true) ↔ ∃ x, f x = true := by
+lemma satViaCover_correct (f : BoolFun n) (_h : ℕ) :
+    (∃ x, satViaCover (n:=n) f _h = some x ∧ f x = true) ↔ ∃ x, f x = true := by
   classical
   unfold satViaCover
   by_cases hx : ∃ x, f x = true
@@ -43,8 +43,8 @@ lemma satViaCover_correct (f : BoolFun n) (h : ℕ) :
       rcases h with ⟨x, hxtrue⟩
       exact False.elim (hx ⟨x, hxtrue⟩)
 
-lemma satViaCover_none (f : BoolFun n) (h : ℕ) :
-    satViaCover (n:=n) f h = none ↔ ∀ x, f x = false := by
+lemma satViaCover_none (f : BoolFun n) (_h : ℕ) :
+    satViaCover (n:=n) f _h = none ↔ ∀ x, f x = false := by
   classical
   unfold satViaCover
   by_cases hx : ∃ x, f x = true
@@ -61,11 +61,11 @@ lemma satViaCover_none (f : BoolFun n) (h : ℕ) :
       exact hx ⟨x, by simpa using hxtrue⟩
     simp [satViaCover, hx, hxforall]
 
-noncomputable def satViaCover_time (f : BoolFun n) (h : ℕ) : ℕ :=
+noncomputable def satViaCover_time (f : BoolFun n) (_h : ℕ) : ℕ :=
   (Finset.univ.filter fun x : Point n => f x = true).card
 
-lemma satViaCover_time_le_pow (f : BoolFun n) (h : ℕ) :
-    satViaCover_time (n:=n) f h ≤ 2 ^ n := by
+lemma satViaCover_time_le_pow (f : BoolFun n) (_h : ℕ) :
+    satViaCover_time (n:=n) f _h ≤ 2 ^ n := by
   classical
   unfold satViaCover_time
   have hle := Finset.card_filter_le (s := Finset.univ)
@@ -74,8 +74,8 @@ lemma satViaCover_time_le_pow (f : BoolFun n) (h : ℕ) :
     simpa using (Fintype.card_fun (Fin n) Bool)
   simpa [hcard] using hle
 
-lemma satViaCover_time_bound (f : BoolFun n) (h : ℕ) :
-    satViaCover_time (n:=n) f h ≤ 2 ^ n :=
-  satViaCover_time_le_pow (f := f) (h := h)
+lemma satViaCover_time_bound (f : BoolFun n) (_h : ℕ) :
+    satViaCover_time (n:=n) f _h ≤ 2 ^ n :=
+  satViaCover_time_le_pow (f := f) (_h := _h)
 
 end Pnp2.Algorithms

--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -56,21 +56,21 @@ variable {n : ℕ}
 It enumerates the rectangles produced by `Cover.coverFamily`, turning the finite set into an explicit list.
 -/
 def buildCoverCompute (F : Family n) (h : ℕ)
-    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=
   []
 @[simp] lemma buildCoverCompute_empty (h : ℕ)
-    (hH : BoolFunc.H₂ (∅ : Family n) ≤ (h : ℝ)) :
-    buildCoverCompute (F := (∅ : Family n)) (h := h) hH = [] :=
+    (_hH : BoolFunc.H₂ (∅ : Family n) ≤ (h : ℝ)) :
+    buildCoverCompute (F := (∅ : Family n)) (h := h) _hH = [] :=
   rfl
 /--
 Basic specification for `buildCoverCompute`. It simply expands `Cover.coverFamily` into a list,
 so the rectangles remain monochromatic and the length bound follows from `coverFamily_card_bound`.
 -/
 lemma buildCoverCompute_spec (F : Family n) (h : ℕ)
-    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
-    (∀ R ∈ (buildCoverCompute (F := F) (h := h) hH).toFinset,
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (∀ R ∈ (buildCoverCompute (F := F) (h := h) _hH).toFinset,
         Subcube.monochromaticForFamily R F) ∧
-    (buildCoverCompute (F := F) (h := h) hH).length ≤ mBound n h := by
+    (buildCoverCompute (F := F) (h := h) _hH).length ≤ mBound n h := by
   classical
   constructor
   · intro R hR; cases hR

--- a/Pnp2/entropy.lean
+++ b/Pnp2/entropy.lean
@@ -22,12 +22,12 @@ namespace BoolFunc
 We work in `ℝ` because later analytic lemmas (`log` monotonicity, etc.) live
 in `ℝ`. -/
 noncomputable
- def collProb {n : ℕ} (F : Family n) : ℝ :=
-  if h : (F.card = 0) then 0 else (F.card : ℝ)⁻¹
+def collProb {n : ℕ} (F : Family n) : ℝ :=
+  if F.card = 0 then 0 else (F.card : ℝ)⁻¹
 
 @[simp] lemma collProb_pos {n : ℕ} {F : Family n} (h : 0 < F.card) :
     collProb F = (F.card : ℝ)⁻¹ := by
-  simp [collProb, h.ne', h]
+  simp [collProb, h.ne']
 
 @[simp] lemma collProb_zero {n : ℕ} {F : Family n} (h : F.card = 0) :
     collProb F = 0 := by simp [collProb, h]
@@ -36,8 +36,9 @@ lemma collProb_nonneg {n : ℕ} (F : Family n) :
     0 ≤ collProb F := by
   by_cases h : F.card = 0
   · simp [collProb, h]
-  · have : 0 < (F.card : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero h
-    simpa [collProb, h] using inv_nonneg.mpr (le_of_lt this)
+  · have hpos : 0 < (F.card : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero h
+    have hnonneg : 0 ≤ (F.card : ℝ)⁻¹ := inv_nonneg.mpr (le_of_lt hpos)
+    simpa [collProb, h] using hnonneg
 
 lemma collProb_le_one {n : ℕ} (F : Family n) :
     collProb F ≤ 1 := by


### PR DESCRIPTION
### **User description**
## Summary
- simplify `collProb` definition and cleanup proofs
- rename unused parameters `_h` and `_hH`
- adjust helper lemmas in `SatCover` and `Cover.Compute`

## Testing
- `lake build`

------
https://chatgpt.com/codex/tasks/task_e_6884451a0ae8832baf64888f2c846343


___

### **PR Type**
Other


___

### **Description**
- Rename unused parameters `h` and `hH` to `_h` and `_hH`

- Simplify `collProb` definition by removing unnecessary variable binding

- Clean up proof structure in `collProb_nonneg` lemma


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Unused Parameters"] --> B["Rename to _h, _hH"]
  C["collProb Definition"] --> D["Remove unnecessary binding"]
  E["Proof Structure"] --> F["Add intermediate variables"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SatCover.lean</strong><dd><code>Rename unused parameter h to _h</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Algorithms/SatCover.lean

<ul><li>Rename unused parameter <code>h</code> to <code>_h</code> in all function signatures<br> <li> Update function calls to use <code>_h</code> instead of <code>h</code><br> <li> Maintain same functionality with cleaner parameter naming</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/620/files#diff-0787c19ee93b91a5a758115e134a58975939f1e7a4305db8963438f0482cf70c">+11/-11</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Rename unused parameter hH to _hH</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Rename unused parameter <code>hH</code> to <code>_hH</code> in function signatures<br> <li> Update function calls and lemma statements accordingly<br> <li> No functional changes, only parameter naming cleanup</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/620/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entropy.lean</strong><dd><code>Simplify collProb definition and cleanup proofs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/entropy.lean

<ul><li>Simplify <code>collProb</code> definition by removing unnecessary variable binding<br> <li> Restructure <code>collProb_nonneg</code> proof with intermediate variables<br> <li> Remove unused variable <code>h</code> from <code>collProb_pos</code> simp call</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/620/files#diff-c9945293d072d5db339314094c1055ce9e959671dc64f147c5509da4830de9c9">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

