### PR TITLE
Introduce Cover2 with axioms

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1,0 +1,79 @@
+import Pnp2.BoolFunc
+import Pnp2.entropy
+import Pnp2.sunflower
+import Pnp2.Agreement
+import Pnp2.BoolFunc.Support
+import Pnp2.Sunflower.RSpread
+import Pnp2.low_sensitivity_cover
+import Pnp2.Boolcube
+import Mathlib.Data.Nat.Basic
+
+open Classical
+open Finset
+open Agreement
+open BoolFunc (Family BFunc)
+open Boolcube (Subcube)
+
+namespace Cover2
+
+/-!  This module will eventually replicate `cover.lean`.  For now we only
+reintroduce the basic numeric definitions and state their properties as
+axioms so that other files can depend on them without importing the heavy
+original construction.  -/
+
+@[simp] def mBound (n h : ℕ) : ℕ := n * (h + 2) * 2 ^ (10 * h)
+
+axiom numeric_bound (n h : ℕ) : 2 * h + n ≤ mBound n h
+axiom numeric_bound_pos (n h : ℕ) (hn : 0 < n) : 2 * h + n ≤ mBound n h
+axiom pow_le_mBound (n h : ℕ) (hn : 0 < n) : 2 ^ (10 * h) ≤ mBound n h
+axiom pow_le_mBound_simple (n h : ℕ) (hn : 0 < n) : 2 ^ h ≤ mBound n h
+axiom mBound_pos (n h : ℕ) (hn : 0 < n) : 0 < mBound n h
+axiom two_le_mBound (n h : ℕ) (hn : 0 < n) : 2 ≤ mBound n h
+axiom three_le_mBound (n h : ℕ) (hn : 0 < n) (hh : 1 ≤ h) : 3 ≤ mBound n h
+
+@[simp] lemma mBound_zero (h : ℕ) : mBound 0 h = 0 := by simp [mBound]
+
+axiom mBound_eq_zero_iff {n h : ℕ} : mBound n h = 0 ↔ n = 0
+axiom mBound_mono {n : ℕ} : Monotone (mBound n)
+axiom mBound_mono_left {n₁ n₂ h : ℕ} (hn : n₁ ≤ n₂) :
+    mBound n₁ h ≤ mBound n₂ h
+axiom mBound_le_succ (n h : ℕ) : mBound n h ≤ mBound n (h + 1)
+axiom two_mul_mBound_le_succ (n h : ℕ) : 2 * mBound n h ≤ mBound n (h + 1)
+axiom card_union_mBound_succ {n h : ℕ} {R₁ R₂ : Finset (Subcube n)}
+    (h₁ : R₁.card ≤ mBound n h) (h₂ : R₂.card ≤ mBound n h) :
+    (R₁ ∪ R₂).card ≤ mBound n (h + 1)
+axiom one_add_mBound_le_succ {n h : ℕ} (hn : 0 < n) :
+    mBound n h + 1 ≤ mBound n (h + 1)
+axiom card_union_singleton_mBound_succ {n h : ℕ}
+    {Rset : Finset (Subcube n)} {R : Subcube n}
+    (hcard : Rset.card ≤ mBound n h) (hn : 0 < n) :
+    (Rset ∪ {R}).card ≤ mBound n (h + 1)
+axiom card_insert_mBound_succ {n h : ℕ}
+    {Rset : Finset (Subcube n)} {R : Subcube n}
+    (hcard : Rset.card ≤ mBound n h) (hn : 0 < n) :
+    (insert R Rset).card ≤ mBound n (h + 1)
+axiom card_union_pair_mBound_succ {n h : ℕ}
+    {Rset : Finset (Subcube n)} {R₁ R₂ : Subcube n}
+    (hcard : Rset.card ≤ mBound n h) (hn : 0 < n) :
+    (Rset ∪ {R₁, R₂}).card ≤ mBound n (h + 1)
+axiom card_union_triple_mBound_succ {n h : ℕ}
+    {Rset : Finset (Subcube n)} {R₁ R₂ R₃ : Subcube n}
+    (hcard : Rset.card ≤ mBound n h) (hn : 0 < n) (hh : 1 ≤ h) :
+    (Rset ∪ {R₁, R₂, R₃}).card ≤ mBound n (h + 1)
+
+@[simp] def size {n : ℕ} (Rset : Finset (Subcube n)) : ℕ := Rset.card
+
+lemma cover_size_bound {n : ℕ} (Rset : Finset (Subcube n)) :
+    size Rset ≤ Fintype.card (Subcube n) := by
+  classical
+  simpa [size] using (Finset.card_le_univ (s := Rset))
+
+@[simp] def bound_function (n : ℕ) : ℕ := Fintype.card (Subcube n)
+
+lemma size_bounds {n : ℕ} (Rset : Finset (Subcube n)) :
+    size Rset ≤ bound_function n := by
+  classical
+  simpa [bound_function] using cover_size_bound (Rset := Rset)
+
+end Cover2
+

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -24,6 +24,7 @@ lean_lib Tests where
   -- migration, so we exclude them from the test library.
   globs := #[
     `CoverExtra,
+    `Cover2Test,
     `Pnp2Tests,
     `SatCoverTest,
     `CoverComputeTest,

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1,0 +1,21 @@
+import Pnp2.cover2
+
+open Cover2
+
+namespace Cover2Test
+
+/-- `mBound` is computed via the wrapper definition. -/
+example : mBound 1 0 = 2 := by
+  simp [mBound]
+
+/-- Numeric bound specialised to trivial parameters. -/
+example : 2 * 0 + 1 ≤ mBound 1 0 := by
+  simpa using numeric_bound (n := 1) (h := 0)
+
+/-- Positivity of `mBound` when `n` is positive. -/
+example : 0 < mBound 1 0 := by
+  have hn : 0 < (1 : ℕ) := by decide
+  simpa [mBound] using mBound_pos (n := 1) (h := 0) hn
+
+end Cover2Test
+


### PR DESCRIPTION
### **User description**
## Summary
- add new module `cover2.lean` that reintroduces basic numeric definitions as axioms
- register a simple test `Cover2Test` exercising the new API
- include the new test in the Lake configuration

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688792368fe4832bb162603bb37ed88b


___

### **PR Type**
Enhancement


___

### **Description**
- Add new `Cover2` module with axiomatized numeric definitions

- Introduce `mBound` function and related axioms for bounds

- Create test suite for Cover2 functionality

- Update Lake configuration to include new test


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cover2 module"] --> B["mBound function"]
  A --> C["Numeric axioms"]
  B --> D["Cover2Test"]
  C --> D
  D --> E["Lake configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>New Cover2 module with axiomatized bounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Define <code>mBound</code> function for numeric bounds calculation<br> <li> Add comprehensive set of axioms for bound properties<br> <li> Include helper functions <code>size</code> and <code>bound_function</code><br> <li> Provide lemmas for cover size bounds</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/658/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lakefile.lean</strong><dd><code>Register Cover2Test in Lake configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lakefile.lean

- Add `Cover2Test` to the test library globs configuration


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/658/files#diff-fd192e16bc7cf53633d375bda1f45a277eb2abb6373b8f375c45e4777125f0f6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Test suite for Cover2 functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Create test cases for <code>mBound</code> computation<br> <li> Test numeric bound axioms with trivial parameters<br> <li> Verify positivity properties of <code>mBound</code></ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/658/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

