### PR TITLE
feat: add mu_union_lt lemma and test

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -951,6 +951,32 @@ lemma mu_mono_subset {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ}
   have := hrewrite ▸ hmain
   simpa using this
 
+/-- `mu_union_lt` generalises `mu_union_singleton_lt` to an arbitrary set of
+rectangles.  If some uncovered pair of `R₁` is covered by a rectangle from
+`R₂`, then the measure strictly decreases after taking the union. -/
+lemma mu_union_lt {F : Family n} {R₁ R₂ : Finset (Subcube n)} {h : ℕ}
+    (hx : ∃ p ∈ uncovered (n := n) F R₁, ∃ R ∈ R₂, p.2 ∈ₛ R) :
+    mu (n := n) F h (R₁ ∪ R₂) < mu (n := n) F h R₁ := by
+  classical
+  rcases hx with ⟨p, hpU, R, hR, hpR⟩
+  -- First insert the specific rectangle that covers `p`.
+  have hx_singleton : ∃ q ∈ uncovered (n := n) F R₁, q.2 ∈ₛ R :=
+    ⟨p, hpU, hpR⟩
+  have hstep :=
+    mu_union_singleton_lt (F := F) (Rset := R₁) (R := R)
+      (h := h) hx_singleton
+  -- Adding more rectangles cannot increase the measure.
+  have hsubset : R₁ ∪ {R} ⊆ R₁ ∪ R₂ := by
+    intro x hx'
+    rcases Finset.mem_union.mp hx' with hx₁ | hx₂
+    · exact Finset.mem_union.mpr <| Or.inl hx₁
+    · rcases Finset.mem_singleton.mp hx₂ with rfl
+      exact Finset.mem_union.mpr <| Or.inr hR
+  have hmono :=
+    mu_mono_subset (F := F) (h := h)
+      (R₁ := R₁ ∪ {R}) (R₂ := R₁ ∪ R₂) hsubset
+  exact lt_of_le_of_lt hmono hstep
+
 /-- `mu_union_double_succ_le` combines the single-rectangle estimate with
 monotonicity.  If some rectangle in `R₂` covers two distinct uncovered pairs of
 `R₁`, then the measure drops by at least two after taking the union. -/

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -545,6 +545,39 @@ example :
       (n := 1)
       hsub
 
+/-- `mu_union_lt` strictly decreases the measure when a rectangle from `R₂`
+covers an uncovered pair of `R₁`. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun x : Point 1 => x 0)} : BoolFunc.Family 1)
+        0 ((∅ : Finset (Subcube 1)) ∪ {Subcube.full}) <
+    Cover2.mu (n := 1)
+        ({(fun x : Point 1 => x 0)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  -- A single uncovered input for the projection function.
+  let f : BFunc 1 := fun x => x 0
+  let x : Point 1 := fun _ => true
+  have hf : f ∈ ({f} : BoolFunc.Family 1) := by simp
+  have hxval : f x = true := by simp [f, x]
+  have hnc : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x := by
+    intro R hR; cases hR
+  have hx :
+      ∃ p, p ∈ Cover2.uncovered (n := 1) ({f} : BoolFunc.Family 1)
+            (∅ : Finset (Subcube 1)) ∧
+          ∃ R, R ∈ ({Subcube.full (n := 1)} : Finset (Subcube 1)) ∧
+            Boolcube.Subcube.Mem R (p.2) := by
+    refine ⟨⟨f, x⟩, ?_, ?_⟩
+    · exact ⟨hf, hxval, hnc⟩
+    · refine ⟨Subcube.full (n := 1), ?_, ?_⟩
+      · simp
+      · simp [x]
+  simpa using
+    Cover2.mu_union_lt
+      (n := 1) (F := {f})
+      (R₁ := (∅ : Finset (Subcube 1)))
+      (R₂ := {Subcube.full}) (h := 0) hx
+
 /-- `mu_union_singleton_triple_succ_le` ensures a drop of at least three when
 three distinct pairs are covered. -/
 example :


### PR DESCRIPTION
### **User description**
## Summary
- port `mu_union_lt` lemma from `cover` to `cover2`
- add test verifying `mu_union_lt` for a simple projection function

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688b5f43b6b8832ba21f2aa9c1ff3677


___

### **PR Type**
Enhancement


___

### **Description**
- Add `mu_union_lt` lemma generalizing measure decrease for arbitrary rectangle sets

- Include comprehensive test verifying lemma with projection function example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mu_union_singleton_lt"] --> B["mu_union_lt"]
  B --> C["Test with projection function"]
  D["Uncovered pairs"] --> B
  E["Rectangle coverage"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add mu_union_lt lemma for arbitrary rectangle unions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_union_lt</code> lemma generalizing measure decrease for arbitrary <br>rectangle sets<br> <li> Implement proof using existing <code>mu_union_singleton_lt</code> and monotonicity <br>properties<br> <li> Add comprehensive documentation explaining the lemma's purpose and <br>conditions</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/709/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add mu_union_lt test with projection function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example verifying <code>mu_union_lt</code> with projection function<br> <li> Construct specific uncovered pair scenario with empty initial set<br> <li> Demonstrate strict measure decrease when adding full subcube</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/709/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

