### PR TITLE
Add AllOnesCovered lemma to cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -295,5 +295,17 @@ lemma NotCovered.monotone {R₁ R₂ : Finset (Subcube n)} (hsub : R₁ ⊆ R₂
   intro R hR
   exact hx R (hsub hR)
 
+/-- All `1`-inputs of `F` lie in some rectangle of `Rset`. -/
+@[simp]
+def AllOnesCovered (F : Family n) (Rset : Finset (Subcube n)) : Prop :=
+  ∀ f ∈ F, ∀ x, f x = true → ∃ R ∈ Rset, x ∈ₛ R
+
+lemma AllOnesCovered.full (F : Family n) :
+    AllOnesCovered (n := n) F ({Subcube.full} : Finset (Subcube n)) := by
+  classical
+  intro f hf x hx
+  refine ⟨Subcube.full, by simp, ?_⟩
+  simpa using (Subcube.mem_full (n := n) (x := x))
+
 end Cover2
 

--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -302,7 +302,6 @@ def AllOnesCovered (F : Family n) (Rset : Finset (Subcube n)) : Prop :=
 
 lemma AllOnesCovered.full (F : Family n) :
     AllOnesCovered (n := n) F ({Subcube.full} : Finset (Subcube n)) := by
-  classical
   intro f hf x hx
   refine ⟨Subcube.full, by simp, ?_⟩
   simpa using (Subcube.mem_full (n := n) (x := x))

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -70,10 +70,7 @@ example :
     Cover2.AllOnesCovered (n := 1)
       ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
       ({Subcube.full} : Finset (Subcube 1)) := by
-  classical
-  let Fset : BoolFunc.Family 1 := {(fun _ : Point 1 => true)}
-  have h := Cover2.AllOnesCovered.full (F := Fset)
-  simpa [Fset] using h
+  exact Cover2.AllOnesCovered.full _
 
 end Cover2Test
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -65,5 +65,15 @@ example (x : Point 1) (R : Subcube 1)
     Cover2.NotCovered.monotone (n := 1) (R₁ := (∅ : Finset (Subcube 1)))
       (R₂ := {R}) hsub hx
 
+/-- A single full rectangle covers all `1`-inputs. -/
+example :
+    Cover2.AllOnesCovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      ({Subcube.full} : Finset (Subcube 1)) := by
+  classical
+  let Fset : BoolFunc.Family 1 := {(fun _ : Point 1 => true)}
+  have h := Cover2.AllOnesCovered.full (F := Fset)
+  simpa [Fset] using h
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- expand `cover2` with `AllOnesCovered` and proof for the full cube
- test the new lemma in `Cover2Test`

## Testing
- `lake build Pnp2.cover2`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6888d64cf5fc832b93187eaeeeb979f1


___

### **PR Type**
Enhancement


___

### **Description**
- Add `AllOnesCovered` definition for checking if all true inputs are covered by rectangles

- Implement proof that full cube covers all true inputs

- Add test case demonstrating the new lemma functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AllOnesCovered definition"] --> B["full cube lemma"]
  B --> C["test verification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add AllOnesCovered definition and full cube lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>AllOnesCovered</code> definition to check if all true function inputs are <br>covered by rectangles<br> <li> Implement <code>AllOnesCovered.full</code> lemma proving that a full cube covers <br>all true inputs</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/679/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for AllOnesCovered lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example demonstrating <code>AllOnesCovered</code> with full rectangle <br>coverage<br> <li> Verify the new lemma works for a simple boolean function case</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/679/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

