### PR TITLE
Add test for canonical circuit equality

### DIFF
--- a/test/Basic.lean
+++ b/test/Basic.lean
@@ -198,18 +198,27 @@ example (n : ℕ) (c : Boolcube.Circuit n) (x : Boolcube.Point n) :
   simpa using Boolcube.Circuit.eval_canonical (c := c) (x := x)
 
 -- Circuits with the same canonical form are extensionally equal.
-example {n : ℕ} {c₁ c₂ : Boolcube.Circuit n}
-    (h : Boolcube.Circuit.canonical c₁ = Boolcube.Circuit.canonical c₂)
-    (x : Boolcube.Point n) :
-    Boolcube.Circuit.eval c₁ x = Boolcube.Circuit.eval c₂ x := by
-  have hfun := Boolcube.Circuit.canonical_inj (c₁ := c₁) (c₂ := c₂) h
-  simpa using hfun x
+  example {n : ℕ} {c₁ c₂ : Boolcube.Circuit n}
+      (h : Boolcube.Circuit.canonical c₁ = Boolcube.Circuit.canonical c₂)
+      (x : Boolcube.Point n) :
+      Boolcube.Circuit.eval c₁ x = Boolcube.Circuit.eval c₂ x := by
+    have hfun := Boolcube.Circuit.canonical_inj (c₁ := c₁) (c₂ := c₂) h
+    simpa using hfun x
 
--- Double negation is eliminated by canonicalisation.
+-- Equality of canonical circuits is equivalent to extensional equality.
+example {n : ℕ} (c₁ c₂ : Boolcube.Circuit n) :
+    Boolcube.Circuit.canonical c₁ = Boolcube.Circuit.canonical c₂ ↔
+      (∀ x, Boolcube.Circuit.eval c₁ x = Boolcube.Circuit.eval c₂ x) := by
+  classical
+  simpa [Boolcube.Circuit.eqv] using
+    Boolcube.Circuit.canonical_eq_iff_eqv (c₁ := c₁) (c₂ := c₂)
+
+-- A simple instantiation: double negation does not change the canonical form.
 example :
     Boolcube.Circuit.canonical (Boolcube.Circuit.var (0 : Fin 1)) =
       Boolcube.Circuit.canonical
-        (Boolcube.Circuit.not (Boolcube.Circuit.not (Boolcube.Circuit.var 0))) := by
+        (Boolcube.Circuit.not (Boolcube.Circuit.not (Boolcube.Circuit.var 0))) :=
+by
   decide
 
 example (x : Boolcube.Point 1) :


### PR DESCRIPTION
### **User description**
## Summary
- extend `Basic.lean` with examples about `canonical_eq_iff_eqv`
- confirm double-negation canonicalisation via new example

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886c394eef8832b89f2ae3b9054ae05


___

### **PR Type**
Tests


___

### **Description**
- Add test for canonical circuit equivalence theorem

- Demonstrate double-negation canonicalization example

- Extend test coverage for circuit canonical forms


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Circuit c₁"] --> B["canonical c₁"]
  C["Circuit c₂"] --> D["canonical c₂"]
  B --> E["Equivalence Test"]
  D --> E
  E --> F["Extensional Equality"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Basic.lean</strong><dd><code>Add canonical equivalence and double-negation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Basic.lean

<ul><li>Add test demonstrating canonical equivalence theorem<br> <li> Include example showing double-negation canonicalization<br> <li> Extend existing circuit canonicalization test coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/656/files#diff-fbce6bd3531ab84591373af266126062c709cd0ae19cbe7688fce16a26bb1f1b">+18/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

