### PR TITLE
Add missing numeric bound lemma

### DIFF
--- a/Pnp2/cover_numeric.lean
+++ b/Pnp2/cover_numeric.lean
@@ -47,6 +47,29 @@ lemma minCoverSize_bound
     minCoverSize F (h := N - Nδ) h₀ ≤ 2 ^ (N - Nδ) := by
   simpa using buildCover_size_bound (F := F) (Nδ := Nδ) (h₀ := h₀) hn
 
+/--
+Simple numeric bound on `minCoverSize` without the dimension positivity
+assumption.  The bound is immediate when `N = 0`, otherwise we reuse
+`minCoverSize_bound` with the derived positivity proof.
+-/
+lemma numeric_bound
+    (h₀ : H₂ F ≤ (N - Nδ : ℝ)) :
+    minCoverSize F (h := N - Nδ) h₀ ≤ 2 ^ (N - Nδ) := by
+  classical
+  by_cases hN : N = 0
+  · -- The bound from `familyEntropyCover` collapses to `0` when `N = 0`.
+    have hcard :=
+      (Boolcube.familyEntropyCover (F := F) (h := N - Nδ) h₀).bound
+    have hzero : Cover.mBound N (N - Nδ) = 0 := by simpa [Cover.mBound, hN]
+    have hsize :
+        minCoverSize F (h := N - Nδ) h₀ ≤ 0 := by
+      simpa [minCoverSize, hzero] using hcard
+    have hpos : (0 : ℕ) ≤ 2 ^ (N - Nδ) := Nat.zero_le _
+    exact hsize.trans hpos
+  · -- In the positive dimension case we invoke `minCoverSize_bound`.
+    have hn : 0 < N := Nat.pos_of_ne_zero hN
+    simpa using minCoverSize_bound (F := F) (Nδ := Nδ) (h₀ := h₀) hn
+
 /-!  `buildCover_card n` denotes the size of the cover returned by the
 experimental algorithm on families of dimension `n`.  The precise
 definition is irrelevant for this file; we only record the asymptotic


### PR DESCRIPTION
### **User description**
## Summary
- implement `CoverNumeric.numeric_bound` for entropy-based cover bounds
- reuse `minCoverSize_bound` when dimension is positive

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68869214a6d0832b952b7ea56373ece9


___

### **PR Type**
Enhancement


___

### **Description**
- Add `numeric_bound` lemma for entropy-based cover bounds

- Remove dimension positivity requirement from bound computation

- Handle zero dimension case with explicit proof

- Reuse existing `minCoverSize_bound` for positive dimensions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["minCoverSize_bound (N > 0)"] --> B["numeric_bound (any N)"]
  C["Zero dimension case"] --> B
  D["Positive dimension case"] --> A
  D --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_numeric.lean</strong><dd><code>Add dimension-agnostic numeric bound lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover_numeric.lean

<ul><li>Add <code>numeric_bound</code> lemma that works for any dimension N<br> <li> Handle N = 0 case using <code>familyEntropyCover</code> bound collapse<br> <li> Delegate positive N case to existing <code>minCoverSize_bound</code><br> <li> Include comprehensive documentation explaining the approach</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/652/files#diff-0acbf13f4bea2ab97bfb42baf8aa5e08d3e58f158d8390d7fd8191fa66f51eca">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

