### PR TITLE
Add mu_union_le lemma to Cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -489,5 +489,31 @@ lemma mu_union_singleton_double_lt {F : Family n} {Rset : Finset (Subcube n)}
   -- Apply the basic inequality for a newly covered pair.
   exact mu_union_singleton_lt (F := F) (Rset := Rset) (R := R) (h := h) hx
 
+/-!
+Taking the union of two rectangle sets cannot increase the measure `μ`.  This
+simple monotonicity fact follows by induction on the second set using the
+single--rectangle lemma `mu_union_singleton_le`.
+-/
+lemma mu_union_le {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ} :
+    mu (n := n) F h (R₁ ∪ R₂) ≤ mu (n := n) F h R₁ := by
+  classical
+  -- We induct over `R₂`, inserting one rectangle at a time.
+  refine Finset.induction_on R₂ ?base ?step
+  · -- Base case: union with the empty set has no effect.
+    simp [mu]
+  · -- Induction step: insert a rectangle `R` into the growing set `S`.
+    intro R S hR hIH
+    -- First bound the union with `R` using the single-rectangle lemma.
+    have hstep :=
+      mu_union_singleton_le (F := F) (Rset := R₁ ∪ S) (R := R) (h := h)
+    -- Combine with the induction hypothesis.
+    have hcomb := le_trans hstep hIH
+    -- Reassociate unions to match the induction hypothesis.
+    have : R₁ ∪ insert R S = (R₁ ∪ S) ∪ {R} := by
+      ext x; by_cases hx : x = R
+      · subst hx; simp [hR]
+      · simp [Finset.mem_insert, hx]
+    simpa [this, Finset.union_assoc] using hcomb
+
 end Cover2
 


### PR DESCRIPTION
### **User description**
## Summary
- extend `cover2.lean` with `mu_union_le` lemma
- compile project and run tests

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688a427627d0832b970efad7b3157ade


___

### **PR Type**
Enhancement


___

### **Description**
- Add `mu_union_le` lemma proving monotonicity property

- Extends measure theory with union inequality bound

- Uses induction on finite sets with single-rectangle lemma


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mu_union_singleton_le"] --> B["mu_union_le lemma"]
  B --> C["Finset induction proof"]
  C --> D["Monotonicity property"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add mu_union_le monotonicity lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_union_le</code> lemma with comprehensive documentation<br> <li> Implement induction-based proof using <code>mu_union_singleton_le</code><br> <li> Establish monotonicity property for measure function</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/698/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

