### PR TITLE
feat: characterize empty uncovered search

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -315,6 +315,24 @@ def firstUncovered (F : Family n) (Rset : Finset (Subcube n)) :
   else
     none
 
+@[simp] lemma firstUncovered_none_iff (F : Family n)
+    (R : Finset (Subcube n)) :
+    firstUncovered (n := n) F R = none ↔
+      uncovered (n := n) F R = (∅ : Set (Σ f : BFunc n, Point n)) := by
+  classical
+  unfold firstUncovered
+  by_cases h : (uncovered (n := n) F R).Nonempty
+  ·
+    have hne : uncovered (n := n) F R ≠ (∅ : Set _) :=
+      Set.nonempty_iff_ne_empty.mp h
+    simp [h, Set.nonempty_iff_ne_empty, hne]
+  ·
+    have hempty : uncovered (n := n) F R = (∅ : Set _) := by
+      apply Set.eq_empty_iff_forall_notMem.mpr
+      intro p hp
+      exact h ⟨p, hp⟩
+    simp [h, Set.nonempty_iff_ne_empty, hempty]
+
 
 /-- All `1`-inputs of `F` lie in some rectangle of `Rset`. -/
 @[simp]

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -174,6 +174,21 @@ example (R₁ R₂ : Finset (Subcube 1)) :
       (F := {(fun _ : Point 1 => true)})
       (R₁ := R₁) (R₂ := R₂)
 
+/-- `firstUncovered` returns `none` precisely when the uncovered set is empty. -/
+example :
+    Cover2.firstUncovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      (∅ : Finset (Subcube 1)) = none ↔
+    Cover2.uncovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      (∅ : Finset (Subcube 1)) =
+        (∅ : Set (Sigma (fun _ => Point 1))) := by
+  simpa using
+    (Cover2.firstUncovered_none_iff
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (R := (∅ : Finset (Subcube 1))))
+
 /-- `μ` is nonnegative by construction. -/
 example :
     0 ≤ Cover2.mu (n := 1)


### PR DESCRIPTION
### **User description**
## Summary
- add lemma equating `firstUncovered = none` with an empty uncovered set
- extend Cover2 tests with a check for this new lemma

## Testing
- `lake build Pnp2.cover2`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688b66d2a7b8832b9e001add1769ac8e


___

### **PR Type**
Enhancement


___

### **Description**
- Add lemma characterizing empty uncovered search

- Extend Cover2 tests with new lemma verification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["firstUncovered function"] --> B["New lemma: firstUncovered_none_iff"]
  B --> C["Test verification"]
  B --> D["Empty uncovered set equivalence"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add lemma for empty uncovered characterization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>firstUncovered_none_iff</code> lemma with simp attribute<br> <li> Prove equivalence between <code>firstUncovered = none</code> and empty uncovered <br>set<br> <li> Use classical logic and case analysis on nonemptiness</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/711/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for firstUncovered none equivalence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example verifying the new <code>firstUncovered_none_iff</code> lemma<br> <li> Test equivalence between <code>firstUncovered</code> returning <code>none</code> and empty <br>uncovered set</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/711/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

