### PR TITLE
Port numeric_bound proof to cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -24,8 +24,7 @@ original construction.  -/
 
 @[simp] def mBound (n h : ℕ) : ℕ := n * (h + 2) * 2 ^ (10 * h)
 
-axiom numeric_bound (n h : ℕ) : 2 * h + n ≤ mBound n h
-lemma numeric_bound_pos (n h : ℕ) (hn : 0 < n) :
+lemma numeric_bound (n h : ℕ) (hn : 0 < n) :
     2 * h + n ≤ mBound n h := by
   classical
   cases h with
@@ -52,6 +51,10 @@ lemma numeric_bound_pos (n h : ℕ) (hn : 0 < n) :
           _ ≤ (n * (h + 1 + 2)) * 2 ^ (10 * (h + 1)) :=
             Nat.mul_le_mul_left _ hpow
       simpa [mBound] using this
+
+lemma numeric_bound_pos (n h : ℕ) (hn : 0 < n) :
+    2 * h + n ≤ mBound n h :=
+  numeric_bound (n := n) (h := h) hn
 lemma pow_le_mBound (n h : ℕ) (hn : 0 < n) :
     2 ^ (10 * h) ≤ mBound n h := by
   have hpos : 0 < n * (h + 2) := by


### PR DESCRIPTION
### **User description**
## Summary
- replace the axiom `numeric_bound` in `cover2.lean` with a full proof
- provide `numeric_bound_pos` as an alias

## Testing
- `lake build Pnp2.cover2`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688842f3e4b8832b9e450746281ce3d2


___

### **PR Type**
Enhancement


___

### **Description**
- Replace axiom `numeric_bound` with complete proof

- Add `numeric_bound_pos` as alias lemma

- Maintain same functionality with proper mathematical foundation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["axiom numeric_bound"] --> B["lemma numeric_bound with proof"]
  B --> C["lemma numeric_bound_pos as alias"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Convert axiom to proven lemma with alias</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Converted <code>numeric_bound</code> from axiom to proven lemma<br> <li> Added positivity constraint <code>(hn : 0 < n)</code> to main lemma<br> <li> Created <code>numeric_bound_pos</code> as alias for backward compatibility<br> <li> Maintained existing proof structure and mathematical content</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/677/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

