### PR TITLE
Add mu measure lemma to Cover2

### DIFF
--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -159,5 +159,21 @@ example (R₁ R₂ : Finset (Subcube 1)) :
       (F := {(fun _ : Point 1 => true)})
       (R₁ := R₁) (R₂ := R₂)
 
+/-- Inserting a rectangle never increases the measure `mu`. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}) ≤
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  simpa using
+    Cover2.mu_union_singleton_le
+      (n := 1)
+      (F := {(fun _ : Point 1 => true)})
+      (Rset := (∅ : Finset (Subcube 1)))
+      (R := Subcube.full) (h := 0)
+
 end Cover2Test
 


### PR DESCRIPTION
## Summary
- define `Cover2.mu` as a noncomputable size measure
- prove `Cover2.mu_union_singleton_le`
- add a regression test verifying the new lemma

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688961a4e680832b90293bf118f29a0d