### PR TITLE
feat: port mu_of_allCovered

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -471,7 +471,35 @@ noncomputable def mu (F : Family n) (h : ℕ) (Rset : Finset (Subcube n)) : ℕ 
   2 * h + (uncovered (n := n) F Rset).toFinset.card
 
 /-!
-If the measure `μ` equals `2 * h`, then no uncovered pairs remain.
+If all `1`‑inputs of `F` already lie inside some rectangle of `Rset`,
+then the uncovered set is empty and the measure `μ` collapses to `2 * h`.
+-/
+  lemma mu_of_allCovered {F : Family n} {Rset : Finset (Subcube n)} {h : ℕ}
+      (hcov : AllOnesCovered (n := n) F Rset) :
+      mu (n := n) F h Rset = 2 * h := by
+    classical
+    -- Replace the uncovered set by `∅` using the coverage assumption.
+    have hzero :
+        uncovered (n := n) F Rset =
+          (∅ : Set (Σ f : BFunc n, Point n)) :=
+      uncovered_eq_empty_of_allCovered
+        (n := n) (F := F) (Rset := Rset) hcov
+    -- Unfold `μ` and simplify using the empty uncovered set.
+    calc
+      mu (n := n) F h Rset
+          = 2 * h + (uncovered (n := n) F Rset).toFinset.card := rfl
+      _ = 2 * h + (∅ : Set (Σ f : BFunc n, Point n)).toFinset.card := by
+          -- Apply `congrArg` to rewrite the uncovered set using `hzero`.
+          have := congrArg
+            (fun s : Set (Σ f : BFunc n, Point n) => 2 * h + s.toFinset.card)
+            hzero
+          simpa using this
+      _ = 2 * h + 0 := by simp
+      _ = 2 * h := by simp
+    
+
+/-!
+Conversely, if the measure `μ` equals `2 * h`, then no uncovered pairs remain.
 Consequently all `1`‑inputs of `F` must already be covered by `Rset`.
 -/
 lemma allOnesCovered_of_mu_eq {F : Family n} {Rset : Finset (Subcube n)}

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 55 |
+| Fully migrated | 56 |
 | Axioms | 0 |
-| Pending | 33 |
+| Pending | 32 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -63,6 +63,7 @@ AllOnesCovered.superset
 AllOnesCovered.union
 AllOnesCovered.insert
 allOnesCovered_of_firstUncovered_none
+mu_of_allCovered
 allOnesCovered_of_mu_eq
 uncovered_eq_empty_of_allCovered
 uncovered_subset_of_union_singleton
@@ -84,7 +85,7 @@ mu_union_triple_lt
 mu_union_triple_succ_le
 ```
 
-### Not yet ported (33 lemmas)
+### Not yet ported (32 lemmas)
 
 ```
 buildCover_card_bound
@@ -116,7 +117,6 @@ mono_union
 mu_buildCover_le_start
 mu_buildCover_lt_start
 sunflower_step
-mu_of_allCovered
 mu_of_firstUncovered_none
 mu_union_buildCover_le
 mu_union_buildCover_lt
@@ -125,7 +125,7 @@ mu_union_buildCover_lt
 ## Next steps
 
 1. Port the remaining combinatorial facts about uncovered inputs and the
-   termination measure (e.g., `mu_of_allCovered` and related lemmas).
+   termination measure (e.g., `mu_of_firstUncovered_none` and related lemmas).
 2. Recreate the recursion `buildCover` and its counting bounds,
    replacing each remaining axiom with its full proof.
 3. Once all lemmas are available, `cover2.lean` can replace `cover.lean` in the

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -265,6 +265,22 @@ example :
       (F := ({(fun _ : Point 1 => false)} : BoolFunc.Family 1))
       (Rset := (∅ : Finset (Subcube 1))) hfu)
 
+/-- If all `1`-inputs are covered, the measure collapses to `2 * h`. -/
+example :
+    Cover2.mu (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      0 ({Subcube.full} : Finset (Subcube 1)) = 2 * 0 := by
+  have hcov : Cover2.AllOnesCovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      ({Subcube.full} : Finset (Subcube 1)) :=
+    Cover2.AllOnesCovered.full _
+  simpa using
+    Cover2.mu_of_allCovered
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (Rset := ({Subcube.full} : Finset (Subcube 1)))
+      (h := 0) hcov
+
 /-- `allOnesCovered_of_mu_eq` infers coverage from a collapsed measure. -/
 example :
     Cover2.AllOnesCovered (n := 1)


### PR DESCRIPTION
## Summary
- add a full proof for `mu_of_allCovered` in `cover2`
- test that `mu` collapses when every 1-input is covered
- update cover migration plan counts and lemma lists

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688bda048358832b906c589df6061bf9