### PR TITLE
feat: add triple-cover measure lemma

### DIFF
--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -372,6 +372,66 @@ example :
       (n := 1)
       hsub
 
+/-- `mu_union_singleton_triple_succ_le` ensures a drop of at least three when
+three distinct pairs are covered. -/
+example :
+    Cover2.mu (n := 2)
+        ({(fun _ : Point 2 => true)} : BoolFunc.Family 2)
+        0 ((∅ : Finset (Subcube 2)) ∪ {Subcube.full}) + 3 ≤
+    Cover2.mu (n := 2)
+        ({(fun _ : Point 2 => true)} : BoolFunc.Family 2)
+        0 (∅ : Finset (Subcube 2)) := by
+  classical
+  -- Three uncovered inputs for the constant-true function.
+  let f : BFunc 2 := fun _ => true
+  let x₁ : Point 2 := fun _ => true
+  let x₂ : Point 2 := fun
+    | 0 => false
+    | 1 => true
+  let x₃ : Point 2 := fun
+    | 0 => true
+    | 1 => false
+  have hf : f ∈ ({f} : BoolFunc.Family 2) := by simp
+  have hx₁val : f x₁ = true := by simp [f, x₁]
+  have hx₂val : f x₂ = true := by simp [f, x₂]
+  have hx₃val : f x₃ = true := by simp [f, x₃]
+  have hnc₁ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₁ :=
+    by intro R hR; cases hR
+  have hnc₂ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₂ :=
+    by intro R hR; cases hR
+  have hnc₃ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₃ :=
+    by intro R hR; cases hR
+  have hp₁ : ⟨f, x₁⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₁val, hnc₁⟩
+  have hp₂ : ⟨f, x₂⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₂val, hnc₂⟩
+  have hp₃ : ⟨f, x₃⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₃val, hnc₃⟩
+  have hx₁R : x₁ ∈ₛ Subcube.full := by simp [x₁]
+  have hx₂R : x₂ ∈ₛ Subcube.full := by simp [x₂]
+  have hx₃R : x₃ ∈ₛ Subcube.full := by simp [x₃]
+  have hne₁₂ : (⟨f, x₁⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₂⟩ := by
+    intro h
+    have hx : x₁ = x₂ := congrArg Sigma.snd h
+    have hx0 : x₁ 0 = x₂ 0 := congrArg (fun g => g 0) hx
+    simp [x₁, x₂] at hx0
+  have hne₁₃ : (⟨f, x₁⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₃⟩ := by
+    intro h
+    have hx : x₁ = x₃ := congrArg Sigma.snd h
+    have hx0 : x₁ 1 = x₃ 1 := congrArg (fun g => g 1) hx
+    simp [x₁, x₃] at hx0
+  have hne₂₃ : (⟨f, x₂⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₃⟩ := by
+    intro h
+    have hx : x₂ = x₃ := congrArg Sigma.snd h
+    have hx0 : x₂ 0 = x₃ 0 := congrArg (fun g => g 0) hx
+    simp [x₂, x₃] at hx0
+  simpa using
+    Cover2.mu_union_singleton_triple_succ_le
+      (n := 2) (F := {f}) (Rset := (∅ : Finset (Subcube 2)))
+      (R := Subcube.full) (h := 0)
+      (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩) (p₃ := ⟨f, x₃⟩)
+      hp₁ hp₂ hp₃ hx₁R hx₂R hx₃R hne₁₂ hne₁₃ hne₂₃
+
 /-- `mu_union_singleton_triple_lt` specialises the strict inequality to three
 distinct uncovered pairs. -/
 example :


### PR DESCRIPTION
### **User description**
## Summary
- prove `mu_union_singleton_triple_succ_le` giving a 3-point drop when a rectangle covers three distinct uncovered pairs
- add regression example exercising the new lemma

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688ab00ef5b8832b80b8ce3bcb3ca375


___

### **PR Type**
Enhancement


___

### **Description**
- Add `mu_union_singleton_triple_succ_le` lemma for 3-point measure drop

- Prove rectangle covering three distinct pairs decreases measure by ≥3

- Add comprehensive regression test with concrete example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Three uncovered pairs"] --> B["Add covering rectangle"]
  B --> C["Measure drops by ≥3"]
  D["New lemma"] --> E["Regression test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add triple-cover measure lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_union_singleton_triple_succ_le</code> lemma proving 3-point measure <br>drop<br> <li> Implement proof using cardinality arguments and set erasure<br> <li> Show rectangle covering three distinct pairs reduces measure by at <br>least 3</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/704/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+116/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add triple-cover regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add comprehensive test for <code>mu_union_singleton_triple_succ_le</code><br> <li> Create concrete example with constant-true function and three distinct <br>points<br> <li> Verify 3-point measure drop when full subcube covers all pairs</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/704/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

