### PR TITLE
Add canonical equality equivalence

### DIFF
--- a/Pnp2/canonical_circuit.lean
+++ b/Pnp2/canonical_circuit.lean
@@ -179,6 +179,33 @@ lemma exists_input_of_canonical_ne {n : ℕ} {c₁ c₂ : Canon n}
   -- or versus and
   · refine ⟨fun _ => false, by simp⟩
 
+/-- Two circuits have the same canonical form *iff* they are extensionally
+    equivalent, i.e. they compute the same Boolean function.  The forward
+    implication is `canonical_inj`.  For the converse we show that if the
+    canonical forms differ then `exists_input_of_canonical_ne` produces an
+    input where the evaluations disagree, contradicting `eqv`. -/
+theorem canonical_eq_iff_eqv {n : ℕ} (c₁ c₂ : Circuit n) :
+    canonical c₁ = canonical c₂ ↔ eqv c₁ c₂ := by
+  constructor
+  · -- Soundness: identical canonical forms yield equal evaluations.
+    intro h
+    exact canonical_inj (c₁ := c₁) (c₂ := c₂) h
+  · -- Completeness: if the circuits agree on every input, their canonical
+    -- forms must coincide.  We argue by contrapositive.
+    intro h
+    classical
+    by_contra hneq
+    -- Obtain a counterexample input where the canonical circuits disagree.
+    have ⟨x, hx⟩ :=
+      exists_input_of_canonical_ne (c₁ := canonical c₁)
+        (c₂ := canonical c₂) hneq
+    -- Relate canonical evaluation back to the original circuits.
+    have hx₁ := eval_canonical (c := c₁) (x := x)
+    have hx₂ := eval_canonical (c := c₂) (x := x)
+    -- `hx` shows `eval c₁ x ≠ eval c₂ x`, contradicting `eqv`.
+    have : eval c₁ x ≠ eval c₂ x := by simpa [hx₁, hx₂] using hx
+    exact this (h x)
+
 /-- Length bound for canonical descriptions.  Each gate contributes at most
     `O(log n)` bits, hence a circuit of size `m` yields a description of
     length `O(m log n)`.  In particular, if `sizeOf c ≤ n^d` then the


### PR DESCRIPTION
### **User description**
## Summary
- prove `canonical_eq_iff_eqv` linking canonical forms to circuit equivalence

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688628ca71b0832bb2fbff43896f275e


___

### **PR Type**
Enhancement


___

### **Description**
- Add canonical equivalence theorem proving circuits equivalent iff canonical forms equal

- Establish bidirectional relationship between canonical forms and circuit equivalence

- Complete proof using contrapositive argument with counterexample input


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Circuit c₁"] --> B["canonical c₁"]
  C["Circuit c₂"] --> D["canonical c₂"]
  B -.-> E["canonical_eq_iff_eqv"]
  D -.-> E
  E --> F["eqv c₁ c₂"]
  F -.-> G["Same Boolean function"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>canonical_circuit.lean</strong><dd><code>Add canonical equivalence theorem with bidirectional proof</code></dd></summary>
<hr>

Pnp2/canonical_circuit.lean

<ul><li>Add <code>canonical_eq_iff_eqv</code> theorem proving canonical forms equal iff <br>circuits equivalent<br> <li> Implement bidirectional proof with soundness and completeness <br>directions<br> <li> Use contrapositive argument with <code>exists_input_of_canonical_ne</code> for <br>completeness<br> <li> Add comprehensive documentation explaining the theorem's significance</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/641/files#diff-06bf4de316d49d638f1afb1351600b8b4f80cc4f9f085251eed10105ef7be4d0">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

