### PR TITLE
Port lemma mu_union_singleton_double_lt

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -472,5 +472,19 @@ lemma mu_union_singleton_succ_le {F : Family n} {Rset : Finset (Subcube n)}
     mu_union_singleton_lt (F := F) (Rset := Rset) (R := R) (h := h) hx
   exact Nat.succ_le_of_lt hlt
 
+/-- A corollary of `mu_union_singleton_double_succ_le`: if two distinct pairs
+become covered by inserting a rectangle, the measure drops strictly. -/
+lemma mu_union_singleton_double_lt {F : Family n} {Rset : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    {p₁ p₂ : Σ f : BFunc n, Point n}
+    (hp₁ : p₁ ∈ uncovered (n := n) F Rset) (hp₂ : p₂ ∈ uncovered (n := n) F Rset)
+    (hp₁R : p₁.2 ∈ₛ R) (hp₂R : p₂.2 ∈ₛ R) (hne : p₁ ≠ p₂) :
+    mu (n := n) F h (Rset ∪ {R}) < mu (n := n) F h Rset := by
+  classical
+  -- Covering even a single uncovered pair suffices for a strict drop.
+  have hx : ∃ p ∈ uncovered (n := n) F Rset, p.2 ∈ₛ R := ⟨p₁, hp₁, hp₁R⟩
+  -- Apply the basic inequality for one newly covered pair.
+  exact mu_union_singleton_lt (F := F) (Rset := Rset) (R := R) (h := h) hx
+
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -231,5 +231,48 @@ example :
       (Rset := (∅ : Finset (Subcube 1)))
       (R := Subcube.full) (h := 0) hx
 
+/-- `mu_union_singleton_double_lt` shows that covering two distinct pairs
+drops the measure strictly. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}) <
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  -- Two distinct points both covered by `Subcube.full`.
+  let f : BFunc 1 := fun _ => true
+  let x₁ : Point 1 := fun _ => true
+  let x₂ : Point 1 := fun _ => false
+  have hf : f ∈ ({f} : BoolFunc.Family 1) := by simp
+  have hx1val : f x₁ = true := by simp [f, x₁]
+  have hx2val : f x₂ = true := by simp [f, x₂]
+  have hnc1 : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x₁ := by
+    intro R hR; cases hR
+  have hnc2 : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x₂ := by
+    intro R hR; cases hR
+  let p₁ : Σ g : BFunc 1, Point 1 := ⟨f, x₁⟩
+  let p₂ : Σ g : BFunc 1, Point 1 := ⟨f, x₂⟩
+  have hp₁ : p₁ ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+      (∅ : Finset (Subcube 1)) := by exact ⟨hf, hx1val, hnc1⟩
+  have hp₂ : p₂ ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+      (∅ : Finset (Subcube 1)) := by exact ⟨hf, hx2val, hnc2⟩
+  have hx₁ : x₁ ∈ₛ Subcube.full := by simp [x₁]
+  have hx₂ : x₂ ∈ₛ Subcube.full := by simp [x₂]
+  have hne_point : x₁ ≠ x₂ := by
+    intro hx
+    have := congrArg (fun v => v 0) hx
+    simpa [x₁, x₂] using this
+  have hne : p₁ ≠ p₂ := by
+    intro h; have := congrArg Sigma.snd h; exact hne_point this
+  simpa [p₁, p₂] using
+    Cover2.mu_union_singleton_double_lt
+      (n := 1) (F := {f})
+      (Rset := (∅ : Finset (Subcube 1)))
+      (R := Subcube.full) (h := 0)
+      (p₁ := p₁) (p₂ := p₂)
+      hp₁ hp₂ hx₁ hx₂ hne
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- define `mu_union_singleton_double_lt` in `cover2.lean`
- add a test demonstrating the lemma in `Cover2Test.lean`

## Testing
- `lake build Pnp2.cover2`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68899cd6bf74832b9537aa63ce1b3b51


___

### **PR Type**
Enhancement


___

### **Description**
- Add `mu_union_singleton_double_lt` lemma to cover2.lean

- Prove measure drops strictly when covering two distinct pairs

- Include comprehensive test demonstrating the lemma


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["uncovered pairs p₁, p₂"] --> B["add rectangle R"]
  B --> C["both pairs covered by R"]
  C --> D["measure drops strictly"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add double coverage strict inequality lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_union_singleton_double_lt</code> lemma with formal proof<br> <li> Lemma shows measure drops strictly when rectangle covers two distinct <br>uncovered pairs<br> <li> Uses existing <code>mu_union_singleton_lt</code> lemma as foundation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/694/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for double coverage lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add comprehensive test for <code>mu_union_singleton_double_lt</code> lemma<br> <li> Construct two distinct points and prove they satisfy lemma conditions<br> <li> Demonstrate strict inequality with concrete boolean function example</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/694/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

