### PR TITLE
Port missing NotCovered lemmas

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -13,7 +13,10 @@ open Classical
 open Finset
 open Agreement
 open BoolFunc (Family BFunc)
-open Boolcube (Subcube)
+open Boolcube (Point Subcube)
+
+-- Local notation for membership in a subcube of the Boolean cube.
+notation x " ∈ₛ " R => Boolcube.Subcube.Mem R x
 
 namespace Cover2
 
@@ -271,6 +274,26 @@ lemma size_bounds {n : ℕ} (Rset : Finset (Subcube n)) :
     size Rset ≤ bound_function n := by
   classical
   simpa [bound_function] using cover_size_bound (Rset := Rset)
+
+/-! ## Auxiliary predicates -/
+
+variable {n h : ℕ} (F : Family n)
+
+/-- `x` is **not yet covered** by `Rset`. -/
+def NotCovered (Rset : Finset (Subcube n)) (x : Point n) : Prop :=
+  ∀ R ∈ Rset, ¬ x ∈ₛ R
+
+@[simp] lemma notCovered_empty (x : Point n) :
+    NotCovered (n := n) (Rset := (∅ : Finset (Subcube n))) x := by
+  intro R hR
+  -- `hR` is impossible since the set is empty
+  exact False.elim (by simpa using hR)
+
+lemma NotCovered.monotone {R₁ R₂ : Finset (Subcube n)} (hsub : R₁ ⊆ R₂)
+    {x : Point n} (hx : NotCovered (n := n) (Rset := R₂) x) :
+    NotCovered (n := n) (Rset := R₁) x := by
+  intro R hR
+  exact hx R (hsub hR)
 
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1,6 +1,6 @@
 import Pnp2.cover2
 
-open Boolcube (Subcube)
+open Boolcube (Point Subcube)
 
 open Cover2
 
@@ -49,6 +49,21 @@ example :
     (card_insert_mBound_succ (n := 1) (h := 0)
       (Rset := (∅ : Finset (Subcube 1))) (R := Subcube.full)
       hcard hn)
+
+/-- Nothing is covered by an empty set of rectangles. -/
+example (x : Point 1) :
+    Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x := by
+  simpa using Cover2.notCovered_empty (n := 1) (x := x)
+
+/-- `NotCovered` is monotone under set inclusion. -/
+example (x : Point 1) (R : Subcube 1)
+    (hx : Cover2.NotCovered (n := 1) (Rset := {R}) x) :
+    Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x := by
+  have hsub : (∅ : Finset (Subcube 1)) ⊆ {R} := by
+    intro r hr; cases hr
+  simpa using
+    Cover2.NotCovered.monotone (n := 1) (R₁ := (∅ : Finset (Subcube 1)))
+      (R₂ := {R}) hsub hx
 
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- port `NotCovered` and basic properties from `cover` to `cover2`
- expose membership notation for `Boolcube.Subcube`
- extend `Cover2Test` to exercise the new predicates

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6888c6238a8c832b855f77cbe69f82a3


___

### **PR Type**
Enhancement


___

### **Description**
- Port `NotCovered` predicate and lemmas from `cover` to `cover2`

- Add membership notation for `Boolcube.Subcube`

- Extend test coverage for new predicates

- Add monotonicity property for `NotCovered`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover.lean"] -- "port predicates" --> B["cover2.lean"]
  B -- "add notation" --> C["∈ₛ membership"]
  B -- "define" --> D["NotCovered predicate"]
  D -- "prove" --> E["monotonicity lemma"]
  B -- "test" --> F["Cover2Test.lean"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add NotCovered predicate with properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add local notation <code>∈ₛ</code> for subcube membership<br> <li> Define <code>NotCovered</code> predicate for uncovered points<br> <li> Add <code>notCovered_empty</code> simp lemma<br> <li> Prove monotonicity property for <code>NotCovered</code></ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/678/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Extend tests for NotCovered predicate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Import <code>Point</code> type from <code>Boolcube</code><br> <li> Add test for empty set coverage<br> <li> Add test for <code>NotCovered</code> monotonicity property</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/678/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

