### PR TITLE
Improve sunflower exports

### DIFF
--- a/Pnp2/sunflower.lean
+++ b/Pnp2/sunflower.lean
@@ -3,11 +3,30 @@ import Mathlib.Data.Nat.Factorial.Basic
 import Mathlib.Data.Finset.Card
 import Pnp2.Sunflower.Sunflower
 
-/--!
-This file re-exports the classical sunflower lemma now formalised within the
-`Pnp2` namespace. Importing `Pnp2.Sunflower.Sunflower` provides the definitions
-`Sunflower.IsSunflower` and `Sunflower.HasSunflower` together with the theorem
-`Sunflower.sunflower_exists`.  Keeping a small wrapper avoids sprinkling the
-longer path throughout the rest of the library.
+/-! `sunflower.lean`
+===================
+
+This small module re-exports the definitions and main lemma from
+`Pnp2.Sunflower.Sunflower`.  Downstream files can simply `import
+Pnp2.sunflower` to make use of the classical sunflower lemma without
+needing to remember the longer path.  No additional functionality is
+introduced here; we only provide a convenient alias.
 -/
+
+namespace Sunflower
+
+export Pnp2.Sunflower.Sunflower (IsSunflower HasSunflower)
+
+/-- Re-export of `Sunflower.sunflower_exists` with a shorter path. -/
+theorem sunflower_exists
+    {α : Type} [DecidableEq α]
+    (𝓢 : Finset (Finset α)) (w p : ℕ)
+    (hw : 0 < w) (hp : 2 ≤ p)
+    (h_size : (p - 1).factorial * w ^ p < 𝓢.card)
+    (h_w : ∀ A ∈ 𝓢, A.card = w) :
+    HasSunflower 𝓢 w p :=
+  Pnp2.Sunflower.Sunflower.sunflower_exists
+    (𝓢 := 𝓢) (w := w) (p := p) hw hp h_size h_w
+
+end Sunflower
 


### PR DESCRIPTION
### **User description**
## Summary
- add a short wrapper in `sunflower.lean` to re-export the main lemma

## Testing
- `lake build`
- `lake exe tests`

------
https://chatgpt.com/codex/tasks/task_e_6884db5b2ed4832b81ae4fbdf0798505


___

### **PR Type**
Enhancement


___

### **Description**
- Add convenient re-export wrapper for sunflower lemma

- Provide shorter import path for downstream usage

- Export key definitions and main theorem


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pnp2.Sunflower.Sunflower"] -- "re-export" --> B["Pnp2.sunflower"]
  B -- "provides" --> C["IsSunflower"]
  B -- "provides" --> D["HasSunflower"]
  B -- "provides" --> E["sunflower_exists"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sunflower.lean</strong><dd><code>Add sunflower lemma re-export wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/sunflower.lean

<ul><li>Added <code>Sunflower</code> namespace with re-exported definitions<br> <li> Created wrapper <code>sunflower_exists</code> theorem with shorter path<br> <li> Updated documentation to explain re-export purpose<br> <li> Exported <code>IsSunflower</code> and <code>HasSunflower</code> from main module</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/627/files#diff-26951b13f0f811f37dfb1a6706328588815ec16bf31b0240c2d1e0c2e9108435">+25/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

