### PR TITLE
Fix SunflowerFam.exists_of_large_family proof

### DIFF
--- a/Pnp2/Sunflower/Sunflower.lean
+++ b/Pnp2/Sunflower/Sunflower.lean
@@ -76,23 +76,30 @@ lemma exists_of_large_family
     (hbig : F.card > Nat.factorial (t - 1) * w ^ t) :
     ∃ S : SunflowerFam n t, S.petals ⊆ F := by
   classical
+  -- Apply the classical sunflower lemma to obtain a `t`-sunflower inside `F`.
   rcases sunflower_exists (𝓢 := F) (w := w) (p := t) hw ht
       (by simpa using hbig) hcard with
-    ⟨pet, hsub, core, hSun, hsize⟩
-  refine ⟨⟨pet, by simpa using hSun.card_p, core, ?_, ?_⟩, hsub⟩
-  · intro P hP
+    ⟨pet, hsub, core, hSun, hcards⟩
+  -- Break down the `IsSunflower` structure into its two components.
+  rcases hSun with ⟨hsize, hpair⟩
+  -- We now show that the common `core` is contained in every petal.
+  have hsub_core : ∀ P ∈ pet, core ⊆ P := by
+    intro P hP
+    -- Show that the family has at least two petals.
     have h_two : 1 < pet.card := by
-      have h : 2 ≤ pet.card := by simpa [hSun.card_p] using ht
-      simpa using (Nat.succ_le_iff.mp h)
-    obtain ⟨Q, hQ, hQne⟩ := Finset.exists_ne_of_one_lt_card h_two P
-    have hPQ := hSun.pairwise_inter (A := P) (by simpa using hP)
-      (B := Q) (by simpa using hQ) (Ne.symm hQne)
-    intro x hx
-    have hx' : x ∈ P ∩ Q := by simpa [hPQ] using hx
-    exact (Finset.mem_inter.mp hx').1
-  · intro P₁ h₁ P₂ h₂ hne
-    exact hSun.pairwise_inter (A := P₁) (by simpa using h₁)
-      (B := P₂) (by simpa using h₂) hne
+      have h : 2 ≤ pet.card := by simpa [hsize] using ht
+      have h12 : 1 < 2 := by decide
+      exact lt_of_lt_of_le h12 h
+    -- Obtain a different petal `Q` using `exists_ne_of_one_lt_card`.
+    obtain ⟨Q, hQ, hne⟩ := Finset.exists_ne_of_one_lt_card h_two P
+    -- The sunflower property says `P ∩ Q = core`, hence `core ⊆ P`.
+    have hPQ := hpair (A := P) hP (B := Q) hQ (Ne.symm hne)
+    simpa [hPQ] using (Finset.inter_subset_left : P ∩ Q ⊆ P)
+  -- Assemble the final `SunflowerFam` structure.
+  refine ⟨⟨pet, hsize, core, hsub_core, ?_⟩, hsub⟩
+  -- The pairwise intersection condition follows directly from `hpair`.
+  intro P₁ h₁ P₂ h₂ hne
+  exact hpair (A := P₁) h₁ (B := P₂) h₂ hne
 
 end SunflowerFam
 


### PR DESCRIPTION
### **User description**
## Summary
- improve `SunflowerFam.exists_of_large_family`
  - destruct `IsSunflower` to extract cardinality and pairwise intersection
  - prove every petal contains the core using the sunflower property
  - clean up pairwise intersection usage

## Testing
- `lake build Tests`

------
https://chatgpt.com/codex/tasks/task_e_68856f0116d8832bbfef21020b2629b0


___

### **PR Type**
Bug fix


___

### **Description**
- Fix proof structure in `SunflowerFam.exists_of_large_family`

- Properly destructure `IsSunflower` into cardinality and pairwise intersection

- Correct core subset proof using sunflower intersection property

- Add detailed comments explaining proof steps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["IsSunflower structure"] --> B["Destructure into components"]
  B --> C["Extract cardinality hsize"]
  B --> D["Extract pairwise intersection hpair"]
  C --> E["Prove core subset property"]
  D --> E
  E --> F["Assemble SunflowerFam structure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sunflower.lean</strong><dd><code>Fix sunflower family proof structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Sunflower/Sunflower.lean

<ul><li>Restructure proof by properly destructuring <code>IsSunflower</code> into <code>hsize</code> and <br><code>hpair</code><br> <li> Fix core subset proof using intersection property <code>P ∩ Q = core</code><br> <li> Add comprehensive comments explaining each proof step<br> <li> Simplify final structure assembly using extracted components</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/629/files#diff-50ab50bf1e1750ed334aa084232c0dd854cab00f5f397a6eeb2c651f34e2874b">+21/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

