### PR TITLE
feat: add basic nonnegativity lemma for mBound

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -30,6 +30,9 @@ original construction.  -/
 
 @[simp] def mBound (n h : ℕ) : ℕ := n * (h + 2) * 2 ^ (10 * h)
 
+lemma mBound_nonneg (n h : ℕ) : 0 ≤ mBound n h := by
+  exact Nat.zero_le _
+
 lemma numeric_bound (n h : ℕ) (hn : 0 < n) :
     2 * h + n ≤ mBound n h := by
   classical

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -12,6 +12,10 @@ namespace Cover2Test
 example : mBound 1 0 = 2 := by
   simp [mBound]
 
+/-- `mBound` is nonnegative for all inputs. -/
+example : 0 ≤ mBound 1 0 := by
+  simpa using Cover2.mBound_nonneg (n := 1) (h := 0)
+
 /-- Numeric bound specialised to trivial parameters using the positive version. -/
 example : 2 * 0 + 1 ≤ mBound 1 0 := by
   have hn : 0 < (1 : ℕ) := by decide


### PR DESCRIPTION
## Summary
- add `mBound_nonneg` lemma expressing trivial nonnegativity of the numeric bound
- extend Cover2 tests to validate the new lemma

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688b6e55f654832babf436e8bee67736