### PR TITLE
Add basic cover size lemmas

### DIFF
--- a/Pnp2/cover_size.lean
+++ b/Pnp2/cover_size.lean
@@ -43,6 +43,15 @@ lemma subcube_monochromatic_base {n : ℕ} (s : Subcube n)
 -- In this toy development we do not prove any meaningful
 -- monochromaticity statement beyond the base case above.
 
+@[simp] lemma size_empty {n : ℕ} :
+    size (n := n) (∅ : Cover n) = 0 := by
+  simp [size]
+
+lemma size_union_le {n : ℕ} (c₁ c₂ : Cover n) :
+    size (c₁ ∪ c₂) ≤ size c₁ + size c₂ := by
+  classical
+  simpa [size] using Finset.card_union_le (s := c₁) (t := c₂)
+
 /-! ### Size bound for covers -/
 
 /-- An explicit upper bound function used in the toy estimate. -/


### PR DESCRIPTION
## Summary
- add `size_empty` and `size_union_le` lemmas in `cover_size`

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68869214a6d0832b952b7ea56373ece9