### PR TITLE
feat: port coverage lemma to cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -403,6 +403,36 @@ lemma uncovered_eq_empty_of_allCovered {F : Family n}
   · intro hp
     cases hp
 
+lemma allOnesCovered_of_firstUncovered_none {F : Family n}
+    {Rset : Finset (Subcube n)}
+    (hfu : firstUncovered (n := n) F Rset = none) :
+    AllOnesCovered (n := n) F Rset := by
+  classical
+  intro f hf x hx
+  by_contra hxcov
+  -- If `x` were uncovered, the pair `⟨f, x⟩` would belong to the uncovered set.
+  have hxNC : NotCovered (n := n) (Rset := Rset) x := by
+    intro R hR hxR
+    exact hxcov ⟨R, hR, hxR⟩
+  have hx_mem' : (⟨f, x⟩ : Σ f : BFunc n, Point n)
+      ∈ uncovered (n := n) F Rset := ⟨hf, hx, hxNC⟩
+  -- But the uncovered set is empty by assumption.
+  have hempty : uncovered (n := n) F Rset =
+      (∅ : Set (Σ f : BFunc n, Point n)) :=
+    (firstUncovered_none_iff (n := n) (F := F) (R := Rset)).1 hfu
+  -- The assumption gives a witness in the uncovered set, contradicting emptiness.
+  have hx_mem : f ∈ F ∧ f x = true ∧ NotCovered (n := n) (Rset := Rset) x :=
+    hx_mem'
+  have hx_mem_set : (⟨f, x⟩ : Σ f : BFunc n, Point n)
+      ∈ uncovered (n := n) F Rset := by
+    simpa [uncovered] using hx_mem
+  have hx_eq := congrArg (fun s => (⟨f, x⟩ : Σ f : BFunc n, Point n) ∈ s) hempty
+  have hx_empty : (⟨f, x⟩ : Σ f : BFunc n, Point n)
+      ∈ (∅ : Set (Σ f : BFunc n, Point n)) := by
+    have := Eq.mp hx_eq hx_mem_set
+    simpa using this
+  cases hx_empty
+
 /-!
 `uncovered` is monotone with respect to the set of rectangles.  Adding a new
 rectangle can only remove uncovered pairs.  The next lemmas capture this

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -189,6 +189,43 @@ example :
       (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
       (R := (∅ : Finset (Subcube 1))))
 
+/-- If `firstUncovered` returns `none`, all `1`‑inputs are covered. -/
+example :
+    Cover2.AllOnesCovered (n := 1)
+      ({(fun _ : Point 1 => false)} : BoolFunc.Family 1)
+      (∅ : Finset (Subcube 1)) := by
+  classical
+  -- The uncovered set is empty since the function has no `1`-inputs.
+  have hcov : Cover2.AllOnesCovered (n := 1)
+      ({(fun _ : Point 1 => false)} : BoolFunc.Family 1)
+      (∅ : Finset (Subcube 1)) := by
+    simpa using
+      (Cover2.AllOnesCovered.empty
+        (n := 1)
+        (F := ({(fun _ : Point 1 => false)} : BoolFunc.Family 1)))
+  have huncov : Cover2.uncovered (n := 1)
+      ({(fun _ : Point 1 => false)} : BoolFunc.Family 1)
+      (∅ : Finset (Subcube 1)) =
+      (∅ : Set (Sigma (fun _ => Point 1))) :=
+    Cover2.uncovered_eq_empty_of_allCovered
+      (n := 1) (F := ({(fun _ : Point 1 => false)} : BoolFunc.Family 1))
+      (Rset := (∅ : Finset (Subcube 1))) hcov
+  have hfu :
+      Cover2.firstUncovered (n := 1)
+        ({(fun _ : Point 1 => false)} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1)) = none := by
+    exact
+      (Cover2.firstUncovered_none_iff
+        (n := 1)
+        (F := ({(fun _ : Point 1 => false)} : BoolFunc.Family 1))
+        (R := (∅ : Finset (Subcube 1)))).2 huncov
+  -- Invoke the main lemma.
+  simpa using
+    (Cover2.allOnesCovered_of_firstUncovered_none
+      (n := 1)
+      (F := ({(fun _ : Point 1 => false)} : BoolFunc.Family 1))
+      (Rset := (∅ : Finset (Subcube 1))) hfu)
+
 /-- `μ` is nonnegative by construction. -/
 example :
     0 ≤ Cover2.mu (n := 1)


### PR DESCRIPTION
### **User description**
## Summary
- port `allOnesCovered_of_firstUncovered_none` into `cover2` with explicit proof
- exercise the new lemma in Cover2Test

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688b6e55f654832babf436e8bee67736


___

### **PR Type**
Enhancement


___

### **Description**
- Port `allOnesCovered_of_firstUncovered_none` lemma from cover to cover2

- Add comprehensive test case exercising the new lemma

- Establish connection between `firstUncovered` returning `none` and coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["firstUncovered = none"] --> B["uncovered set empty"]
  B --> C["AllOnesCovered property"]
  C --> D["test validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add coverage lemma with explicit proof</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>allOnesCovered_of_firstUncovered_none</code> lemma with explicit proof<br> <li> Establish logical connection between <code>firstUncovered</code> and coverage <br>properties<br> <li> Use classical reasoning and proof by contradiction approach</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/712/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test case for coverage lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add comprehensive test case for the new coverage lemma<br> <li> Demonstrate usage with boolean function having no 1-inputs<br> <li> Validate the connection between empty uncovered set and coverage</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/712/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

