### PR TITLE
Port lemma uncovered_subset_of_union

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -367,5 +367,29 @@ lemma uncovered_eq_empty_of_allCovered {F : Family n}
   · intro hp
     cases hp
 
+/-!  Adding rectangles can only shrink the uncovered set.  Inserting a single
+rectangle therefore produces a subset of the original uncovered pairs. -/
+lemma uncovered_subset_of_union_singleton {F : Family n}
+    {Rset : Finset (Subcube n)} {R : Subcube n} :
+    uncovered (n := n) F (Rset ∪ {R}) ⊆ uncovered (n := n) F Rset := by
+  classical
+  intro p hp
+  rcases hp with ⟨hf, hx, hnc⟩
+  refine ⟨hf, hx, ?_⟩
+  intro S hS
+  exact hnc S (by exact Finset.mem_union.mpr <| Or.inl hS)
+
+/-- Extending the rectangle set by any finite collection cannot create new
+uncovered pairs. -/
+lemma uncovered_subset_of_union {F : Family n}
+    {R₁ R₂ : Finset (Subcube n)} :
+    uncovered (n := n) F (R₁ ∪ R₂) ⊆ uncovered (n := n) F R₁ := by
+  classical
+  intro p hp
+  rcases hp with ⟨hf, hx, hnc⟩
+  refine ⟨hf, hx, ?_⟩
+  intro S hS
+  exact hnc S (by exact Finset.mem_union.mpr <| Or.inl hS)
+
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -129,5 +129,19 @@ example :
       (F := {(fun _ : Point 1 => true)})
       (Rset := {Subcube.full}) hcov
 
+/-- Adding a rectangle cannot create new uncovered inputs. -/
+example :
+    Cover2.uncovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}) ⊆
+    Cover2.uncovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      (∅ : Finset (Subcube 1)) := by
+  classical
+  simpa using
+    (Cover2.uncovered_subset_of_union_singleton (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (Rset := (∅ : Finset (Subcube 1))) (R := Subcube.full))
+
 end Cover2Test
 


### PR DESCRIPTION
## Summary
- port `uncovered_subset_of_union_singleton` and `uncovered_subset_of_union` from `cover.lean` to `cover2.lean`
- add a small example test using the new lemma

## Testing
- `lake build Tests`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68894bf24790832ba527a1c0d6be5fa0