### PR TITLE
feat: port triple union lemma

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -711,6 +711,152 @@ lemma mu_union_singleton_triple_succ_le {F : Family n} {Rset : Finset (Subcube n
   -- Rewrite everything in terms of `μ`.
   simpa [mu, S, T, add_comm, add_left_comm, add_assoc] using this
 
+lemma mu_union_singleton_quad_succ_le {F : Family n} {Rset : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    {p₁ p₂ p₃ p₄ : Σ f : BFunc n, Point n}
+    (hp₁ : p₁ ∈ uncovered (n := n) F Rset)
+    (hp₂ : p₂ ∈ uncovered (n := n) F Rset)
+    (hp₃ : p₃ ∈ uncovered (n := n) F Rset)
+    (hp₄ : p₄ ∈ uncovered (n := n) F Rset)
+    (hp₁R : p₁.2 ∈ₛ R) (hp₂R : p₂.2 ∈ₛ R)
+    (hp₃R : p₃.2 ∈ₛ R) (hp₄R : p₄.2 ∈ₛ R)
+    (hne₁₂ : p₁ ≠ p₂) (hne₁₃ : p₁ ≠ p₃) (hne₁₄ : p₁ ≠ p₄)
+    (hne₂₃ : p₂ ≠ p₃) (hne₂₄ : p₂ ≠ p₄) (hne₃₄ : p₃ ≠ p₄) :
+    mu (n := n) F h (Rset ∪ {R}) + 4 ≤ mu (n := n) F h Rset := by
+  classical
+  -- Abbreviations for the uncovered sets before and after inserting `R`.
+  let S : Finset (Σ f : BFunc n, Point n) :=
+    (uncovered (n := n) F Rset).toFinset
+  let T : Finset (Σ f : BFunc n, Point n) :=
+    (uncovered (n := n) F (Rset ∪ {R})).toFinset
+  -- Adding a rectangle cannot create new uncovered pairs.
+  have hsub_main : T ⊆ S := by
+    intro x hxT
+    have hx' : x ∈ uncovered (n := n) F (Rset ∪ {R}) := by
+      simpa [T] using hxT
+    have hx'' : x ∈ uncovered (n := n) F Rset :=
+      uncovered_subset_of_union_singleton (F := F) (Rset := Rset) (R := R) hx'
+    simpa [S] using hx''
+  -- Membership facts for the four pairs.
+  have hp₁S : p₁ ∈ S := by simpa [S] using hp₁
+  have hp₂S : p₂ ∈ S := by simpa [S] using hp₂
+  have hp₃S : p₃ ∈ S := by simpa [S] using hp₃
+  have hp₄S : p₄ ∈ S := by simpa [S] using hp₄
+  -- After inserting `R`, none of the pairs remain uncovered.
+  have hp₁T : p₁ ∉ T := by
+    intro hx
+    have hx' : p₁ ∈ uncovered (n := n) F (Rset ∪ {R}) := by simpa [T] using hx
+    rcases hx' with ⟨_, _, hnc⟩
+    exact hnc R (by simp) hp₁R
+  have hp₂T : p₂ ∉ T := by
+    intro hx
+    have hx' : p₂ ∈ uncovered (n := n) F (Rset ∪ {R}) := by simpa [T] using hx
+    rcases hx' with ⟨_, _, hnc⟩
+    exact hnc R (by simp) hp₂R
+  have hp₃T : p₃ ∉ T := by
+    intro hx
+    have hx' : p₃ ∈ uncovered (n := n) F (Rset ∪ {R}) := by simpa [T] using hx
+    rcases hx' with ⟨_, _, hnc⟩
+    exact hnc R (by simp) hp₃R
+  have hp₄T : p₄ ∉ T := by
+    intro hx
+    have hx' : p₄ ∈ uncovered (n := n) F (Rset ∪ {R}) := by simpa [T] using hx
+    rcases hx' with ⟨_, _, hnc⟩
+    exact hnc R (by simp) hp₄R
+  -- The new uncovered set is contained in `S.erase p₁.erase p₂.erase p₃.erase p₄`.
+  have hsub4 :
+      T ⊆ (((S.erase p₁).erase p₂).erase p₃).erase p₄ := by
+    intro x hxT
+    have hxS : x ∈ S := hsub_main hxT
+    have hxne1 : x ≠ p₁ := by
+      intro hxEq
+      have : p₁ ∈ T := by simpa [T, hxEq] using hxT
+      exact hp₁T this
+    have hxne2 : x ≠ p₂ := by
+      intro hxEq
+      have : p₂ ∈ T := by simpa [T, hxEq] using hxT
+      exact hp₂T this
+    have hxne3 : x ≠ p₃ := by
+      intro hxEq
+      have : p₃ ∈ T := by simpa [T, hxEq] using hxT
+      exact hp₃T this
+    have hxne4 : x ≠ p₄ := by
+      intro hxEq
+      have : p₄ ∈ T := by simpa [T, hxEq] using hxT
+      exact hp₄T this
+    have hx1 : x ∈ S.erase p₁ := Finset.mem_erase.mpr ⟨hxne1, hxS⟩
+    have hx2 : x ∈ (S.erase p₁).erase p₂ :=
+      Finset.mem_erase.mpr ⟨hxne2, hx1⟩
+    have hx3 : x ∈ ((S.erase p₁).erase p₂).erase p₃ :=
+      Finset.mem_erase.mpr ⟨hxne3, hx2⟩
+    exact Finset.mem_erase.mpr ⟨hxne4, hx3⟩
+  -- Cardinalities of the intermediate sets.
+  have hp₂_in_erase1 : p₂ ∈ S.erase p₁ :=
+    Finset.mem_erase.mpr ⟨hne₁₂.symm, hp₂S⟩
+  have hp₃_in_erase2 : p₃ ∈ (S.erase p₁).erase p₂ := by
+    have hp₃_in_erase1 : p₃ ∈ S.erase p₁ :=
+      Finset.mem_erase.mpr ⟨hne₁₃.symm, hp₃S⟩
+    exact Finset.mem_erase.mpr ⟨hne₂₃.symm, hp₃_in_erase1⟩
+  have hp₄_in_erase3 : p₄ ∈ ((S.erase p₁).erase p₂).erase p₃ := by
+    have hp₄_in_erase1 : p₄ ∈ S.erase p₁ :=
+      Finset.mem_erase.mpr ⟨hne₁₄.symm, hp₄S⟩
+    have hp₄_in_erase2 : p₄ ∈ (S.erase p₁).erase p₂ :=
+      Finset.mem_erase.mpr ⟨hne₂₄.symm, hp₄_in_erase1⟩
+    exact Finset.mem_erase.mpr ⟨hne₃₄.symm, hp₄_in_erase2⟩
+  have hcard_le :
+      T.card ≤ ((((S.erase p₁).erase p₂).erase p₃).erase p₄).card :=
+    Finset.card_le_card hsub4
+  have hcard1 : (S.erase p₁).card = S.card - 1 :=
+    Finset.card_erase_of_mem hp₁S
+  have hcard2 :
+      ((S.erase p₁).erase p₂).card = (S.erase p₁).card - 1 :=
+    Finset.card_erase_of_mem hp₂_in_erase1
+  have hcard3 :
+      (((S.erase p₁).erase p₂).erase p₃).card =
+        ((S.erase p₁).erase p₂).card - 1 :=
+    Finset.card_erase_of_mem hp₃_in_erase2
+  have hcard4 :
+      ((((S.erase p₁).erase p₂).erase p₃).erase p₄).card =
+        (((S.erase p₁).erase p₂).erase p₃).card - 1 :=
+    Finset.card_erase_of_mem hp₄_in_erase3
+  have hcard_final : T.card ≤ S.card - 4 := by
+    have := hcard_le
+    simpa [hcard1, hcard2, hcard3, hcard4] using this
+  -- `S` contains the four distinct pairs, so its cardinality is at least four.
+  have hfour : 4 ≤ S.card := by
+    classical
+    have hsub_quad : ({p₁, p₂, p₃, p₄} : Finset _) ⊆ S := by
+      intro x hx
+      have hx' : x = p₁ ∨ x = p₂ ∨ x = p₃ ∨ x = p₄ := by
+        simpa [Finset.mem_insert, Finset.mem_singleton, or_assoc, or_left_comm,
+              or_comm] using hx
+      rcases hx' with h₁ | hx'
+      · subst h₁; simpa using hp₁S
+      rcases hx' with h₂ | hx'
+      · subst h₂; simpa using hp₂S
+      rcases hx' with h₃ | h₄
+      · subst h₃; simpa using hp₃S
+      · subst h₄; simpa using hp₄S
+    have hcard_quad : ({p₁, p₂, p₃, p₄} : Finset _).card = 4 := by
+      classical
+      have hnot12 : p₁ ≠ p₂ := hne₁₂
+      have hnot13 : p₁ ≠ p₃ := hne₁₃
+      have hnot14 : p₁ ≠ p₄ := hne₁₄
+      have hnot23 : p₂ ≠ p₃ := hne₂₃
+      have hnot24 : p₂ ≠ p₄ := hne₂₄
+      have hnot34 : p₃ ≠ p₄ := hne₃₄
+      simp [Finset.card_insert_of_notMem, Finset.card_insert_of_mem,
+            hnot12, hnot13, hnot14, hnot23, hnot24, hnot34]
+    have hfour_aux : 4 ≤ ({p₁, p₂, p₃, p₄} : Finset _).card := by
+      simpa [hcard_quad]
+    exact hfour_aux.trans (Finset.card_le_card hsub_quad)
+  -- Convert the difference bound into the desired inequality.
+  have hdiff := (Nat.le_sub_iff_add_le hfour).mp hcard_final
+  -- Add the `2 * h` entropy contribution to both sides.
+  have := Nat.add_le_add_left hdiff (2 * h)
+  -- Rewrite everything in terms of `μ`.
+  simpa [mu, S, T, add_comm, add_left_comm, add_assoc] using this
+
 
 /-!
 Taking the union of two rectangle sets cannot increase the measure `μ`.  This
@@ -808,6 +954,62 @@ lemma mu_union_double_lt {F : Family n} {R₁ R₂ : Finset (Subcube n)}
       (R := R) (h := h) hp₁ hp₂ hp₁R hp₂R hne hmem
   have hsucc : mu (n := n) F h (R₁ ∪ R₂) + 1 ≤ mu (n := n) F h R₁ := by
     have hstep : (1 : ℕ) ≤ 2 := by decide
+    have := Nat.add_le_add_left hstep (mu (n := n) F h (R₁ ∪ R₂))
+    exact this.trans hdrop
+  exact Nat.lt_of_succ_le hsucc
+
+/-!
+`mu_union_triple_succ_le` extends `mu_union_double_succ_le` to the case of
+three distinct uncovered pairs.  If some rectangle in `R₂` covers all three,
+then taking the union with `R₂` decreases the measure by at least three.
+-/
+lemma mu_union_triple_succ_le {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    {p₁ p₂ p₃ : Σ f : BFunc n, Point n}
+    (hp₁ : p₁ ∈ uncovered (n := n) F R₁)
+    (hp₂ : p₂ ∈ uncovered (n := n) F R₁)
+    (hp₃ : p₃ ∈ uncovered (n := n) F R₁)
+    (hp₁R : p₁.2 ∈ₛ R) (hp₂R : p₂.2 ∈ₛ R) (hp₃R : p₃.2 ∈ₛ R)
+    (hne₁₂ : p₁ ≠ p₂) (hne₁₃ : p₁ ≠ p₃) (hne₂₃ : p₂ ≠ p₃)
+    (hmem : R ∈ R₂) :
+    mu (n := n) F h (R₁ ∪ R₂) + 3 ≤ mu (n := n) F h R₁ := by
+  classical
+  -- Taking the union with a larger set can only reduce the measure.
+  have hsub : R₁ ∪ {R} ⊆ R₁ ∪ R₂ := by
+    intro x hx
+    rcases Finset.mem_union.mp hx with hx₁ | hx₂
+    · exact Finset.mem_union.mpr <| Or.inl hx₁
+    · rcases Finset.mem_singleton.mp hx₂ with rfl
+      exact Finset.mem_union.mpr <| Or.inr hmem
+  have hmono :=
+    mu_mono_subset (F := F) (h := h) (R₁ := R₁ ∪ {R}) (R₂ := R₁ ∪ R₂) hsub
+  -- Covering the three pairs with `R` yields a drop of at least three.
+  have htriple :=
+    mu_union_singleton_triple_succ_le (F := F) (Rset := R₁) (R := R) (h := h)
+      hp₁ hp₂ hp₃ hp₁R hp₂R hp₃R hne₁₂ hne₁₃ hne₂₃
+  have := add_le_add_right hmono 3
+  exact le_trans this htriple
+
+/-- `mu_union_triple_lt` is the strict version of `mu_union_triple_succ_le`. -/
+lemma mu_union_triple_lt {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    {R : Subcube n} {h : ℕ}
+    {p₁ p₂ p₃ : Σ f : BFunc n, Point n}
+    (hp₁ : p₁ ∈ uncovered (n := n) F R₁)
+    (hp₂ : p₂ ∈ uncovered (n := n) F R₁)
+    (hp₃ : p₃ ∈ uncovered (n := n) F R₁)
+    (hp₁R : p₁.2 ∈ₛ R) (hp₂R : p₂.2 ∈ₛ R) (hp₃R : p₃.2 ∈ₛ R)
+    (hne₁₂ : p₁ ≠ p₂) (hne₁₃ : p₁ ≠ p₃) (hne₂₃ : p₂ ≠ p₃)
+    (hmem : R ∈ R₂) :
+    mu (n := n) F h (R₁ ∪ R₂) < mu (n := n) F h R₁ := by
+  classical
+  -- First obtain the additive inequality dropping by three.
+  have hdrop :=
+    mu_union_triple_succ_le (F := F) (R₁ := R₁) (R₂ := R₂)
+      (R := R) (h := h) hp₁ hp₂ hp₃ hp₁R hp₂R hp₃R
+      hne₁₂ hne₁₃ hne₂₃ hmem
+  -- Convert it into a strict inequality.
+  have hsucc : mu (n := n) F h (R₁ ∪ R₂) + 1 ≤ mu (n := n) F h R₁ := by
+    have hstep : (1 : ℕ) ≤ 3 := by decide
     have := Nat.add_le_add_left hstep (mu (n := n) F h (R₁ ∪ R₂))
     exact this.trans hdrop
   exact Nat.lt_of_succ_le hsucc

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -6,7 +6,7 @@ interface for downstream files while gradually re-establishing all results.
 
 ## Overview
 
-* `cover.lean` contains 89 lemmas supporting the recursive construction of a
+* `cover.lean` contains 88 lemmas supporting the recursive construction of a
   rectangular cover.  The file is self‑contained but heavy.
 * `cover2.lean` reintroduces the key numeric definitions and currently provides
   only a subset of these lemmas.
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 33 |
+| Fully migrated | 44 |
 | Axioms | 0 |
-| Pending | 55 |
+| Pending | 44 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -60,9 +60,20 @@ AllOnesCovered.insert
 uncovered_eq_empty_of_allCovered
 uncovered_subset_of_union_singleton
 uncovered_subset_of_union
+mu_mono_subset
+mu_union_double_lt
+mu_union_double_succ_le
+mu_union_le
+mu_union_singleton_double_lt
+mu_union_singleton_double_succ_le
+mu_union_singleton_triple_lt
+mu_union_singleton_triple_succ_le
+mu_union_singleton_quad_succ_le
+mu_union_triple_lt
+mu_union_triple_succ_le
 ```
 
-### Not yet ported (55 lemmas)
+### Not yet ported (44 lemmas)
 
 ```
 allOnesCovered_of_firstUncovered_none
@@ -100,23 +111,12 @@ mu_buildCover_lt_start
 mu_gt_of_firstUncovered_some
 mu_lower_bound
 mu_mono_h
-mu_mono_subset
 mu_nonneg
 mu_of_allCovered
 mu_of_firstUncovered_none
 mu_union_buildCover_le
 mu_union_buildCover_lt
-mu_union_double_lt
-mu_union_double_succ_le
-mu_union_le
 mu_union_lt
-mu_union_singleton_double_lt
-mu_union_singleton_double_succ_le
-mu_union_singleton_quad_succ_le
-mu_union_singleton_triple_lt
-mu_union_singleton_triple_succ_le
-mu_union_triple_lt
-mu_union_triple_succ_le
 sunflower_step
 uncovered_card_bound
 uncovered_init_bound_empty

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -350,6 +350,129 @@ example :
       (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩)
       hp₁ hp₂ hx₁R hx₂R hne hmem
 
+/-- `mu_union_triple_succ_le` bounds the drop when a rectangle from a larger
+family covers three distinct uncovered pairs. -/
+example :
+    Cover2.mu (n := 2)
+        ({(fun _ : Point 2 => true)} : BoolFunc.Family 2)
+        0 ((
+            (∅ : Finset (Subcube 2))
+            ) ∪ {Subcube.full}) + 3 ≤
+    Cover2.mu (n := 2)
+        ({(fun _ : Point 2 => true)} : BoolFunc.Family 2)
+        0 (∅ : Finset (Subcube 2)) := by
+  classical
+  -- Three uncovered inputs for the constant-true function.
+  let f : BFunc 2 := fun _ => true
+  let x₁ : Point 2 := fun _ => true
+  let x₂ : Point 2 := fun
+    | 0 => false
+    | 1 => true
+  let x₃ : Point 2 := fun
+    | 0 => true
+    | 1 => false
+  have hf : f ∈ ({f} : BoolFunc.Family 2) := by simp
+  have hx₁val : f x₁ = true := by simp [f, x₁]
+  have hx₂val : f x₂ = true := by simp [f, x₂]
+  have hx₃val : f x₃ = true := by simp [f, x₃]
+  have hnc₁ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₁ :=
+    by intro R hR; cases hR
+  have hnc₂ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₂ :=
+    by intro R hR; cases hR
+  have hnc₃ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₃ :=
+    by intro R hR; cases hR
+  have hp₁ : ⟨f, x₁⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₁val, hnc₁⟩
+  have hp₂ : ⟨f, x₂⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₂val, hnc₂⟩
+  have hp₃ : ⟨f, x₃⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₃val, hnc₃⟩
+  have hx₁R : x₁ ∈ₛ Subcube.full := by simp [x₁]
+  have hx₂R : x₂ ∈ₛ Subcube.full := by simp [x₂]
+  have hx₃R : x₃ ∈ₛ Subcube.full := by simp [x₃]
+  have hne₁₂ : (⟨f, x₁⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₂⟩ := by
+    intro h
+    have hx : x₁ = x₂ := congrArg Sigma.snd h
+    have hx0 : x₁ 0 = x₂ 0 := congrArg (fun g => g 0) hx
+    simp [x₁, x₂] at hx0
+  have hne₁₃ : (⟨f, x₁⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₃⟩ := by
+    intro h
+    have hx : x₁ = x₃ := congrArg Sigma.snd h
+    have hx0 : x₁ 1 = x₃ 1 := congrArg (fun g => g 1) hx
+    simp [x₁, x₃] at hx0
+  have hne₂₃ : (⟨f, x₂⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₃⟩ := by
+    intro h
+    have hx : x₂ = x₃ := congrArg Sigma.snd h
+    have hx0 : x₂ 0 = x₃ 0 := congrArg (fun g => g 0) hx
+    simp [x₂, x₃] at hx0
+  have hmem : Subcube.full ∈ ({Subcube.full} : Finset (Subcube 2)) := by simp
+  simpa using
+    Cover2.mu_union_triple_succ_le
+      (n := 2) (F := {f}) (R₁ := (∅ : Finset (Subcube 2)))
+      (R₂ := {Subcube.full}) (R := Subcube.full) (h := 0)
+      (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩) (p₃ := ⟨f, x₃⟩)
+      hp₁ hp₂ hp₃ hx₁R hx₂R hx₃R hne₁₂ hne₁₃ hne₂₃ hmem
+
+/-- `mu_union_triple_lt` gives the strict inequality for the same setup. -/
+example :
+    Cover2.mu (n := 2)
+        ({(fun _ : Point 2 => true)} : BoolFunc.Family 2)
+        0 ((∅ : Finset (Subcube 2)) ∪ {Subcube.full}) <
+    Cover2.mu (n := 2)
+        ({(fun _ : Point 2 => true)} : BoolFunc.Family 2)
+        0 (∅ : Finset (Subcube 2)) := by
+  classical
+  -- Reuse the witnesses from the previous example.
+  let f : BFunc 2 := fun _ => true
+  let x₁ : Point 2 := fun _ => true
+  let x₂ : Point 2 := fun
+    | 0 => false
+    | 1 => true
+  let x₃ : Point 2 := fun
+    | 0 => true
+    | 1 => false
+  have hf : f ∈ ({f} : BoolFunc.Family 2) := by simp
+  have hx₁val : f x₁ = true := by simp [f, x₁]
+  have hx₂val : f x₂ = true := by simp [f, x₂]
+  have hx₃val : f x₃ = true := by simp [f, x₃]
+  have hnc₁ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₁ :=
+    by intro R hR; cases hR
+  have hnc₂ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₂ :=
+    by intro R hR; cases hR
+  have hnc₃ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₃ :=
+    by intro R hR; cases hR
+  have hp₁ : ⟨f, x₁⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₁val, hnc₁⟩
+  have hp₂ : ⟨f, x₂⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₂val, hnc₂⟩
+  have hp₃ : ⟨f, x₃⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₃val, hnc₃⟩
+  have hx₁R : x₁ ∈ₛ Subcube.full := by simp [x₁]
+  have hx₂R : x₂ ∈ₛ Subcube.full := by simp [x₂]
+  have hx₃R : x₃ ∈ₛ Subcube.full := by simp [x₃]
+  have hne₁₂ : (⟨f, x₁⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₂⟩ := by
+    intro h
+    have hx : x₁ = x₂ := congrArg Sigma.snd h
+    have hx0 : x₁ 0 = x₂ 0 := congrArg (fun g => g 0) hx
+    simp [x₁, x₂] at hx0
+  have hne₁₃ : (⟨f, x₁⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₃⟩ := by
+    intro h
+    have hx : x₁ = x₃ := congrArg Sigma.snd h
+    have hx0 : x₁ 1 = x₃ 1 := congrArg (fun g => g 1) hx
+    simp [x₁, x₃] at hx0
+  have hne₂₃ : (⟨f, x₂⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₃⟩ := by
+    intro h
+    have hx : x₂ = x₃ := congrArg Sigma.snd h
+    have hx0 : x₂ 0 = x₃ 0 := congrArg (fun g => g 0) hx
+    simp [x₂, x₃] at hx0
+  have hmem : Subcube.full ∈ ({Subcube.full} : Finset (Subcube 2)) := by simp
+  simpa using
+    Cover2.mu_union_triple_lt
+      (n := 2) (F := {f}) (R₁ := (∅ : Finset (Subcube 2)))
+      (R₂ := {Subcube.full}) (R := Subcube.full) (h := 0)
+      (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩) (p₃ := ⟨f, x₃⟩)
+      hp₁ hp₂ hp₃ hx₁R hx₂R hx₃R hne₁₂ hne₁₃ hne₂₃ hmem
+
 /-- `mu_mono_subset` expresses that enlarging the set of rectangles can only
 decrease the measure.  We test it on a simple pair of sets. -/
 example :
@@ -491,6 +614,89 @@ example :
       (R := Subcube.full) (h := 0)
       (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩) (p₃ := ⟨f, x₃⟩)
       hp₁ hp₂ hp₃ hx₁R hx₂R hx₃R hne₁₂ hne₁₃ hne₂₃
+
+/-- `mu_union_singleton_quad_succ_le` ensures a drop of at least four when
+four distinct pairs are covered. -/
+example :
+    Cover2.mu (n := 2)
+        ({(fun _ : Point 2 => true)} : BoolFunc.Family 2)
+        0 ((∅ : Finset (Subcube 2)) ∪ {Subcube.full}) + 4 ≤
+    Cover2.mu (n := 2)
+        ({(fun _ : Point 2 => true)} : BoolFunc.Family 2)
+        0 (∅ : Finset (Subcube 2)) := by
+  classical
+  -- Four uncovered inputs for the constant-true function.
+  let f : BFunc 2 := fun _ => true
+  let x₁ : Point 2 := fun _ => true
+  let x₂ : Point 2 := fun
+    | 0 => false
+    | 1 => true
+  let x₃ : Point 2 := fun
+    | 0 => true
+    | 1 => false
+  let x₄ : Point 2 := fun _ => false
+  have hf : f ∈ ({f} : BoolFunc.Family 2) := by simp
+  have hx₁val : f x₁ = true := by simp [f, x₁]
+  have hx₂val : f x₂ = true := by simp [f, x₂]
+  have hx₃val : f x₃ = true := by simp [f, x₃]
+  have hx₄val : f x₄ = true := by simp [f, x₄]
+  have hnc₁ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₁ :=
+    by intro R hR; cases hR
+  have hnc₂ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₂ :=
+    by intro R hR; cases hR
+  have hnc₃ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₃ :=
+    by intro R hR; cases hR
+  have hnc₄ : Cover2.NotCovered (n := 2) (Rset := (∅ : Finset (Subcube 2))) x₄ :=
+    by intro R hR; cases hR
+  have hp₁ : ⟨f, x₁⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₁val, hnc₁⟩
+  have hp₂ : ⟨f, x₂⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₂val, hnc₂⟩
+  have hp₃ : ⟨f, x₃⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₃val, hnc₃⟩
+  have hp₄ : ⟨f, x₄⟩ ∈ Cover2.uncovered (n := 2) ({f} : BoolFunc.Family 2)
+        (∅ : Finset (Subcube 2)) := ⟨hf, hx₄val, hnc₄⟩
+  have hx₁R : x₁ ∈ₛ Subcube.full := by simp [x₁]
+  have hx₂R : x₂ ∈ₛ Subcube.full := by simp [x₂]
+  have hx₃R : x₃ ∈ₛ Subcube.full := by simp [x₃]
+  have hx₄R : x₄ ∈ₛ Subcube.full := by simp [x₄]
+  have hne₁₂ : (⟨f, x₁⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₂⟩ := by
+    intro h
+    have hx : x₁ = x₂ := congrArg Sigma.snd h
+    have hx0 : x₁ 0 = x₂ 0 := congrArg (fun g => g 0) hx
+    simp [x₁, x₂] at hx0
+  have hne₁₃ : (⟨f, x₁⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₃⟩ := by
+    intro h
+    have hx : x₁ = x₃ := congrArg Sigma.snd h
+    have hx0 : x₁ 1 = x₃ 1 := congrArg (fun g => g 1) hx
+    simp [x₁, x₃] at hx0
+  have hne₁₄ : (⟨f, x₁⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₄⟩ := by
+    intro h
+    have hx : x₁ = x₄ := congrArg Sigma.snd h
+    have hx0 : x₁ 0 = x₄ 0 := congrArg (fun g => g 0) hx
+    simp [x₁, x₄] at hx0
+  have hne₂₃ : (⟨f, x₂⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₃⟩ := by
+    intro h
+    have hx : x₂ = x₃ := congrArg Sigma.snd h
+    have hx0 : x₂ 0 = x₃ 0 := congrArg (fun g => g 0) hx
+    simp [x₂, x₃] at hx0
+  have hne₂₄ : (⟨f, x₂⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₄⟩ := by
+    intro h
+    have hx : x₂ = x₄ := congrArg Sigma.snd h
+    have hx1 : x₂ 1 = x₄ 1 := congrArg (fun g => g 1) hx
+    simp [x₂, x₄] at hx1
+  have hne₃₄ : (⟨f, x₃⟩ : Σ g : BFunc 2, Point 2) ≠ ⟨f, x₄⟩ := by
+    intro h
+    have hx : x₃ = x₄ := congrArg Sigma.snd h
+    have hx0 : x₃ 0 = x₄ 0 := congrArg (fun g => g 0) hx
+    simp [x₃, x₄] at hx0
+  simpa using
+    Cover2.mu_union_singleton_quad_succ_le
+      (n := 2) (F := {f}) (Rset := (∅ : Finset (Subcube 2)))
+      (R := Subcube.full) (h := 0)
+      (p₁ := ⟨f, x₁⟩) (p₂ := ⟨f, x₂⟩) (p₃ := ⟨f, x₃⟩) (p₄ := ⟨f, x₄⟩)
+      hp₁ hp₂ hp₃ hp₄ hx₁R hx₂R hx₃R hx₄R
+      hne₁₂ hne₁₃ hne₁₄ hne₂₃ hne₂₄ hne₃₄
 
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- prove lemmas `mu_union_triple_succ_le` and `mu_union_triple_lt` in `cover2.lean`
- test triple-union measure drop on explicit constant functions
- expand migration documentation with current lemma counts

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688ab86a51c4832b86ac0bc0205fe9d5


___

### **PR Type**
Enhancement


___

### **Description**
- Port triple union lemmas from cover.lean to cover2.lean

- Add quadruple union lemma for four distinct pairs

- Expand test coverage with concrete examples

- Update migration documentation with current progress


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover.lean"] -- "port lemmas" --> B["cover2.lean"]
  B -- "add tests" --> C["Cover2Test.lean"]
  B -- "update counts" --> D["migration docs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Port triple union lemmas and add quad support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_union_singleton_quad_succ_le</code> lemma for four distinct pairs<br> <li> Port <code>mu_union_triple_succ_le</code> and <code>mu_union_triple_lt</code> lemmas<br> <li> Implement measure drop bounds for triple and quadruple unions<br> <li> Add comprehensive proof structure with cardinality bounds</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/705/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+202/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add comprehensive tests for union lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test examples for <code>mu_union_triple_succ_le</code> and <code>mu_union_triple_lt</code><br> <li> Add test for <code>mu_union_singleton_quad_succ_le</code> with four distinct pairs<br> <li> Use constant-true function with explicit point definitions<br> <li> Verify measure drop bounds with concrete witnesses</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/705/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+206/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 33 to 44 lemmas<br> <li> Update pending count from 55 to 44 lemmas<br> <li> Move 11 union-related lemmas from pending to migrated section<br> <li> Adjust total lemma count from 89 to 88</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/705/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+15/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

