### PR TITLE
Fix doc comment in Sunflower module

### DIFF
--- a/Pnp2/Sunflower/Sunflower.lean
+++ b/Pnp2/Sunflower/Sunflower.lean
@@ -40,10 +40,11 @@ namespace Finset
 
 /-! ### Auxiliary: intersection of a family of finsets -/
 
-/** `interFinset s` returns the intersection of all sets in `s` as an
+/-! `interFinset s` returns the intersection of all sets in `s` as an
 `Option` value. It is `none` when `s` is empty and `some` of the actual
 intersection otherwise. This helper replaces the older `interFinset`
-defined in previous versions of this project. -/
+defined in previous versions of this project.
+-/
 def interFinset (s : Finset (Finset α)) : Option (Finset α) := by
   classical
   by_cases h : s.Nonempty


### PR DESCRIPTION
### **User description**
## Summary
- correct malformed doc comment in `Sunflower/Sunflower.lean`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884451a0ae8832baf64888f2c846343


___

### **PR Type**
Documentation


___

### **Description**
- Fix malformed doc comment syntax in Sunflower module


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sunflower.lean</strong><dd><code>Fix documentation comment syntax</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Sunflower/Sunflower.lean

<ul><li>Convert malformed <code>/** */</code> comment to proper <code>/-! -/</code> documentation <br>comment<br> <li> Fix formatting and structure of the <code>interFinset</code> function documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/621/files#diff-50ab50bf1e1750ed334aa084232c0dd854cab00f5f397a6eeb2c651f34e2874b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

