### PR TITLE
Port AllOnesCovered lemmas

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -7,6 +7,7 @@ import Pnp2.Sunflower.RSpread
 import Pnp2.low_sensitivity_cover
 import Pnp2.Boolcube
 import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Finset.Basic
 import Mathlib.Tactic
 
 open Classical
@@ -305,6 +306,32 @@ lemma AllOnesCovered.full (F : Family n) :
   intro f hf x hx
   refine ⟨Subcube.full, by simp, ?_⟩
   simp
+
+lemma AllOnesCovered.superset {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    (h₁ : AllOnesCovered (n := n) F R₁) (hsub : R₁ ⊆ R₂) :
+    AllOnesCovered (n := n) F R₂ := by
+  intro f hf x hx
+  rcases h₁ f hf x hx with ⟨R, hR, hxR⟩
+  exact ⟨R, hsub hR, hxR⟩
+
+lemma AllOnesCovered.union {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    (h₁ : AllOnesCovered (n := n) F R₁) (h₂ : AllOnesCovered (n := n) F R₂) :
+    AllOnesCovered (n := n) F (R₁ ∪ R₂) := by
+  intro f hf x hx
+  by_cases hx1 : ∃ R ∈ R₁, x ∈ₛ R
+  · rcases hx1 with ⟨R, hR, hxR⟩
+    exact ⟨R, by simpa [Finset.mem_union] using Or.inl hR, hxR⟩
+  · rcases h₂ f hf x hx with ⟨R, hR, hxR⟩
+    exact ⟨R, by simpa [Finset.mem_union, hx1] using Or.inr hR, hxR⟩
+
+lemma AllOnesCovered.insert {F : Family n} {Rset : Finset (Subcube n)}
+    {R : Subcube n} (hcov : AllOnesCovered (n := n) F Rset) :
+    AllOnesCovered (n := n) F (Insert.insert R Rset) := by
+  classical
+  have hsub : Rset ⊆ Insert.insert R Rset := by
+    intro S hS; exact Finset.mem_insert.mpr (Or.inr hS)
+  exact AllOnesCovered.superset (F := F) (R₁ := Rset)
+    (R₂ := Insert.insert R Rset) hcov hsub
 
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -72,5 +72,48 @@ example :
       ({Subcube.full} : Finset (Subcube 1)) := by
   exact Cover2.AllOnesCovered.full _
 
+/-- `AllOnesCovered.superset` allows enlarging the rectangle set. -/
+example :
+    Cover2.AllOnesCovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      ({Subcube.full, Subcube.full} : Finset (Subcube 1)) := by
+  classical
+  have hcov : Cover2.AllOnesCovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      ({Subcube.full} : Finset (Subcube 1)) :=
+    Cover2.AllOnesCovered.full _
+  have hsub : ({Subcube.full} : Finset (Subcube 1)) ⊆ {Subcube.full, Subcube.full} := by
+    intro R hR
+    simp [Finset.mem_insert, Finset.mem_singleton] at hR
+    simp [Finset.mem_insert, Finset.mem_singleton, hR]
+  exact
+    Cover2.AllOnesCovered.superset (F := {(fun _ : Point 1 => true)})
+      (R₁ := {Subcube.full}) (R₂ := {Subcube.full, Subcube.full})
+      hcov hsub
+
+/-- The union of two covers is again a cover. -/
+example :
+    Cover2.AllOnesCovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      ({Subcube.full} ∪ {Subcube.full} : Finset (Subcube 1)) := by
+  classical
+  have hcov := Cover2.AllOnesCovered.full
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+  simpa using
+    Cover2.AllOnesCovered.union (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (R₁ := {Subcube.full}) (R₂ := {Subcube.full}) hcov hcov
+
+/-- Inserting a rectangle preserves coverage. -/
+example :
+    Cover2.AllOnesCovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      (insert Subcube.full {Subcube.full} : Finset (Subcube 1)) := by
+  classical
+  have hcov := Cover2.AllOnesCovered.full
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+  simpa using
+    Cover2.AllOnesCovered.insert (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (Rset := {Subcube.full}) (R := Subcube.full) hcov
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- ported lemmas `AllOnesCovered.superset`, `.union` and `.insert` to `cover2`
- added examples exercising these lemmas in `Cover2Test`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6888f54639b8832b8ecd841dc8d908e1


___

### **PR Type**
Enhancement


___

### **Description**
- Added three new `AllOnesCovered` lemmas to `cover2.lean`

- Ported `superset`, `union`, and `insert` lemmas from original cover

- Added comprehensive test examples exercising new lemmas

- Enhanced mathematical coverage properties for subcube families


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AllOnesCovered base"] --> B["superset lemma"]
  A --> C["union lemma"]  
  A --> D["insert lemma"]
  B --> E["Test examples"]
  C --> E
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add three AllOnesCovered lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Added import for <code>Mathlib.Data.Finset.Basic</code><br> <li> Implemented <code>AllOnesCovered.superset</code> lemma for subset preservation<br> <li> Implemented <code>AllOnesCovered.union</code> lemma for combining covers<br> <li> Implemented <code>AllOnesCovered.insert</code> lemma for adding rectangles</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/682/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add comprehensive test examples for new lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Added test example for <code>AllOnesCovered.superset</code> functionality<br> <li> Added test example for <code>AllOnesCovered.union</code> operation<br> <li> Added test example for <code>AllOnesCovered.insert</code> operation<br> <li> All tests use classical logic and demonstrate lemma usage</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/682/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

