### PR TITLE
Minor fix in satViaCover_time

### DIFF
--- a/Pnp2/Algorithms/SatCover.lean
+++ b/Pnp2/Algorithms/SatCover.lean
@@ -62,6 +62,7 @@ lemma satViaCover_none (f : BoolFun n) (h : ℕ) :
     simp [satViaCover, hx, hxforall]
 
 noncomputable def satViaCover_time (f : BoolFun n) (h : ℕ) : ℕ :=
+  let _ := h -- retain parameter for future complexity bounds
   (Finset.univ.filter fun x : Point n => f x = true).card
 
 lemma satViaCover_time_le_pow (f : BoolFun n) (h : ℕ) :


### PR DESCRIPTION
## Summary
- silence `unusedVariables` linter in `satViaCover_time`

## Testing
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_6884451a0ae8832baf64888f2c846343