### PR TITLE
Port lemma mu_union_singleton_double_succ_le

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -489,6 +489,95 @@ lemma mu_union_singleton_double_lt {F : Family n} {Rset : Finset (Subcube n)}
   -- Apply the basic inequality for a newly covered pair.
   exact mu_union_singleton_lt (F := F) (Rset := Rset) (R := R) (h := h) hx
 
+/--
+If a rectangle covers two distinct uncovered pairs, the measure drops by at
+least two after inserting this rectangle.  This strengthening of
+`mu_union_singleton_succ_le` mirrors the bookkeeping argument from the original
+`cover` module.
+-/
+lemma mu_union_singleton_double_succ_le {F : Family n} {Rset : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    {p₁ p₂ : Σ f : BFunc n, Point n}
+    (hp₁ : p₁ ∈ uncovered (n := n) F Rset) (hp₂ : p₂ ∈ uncovered (n := n) F Rset)
+    (hp₁R : p₁.2 ∈ₛ R) (hp₂R : p₂.2 ∈ₛ R) (hne : p₁ ≠ p₂) :
+    mu (n := n) F h (Rset ∪ {R}) + 2 ≤ mu (n := n) F h Rset := by
+  classical
+  -- Abbreviations for the uncovered sets before and after inserting `R`.
+  let S : Finset (Σ f : BFunc n, Point n) :=
+    (uncovered (n := n) F Rset).toFinset
+  let T : Finset (Σ f : BFunc n, Point n) :=
+    (uncovered (n := n) F (Rset ∪ {R})).toFinset
+  -- Adding a rectangle cannot create new uncovered pairs.
+  have hsub_main : T ⊆ S := by
+    intro x hxT
+    have hx' : x ∈ uncovered (n := n) F (Rset ∪ {R}) := by
+      simpa [T] using hxT
+    have hx'' : x ∈ uncovered (n := n) F Rset :=
+      uncovered_subset_of_union_singleton
+        (F := F) (Rset := Rset) (R := R) hx'
+    simpa [S] using hx''
+  -- Membership facts for the two pairs.
+  have hp₁S : p₁ ∈ S := by simpa [S] using hp₁
+  have hp₂S : p₂ ∈ S := by simpa [S] using hp₂
+  -- After adding `R`, the pairs `p₁` and `p₂` are no longer uncovered.
+  have hp₁T : p₁ ∉ T := by
+    intro hx
+    have hx' : p₁ ∈ uncovered (n := n) F (Rset ∪ {R}) := by
+      simpa [T] using hx
+    rcases hx' with ⟨_, _, hnc⟩
+    exact hnc R (by simp) hp₁R
+  have hp₂T : p₂ ∉ T := by
+    intro hx
+    have hx' : p₂ ∈ uncovered (n := n) F (Rset ∪ {R}) := by
+      simpa [T] using hx
+    rcases hx' with ⟨_, _, hnc⟩
+    exact hnc R (by simp) hp₂R
+  -- The new uncovered set is contained in `S.erase p₁.erase p₂`.
+  have hsub2 : T ⊆ (S.erase p₁).erase p₂ := by
+    intro x hxT
+    have hxS : x ∈ S := hsub_main hxT
+    have hxne1 : x ≠ p₁ := by
+      intro hxEq
+      have : p₁ ∈ T := by simpa [T, hxEq] using hxT
+      exact hp₁T this
+    have hxne2 : x ≠ p₂ := by
+      intro hxEq
+      have : p₂ ∈ T := by simpa [T, hxEq] using hxT
+      exact hp₂T this
+    have hx1 : x ∈ S.erase p₁ := Finset.mem_erase.mpr ⟨hxne1, hxS⟩
+    exact Finset.mem_erase.mpr ⟨hxne2, hx1⟩
+  -- Cardinalities of the intermediate sets.
+  have hp₂_in_erase1 : p₂ ∈ S.erase p₁ :=
+    Finset.mem_erase.mpr ⟨hne.symm, hp₂S⟩
+  have hcard_le : T.card ≤ ((S.erase p₁).erase p₂).card :=
+    Finset.card_le_card hsub2
+  have hcard1 : (S.erase p₁).card = S.card - 1 :=
+    Finset.card_erase_of_mem hp₁S
+  have hcard2 : ((S.erase p₁).erase p₂).card = (S.erase p₁).card - 1 :=
+    Finset.card_erase_of_mem hp₂_in_erase1
+  have hcard_final : T.card ≤ S.card - 2 := by
+    have := hcard_le
+    simpa [hcard1, hcard2] using this
+  -- `S` contains both `p₁` and `p₂`, so its cardinality is at least two.
+  have htwo : 2 ≤ S.card := by
+    classical
+    have hsub_pair : ({p₁, p₂} : Finset _) ⊆ S := by
+      intro x hx
+      rcases Finset.mem_insert.mp hx with hx | hx
+      · simpa [hx] using hp₁S
+      · have hx' := Finset.mem_singleton.mp hx; simpa [hx'] using hp₂S
+    have hcard_pair : ({p₁, p₂} : Finset _).card = 2 := by
+      classical
+      simpa using Finset.card_pair (a := p₁) (b := p₂) hne
+    have htwo_aux : 2 ≤ ({p₁, p₂} : Finset _).card := by simpa [hcard_pair]
+    exact le_trans htwo_aux (Finset.card_le_card hsub_pair)
+  -- Convert the difference bound into the desired inequality.
+  have hdiff := (Nat.le_sub_iff_add_le htwo).mp hcard_final
+  -- Add the `2 * h` entropy contribution to both sides.
+  have := Nat.add_le_add_left hdiff (2 * h)
+  -- Rewrite everything in terms of `μ`.
+  simpa [mu, S, T, add_comm, add_left_comm, add_assoc] using this
+
 /-!
 Taking the union of two rectangle sets cannot increase the measure `μ`.  This
 simple monotonicity fact follows by induction on the second set using the


### PR DESCRIPTION
### **User description**
## Summary
- port `mu_union_singleton_double_succ_le` from `cover.lean` to `cover2.lean`
- implement missing numeric and set inclusions using existing lemmas
- adapt proofs with `card_pair` and `card_le_card`
- clean up membership proofs

## Testing
- `lake build Pnp2.cover2`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688a4b7db6bc832bb31411cf5841abd0


___

### **PR Type**
Enhancement


___

### **Description**
- Port `mu_union_singleton_double_succ_le` lemma from cover.lean

- Implement cardinality-based proof using finset operations

- Add documentation for measure drop when covering two pairs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original uncovered set S"] --> B["Remove p₁ and p₂"]
  B --> C["New uncovered set T"]
  C --> D["Measure drops by at least 2"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Port double successor lemma with cardinality proof</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_union_singleton_double_succ_le</code> lemma with full proof<br> <li> Implement cardinality-based argument using finset operations<br> <li> Add comprehensive documentation explaining the strengthened bound<br> <li> Use classical reasoning and membership proofs for uncovered pairs</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/699/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+89/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

