### PR TITLE
Refactor SatCover lemmas

### DIFF
--- a/Pnp2/Algorithms/SatCover.lean
+++ b/Pnp2/Algorithms/SatCover.lean
@@ -34,11 +34,11 @@ lemma satViaCover_correct (f : BoolFun n) (h : ℕ) :
       exact ⟨x, hxtrue⟩
     · intro _
       refine ⟨Classical.choose hx, ?_, hxval⟩
-      simp [satViaCover, hx, hxval]
+      simp [hx]
   · constructor
     · intro hres
       rcases hres with ⟨x, hxres, _⟩
-      simp [satViaCover, hx] at hxres
+      simp [hx] at hxres
     · intro h
       rcases h with ⟨x, hxtrue⟩
       exact False.elim (hx ⟨x, hxtrue⟩)
@@ -53,13 +53,15 @@ lemma satViaCover_none (f : BoolFun n) (h : ℕ) :
       intro h'
       have := h' x
       simp [hxtrue] at this
-    have hxval := Classical.choose_spec hx
-    simp [satViaCover, hx, hxval, hxfalse]
+    simp [hx]
   · have hxforall : ∀ x, f x = false := by
       intro x
       by_contra hxtrue
       exact hx ⟨x, by simpa using hxtrue⟩
-    simp [satViaCover, hx, hxforall]
+    have hnone : satViaCover (n:=n) f h = none := by simp [satViaCover, hx]
+    constructor
+    · intro _; exact hxforall
+    · intro _; simpa [hnone]
 
 noncomputable def satViaCover_time (f : BoolFun n) (h : ℕ) : ℕ :=
   let _ := h -- retain parameter for future complexity bounds
@@ -72,7 +74,7 @@ lemma satViaCover_time_le_pow (f : BoolFun n) (h : ℕ) :
   have hle := Finset.card_filter_le (s := Finset.univ)
       (p := fun x : Point n => f x = true)
   have hcard : (Finset.univ : Finset (Point n)).card = 2 ^ n := by
-    simpa using (Fintype.card_fun (Fin n) Bool)
+    simp
   simpa [hcard] using hle
 
 lemma satViaCover_time_bound (f : BoolFun n) (h : ℕ) :

--- a/Pnp2/Algorithms/SatCover.lean
+++ b/Pnp2/Algorithms/SatCover.lean
@@ -58,10 +58,9 @@ lemma satViaCover_none (f : BoolFun n) (h : ℕ) :
       intro x
       by_contra hxtrue
       exact hx ⟨x, by simpa using hxtrue⟩
-    have hnone : satViaCover (n:=n) f h = none := by simp [satViaCover, hx]
     constructor
     · intro _; exact hxforall
-    · intro _; simpa [hnone]
+    · intro _; simp [satViaCover, hx]
 
 noncomputable def satViaCover_time (f : BoolFun n) (h : ℕ) : ℕ :=
   let _ := h -- retain parameter for future complexity bounds


### PR DESCRIPTION
### **User description**
## Summary
- clean up `satViaCover` proofs
- fix simp lines and adjust `satViaCover_time_le_pow`

## Testing
- `lake build Pnp2/Algorithms/SatCover.lean`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6886afcae58c832b9179a42cde150d70


___

### **PR Type**
Enhancement


___

### **Description**
- Simplify simp lemma calls in SatCover proofs

- Remove redundant parameters from simp statements

- Restructure proof logic for better clarity

- Fix proof structure in `satViaCover_none` lemma


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original proofs"] --> B["Remove redundant simp parameters"]
  B --> C["Restructure proof logic"]
  C --> D["Cleaner, more maintainable code"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SatCover.lean</strong><dd><code>Simplify simp calls and restructure proofs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Algorithms/SatCover.lean

<ul><li>Simplified <code>simp</code> calls by removing redundant parameters like <br><code>satViaCover</code>, <code>hxval</code><br> <li> Restructured <code>satViaCover_none</code> proof with explicit constructor/intro <br>pattern<br> <li> Fixed <code>satViaCover_time_le_pow</code> by replacing <code>simpa using</code> with <code>simp</code><br> <li> Improved proof readability and maintainability</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/654/files#diff-0787c19ee93b91a5a758115e134a58975939f1e7a4305db8963438f0482cf70c">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

