### PR TITLE
Clarify canonical equality theorem

### DIFF
--- a/Pnp2/canonical_circuit.lean
+++ b/Pnp2/canonical_circuit.lean
@@ -303,6 +303,14 @@ theorem canonical_eq_iff_eqv {n : ℕ} (c₁ c₂ : Circuit n) :
     have : eval c₁ x ≠ eval c₂ x := by simpa [hx₁, hx₂] using hx
     exact this (h x)
 
+/-!
+The theorem `canonical_eq_iff_eqv` establishes that canonicalisation is
+**both sound and complete** with respect to circuit evaluation.  Two circuits
+have identical canonical representations exactly when they compute the same
+Boolean function.  This fact underpins later counting arguments where each
+equivalence class of circuits can be represented by a unique canonical member.
+-/
+
 /-- Length bound for canonical descriptions.  Each gate contributes at most
     `O(log n)` bits, hence a circuit of size `m` yields a description of
     length `O(m log n)`.  In particular, if `sizeOf c ≤ n^d` then the


### PR DESCRIPTION
### **User description**
## Summary
- add explanatory comment emphasizing the soundness and completeness of `canonical_eq_iff_eqv`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6886afcae58c832b9179a42cde150d70


___

### **PR Type**
Documentation


___

### **Description**
- Add explanatory comment for `canonical_eq_iff_eqv` theorem

- Emphasize soundness and completeness properties

- Clarify role in circuit equivalence representation


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>canonical_circuit.lean</strong><dd><code>Document canonical equivalence theorem properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/canonical_circuit.lean

<ul><li>Added multi-line comment explaining <code>canonical_eq_iff_eqv</code> theorem<br> <li> Emphasized soundness and completeness properties<br> <li> Clarified role in circuit equivalence class representation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/653/files#diff-06bf4de316d49d638f1afb1351600b8b4f80cc4f9f085251eed10105ef7be4d0">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

