### PR TITLE
Port mu_mono_subset

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -604,5 +604,35 @@ lemma mu_union_le {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ} :
       · simp [Finset.mem_insert, hx]
     simpa [this, Finset.union_assoc] using hcomb
 
+/-!  A convenient corollary of `mu_union_le`: if `R₁ ⊆ R₂`, then `μ` for the
+smaller set dominates the measure for the larger one.  In other words,
+adding rectangles can only decrease the measure. -/
+lemma mu_mono_subset {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ}
+    (hsub : R₁ ⊆ R₂) :
+    mu (n := n) F h R₂ ≤ mu (n := n) F h R₁ := by
+  classical
+  -- Express `R₂` as `R₁ ∪ (R₂ \ R₁)` and apply `mu_union_le`.
+  have hunion : R₂ = R₁ ∪ (R₂ \ R₁) := by
+    ext x; by_cases hx : x ∈ R₁
+    · constructor
+      · intro _; exact Finset.mem_union.mpr <| Or.inl hx
+      · intro _; exact hsub hx
+    · constructor
+      · intro hxR2
+        have hxRdiff : x ∈ R₂ \ R₁ :=
+          Finset.mem_sdiff.mpr ⟨hxR2, by simpa [hx]⟩
+        exact Finset.mem_union.mpr <| Or.inr hxRdiff
+      · intro hxUnion
+        rcases Finset.mem_union.mp hxUnion with hx₁ | hx₂
+        · exact hsub hx₁
+        · exact (Finset.mem_sdiff.mp hx₂).1
+  have hmain := mu_union_le (n := n) (F := F) (h := h)
+      (R₁ := R₁) (R₂ := R₂ \ R₁)
+  have hrewrite :
+      mu (n := n) F h R₂ = mu (n := n) F h (R₁ ∪ (R₂ \ R₁)) :=
+    congrArg (fun S => mu (n := n) F h S) hunion
+  have := hrewrite ▸ hmain
+  simpa using this
+
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -271,5 +271,27 @@ example :
       (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩)
       hp₁ hp₂ hx₁R hx₂R hne
 
+/-- `mu_mono_subset` expresses that enlarging the set of rectangles can only
+decrease the measure.  We test it on a simple pair of sets. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 {Subcube.full} ≤
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  let Fset : BoolFunc.Family 1 := {(fun _ : Point 1 => true)}
+  have hsub : (∅ : Finset (Subcube 1)) ⊆ {Subcube.full} := by
+    intro R hR; cases hR
+  simpa using
+    Cover2.mu_mono_subset
+      (F := Fset)
+      (R₁ := (∅ : Finset (Subcube 1)))
+      (R₂ := {Subcube.full})
+      (h := 0)
+      (n := 1)
+      hsub
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- migrate the monotonicity lemma `mu_mono_subset` from `cover` into `cover2`
- test the lemma in `Cover2Test`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688a55525a54832ba9ddd43586ba3c7b


___

### **PR Type**
Enhancement


___

### **Description**
- Add `mu_mono_subset` lemma proving monotonicity property

- Demonstrate that enlarging rectangle sets decreases measure

- Include comprehensive test case validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mu_union_le lemma"] --> B["mu_mono_subset lemma"]
  B --> C["Test validation"]
  B --> D["Monotonicity property"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add monotonicity lemma for measure function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_mono_subset</code> lemma with detailed proof<br> <li> Prove that <code>R₁ ⊆ R₂</code> implies <code>mu F h R₂ ≤ mu F h R₁</code><br> <li> Use classical logic and set decomposition approach<br> <li> Include comprehensive documentation comments</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/701/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for monotonicity lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test case for <code>mu_mono_subset</code> lemma<br> <li> Test with empty set and full subcube comparison<br> <li> Validate monotonicity property with concrete example</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/701/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

