### PR TITLE
Port uncovered lemma

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -296,6 +296,24 @@ lemma NotCovered.monotone {R₁ R₂ : Finset (Subcube n)} (hsub : R₁ ⊆ R₂
   intro R hR
   exact hx R (hsub hR)
 
+/-! ### Uncovered points and search utilities -/
+
+/-- The set of all uncovered `1`-inputs (paired with their functions). -/
+@[simp]
+def uncovered (F : Family n) (Rset : Finset (Subcube n)) :
+    Set (Σ f : BFunc n, Point n) :=
+  {p | p.1 ∈ F ∧ p.1 p.2 = true ∧ NotCovered (n := n) (Rset := Rset) p.2}
+
+/-- Optionally return the *first* uncovered pair. -/
+noncomputable
+def firstUncovered (F : Family n) (Rset : Finset (Subcube n)) :
+    Option (Σ f : BFunc n, Point n) :=
+  if h : (uncovered (n := n) F Rset).Nonempty then
+    some h.choose
+  else
+    none
+
+
 /-- All `1`-inputs of `F` lie in some rectangle of `Rset`. -/
 @[simp]
 def AllOnesCovered (F : Family n) (Rset : Finset (Subcube n)) : Prop :=
@@ -332,6 +350,22 @@ lemma AllOnesCovered.insert {F : Family n} {Rset : Finset (Subcube n)}
     intro S hS; exact Finset.mem_insert.mpr (Or.inr hS)
   exact AllOnesCovered.superset (F := F) (R₁ := Rset)
     (R₂ := Insert.insert R Rset) hcov hsub
+
+lemma uncovered_eq_empty_of_allCovered {F : Family n}
+    {Rset : Finset (Subcube n)}
+    (hcov : AllOnesCovered (n := n) F Rset) :
+    uncovered (n := n) F Rset = (∅ : Set (Σ f : BFunc n, Point n)) := by
+  classical
+  ext p; constructor
+  · intro hp
+    have hf : p.1 ∈ F := hp.1
+    have hx : p.1 p.2 = true := hp.2.1
+    have hnc : NotCovered (n := n) (Rset := Rset) p.2 := hp.2.2
+    rcases hcov p.1 hf p.2 hx with ⟨R, hR, hxR⟩
+    have : ¬ Boolcube.Subcube.Mem R p.2 := hnc R hR
+    exact False.elim (this hxR)
+  · intro hp
+    cases hp
 
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -115,5 +115,19 @@ example :
     Cover2.AllOnesCovered.insert (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
       (Rset := {Subcube.full}) (R := Subcube.full) hcov
 
+/-- If all `1`-inputs are covered by a single full rectangle, the uncovered set
+is empty. -/
+example :
+    Cover2.uncovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      ({Subcube.full} : Finset (Subcube 1)) = (∅ : Set (Sigma (fun _ => Point 1))) := by
+  have hcov := Cover2.AllOnesCovered.full
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+  simpa using
+    Cover2.uncovered_eq_empty_of_allCovered
+      (n := 1)
+      (F := {(fun _ : Point 1 => true)})
+      (Rset := {Subcube.full}) hcov
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- extend `cover2.lean` with `uncovered` definition and helper
- rework `firstUncovered` with a simple choice-based definition
- prove `uncovered_eq_empty_of_allCovered`
- add regression test

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68892a10f744832b9057accb598744e7


___

### **PR Type**
Enhancement


___

### **Description**
- Add `uncovered` definition for tracking uncovered 1-inputs

- Implement `firstUncovered` utility with choice-based selection

- Prove `uncovered_eq_empty_of_allCovered` theorem

- Add regression test for uncovered functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Family F"] --> B["uncovered definition"]
  B --> C["firstUncovered utility"]
  B --> D["uncovered_eq_empty_of_allCovered theorem"]
  E["AllOnesCovered"] --> D
  D --> F["regression test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add uncovered points tracking utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>uncovered</code> definition for tracking uncovered 1-inputs with their <br>functions<br> <li> Implement <code>firstUncovered</code> utility using choice-based selection<br> <li> Prove <code>uncovered_eq_empty_of_allCovered</code> theorem connecting coverage to <br>empty uncovered set</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/683/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add uncovered functionality regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add regression test demonstrating <code>uncovered_eq_empty_of_allCovered</code> <br>theorem<br> <li> Test with single full rectangle covering all 1-inputs</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/683/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

