### PR TITLE
Add circuit equivalence helper

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -205,6 +205,19 @@ example {n : ℕ} {c₁ c₂ : Boolcube.Circuit n}
   have hfun := Boolcube.Circuit.canonical_inj (c₁ := c₁) (c₂ := c₂) h
   simpa using hfun x
 
+-- Extensionally equal circuits may still have distinct canonical forms.
+example :
+    Boolcube.Circuit.canonical (Boolcube.Circuit.var (0 : Fin 1)) ≠
+      Boolcube.Circuit.canonical
+        (Boolcube.Circuit.not (Boolcube.Circuit.not (Boolcube.Circuit.var 0))) := by
+  decide
+
+example (x : Boolcube.Point 1) :
+    Boolcube.Circuit.eval (Boolcube.Circuit.var 0) x =
+      Boolcube.Circuit.eval
+        (Boolcube.Circuit.not (Boolcube.Circuit.not (Boolcube.Circuit.var 0))) x := by
+  simp
+
 -- Encoding length of a canonical circuit is bounded by `codeLen`.
 example {n : ℕ} (c : Boolcube.Circuit.Canon n) :
     (Boolcube.Circuit.encodeCanon c).length ≤


### PR DESCRIPTION
### **User description**
## Summary
- define `Circuit.eqv` for extensional equivalence of circuits
- expose reflexivity, symmetry and transitivity lemmas
- update `canonical_inj` to use the new relation
- document that canonical forms are sound but not complete
- add examples showing non-equivalent canonical forms despite equal behaviour

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6886223f6b00832b9850adab64ecbaa9


___

### **PR Type**
Enhancement


___

### **Description**
- Add `Circuit.eqv` for extensional equivalence of circuits

- Provide reflexivity, symmetry, and transitivity lemmas

- Update `canonical_inj` to use new equivalence relation

- Add examples showing canonical form limitations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Circuit.eqv definition"] --> B["Equivalence properties"]
  B --> C["canonical_inj update"]
  C --> D["Test examples"]
  B --> E["Reflexivity lemma"]
  B --> F["Symmetry lemma"]
  B --> G["Transitivity lemma"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>canonical_circuit.lean</strong><dd><code>Add circuit equivalence relation and properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/canonical_circuit.lean

<ul><li>Define <code>Circuit.eqv</code> for extensional equivalence of circuits<br> <li> Add reflexivity, symmetry, and transitivity lemmas for equivalence<br> <li> Update <code>canonical_inj</code> theorem to use new <code>eqv</code> relation<br> <li> Document soundness vs completeness of canonical forms</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/639/files#diff-06bf4de316d49d638f1afb1351600b8b4f80cc4f9f085251eed10105ef7be4d0">+22/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Basic.lean</strong><dd><code>Add canonical form completeness counterexamples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Basic.lean

<ul><li>Add examples showing circuits with different canonical forms but same <br>behavior<br> <li> Demonstrate that <code>var 0</code> and <code>not (not (var 0))</code> are extensionally equal<br> <li> Show canonical forms are not complete (different forms for equivalent <br>circuits)</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/639/files#diff-fbce6bd3531ab84591373af266126062c709cd0ae19cbe7688fce16a26bb1f1b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

