### PR TITLE
Port lemma and add test

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -472,5 +472,22 @@ lemma mu_union_singleton_succ_le {F : Family n} {Rset : Finset (Subcube n)}
     mu_union_singleton_lt (F := F) (Rset := Rset) (R := R) (h := h) hx
   exact Nat.succ_le_of_lt hlt
 
+/--
+If a rectangle covers two distinct uncovered pairs, the measure drops strictly
+after inserting this rectangle.  The proof reuses the single-pair inequality on
+one witness.
+-/
+lemma mu_union_singleton_double_lt {F : Family n} {Rset : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    {p₁ p₂ : Σ f : BFunc n, Point n}
+    (hp₁ : p₁ ∈ uncovered (n := n) F Rset) (hp₂ : p₂ ∈ uncovered (n := n) F Rset)
+    (hp₁R : p₁.2 ∈ₛ R) (hp₂R : p₂.2 ∈ₛ R) (hne : p₁ ≠ p₂) :
+    mu (n := n) F h (Rset ∪ {R}) < mu (n := n) F h Rset := by
+  classical
+  -- It suffices to cover one of the two pairs.
+  have hx : ∃ p ∈ uncovered (n := n) F Rset, p.2 ∈ₛ R := ⟨p₁, hp₁, hp₁R⟩
+  -- Apply the basic inequality for a newly covered pair.
+  exact mu_union_singleton_lt (F := F) (Rset := Rset) (R := R) (h := h) hx
+
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -231,5 +231,45 @@ example :
       (Rset := (∅ : Finset (Subcube 1)))
       (R := Subcube.full) (h := 0) hx
 
+/-- `mu_union_singleton_double_lt` specialises the strict inequality to two
+distinct uncovered pairs. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}) <
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  -- Two uncovered inputs for the constant-true function.
+  let f : BFunc 1 := fun _ => true
+  let x₁ : Point 1 := fun _ => true
+  let x₂ : Point 1 := fun _ => false
+  have hf : f ∈ ({f} : BoolFunc.Family 1) := by simp
+  have hx₁val : f x₁ = true := by simp [f, x₁]
+  have hx₂val : f x₂ = true := by simp [f, x₂]
+  have hnc₁ : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x₁ := by
+    intro R hR; cases hR
+  have hnc₂ : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x₂ := by
+    intro R hR; cases hR
+  have hp₁ : ⟨f, x₁⟩ ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1)) := ⟨hf, hx₁val, hnc₁⟩
+  have hp₂ : ⟨f, x₂⟩ ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1)) := ⟨hf, hx₂val, hnc₂⟩
+  have hx₁R : x₁ ∈ₛ Subcube.full := by simp [x₁]
+  have hx₂R : x₂ ∈ₛ Subcube.full := by simp [x₂]
+  have hxne : x₁ ≠ x₂ := by
+    intro hx
+    have h0 : x₁ 0 = x₂ 0 := congrArg (fun p => p 0) hx
+    simpa [x₁, x₂] using h0
+  have hne : (⟨f, x₁⟩ : Σ g : BFunc 1, Point 1) ≠ ⟨f, x₂⟩ := by
+    intro h; apply hxne; exact congrArg Sigma.snd h
+  simpa using
+    Cover2.mu_union_singleton_double_lt
+      (n := 1) (F := {f}) (Rset := (∅ : Finset (Subcube 1)))
+      (R := Subcube.full) (h := 0)
+      (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩)
+      hp₁ hp₂ hx₁R hx₂R hne
+
 end Cover2Test
 


### PR DESCRIPTION
## Summary
- add `mu_union_singleton_double_lt` to `cover2`
- test the new lemma in `Cover2Test`

## Testing
- `lake build`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68899cd6bf74832b9537aa63ce1b3b51