### PR TITLE
feat: port uncovered_card_bound lemma

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1128,5 +1128,30 @@ lemma mu_union_triple_lt {F : Family n} {R₁ R₂ : Finset (Subcube n)}
     exact this.trans hdrop
   exact Nat.lt_of_succ_le hsucc
 
+/-! ### Coarse bound on the number of uncovered pairs -/
+
+lemma uncovered_card_bound (F : Family n) (Rset : Finset (Subcube n)) :
+    (uncovered (n := n) F Rset).toFinset.card ≤ F.card * 2 ^ n := by
+  classical
+  -- Each uncovered pair corresponds to a function from `F` and a cube point.
+  have hsubset : (uncovered (n := n) F Rset).toFinset ⊆
+      F.sigma (fun _ => (Finset.univ : Finset (Point n))) := by
+    intro p hp
+    have hp' : p ∈ uncovered (n := n) F Rset := by simpa using hp
+    rcases hp' with ⟨hf, hx, _⟩
+    have hx' : p.2 ∈ (Finset.univ : Finset (Point n)) := by simp
+    exact Finset.mem_sigma.mpr ⟨hf, hx'⟩
+  have hcard := Finset.card_le_card hsubset
+  -- Cardinality of a sigma-type splits multiplicatively for a constant fiber.
+  have hprod : (F.sigma fun _ => (Finset.univ : Finset (Point n))).card =
+      F.card * (Finset.univ : Finset (Point n)).card := by
+    classical
+    simpa [Finset.card_sigma, Finset.sum_const, Nat.mul_comm, Nat.mul_left_comm,
+      Nat.mul_assoc]
+  -- The Boolean cube has size `2 ^ n`.
+  have hcube : (Finset.univ : Finset (Point n)).card = 2 ^ n := by
+    simpa using (Fintype.card_vector (α := Bool) (n := n))
+  simpa [hprod, hcube] using hcard
+
 end Cover2
 

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 44 |
+| Fully migrated | 45 |
 | Axioms | 0 |
-| Pending | 44 |
+| Pending | 43 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -60,6 +60,7 @@ AllOnesCovered.insert
 uncovered_eq_empty_of_allCovered
 uncovered_subset_of_union_singleton
 uncovered_subset_of_union
+uncovered_card_bound
 mu_mono_subset
 mu_union_double_lt
 mu_union_double_succ_le
@@ -73,7 +74,7 @@ mu_union_triple_lt
 mu_union_triple_succ_le
 ```
 
-### Not yet ported (44 lemmas)
+### Not yet ported (43 lemmas)
 
 ```
 allOnesCovered_of_firstUncovered_none
@@ -118,7 +119,6 @@ mu_union_buildCover_le
 mu_union_buildCover_lt
 mu_union_lt
 sunflower_step
-uncovered_card_bound
 uncovered_init_bound_empty
 uncovered_init_coarse_bound
 ```

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -3,6 +3,7 @@ import Pnp2.BoolFunc
 
 open Boolcube (Point Subcube)
 open BoolFunc (BFunc Family)
+open Classical
 
 open Cover2
 
@@ -177,6 +178,19 @@ example (R₁ R₂ : Finset (Subcube 1)) :
       (n := 1)
       (F := {(fun _ : Point 1 => true)})
       (R₁ := R₁) (R₂ := R₂)
+
+/-- The coarse cardinality bound on uncovered pairs. -/
+example :
+    (Cover2.uncovered (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1))).toFinset.card ≤
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1).card * 2 ^ 1 := by
+  classical
+  simpa using
+    Cover2.uncovered_card_bound
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (Rset := (∅ : Finset (Subcube 1)))
 
 /-- `firstUncovered` returns `none` precisely when the uncovered set is empty. -/
 example :


### PR DESCRIPTION
## Summary
- port `uncovered_card_bound` to `cover2.lean` with full proof
- document new lemma in migration plan
- add regression test for the coarse uncovered-pair bound

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688b855a46a4832bbbecc09391fc01fb