### PR TITLE
Port mu_union_double lemmas

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -652,5 +652,49 @@ lemma mu_mono_subset {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ}
   have := hrewrite ▸ hmain
   simpa using this
 
+/-- `mu_union_double_succ_le` combines the single-rectangle estimate with
+monotonicity.  If some rectangle in `R₂` covers two distinct uncovered pairs of
+`R₁`, then the measure drops by at least two after taking the union. -/
+lemma mu_union_double_succ_le {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    {p₁ p₂ : Σ f : BFunc n, Point n}
+    (hp₁ : p₁ ∈ uncovered (n := n) F R₁) (hp₂ : p₂ ∈ uncovered (n := n) F R₁)
+    (hp₁R : p₁.2 ∈ₛ R) (hp₂R : p₂.2 ∈ₛ R) (hne : p₁ ≠ p₂)
+    (hmem : R ∈ R₂) :
+    mu (n := n) F h (R₁ ∪ R₂) + 2 ≤ mu (n := n) F h R₁ := by
+  classical
+  -- Adding additional rectangles can only decrease the measure.
+  have hsub : R₁ ∪ {R} ⊆ R₁ ∪ R₂ := by
+    intro x hx
+    rcases Finset.mem_union.mp hx with hx₁ | hx₂
+    · exact Finset.mem_union.mpr <| Or.inl hx₁
+    · rcases Finset.mem_singleton.mp hx₂ with rfl
+      exact Finset.mem_union.mpr <| Or.inr hmem
+  have hmono := mu_mono_subset (F := F) (h := h)
+      (R₁ := R₁ ∪ {R}) (R₂ := R₁ ∪ R₂) hsub
+  have hdouble := mu_union_singleton_double_succ_le
+      (F := F) (Rset := R₁) (R := R) (h := h)
+      hp₁ hp₂ hp₁R hp₂R hne
+  have := add_le_add_right hmono 2
+  exact le_trans this hdouble
+
+/-- `mu_union_double_lt` is the strict version of `mu_union_double_succ_le`. -/
+lemma mu_union_double_lt {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    {p₁ p₂ : Σ f : BFunc n, Point n}
+    (hp₁ : p₁ ∈ uncovered (n := n) F R₁) (hp₂ : p₂ ∈ uncovered (n := n) F R₁)
+    (hp₁R : p₁.2 ∈ₛ R) (hp₂R : p₂.2 ∈ₛ R) (hne : p₁ ≠ p₂)
+    (hmem : R ∈ R₂) :
+    mu (n := n) F h (R₁ ∪ R₂) < mu (n := n) F h R₁ := by
+  classical
+  have hdrop :=
+    mu_union_double_succ_le (F := F) (R₁ := R₁) (R₂ := R₂)
+      (R := R) (h := h) hp₁ hp₂ hp₁R hp₂R hne hmem
+  have hsucc : mu (n := n) F h (R₁ ∪ R₂) + 1 ≤ mu (n := n) F h R₁ := by
+    have hstep : (1 : ℕ) ≤ 2 := by decide
+    have := Nat.add_le_add_left hstep (mu (n := n) F h (R₁ ∪ R₂))
+    exact this.trans hdrop
+  exact Nat.lt_of_succ_le hsucc
+
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -271,6 +271,85 @@ example :
       (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩)
       hp₁ hp₂ hx₁R hx₂R hne
 
+/-- `mu_union_double_succ_le` bounds the measure drop when the covering
+rectangle is part of a larger set. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}) + 2 ≤
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  -- Reuse the witnesses from the previous example.
+  let f : BFunc 1 := fun _ => true
+  let x₁ : Point 1 := fun _ => true
+  let x₂ : Point 1 := fun _ => false
+  have hf : f ∈ ({f} : BoolFunc.Family 1) := by simp
+  have hx₁val : f x₁ = true := by simp [f, x₁]
+  have hx₂val : f x₂ = true := by simp [f, x₂]
+  have hnc₁ : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x₁ :=
+    by intro R hR; cases hR
+  have hnc₂ : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x₂ :=
+    by intro R hR; cases hR
+  have hp₁ : ⟨f, x₁⟩ ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1)) := ⟨hf, hx₁val, hnc₁⟩
+  have hp₂ : ⟨f, x₂⟩ ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1)) := ⟨hf, hx₂val, hnc₂⟩
+  have hx₁R : x₁ ∈ₛ Subcube.full := by simp [x₁]
+  have hx₂R : x₂ ∈ₛ Subcube.full := by simp [x₂]
+  have hxne : x₁ ≠ x₂ := by
+    intro hx; have h0 : x₁ 0 = x₂ 0 := congrArg (fun p => p 0) hx
+    simpa [x₁, x₂] using h0
+  have hne : (⟨f, x₁⟩ : Σ g : BFunc 1, Point 1) ≠ ⟨f, x₂⟩ := by
+    intro h; apply hxne; exact congrArg Sigma.snd h
+  have hmem : Subcube.full ∈ ({Subcube.full} : Finset (Subcube 1)) := by simp
+  simpa using
+    Cover2.mu_union_double_succ_le
+      (n := 1) (F := {f}) (R₁ := (∅ : Finset (Subcube 1)))
+      (R₂ := {Subcube.full}) (R := Subcube.full) (h := 0)
+      (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩)
+      hp₁ hp₂ hx₁R hx₂R hne hmem
+
+/-- `mu_union_double_lt` yields a strict inequality for the same setup. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}) <
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  -- Reuse the same witnesses as above.
+  let f : BFunc 1 := fun _ => true
+  let x₁ : Point 1 := fun _ => true
+  let x₂ : Point 1 := fun _ => false
+  have hf : f ∈ ({f} : BoolFunc.Family 1) := by simp
+  have hx₁val : f x₁ = true := by simp [f, x₁]
+  have hx₂val : f x₂ = true := by simp [f, x₂]
+  have hnc₁ : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x₁ :=
+    by intro R hR; cases hR
+  have hnc₂ : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x₂ :=
+    by intro R hR; cases hR
+  have hp₁ : ⟨f, x₁⟩ ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1)) := ⟨hf, hx₁val, hnc₁⟩
+  have hp₂ : ⟨f, x₂⟩ ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1)) := ⟨hf, hx₂val, hnc₂⟩
+  have hx₁R : x₁ ∈ₛ Subcube.full := by simp [x₁]
+  have hx₂R : x₂ ∈ₛ Subcube.full := by simp [x₂]
+  have hxne : x₁ ≠ x₂ := by
+    intro hx; have h0 : x₁ 0 = x₂ 0 := congrArg (fun p => p 0) hx
+    simpa [x₁, x₂] using h0
+  have hne : (⟨f, x₁⟩ : Σ g : BFunc 1, Point 1) ≠ ⟨f, x₂⟩ := by
+    intro h; apply hxne; exact congrArg Sigma.snd h
+  have hmem : Subcube.full ∈ ({Subcube.full} : Finset (Subcube 1)) := by simp
+  simpa using
+    Cover2.mu_union_double_lt
+      (n := 1) (F := {f}) (R₁ := (∅ : Finset (Subcube 1)))
+      (R₂ := {Subcube.full}) (R := Subcube.full) (h := 0)
+      (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩)
+      hp₁ hp₂ hx₁R hx₂R hne hmem
+
 /-- `mu_mono_subset` expresses that enlarging the set of rectangles can only
 decrease the measure.  We test it on a simple pair of sets. -/
 example :


### PR DESCRIPTION
### **User description**
## Summary
- ported `mu_union_double_succ_le` and `mu_union_double_lt` from `cover.lean` to
  `cover2.lean`
- added examples using these lemmas in `Cover2Test`
- ensured `lake test` succeeds

## Testing
- `lake build Pnp2.cover2`
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688a97e781dc832b9ac4d8ea942994b5


___

### **PR Type**
Enhancement


___

### **Description**
- Port two key lemmas from `cover.lean` to `cover2.lean`

- Add comprehensive test examples for the ported lemmas

- Ensure measure bounds for union operations with double coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover.lean"] -- "port lemmas" --> B["cover2.lean"]
  B -- "add tests" --> C["Cover2Test.lean"]
  D["mu_union_double_succ_le"] --> B
  E["mu_union_double_lt"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Port mu_union_double lemmas from cover.lean</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_union_double_succ_le</code> lemma with measure bound for double <br>coverage<br> <li> Add <code>mu_union_double_lt</code> lemma providing strict inequality version<br> <li> Both lemmas handle cases where rectangles cover two distinct uncovered <br>pairs</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/703/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test examples for ported lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add comprehensive test example for <code>mu_union_double_succ_le</code> lemma<br> <li> Add test example for <code>mu_union_double_lt</code> lemma with strict inequality<br> <li> Both tests use boolean function families with full subcube coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/703/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

