### PR TITLE
feat: add buildCover stub and mu_union_buildCover_le

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1077,5 +1077,33 @@ lemma mu_union_triple_lt {F : Family n} {R₁ R₂ : Finset (Subcube n)}
     exact this.trans hdrop
   exact Nat.lt_of_succ_le hsucc
 
+/-! ### Placeholder cover construction
+
+The original development defines a sophisticated recursive procedure
+`buildCover`.  In this port we only require a minimal stub returning the
+empty set so that later lemmas depending on its interface can already be
+stated and proved.  The full construction will replace this definition in a
+future update. -/
+
+noncomputable
+def buildCover {n : ℕ} (F : Family n) (h : ℕ)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (Rset : Finset (Subcube n) := ∅) : Finset (Subcube n) :=
+  (∅ : Finset (Subcube n))
+
+/--  Adding the rectangles produced by `buildCover` cannot increase the
+measure `μ`.  This is a direct consequence of `mu_union_le` since our current
+stub returns an empty set. -/
+lemma mu_union_buildCover_le {n : ℕ} {F : Family n} {h : ℕ}
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) (Rset : Finset (Subcube n)) :
+    mu (n := n) F h
+        (Rset ∪ buildCover (n := n) (F := F) (h := h) hH Rset) ≤
+      mu (n := n) F h Rset := by
+  classical
+  -- Instantiating `mu_union_le` with the result of `buildCover`.
+  simpa [buildCover] using
+    mu_union_le (n := n) (F := F) (h := h) (R₁ := Rset)
+      (R₂ := buildCover (n := n) (F := F) (h := h) hH Rset)
+
 end Cover2
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -781,5 +781,24 @@ example :
       hp₁ hp₂ hp₃ hp₄ hx₁R hx₂R hx₃R hx₄R
       hne₁₂ hne₁₃ hne₁₄ hne₂₃ hne₂₄ hne₃₄
 
+/-- `mu_union_buildCover_le` specialises to a reflexive inequality for the
+empty family and entropy budget `0`. -/
+example :
+    Cover2.mu (n := 1) (F := (∅ : BoolFunc.Family 1)) 0
+        ((∅ : Finset (Subcube 1)) ∪
+          Cover2.buildCover (n := 1)
+            (F := (∅ : BoolFunc.Family 1)) (h := 0)
+            (hH := by simpa [BoolFunc.H₂])
+            (Rset := (∅ : Finset (Subcube 1))))
+        ≤ Cover2.mu (n := 1) (F := (∅ : BoolFunc.Family 1)) 0
+          (∅ : Finset (Subcube 1)) := by
+  classical
+  -- With the current stub, `buildCover` returns `∅` so the union is unchanged.
+  simpa using
+    Cover2.mu_union_buildCover_le
+      (n := 1) (F := (∅ : BoolFunc.Family 1)) (h := 0)
+      (hH := by simpa [BoolFunc.H₂])
+      (Rset := (∅ : Finset (Subcube 1)))
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- stub Cover2.buildCover so future lemmas can reference a cover construction
- port mu_union_buildCover_le showing union with buildCover doesn't raise μ
- expand Cover2 tests with a scenario using buildCover

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688b66d2a7b8832b9e001add1769ac8e


___

### **PR Type**
Enhancement


___

### **Description**
- Add `buildCover` stub function returning empty set

- Implement `mu_union_buildCover_le` lemma for measure bounds

- Expand test coverage with `buildCover` usage example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCover stub"] --> B["mu_union_buildCover_le lemma"]
  B --> C["test example"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add buildCover stub and measure lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>buildCover</code> stub function returning empty set<br> <li> Implement <code>mu_union_buildCover_le</code> lemma proving union doesn't increase <br>measure<br> <li> Add documentation explaining placeholder nature of implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/710/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add buildCover test example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example demonstrating <code>mu_union_buildCover_le</code> usage<br> <li> Test with empty family and entropy budget 0<br> <li> Verify reflexive inequality property</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/710/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

