### PR TITLE
Add buildCoverCompute_length lemma

### DIFF
--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -62,6 +62,14 @@ def buildCoverCompute (F : Family n) (h : ℕ)
     (hH : BoolFunc.H₂ (∅ : Family n) ≤ (h : ℝ)) :
     buildCoverCompute (F := (∅ : Family n)) (h := h) hH = [] :=
   rfl
+
+/-- The length of `buildCoverCompute` is always zero since the current
+implementation merely returns the empty list.  This lemma keeps the
+interface stable while the constructive cover enumeration is unfinished. -/
+@[simp] lemma buildCoverCompute_length (F : Family n) (h : ℕ)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (buildCoverCompute (F := F) (h := h) hH).length = 0 := by
+  simp [buildCoverCompute]
 /--
 Basic specification for `buildCoverCompute`. It simply expands `Cover.coverFamily` into a list,
 so the rectangles remain monochromatic and the length bound follows from `coverFamily_card_bound`.
@@ -74,6 +82,6 @@ lemma buildCoverCompute_spec (F : Family n) (h : ℕ)
   classical
   constructor
   · intro R hR; cases hR
-  · simp [buildCoverCompute]
+  · simpa [buildCoverCompute] using buildCoverCompute_length (F := F) (h := h) (hH := hH)
 
 end Cover


### PR DESCRIPTION
### **User description**
## Summary
- extend the constructive cover stub with a helper lemma `buildCoverCompute_length`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68869214a6d0832b952b7ea56373ece9


___

### **PR Type**
Enhancement


___

### **Description**
- Add `buildCoverCompute_length` helper lemma for constructive cover

- Improve proof structure using new lemma in specification

- Maintain stable interface during development phase


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCoverCompute function"] --> B["buildCoverCompute_length lemma"]
  B --> C["buildCoverCompute_spec proof"]
  B --> D["Interface stability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Add helper lemma and improve proof structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Add <code>buildCoverCompute_length</code> lemma proving length is always zero<br> <li> Include documentation explaining interface stability purpose<br> <li> Refactor <code>buildCoverCompute_spec</code> proof to use new helper lemma</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/649/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

