### PR TITLE
Implement polynomial SAT reduction

### DIFF
--- a/Pnp2/acc_mcsp_sat.lean
+++ b/Pnp2/acc_mcsp_sat.lean
@@ -367,10 +367,10 @@ lemma SATUsingFCE_correct {N : ℕ} (Φ : Boolcube.Circuit N)
     (hn : N ≥ Bound.n₀ 0) :
     SATUsingFCE Φ hn = true ↔ ∃ x, Circuit.eval Φ x = true := by
   classical
-  let key := sat_reduction (Φ := Φ) (hn := hn)
-  rcases key with ⟨cover, hmono, hcov, hbound⟩
+  have key := Classical.choose_spec (sat_reduction (Φ := Φ) (hn := hn))
+  rcases key with ⟨hmono, hcov, hbound⟩
   unfold SATUsingFCE SATViaCover
-  have := SATViaCover_correct (Φ := Φ) (cover := cover) hmono hcov
+  have := SATViaCover_correct (Φ := Φ) (cover := Classical.choose (sat_reduction (Φ := Φ) (hn := hn))) hmono hcov
   simpa using this
 
 lemma SATUsingFCE_time_bound {N : ℕ} (Φ : Boolcube.Circuit N)


### PR DESCRIPTION
### **User description**
## Summary
- encode Boolean circuits as polynomials over `𝔽₂`
- show evaluation of the polynomial matches circuit evaluation
- expose concrete SAT solver using the entropy cover
- provide time bound for the solver

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68859853517c832b93bd4b0c0abe119a


___

### **PR Type**
Enhancement


___

### **Description**
- Implement polynomial encoding for Boolean circuits over 𝔽₂

- Add concrete SAT solver using entropy cover method

- Provide time complexity bounds for the solver

- Establish correctness proofs for circuit-polynomial equivalence


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Boolean Circuit"] --> B["Polynomial over 𝔽₂"]
  B --> C["Entropy Cover"]
  C --> D["SAT Solver"]
  D --> E["Time Bound 2^(N/100)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>acc_mcsp_sat.lean</strong><dd><code>Polynomial SAT solver implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/acc_mcsp_sat.lean

<ul><li>Add <code>boolToF2</code> conversion function with logical operation identities<br> <li> Implement <code>circuitToPoly</code> for structural circuit-to-polynomial <br>translation<br> <li> Prove <code>eval_circuitToPoly</code> correctness lemma for evaluation equivalence<br> <li> Create concrete <code>SATUsingFCE</code> solver with time bounds and correctness <br>proofs</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/636/files#diff-25a1d8f5b2053b3ba6717ccddf2176946c9d24afebbb2a785cbe67d1f29fa0ad">+97/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

