### PR TITLE
Migrate monotonicity lemmas into cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -114,8 +114,7 @@ lemma mBound_mono_left {n₁ n₂ h : ℕ} (hn : n₁ ≤ n₂) :
   dsimp [mBound]
   have hfac : n₁ * (h + 2) ≤ n₂ * (h + 2) :=
     Nat.mul_le_mul_right (h + 2) hn
-  have := Nat.mul_le_mul hfac (le_rfl : 2 ^ (10 * h) ≤ 2 ^ (10 * h))
-  simpa [Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using this
+  exact Nat.mul_le_mul hfac (le_rfl)
 
 lemma mBound_le_succ (n h : ℕ) : mBound n h ≤ mBound n (h + 1) :=
   mBound_mono (n := n) (Nat.le_succ h)

--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -99,10 +99,26 @@ lemma mBound_eq_zero_iff {n h : ℕ} : mBound n h = 0 ↔ n = 0 := by
       constructor
       · intro hzero; exact False.elim (hneq hzero)
       · intro hfalse; cases hfalse
-axiom mBound_mono {n : ℕ} : Monotone (mBound n)
-axiom mBound_mono_left {n₁ n₂ h : ℕ} (hn : n₁ ≤ n₂) :
-    mBound n₁ h ≤ mBound n₂ h
-axiom mBound_le_succ (n h : ℕ) : mBound n h ≤ mBound n (h + 1)
+lemma mBound_mono {n : ℕ} : Monotone (mBound n) := by
+  intro h₁ h₂ hh
+  dsimp [mBound]
+  have hfac : n * (h₁ + 2) ≤ n * (h₂ + 2) :=
+    Nat.mul_le_mul_left _ (Nat.add_le_add_right hh 2)
+  have hpow : 2 ^ (10 * h₁) ≤ 2 ^ (10 * h₂) := by
+    have := Nat.mul_le_mul_left 10 hh
+    exact Nat.pow_le_pow_right (by decide : 1 ≤ (2 : ℕ)) this
+  exact Nat.mul_le_mul hfac hpow
+
+lemma mBound_mono_left {n₁ n₂ h : ℕ} (hn : n₁ ≤ n₂) :
+    mBound n₁ h ≤ mBound n₂ h := by
+  dsimp [mBound]
+  have hfac : n₁ * (h + 2) ≤ n₂ * (h + 2) :=
+    Nat.mul_le_mul_right (h + 2) hn
+  have := Nat.mul_le_mul hfac (le_rfl : 2 ^ (10 * h) ≤ 2 ^ (10 * h))
+  simpa [Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using this
+
+lemma mBound_le_succ (n h : ℕ) : mBound n h ≤ mBound n (h + 1) :=
+  mBound_mono (n := n) (Nat.le_succ h)
 axiom two_mul_mBound_le_succ (n h : ℕ) : 2 * mBound n h ≤ mBound n (h + 1)
 axiom card_union_mBound_succ {n h : ℕ} {R₁ R₂ : Finset (Subcube n)}
     (h₁ : R₁.card ≤ mBound n h) (h₂ : R₂.card ≤ mBound n h) :


### PR DESCRIPTION
### **User description**
## Summary
- port basic numeric lemmas from `cover.lean` into `cover2.lean`
- provide proofs for `mBound_mono`, `mBound_mono_left`, and `mBound_le_succ`

## Testing
- `lake -Kenv=dev test`

------
https://chatgpt.com/codex/tasks/task_e_688816fffaf0832b99d60b9dd063f827


___

### **PR Type**
Enhancement


___

### **Description**
- Replace axioms with proven lemmas for `mBound` monotonicity

- Provide concrete proofs using multiplication and power inequalities

- Maintain API compatibility while removing axiom dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  axioms["Axiom declarations"] -- "replace with" --> proofs["Proven lemmas"]
  proofs -- "use" --> inequalities["Nat multiplication/power inequalities"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Replace mBound axioms with proofs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Replace three axioms with proven lemmas for <code>mBound</code> monotonicity<br> <li> Add concrete proofs using natural number multiplication and power <br>inequalities<br> <li> Maintain same function signatures and behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/668/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+20/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

