### PR TITLE
Add mu_mono_subset lemma

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -515,5 +515,40 @@ lemma mu_union_le {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ} :
       · simp [Finset.mem_insert, hx]
     simpa [this, Finset.union_assoc] using hcomb
 
+/-!
+`mu_mono_subset` is a convenient monotonicity lemma for the measure `μ` with
+respect to the set of rectangles.  Enlarging the rectangle set can only
+decrease the measure.
+-/
+lemma mu_mono_subset {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ}
+    (hsub : R₁ ⊆ R₂) :
+    mu (n := n) F h R₂ ≤ mu (n := n) F h R₁ := by
+  classical
+  -- Express `R₂` as `R₁ ∪ (R₂ \ R₁)` and apply `mu_union_le`.
+  have hunion : R₂ = R₁ ∪ (R₂ \ R₁) := by
+    ext x; by_cases hx : x ∈ R₁
+    · constructor
+      · intro hxR2
+        exact Finset.mem_union.mpr <| Or.inl hx
+      · intro hunion
+        exact hsub hx
+    · constructor
+      · intro hxR2
+        -- Construct membership in the sdiff using both properties.
+        have hxRdiff : x ∈ R₂ \ R₁ := by
+          have hxpair : x ∈ R₂ ∧ x ∉ R₁ := ⟨hxR2, by simpa [hx]⟩
+          simpa [Finset.mem_sdiff] using hxpair
+        exact Finset.mem_union.mpr <| Or.inr hxRdiff
+      · intro hunion
+        rcases Finset.mem_union.mp hunion with hx₁ | hx₂
+        · exact hsub hx₁
+        · -- Extract membership in `R₂` from the difference set.
+          exact (Finset.mem_sdiff.mp hx₂).1
+  have := mu_union_le (F := F) (h := h) (R₁ := R₁) (R₂ := R₂ \ R₁)
+  -- Rewrite the left-hand side using `hunion` and apply the union lemma.
+  -- Using the subset assumption, simplify the union with a set difference.
+  have hx : R₁ ∪ (R₂ \ R₁) = R₂ := Finset.union_sdiff_of_subset hsub
+  simpa [hx] using this
+
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -271,5 +271,23 @@ example :
       (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩)
       hp₁ hp₂ hx₁R hx₂R hne
 
+/-- `mu_mono_subset` ensures that adding rectangles never increases `μ`. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 ({Subcube.full} : Finset (Subcube 1)) ≤
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  have hsub : (∅ : Finset (Subcube 1)) ⊆ {Subcube.full} := by
+    intro R hR; cases hR
+  simpa using
+    Cover2.mu_mono_subset
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (R₁ := (∅ : Finset (Subcube 1))) (R₂ := {Subcube.full})
+      (h := 0) hsub
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- port `mu_mono_subset` from `cover.lean` to `cover2.lean`
- prove the lemma directly instead of using axioms
- test the new lemma in `Cover2Test`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688a4b7db6bc832bb31411cf5841abd0


___

### **PR Type**
Enhancement


___

### **Description**
- Add `mu_mono_subset` lemma proving monotonicity of measure

- Implement direct proof without axioms using union decomposition

- Add comprehensive test case demonstrating lemma usage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original measure μ"] --> B["mu_mono_subset lemma"]
  B --> C["Monotonicity property"]
  C --> D["Test validation"]
  B --> E["Union decomposition proof"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add monotonicity lemma for measure function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_mono_subset</code> lemma with detailed documentation<br> <li> Implement proof using union decomposition and <code>mu_union_le</code><br> <li> Use classical logic and set difference operations<br> <li> Prove monotonicity: larger rectangle sets yield smaller measures</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/700/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for monotonicity lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test case for <code>mu_mono_subset</code> lemma<br> <li> Demonstrate measure comparison between empty and singleton sets<br> <li> Use classical logic and subset proof</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/700/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

