### PR TITLE
feat: port mu_gt_of_firstUncovered_some

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1167,6 +1167,27 @@ lemma mu_union_triple_lt {F : Family n} {R₁ R₂ : Finset (Subcube n)}
     exact this.trans hdrop
   exact Nat.lt_of_succ_le hsucc
 
+/-!  If `firstUncovered` returns some pair, then the measure exceeds `2 * h`.
+This witness guarantees that the uncovered set has positive cardinality. -/
+lemma mu_gt_of_firstUncovered_some {F : Family n} {Rset : Finset (Subcube n)}
+    {h : ℕ} (hfu : firstUncovered (n := n) F Rset ≠ none) :
+    2 * h < mu (n := n) F h Rset := by
+  classical
+  -- If `firstUncovered` is nonempty, the uncovered set cannot be empty.
+  have hne : uncovered (n := n) F Rset ≠
+      (∅ : Set (Σ f : BFunc n, Point n)) := by
+    intro hempty
+    have := (firstUncovered_none_iff (n := n) (F := F) (R := Rset)).2 hempty
+    exact hfu this
+  -- Obtain an explicit witness from the nonempty uncovered set.
+  obtain ⟨p, hp⟩ := Set.nonempty_iff_ne_empty.mpr hne
+  -- This ensures the cardinality of the finset is positive.
+  have hpos : 0 < (uncovered (n := n) F Rset).toFinset.card :=
+    Finset.card_pos.mpr ⟨p, by simpa using hp⟩
+  -- Conclude that `μ` exceeds `2 * h` by at least one.
+  have := Nat.lt_add_of_pos_right (n := 2 * h) hpos
+  simpa [mu] using this
+
 /-! ### Coarse bound on the number of uncovered pairs -/
 
 lemma uncovered_card_bound (F : Family n) (Rset : Finset (Subcube n)) :

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 54 |
+| Fully migrated | 55 |
 | Axioms | 0 |
-| Pending | 34 |
+| Pending | 33 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -71,6 +71,7 @@ uncovered_card_bound
 uncovered_init_coarse_bound
 uncovered_init_bound_empty
 mu_mono_subset
+mu_gt_of_firstUncovered_some
 mu_union_double_lt
 mu_union_double_succ_le
 mu_union_le
@@ -83,7 +84,7 @@ mu_union_triple_lt
 mu_union_triple_succ_le
 ```
 
-### Not yet ported (34 lemmas)
+### Not yet ported (33 lemmas)
 
 ```
 buildCover_card_bound
@@ -111,12 +112,10 @@ coverFamily_spec_cover
 cover_exists
 lift_mono_of_restrict
 lift_mono_of_restrict_fixOne
-mono_subset
 mono_union
 mu_buildCover_le_start
 mu_buildCover_lt_start
 sunflower_step
-mu_gt_of_firstUncovered_some
 mu_of_allCovered
 mu_of_firstUncovered_none
 mu_union_buildCover_le

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -686,6 +686,35 @@ example :
       (R₁ := (∅ : Finset (Subcube 1)))
       (R₂ := {Subcube.full}) (h := 0) hx
 
+/-- `mu_gt_of_firstUncovered_some` detects progress when an uncovered pair exists. -/
+example :
+    2 * 0 < Cover2.mu (n := 1)
+        ({(fun x : Point 1 => x 0)} : BoolFunc.Family 1)
+        0 (∅ : Finset (Subcube 1)) := by
+  classical
+  -- The projection function has the point `x` with value `1` uncovered.
+  let f : BFunc 1 := fun x => x 0
+  let x : Point 1 := fun _ => true
+  have hf : f ∈ ({f} : BoolFunc.Family 1) := by simp
+  have hxval : f x = true := by simp [f, x]
+  have hnc : Cover2.NotCovered (n := 1) (Rset := (∅ : Finset (Subcube 1))) x := by
+    intro R hR; cases hR
+  have hx : (Cover2.uncovered (n := 1) {f} (∅ : Finset (Subcube 1))).Nonempty :=
+    ⟨⟨f, x⟩, ⟨hf, hxval, hnc⟩⟩
+  have hfu : Cover2.firstUncovered (n := 1) {f} (∅ : Finset (Subcube 1)) ≠ none := by
+    intro hnone
+    have hxne :
+        Cover2.uncovered (n := 1) {f} (∅ : Finset (Subcube 1)) ≠
+          (∅ : Set (Sigma (fun _ : BFunc 1 => Point 1))) :=
+      Set.nonempty_iff_ne_empty.mp hx
+    have hempty :=
+      (Cover2.firstUncovered_none_iff (n := 1) (F := {f})
+        (R := (∅ : Finset (Subcube 1)))).1 hnone
+    exact hxne hempty
+  simpa using
+    Cover2.mu_gt_of_firstUncovered_some
+      (n := 1) (F := {f}) (Rset := (∅ : Finset (Subcube 1))) (h := 0) hfu
+
 /-- `mu_union_singleton_triple_succ_le` ensures a drop of at least three when
 three distinct pairs are covered. -/
 example :


### PR DESCRIPTION
### **User description**
## Summary
- ported `mu_gt_of_firstUncovered_some` to `cover2.lean`
- added regression test using the new lemma
- updated migration plan to track new progress

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688bc7677dfc832bbfc1f5950864c01a


___

### **PR Type**
Enhancement


___

### **Description**
- Port `mu_gt_of_firstUncovered_some` lemma from `cover.lean` to `cover2.lean`

- Add comprehensive regression test for the new lemma

- Update migration documentation to reflect progress


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover.lean"] -- "port lemma" --> B["cover2.lean"]
  B -- "add test" --> C["Cover2Test.lean"]
  D["migration_plan.md"] -- "update counts" --> E["55 migrated, 33 pending"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add mu_gt_of_firstUncovered_some lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_gt_of_firstUncovered_some</code> lemma proving measure exceeds <code>2 * h</code> <br>when <code>firstUncovered</code> returns some pair<br> <li> Include detailed proof using classical logic and witness extraction <br>from nonempty uncovered set</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/717/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add regression test for mu_gt_of_firstUncovered_some</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add comprehensive regression test for <code>mu_gt_of_firstUncovered_some</code><br> <li> Test uses projection function with uncovered point to verify lemma <br>behavior<br> <li> Include detailed proof setup with explicit witness construction</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/717/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update migration counts: 55 fully migrated (up from 54), 33 pending <br>(down from 34)<br> <li> Move <code>mu_gt_of_firstUncovered_some</code> from pending to fully migrated <br>section</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/717/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

