### PR TITLE
Port numeric_bound via cover

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -6,7 +6,9 @@ import Pnp2.BoolFunc.Support
 import Pnp2.Sunflower.RSpread
 import Pnp2.low_sensitivity_cover
 import Pnp2.Boolcube
+import Pnp2.cover  -- access existing proofs
 import Mathlib.Data.Nat.Basic
+import Mathlib.Tactic
 
 open Classical
 open Finset
@@ -23,7 +25,8 @@ original construction.  -/
 
 @[simp] def mBound (n h : ℕ) : ℕ := n * (h + 2) * 2 ^ (10 * h)
 
-axiom numeric_bound (n h : ℕ) : 2 * h + n ≤ mBound n h
+lemma numeric_bound (n h : ℕ) : 2 * h + n ≤ mBound n h := by
+  simpa [mBound, Cover.mBound] using Cover.numeric_bound (n := n) (h := h)
 axiom numeric_bound_pos (n h : ℕ) (hn : 0 < n) : 2 * h + n ≤ mBound n h
 axiom pow_le_mBound (n h : ℕ) (hn : 0 < n) : 2 ^ (10 * h) ≤ mBound n h
 axiom pow_le_mBound_simple (n h : ℕ) (hn : 0 < n) : 2 ^ h ≤ mBound n h


### PR DESCRIPTION
### **User description**
## Summary
- import `Pnp2.cover` and re-use its proof of `numeric_bound`
- add missing tactic imports

## Testing
- `lake build Pnp2.cover2`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6887e1d9590c832b8a645b3020a67618


___

### **PR Type**
Enhancement


___

### **Description**
- Replace axiom with proven lemma for `numeric_bound`

- Import `Pnp2.cover` module for proof reuse

- Add `Mathlib.Tactic` import for tactic support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  axiom["numeric_bound axiom"] -- "replace with" --> lemma["proven lemma"]
  cover["Pnp2.cover import"] -- "provides" --> proof["Cover.numeric_bound proof"]
  proof -- "used in" --> lemma
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Replace axiom with proven lemma from cover</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Import <code>Pnp2.cover</code> module to access existing proofs<br> <li> Add <code>Mathlib.Tactic</code> import for tactic support<br> <li> Replace <code>numeric_bound</code> axiom with proven lemma using <br><code>Cover.numeric_bound</code><br> <li> Implement proof using <code>simpa</code> tactic with bound definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/664/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

