### PR TITLE
feat: port mu_of_firstUncovered_none

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -496,7 +496,17 @@ then the uncovered set is empty and the measure `μ` collapses to `2 * h`.
           simpa using this
       _ = 2 * h + 0 := by simp
       _ = 2 * h := by simp
-    
+
+
+lemma mu_of_firstUncovered_none {F : Family n} {Rset : Finset (Subcube n)}
+    {h : ℕ} (hfu : firstUncovered (n := n) F Rset = none) :
+    mu (n := n) F h Rset = 2 * h := by
+  have hcov : AllOnesCovered (n := n) F Rset :=
+    allOnesCovered_of_firstUncovered_none (n := n) (F := F)
+      (Rset := Rset) hfu
+  simpa using
+    (mu_of_allCovered (n := n) (F := F) (Rset := Rset) (h := h) hcov)
+
 
 /-!
 Conversely, if the measure `μ` equals `2 * h`, then no uncovered pairs remain.

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 56 |
+| Fully migrated | 57 |
 | Axioms | 0 |
-| Pending | 32 |
+| Pending | 31 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -72,6 +72,7 @@ uncovered_card_bound
 uncovered_init_coarse_bound
 uncovered_init_bound_empty
 mu_mono_subset
+mu_of_firstUncovered_none
 mu_gt_of_firstUncovered_some
 mu_union_double_lt
 mu_union_double_succ_le
@@ -85,7 +86,7 @@ mu_union_triple_lt
 mu_union_triple_succ_le
 ```
 
-### Not yet ported (32 lemmas)
+### Not yet ported (31 lemmas)
 
 ```
 buildCover_card_bound
@@ -117,7 +118,6 @@ mono_union
 mu_buildCover_le_start
 mu_buildCover_lt_start
 sunflower_step
-mu_of_firstUncovered_none
 mu_union_buildCover_le
 mu_union_buildCover_lt
 ```
@@ -125,7 +125,7 @@ mu_union_buildCover_lt
 ## Next steps
 
 1. Port the remaining combinatorial facts about uncovered inputs and the
-   termination measure (e.g., `mu_of_firstUncovered_none` and related lemmas).
+   termination measure (e.g., `mu_union_buildCover_le` and related lemmas).
 2. Recreate the recursion `buildCover` and its counting bounds,
    replacing each remaining axiom with its full proof.
 3. Once all lemmas are available, `cover2.lean` can replace `cover.lean` in the

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -731,6 +731,33 @@ example :
     Cover2.mu_gt_of_firstUncovered_some
       (n := 1) (F := {f}) (Rset := (∅ : Finset (Subcube 1))) (h := 0) hfu
 
+/-- If `firstUncovered` returns `none`, the measure collapses to `2 * h`. -/
+example :
+    Cover2.mu (n := 1) (F := (∅ : BoolFunc.Family 1)) 0
+        (∅ : Finset (Subcube 1)) = 0 := by
+  classical
+  -- With an empty family the uncovered set is empty.
+  have hempty :
+      Cover2.uncovered (n := 1) (F := (∅ : BoolFunc.Family 1))
+        (Rset := (∅ : Finset (Subcube 1))) =
+        (∅ : Set (Sigma fun _ : BFunc 1 => Point 1)) := by
+    ext p; constructor
+    · intro hp; cases hp.1
+    · intro hp; cases hp
+  -- Hence `firstUncovered` yields `none`.
+  have hfu : Cover2.firstUncovered (n := 1)
+      (F := (∅ : BoolFunc.Family 1))
+      (Rset := (∅ : Finset (Subcube 1))) = none :=
+    (Cover2.firstUncovered_none_iff (n := 1)
+        (F := (∅ : BoolFunc.Family 1))
+        (R := (∅ : Finset (Subcube 1)))).2 hempty
+  -- Applying the lemma collapses `μ` to `2 * h`.
+  simpa using
+    (Cover2.mu_of_firstUncovered_none (n := 1)
+        (F := (∅ : BoolFunc.Family 1))
+        (Rset := (∅ : Finset (Subcube 1)))
+        (h := 0) hfu)
+
 /-- `mu_union_singleton_triple_succ_le` ensures a drop of at least three when
 three distinct pairs are covered. -/
 example :


### PR DESCRIPTION
### **User description**
## Summary
- port `mu_of_firstUncovered_none` to the lightweight `cover2` module
- add regression test exercising the new lemma
- update cover migration plan to reflect the new proof

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688be527cc20832bba17aa60759c38ec


___

### **PR Type**
Enhancement


___

### **Description**
- Port `mu_of_firstUncovered_none` lemma from cover to cover2 module

- Add regression test for the new lemma functionality

- Update migration plan documentation to reflect progress


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover.lean"] -- "port lemma" --> B["cover2.lean"]
  B -- "add test" --> C["Cover2Test.lean"]
  B -- "update progress" --> D["migration plan"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add mu_of_firstUncovered_none lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mu_of_firstUncovered_none</code> lemma proving measure equals <code>2 * h</code> when <br><code>firstUncovered</code> returns <code>none</code><br> <li> Lemma uses <code>allOnesCovered_of_firstUncovered_none</code> and <code>mu_of_allCovered</code> <br>for proof</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/719/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add regression test for new lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add regression test for <code>mu_of_firstUncovered_none</code> lemma<br> <li> Test uses empty family and empty subcube set to verify measure <br>collapses to <code>2 * h</code><br> <li> Includes proof that empty family has empty uncovered set</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/719/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+27/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 56 to 57 lemmas<br> <li> Move <code>mu_of_firstUncovered_none</code> from pending to fully migrated section<br> <li> Update pending count from 32 to 31 lemmas</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/719/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

