### PR TITLE
Port initial uncovered bounds into `cover2`

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1153,5 +1153,37 @@ lemma uncovered_card_bound (F : Family n) (Rset : Finset (Subcube n)) :
     simpa using (Fintype.card_vector (α := Bool) (n := n))
   simpa [hprod, hcube] using hcard
 
+/--
+`uncovered_init_coarse_bound` specialises the coarse cardinality estimate
+to the initial call of the cover construction where no rectangles are
+present yet.  Even this simple bound is occasionally useful for quick
+sanity checks.
+-/
+lemma uncovered_init_coarse_bound (F : Family n) :
+    (uncovered (n := n) F (∅ : Finset (Subcube n))).toFinset.card ≤
+      F.card * 2 ^ n := by
+  simpa using
+    (uncovered_card_bound (n := n) (F := F)
+      (Rset := (∅ : Finset (Subcube n))))
+
+/--
+If the family itself is empty, the set of initially uncovered pairs is
+trivially empty.  In this case any numeric bound holds; we record a
+simple instance with the dimension `n` for convenience.
+-/
+lemma uncovered_init_bound_empty (F : Family n) (hF : F = (∅ : Family n)) :
+    (uncovered (n := n) F (∅ : Finset (Subcube n))).toFinset.card ≤ n := by
+  classical
+  -- With an empty family no pairs are uncovered, so the cardinality is zero.
+  have hcard :
+      (uncovered (n := n) F (∅ : Finset (Subcube n))).toFinset.card = 0 := by
+    simpa [uncovered, hF]
+  -- Rewrite the goal using `hcard` and conclude with `Nat.zero_le`.
+  have hgoal :
+      (uncovered (n := n) F (∅ : Finset (Subcube n))).toFinset.card ≤ n := by
+    rw [hcard]
+    exact Nat.zero_le n
+  exact hgoal
+
 end Cover2
 

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 45 |
+| Fully migrated | 53 |
 | Axioms | 0 |
-| Pending | 43 |
+| Pending | 35 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -48,19 +48,27 @@ card_union_pair_mBound_succ
 card_union_triple_mBound_succ
 cover_size_bound
 size_bounds
+mu_nonneg
+mu_lower_bound
+mu_mono_h
 mu_union_singleton_le
 mu_union_singleton_lt
 mu_union_singleton_succ_le
+mu_union_lt
 notCovered_empty
 NotCovered.monotone
+firstUncovered_none_iff
 AllOnesCovered.full
 AllOnesCovered.superset
 AllOnesCovered.union
 AllOnesCovered.insert
+allOnesCovered_of_firstUncovered_none
 uncovered_eq_empty_of_allCovered
 uncovered_subset_of_union_singleton
 uncovered_subset_of_union
 uncovered_card_bound
+uncovered_init_coarse_bound
+uncovered_init_bound_empty
 mu_mono_subset
 mu_union_double_lt
 mu_union_double_succ_le
@@ -74,10 +82,9 @@ mu_union_triple_lt
 mu_union_triple_succ_le
 ```
 
-### Not yet ported (43 lemmas)
+### Not yet ported (35 lemmas)
 
 ```
-allOnesCovered_of_firstUncovered_none
 allOnesCovered_of_mu_eq
 buildCover_card_bound
 buildCover_card_bound_base
@@ -102,31 +109,24 @@ coverFamily_mono
 coverFamily_spec
 coverFamily_spec_cover
 cover_exists
-firstUncovered_none_iff
 lift_mono_of_restrict
 lift_mono_of_restrict_fixOne
 mono_subset
 mono_union
 mu_buildCover_le_start
 mu_buildCover_lt_start
+sunflower_step
 mu_gt_of_firstUncovered_some
-mu_lower_bound
-mu_mono_h
-mu_nonneg
 mu_of_allCovered
 mu_of_firstUncovered_none
 mu_union_buildCover_le
 mu_union_buildCover_lt
-mu_union_lt
-sunflower_step
-uncovered_init_bound_empty
-uncovered_init_coarse_bound
 ```
 
 ## Next steps
 
 1. Port the remaining combinatorial facts about uncovered inputs and the
-   termination measure (starting with `firstUncovered_none_iff`).
+   termination measure (e.g., `mu_of_allCovered` and related lemmas).
 2. Recreate the recursion `buildCover` and its counting bounds,
    replacing each remaining axiom with its full proof.
 3. Once all lemmas are available, `cover2.lean` can replace `cover.lean` in the

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -192,6 +192,27 @@ example :
       (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
       (Rset := (∅ : Finset (Subcube 1)))
 
+/-- Coarse bound specialised to the initial uncovered set. -/
+example :
+    (Cover2.uncovered (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1))).toFinset.card ≤
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1).card * 2 ^ 1 := by
+  classical
+  simpa using
+    (Cover2.uncovered_init_coarse_bound
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)))
+
+/-- If the family is empty, the initial uncovered set is empty as well. -/
+example :
+    (Cover2.uncovered (n := 1) (∅ : BoolFunc.Family 1)
+        (∅ : Finset (Subcube 1))).toFinset.card ≤ 1 := by
+  have hF : (∅ : BoolFunc.Family 1) = (∅ : BoolFunc.Family 1) := rfl
+  simpa [hF]
+    using Cover2.uncovered_init_bound_empty
+      (n := 1) (F := (∅ : BoolFunc.Family 1)) (hF := rfl)
+
 /-- `firstUncovered` returns `none` precisely when the uncovered set is empty. -/
 example :
     Cover2.firstUncovered (n := 1)


### PR DESCRIPTION
## Summary
- add `uncovered_init_coarse_bound` and `uncovered_init_bound_empty` to `Cover2`
- exercise new bounds in `Cover2Test`
- refresh migration plan with updated lemma counts

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688b991ff5a4832ba182e7578a48589a