### PR TITLE
Port mu lemmas to Cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -425,5 +425,52 @@ lemma mu_union_singleton_le {F : Family n} {Rset : Finset (Subcube n)}
   have := add_le_add_left hcard (2 * h)
   simpa [mu] using this
 
+/-!
+Adding a rectangle that covers at least one previously uncovered pair strictly
+decreases the measure `μ`.  This lemma will be useful when reasoning about
+progress of the cover construction.
+-/
+lemma mu_union_singleton_lt {F : Family n} {Rset : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    (hx : ∃ p ∈ uncovered (n := n) F Rset, p.2 ∈ₛ R) :
+    mu (n := n) F h (Rset ∪ {R}) < mu (n := n) F h Rset := by
+  classical
+  rcases hx with ⟨p, hpU, hpR⟩
+  have hp_not : p ∉ uncovered (n := n) F (Rset ∪ {R}) := by
+    rcases hpU with ⟨hf, hx, hnc⟩
+    intro hp'
+    rcases hp' with ⟨hf', hx', hnc'⟩
+    have := hnc' R (by simp) hpR
+    exact this
+  have hsub : (uncovered (n := n) F (Rset ∪ {R})).toFinset ⊆
+      (uncovered (n := n) F Rset).toFinset := by
+    intro x hx
+    have hx' : x ∈ uncovered (n := n) F (Rset ∪ {R}) := by simpa using hx
+    have hx'' : x ∈ uncovered (n := n) F Rset :=
+      uncovered_subset_of_union_singleton
+        (F := F) (Rset := Rset) (R := R) hx'
+    simpa using hx''
+  have hproper : ¬((uncovered (n := n) F Rset).toFinset ⊆
+        (uncovered (n := n) F (Rset ∪ {R})).toFinset) := by
+    intro hsubset
+    have hpFin : p ∈ (uncovered (n := n) F Rset).toFinset := by simpa using hpU
+    have := hsubset hpFin
+    exact hp_not (by simpa using this)
+  have hcard := Finset.card_lt_card ⟨hsub, hproper⟩
+  have := Nat.add_lt_add_left hcard (2 * h)
+  simpa [mu] using this
+
+/-!  A convenient corollary of `mu_union_singleton_lt`: if at least one new
+pair becomes covered, the measure decreases by one.  This quantified version is
+occasionally handy for numeric estimates. -/
+lemma mu_union_singleton_succ_le {F : Family n} {Rset : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    (hx : ∃ p ∈ uncovered (n := n) F Rset, p.2 ∈ₛ R) :
+    mu (n := n) F h (Rset ∪ {R}) + 1 ≤ mu (n := n) F h Rset := by
+  classical
+  have hlt :=
+    mu_union_singleton_lt (F := F) (Rset := Rset) (R := R) (h := h) hx
+  exact Nat.succ_le_of_lt hlt
+
 end Cover2
 

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 19 |
+| Fully migrated | 23 |
 | Axioms | 1 |
-| Pending | 67 |
+| Pending | 64 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -47,6 +47,9 @@ card_union_pair_mBound_succ
 card_union_triple_mBound_succ
 cover_size_bound
 size_bounds
+mu_union_singleton_le
+mu_union_singleton_lt
+mu_union_singleton_succ_le
 ```
 
 ### Declared as axioms
@@ -110,10 +113,7 @@ mu_union_le
 mu_union_lt
 mu_union_singleton_double_lt
 mu_union_singleton_double_succ_le
-mu_union_singleton_le
-mu_union_singleton_lt
 mu_union_singleton_quad_succ_le
-mu_union_singleton_succ_le
 mu_union_singleton_triple_lt
 mu_union_singleton_triple_succ_le
 mu_union_triple_lt

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1,6 +1,8 @@
 import Pnp2.cover2
+import Pnp2.BoolFunc
 
 open Boolcube (Point Subcube)
+open BoolFunc (BFunc Family)
 
 open Cover2
 
@@ -174,6 +176,60 @@ example :
       (F := {(fun _ : Point 1 => true)})
       (Rset := (∅ : Finset (Subcube 1)))
       (R := Subcube.full) (h := 0)
+
+/-- Adding a rectangle that covers a new input strictly decreases the measure. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}) <
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  -- Build a witness pair covered by `Subcube.full`.
+  let f : BFunc 1 := fun _ => true
+  let x : Point 1 := fun _ => true
+  have hf : f ∈ ({f} : BoolFunc.Family 1) := by simp
+  have hxval : f x = true := by simp [f, x]
+  have hnc : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x := by
+    intro R hR; cases hR
+  have hx : ∃ p ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1)), p.2 ∈ₛ Subcube.full := by
+    refine ⟨⟨f, x⟩, ?_, ?_⟩
+    · exact ⟨hf, hxval, hnc⟩
+    · simp [x]
+  simpa using
+    Cover2.mu_union_singleton_lt
+      (n := 1) (F := {f})
+      (Rset := (∅ : Finset (Subcube 1)))
+      (R := Subcube.full) (h := 0) hx
+
+/-- `mu_union_singleton_succ_le` provides a convenient inequality on measures. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}) + 1 ≤
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  -- Reuse the witness from the previous example.
+  let f : BFunc 1 := fun _ => true
+  let x : Point 1 := fun _ => true
+  have hf : f ∈ ({f} : BoolFunc.Family 1) := by simp
+  have hxval : f x = true := by simp [f, x]
+  have hnc : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x := by
+    intro R hR; cases hR
+  have hx : ∃ p ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1)), p.2 ∈ₛ Subcube.full := by
+    refine ⟨⟨f, x⟩, ?_, ?_⟩
+    · exact ⟨hf, hxval, hnc⟩
+    · simp [x]
+  simpa using
+    Cover2.mu_union_singleton_succ_le
+      (n := 1) (F := {f})
+      (Rset := (∅ : Finset (Subcube 1)))
+      (R := Subcube.full) (h := 0) hx
 
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- extend `cover2.lean` with `mu_union_singleton_lt` and `mu_union_singleton_succ_le`
- add examples for these lemmas in `Cover2Test`
- update migration notes in `cover_migration_plan.md`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688973883d44832bacffc5d3c69659e3


___

### **PR Type**
Enhancement


___

### **Description**
- Port two mu lemmas from Cover to Cover2

- Add test examples for the new lemmas

- Update migration documentation counts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cover lemmas"] --> B["Cover2 implementation"]
  B --> C["Test examples"]
  B --> D["Documentation update"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add two mu union singleton lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_union_singleton_lt</code> lemma proving strict decrease in measure<br> <li> Add <code>mu_union_singleton_succ_le</code> lemma as convenient corollary<br> <li> Include detailed documentation comments for both lemmas</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/688/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+47/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test examples for new lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add import for <code>BoolFunc</code> module<br> <li> Add example demonstrating <code>mu_union_singleton_lt</code> usage<br> <li> Add example demonstrating <code>mu_union_singleton_succ_le</code> usage</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/688/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 19 to 23<br> <li> Update pending count from 67 to 64<br> <li> Move three lemmas from pending to fully migrated section</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/688/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

