### PR TITLE
feat: migrate lemma in cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -470,6 +470,45 @@ record a minimal API for now. -/
 noncomputable def mu (F : Family n) (h : ℕ) (Rset : Finset (Subcube n)) : ℕ :=
   2 * h + (uncovered (n := n) F Rset).toFinset.card
 
+/-!
+If the measure `μ` equals `2 * h`, then no uncovered pairs remain.
+Consequently all `1`‑inputs of `F` must already be covered by `Rset`.
+-/
+lemma allOnesCovered_of_mu_eq {F : Family n} {Rset : Finset (Subcube n)}
+    {h : ℕ} (hμ : mu (n := n) F h Rset = 2 * h) :
+    AllOnesCovered (n := n) F Rset := by
+  classical
+  -- From the equality on `μ` we deduce that the uncovered set has
+  -- cardinality `0`.
+  have hμ' : 2 * h + (uncovered (n := n) F Rset).toFinset.card =
+      2 * h + 0 := by
+    simpa [mu] using hμ
+  have hcard0 : (uncovered (n := n) F Rset).toFinset.card = 0 :=
+    Nat.add_left_cancel hμ'
+  -- Hence the uncovered set itself is empty.
+  have hset : uncovered (n := n) F Rset =
+      (∅ : Set (Σ f : BFunc n, Point n)) := by
+    classical
+    -- Convert cardinality information into emptiness of the uncovered set.
+    have hfin :
+        (uncovered (n := n) F Rset).toFinset =
+          (∅ : Finset (Σ f : BFunc n, Point n)) :=
+      Finset.card_eq_zero.mp hcard0
+    apply Set.eq_empty_iff_forall_notMem.mpr
+    intro p hp
+    -- Membership in the set contradicts the finset being empty.
+    have hpFin : p ∈ (uncovered (n := n) F Rset).toFinset :=
+      Set.mem_toFinset.mpr hp
+    -- Rewrite using `hfin` and derive a contradiction.
+    rw [hfin] at hpFin
+    cases hpFin
+  -- Conclude by converting the empty uncovered set into coverage.
+  have hfu : firstUncovered (n := n) F Rset = none :=
+    (firstUncovered_none_iff (n := n) (F := F) (R := Rset)).2
+      (by simpa using hset)
+  exact allOnesCovered_of_firstUncovered_none
+      (F := F) (Rset := Rset) hfu
+
 /-!  Basic properties of the measure `μ`. -/
 
 lemma mu_nonneg {F : Family n} {Rset : Finset (Subcube n)} {h : ℕ} :

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 53 |
+| Fully migrated | 54 |
 | Axioms | 0 |
-| Pending | 35 |
+| Pending | 34 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -63,6 +63,7 @@ AllOnesCovered.superset
 AllOnesCovered.union
 AllOnesCovered.insert
 allOnesCovered_of_firstUncovered_none
+allOnesCovered_of_mu_eq
 uncovered_eq_empty_of_allCovered
 uncovered_subset_of_union_singleton
 uncovered_subset_of_union
@@ -82,10 +83,9 @@ mu_union_triple_lt
 mu_union_triple_succ_le
 ```
 
-### Not yet ported (35 lemmas)
+### Not yet ported (34 lemmas)
 
 ```
-allOnesCovered_of_mu_eq
 buildCover_card_bound
 buildCover_card_bound_base
 buildCover_card_bound_lowSens

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -265,6 +265,23 @@ example :
       (F := ({(fun _ : Point 1 => false)} : BoolFunc.Family 1))
       (Rset := (∅ : Finset (Subcube 1))) hfu)
 
+/-- `allOnesCovered_of_mu_eq` infers coverage from a collapsed measure. -/
+example :
+    Cover2.AllOnesCovered (n := 1)
+      (F := (∅ : BoolFunc.Family 1))
+      (Rset := (∅ : Finset (Subcube 1))) := by
+  have hmu :
+      Cover2.mu (n := 1)
+        (F := (∅ : BoolFunc.Family 1))
+        0 (Rset := (∅ : Finset (Subcube 1))) = 2 * 0 := by
+    simp [Cover2.mu, Cover2.uncovered, Cover2.NotCovered]
+  simpa using
+    Cover2.allOnesCovered_of_mu_eq
+      (n := 1)
+      (F := (∅ : BoolFunc.Family 1))
+      (Rset := (∅ : Finset (Subcube 1)))
+      (h := 0) hmu
+
 /-- `μ` is nonnegative by construction. -/
 example :
     0 ≤ Cover2.mu (n := 1)


### PR DESCRIPTION
### **User description**
## Summary
- port `allOnesCovered_of_mu_eq` from legacy cover file to new `cover2.lean`
- exercise new lemma in `Cover2Test` and ensure coverage
- update migration status to reflect new lemma

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688ba913950c832bbf6ad0ac0909fd6f


___

### **PR Type**
Enhancement


___

### **Description**
- Migrate `allOnesCovered_of_mu_eq` lemma from legacy cover file

- Add comprehensive test case for the new lemma

- Update migration documentation to reflect progress


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Legacy cover.lean"] -- "migrate lemma" --> B["cover2.lean"]
  B -- "test coverage" --> C["Cover2Test.lean"]
  B -- "update status" --> D["migration_plan.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add allOnesCovered_of_mu_eq lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>allOnesCovered_of_mu_eq</code> lemma with complete proof<br> <li> Lemma proves coverage when measure μ equals 2*h<br> <li> Uses classical reasoning and cardinality arguments<br> <li> Includes detailed documentation comments</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/716/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for allOnesCovered_of_mu_eq</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add comprehensive test case for <code>allOnesCovered_of_mu_eq</code><br> <li> Test uses empty family and empty subcube set<br> <li> Verifies measure calculation and coverage inference</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/716/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 53 to 54<br> <li> Update pending count from 35 to 34<br> <li> Move <code>allOnesCovered_of_mu_eq</code> to migrated section</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/716/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

