### PR TITLE
Resolve linter warnings

### DIFF
--- a/Pnp2/Algorithms/SatCover.lean
+++ b/Pnp2/Algorithms/SatCover.lean
@@ -16,7 +16,7 @@ implementation simply returns an arbitrary witness using classical
 choice whenever one exists.  The parameter `h` is reserved for future
 complexity bounds and is presently ignored.
 -/
-noncomputable def satViaCover (f : BoolFun n) (h : ℕ) : Option (Point n) :=
+noncomputable def satViaCover (f : BoolFun n) (_h : ℕ) : Option (Point n) :=
   if hx : ∃ x, f x = true then
     some (Classical.choose hx)
   else
@@ -60,7 +60,7 @@ lemma satViaCover_none (f : BoolFun n) (h : ℕ) :
       exact hx ⟨x, by simpa using hxtrue⟩
     constructor
     · intro _; exact hxforall
-    · intro _; simp [satViaCover, hx]
+    · intro _; simp [hx]
 
 noncomputable def satViaCover_time (f : BoolFun n) (h : ℕ) : ℕ :=
   let _ := h -- retain parameter for future complexity bounds

--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -56,7 +56,7 @@ variable {n : ℕ}
 It enumerates the rectangles produced by `Cover.coverFamily`, turning the finite set into an explicit list.
 -/
 def buildCoverCompute (F : Family n) (h : ℕ)
-    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=
   []
 @[simp] lemma buildCoverCompute_empty (h : ℕ)
     (hH : BoolFunc.H₂ (∅ : Family n) ≤ (h : ℝ)) :
@@ -75,13 +75,14 @@ Basic specification for `buildCoverCompute`. It simply expands `Cover.coverFamil
 so the rectangles remain monochromatic and the length bound follows from `coverFamily_card_bound`.
 -/
 lemma buildCoverCompute_spec (F : Family n) (h : ℕ)
-    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
-    (∀ R ∈ (buildCoverCompute (F := F) (h := h) hH).toFinset,
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (∀ R ∈ (buildCoverCompute (F := F) (h := h) _hH).toFinset,
         Subcube.monochromaticForFamily R F) ∧
-    (buildCoverCompute (F := F) (h := h) hH).length ≤ mBound n h := by
+    (buildCoverCompute (F := F) (h := h) _hH).length ≤ mBound n h := by
   classical
   constructor
   · intro R hR; cases hR
-  · simpa [buildCoverCompute] using buildCoverCompute_length (F := F) (h := h) (hH := hH)
+  · simpa [buildCoverCompute] using
+      buildCoverCompute_length (F := F) (h := h) (hH := _hH)
 
 end Cover

--- a/Pnp2/DecisionTree.lean
+++ b/Pnp2/DecisionTree.lean
@@ -420,12 +420,12 @@ lemma path_to_leaf_agrees (t : DecisionTree n) (x : Point n) :
       · have h := ih1 x
         simp [path_to_leaf, hxi] at hq
         cases hq with
-        | inl hq => cases hq; simpa [hxi]
+        | inl hq => cases hq; simp [hxi]
         | inr hq => exact h q hq
       · have h := ih0 x
         simp [path_to_leaf, hxi] at hq
         cases hq with
-        | inl hq => cases hq; simpa [hxi]
+        | inl hq => cases hq; simp [hxi]
         | inr hq => exact h q hq
 
 /-!  If every entry of `p` matches the corresponding coordinate of `x`,
@@ -436,7 +436,7 @@ lemma mem_subcube_of_path_of_agrees (x : Point n) :
   intro p
   induction p with
   | nil =>
-      intro _; simpa using mem_subcube_of_path_nil (n := n) (x := x)
+      intro _; simp [mem_subcube_of_path_nil (n := n) (x := x)]
   | cons q p ih =>
       intro h
       rcases q with ⟨i, b⟩

--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -123,7 +123,7 @@ lemma three_le_mBound (n h : ℕ) (hn : 0 < n) (hh : 1 ≤ h) :
 lemma mBound_eq_zero_iff {n h : ℕ} : mBound n h = 0 ↔ n = 0 := by
   cases n with
   | zero =>
-      simp [mBound_zero]
+      simp
   | succ n =>
       have hpos : 0 < mBound (Nat.succ n) h :=
         mBound_pos (n := Nat.succ n) (h := h) (Nat.succ_pos _)
@@ -253,7 +253,7 @@ lemma card_union_triple_mBound_succ {n h : ℕ}
     have h := le_trans hcard_insert (Nat.add_le_add_right hpair_le_two 1)
     have hrepr : insert R₃ ({R₁, R₂} : Finset (Subcube n)) = {R₁, R₂, R₃} := by
       ext x; by_cases hx : x = R₃ <;> by_cases hx1 : x = R₁ <;> by_cases hx2 : x = R₂ <;>
-        simp [hx, hx1, hx2, Finset.mem_insert, Finset.mem_singleton, or_comm, or_left_comm, or_assoc]
+        simp [hx, hx1, hx2, Finset.mem_insert, Finset.mem_singleton, or_comm]
     simpa [Rtriple, hrepr] using h
   have htriple_bound : Rtriple.card ≤ mBound n h :=
     le_trans htriple_le_three (three_le_mBound (n := n) (h := h) hn hh)
@@ -287,7 +287,7 @@ def NotCovered (Rset : Finset (Subcube n)) (x : Point n) : Prop :=
     NotCovered (n := n) (Rset := (∅ : Finset (Subcube n))) x := by
   intro R hR
   -- `hR` is impossible since the set is empty
-  exact False.elim (by simpa using hR)
+  cases hR
 
 lemma NotCovered.monotone {R₁ R₂ : Finset (Subcube n)} (hsub : R₁ ⊆ R₂)
     {x : Point n} (hx : NotCovered (n := n) (Rset := R₂) x) :
@@ -304,7 +304,7 @@ lemma AllOnesCovered.full (F : Family n) :
     AllOnesCovered (n := n) F ({Subcube.full} : Finset (Subcube n)) := by
   intro f hf x hx
   refine ⟨Subcube.full, by simp, ?_⟩
-  simpa using (Subcube.mem_full (n := n) (x := x))
+  simp
 
 end Cover2
 

--- a/Pnp2/entropy.lean
+++ b/Pnp2/entropy.lean
@@ -22,12 +22,12 @@ namespace BoolFunc
 We work in `ℝ` because later analytic lemmas (`log` monotonicity, etc.) live
 in `ℝ`. -/
 noncomputable
- def collProb {n : ℕ} (F : Family n) : ℝ :=
-  if h : (F.card = 0) then 0 else (F.card : ℝ)⁻¹
+def collProb {n : ℕ} (F : Family n) : ℝ :=
+  if F.card = 0 then 0 else (F.card : ℝ)⁻¹
 
 @[simp] lemma collProb_pos {n : ℕ} {F : Family n} (h : 0 < F.card) :
     collProb F = (F.card : ℝ)⁻¹ := by
-  simp [collProb, h.ne', h]
+  simp [collProb, h.ne']
 
 @[simp] lemma collProb_zero {n : ℕ} {F : Family n} (h : F.card = 0) :
     collProb F = 0 := by simp [collProb, h]
@@ -36,8 +36,9 @@ lemma collProb_nonneg {n : ℕ} (F : Family n) :
     0 ≤ collProb F := by
   by_cases h : F.card = 0
   · simp [collProb, h]
-  · have : 0 < (F.card : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero h
-    simpa [collProb, h] using inv_nonneg.mpr (le_of_lt this)
+  · have hpos : 0 < (F.card : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero h
+    have hnonneg : 0 ≤ (F.card : ℝ)⁻¹ := inv_nonneg.mpr (le_of_lt hpos)
+    simp [collProb, h, hnonneg]
 
 lemma collProb_le_one {n : ℕ} (F : Family n) :
     collProb F ≤ 1 := by
@@ -199,7 +200,7 @@ lemma H₂_filter_le {n : ℕ} (F : Family n)
   · -- The filtered family is empty, so the entropy is zero.
     have hF_ge : 0 ≤ H₂ F := by
       by_cases hF0 : F.card = 0
-      · simpa [H₂, hF0] using (le_of_eq rfl : (0 : ℝ) ≤ 0)
+      · simp [H₂, hF0]
       ·
         have hx : 1 ≤ (F.card : ℝ) := by
           have hpos : 0 < F.card := Nat.pos_of_ne_zero hF0

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -13,12 +13,12 @@ example : mBound 1 0 = 2 := by
 /-- Numeric bound specialised to trivial parameters using the positive version. -/
 example : 2 * 0 + 1 ≤ mBound 1 0 := by
   have hn : 0 < (1 : ℕ) := by decide
-  simpa using numeric_bound_pos (n := 1) (h := 0) hn
+  simp [numeric_bound_pos (n := 1) (h := 0) hn]
 
 /-- `numeric_bound_pos` also holds when `n` is strictly positive. -/
 example : 2 * 0 + 2 ≤ mBound 2 0 := by
   have hn : 0 < (2 : ℕ) := by decide
-  simpa using numeric_bound_pos (n := 2) (h := 0) hn
+  simp [numeric_bound_pos (n := 2) (h := 0) hn]
 
 /-- Doubling the bound for a smaller budget stays below the next budget. -/
 example : 2 * mBound 1 0 ≤ mBound 1 1 := by
@@ -27,12 +27,12 @@ example : 2 * mBound 1 0 ≤ mBound 1 1 := by
 /-- `pow_le_mBound_simple` for trivial parameters. -/
 example : 1 ≤ mBound 1 0 := by
   have hn : 0 < (1 : ℕ) := by decide
-  simpa using pow_le_mBound_simple (n := 1) (h := 0) hn
+  simp [pow_le_mBound_simple (n := 1) (h := 0) hn]
 
 /-- `two_le_mBound` verifies the bound is at least `2`. -/
 example : 2 ≤ mBound 1 0 := by
   have hn : 0 < (1 : ℕ) := by decide
-  simpa using two_le_mBound (n := 1) (h := 0) hn
+  simp [two_le_mBound (n := 1) (h := 0) hn]
 
 /-- Doubling the bound for `h = 0` stays below the next budget. -/
 example : 2 * mBound 1 0 ≤ mBound 1 1 := by

--- a/test/CoverComputeTest.lean
+++ b/test/CoverComputeTest.lean
@@ -12,8 +12,7 @@ example : mBound 1 0 = 2 := by
 
 /-- `mBound` is positive whenever `n > 0`. -/
 example : 0 < mBound 1 0 := by
-  have : 0 < (1 : ℕ) := by decide
-  simpa [mBound] using mBound_pos (n := 1) (h := 0) this
+  simp [mBound]
 
 /-/  `buildCoverCompute` enumerates a small cover for a trivial function. -/
 def trivialFun : BoolFun 1 := fun _ => false
@@ -24,9 +23,9 @@ example :
         classical
         -- Collision entropy of a singleton family is zero.
         have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
-        have hH₂ := BoolFunc.H₂_card_one
+        have _hH₂ := BoolFunc.H₂_card_one
             (F := ({trivialFun} : Boolcube.Family 1)) hcard
-        simpa [hH₂])
+        simp)
       ).length ≤ mBound 1 0 :=
 by
   classical
@@ -34,9 +33,9 @@ by
         (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
         (by
           have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
-          have hH₂ := BoolFunc.H₂_card_one
+          have _hH₂ := BoolFunc.H₂_card_one
               (F := ({trivialFun} : Boolcube.Family 1)) hcard
-          simpa [hH₂])
-  simpa using hspec.2
+          simp)
+  exact hspec.2
 
 end CoverComputeTest

--- a/test/SunflowerTest.lean
+++ b/test/SunflowerTest.lean
@@ -21,8 +21,8 @@ example :
     have hS' := by
       simpa [F] using hS
     rcases hS' with h0 | h1
-    · simpa [h0]
-    · simpa [h1]
+    · simp [h0]
+    · simp [h1]
   have hbig : F.card > Nat.factorial (2 - 1) * 1 ^ 2 := by
     simp [F]
   simpa [F] using


### PR DESCRIPTION
## Summary
- clean up `collProb` definition and proofs
- remove unused parameters and switch several `simpa` calls to `simp`
- tidy linter issues in examples and tests

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6888e605c63c832ba635682047e0d512