### PR TITLE
Port union lemmas to cover2

### DIFF
--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -50,5 +50,17 @@ example :
       (Rset := (∅ : Finset (Subcube 1))) (R := Subcube.full)
       hcard hn)
 
+/-- Uniting with a singleton cover stays within the next budget. -/
+example :
+    ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}).card ≤ mBound 1 1 := by
+  classical
+  have hcard : ((∅ : Finset (Subcube 1)).card) ≤ mBound 1 0 := by
+    simp [mBound]
+  have hn : 0 < (1 : ℕ) := by decide
+  simpa using
+    (card_union_singleton_mBound_succ (n := 1) (h := 0)
+      (Rset := (∅ : Finset (Subcube 1))) (R := Subcube.full)
+      hcard hn)
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- implement `one_add_mBound_le_succ`, `card_union_singleton_mBound_succ`, and `card_insert_mBound_succ` in `cover2.lean`
- extend `Cover2Test` with a check for the new lemma

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6888352714b8832b8b7161e815c2fabd


___

### **PR Type**
Enhancement


___

### **Description**
- Port three union/insert lemmas from axioms to proven implementations

- Add comprehensive proofs for `mBound` cardinality bounds

- Extend test coverage with union singleton example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["axiom declarations"] --> B["proven lemmas"]
  B --> C["mBound cardinality bounds"]
  C --> D["extended test coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Convert axioms to proven lemmas with mBound bounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Convert three axioms to proven lemmas with detailed proofs<br> <li> Implement <code>one_add_mBound_le_succ</code> using positivity and doubling <br>arguments<br> <li> Add <code>card_union_singleton_mBound_succ</code> and <code>card_insert_mBound_succ</code> <br>proofs<br> <li> Use classical logic and cardinality bounds for union operations</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/673/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+39/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add union singleton test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add new test example for union singleton cardinality bound<br> <li> Verify <code>card_union_singleton_mBound_succ</code> with empty set and full <br>subcube<br> <li> Mirror existing insert test structure for consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/673/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

