### PR TITLE
Add finset subset cardinality lemma

### DIFF
--- a/Utils/Finset.lean
+++ b/Utils/Finset.lean
@@ -22,7 +22,6 @@ makes the statement available in the `Utils` namespace. -/
 lemma card_lt_of_ssSubset {α} [DecidableEq α] {s t : Finset α}
     (h : s ⊂ t) :
     s.card < t.card := by
-  classical
   simpa using Finset.card_lt_card h
 
 end Utils

--- a/Utils/Finset.lean
+++ b/Utils/Finset.lean
@@ -16,4 +16,13 @@ lemma card_filter_lt_card {α} [DecidableEq α] {s : Finset α} {p : α → Bool
     simpa [Finset.mem_filter, ha, hpa]
   exact Finset.card_filter_lt_card this
 
+/-!  If `s` is a strict subset of `t`, then the cardinality of `s` is
+strictly smaller than that of `t`.  This wrapper around `Finset.card_lt_card`
+makes the statement available in the `Utils` namespace. -/
+lemma card_lt_of_ssSubset {α} [DecidableEq α] {s t : Finset α}
+    (h : s ⊂ t) :
+    s.card < t.card := by
+  classical
+  simpa using Finset.card_lt_card h
+
 end Utils


### PR DESCRIPTION
### **User description**
## Summary
- add a lemma `card_lt_of_ssSubset` in `Utils/Finset.lean` showing that a strict subset has smaller cardinality

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68869214a6d0832b952b7ea56373ece9


___

### **PR Type**
Enhancement


___

### **Description**
- Add `card_lt_of_ssSubset` lemma for strict subset cardinality

- Wrapper around `Finset.card_lt_card` in Utils namespace


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Finset.card_lt_card"] --> B["Utils.card_lt_of_ssSubset"]
  B --> C["Strict subset has smaller cardinality"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Finset.lean</strong><dd><code>Add strict subset cardinality lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Utils/Finset.lean

<ul><li>Add <code>card_lt_of_ssSubset</code> lemma proving strict subsets have smaller <br>cardinality<br> <li> Include documentation explaining the lemma's purpose as Utils <br>namespace wrapper<br> <li> Use classical reasoning and <code>Finset.card_lt_card</code> for implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/651/files#diff-13a4497bf5b01afd3ed318f8f8b7a7fbaa9d70d1d1d8d41272932cc5643f4a25">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

