### PR TITLE
feat: port mu_of_firstUncovered_none to cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -496,7 +496,16 @@ then the uncovered set is empty and the measure `μ` collapses to `2 * h`.
           simpa using this
       _ = 2 * h + 0 := by simp
       _ = 2 * h := by simp
-    
+lemma mu_of_firstUncovered_none {F : Family n} {Rset : Finset (Subcube n)} {h : ℕ}
+    (hfu : firstUncovered (n := n) F Rset = none) :
+    mu (n := n) F h Rset = 2 * h := by
+  -- Coverage follows from the absence of uncovered pairs.
+  have hcov : AllOnesCovered (n := n) F Rset :=
+    allOnesCovered_of_firstUncovered_none
+      (n := n) (F := F) (Rset := Rset) hfu
+  -- `μ` therefore reduces to `2 * h`.
+  simpa using
+    mu_of_allCovered (n := n) (F := F) (Rset := Rset) (h := h) hcov
 
 /-!
 Conversely, if the measure `μ` equals `2 * h`, then no uncovered pairs remain.

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 56 |
+| Fully migrated | 57 |
 | Axioms | 0 |
-| Pending | 32 |
+| Pending | 31 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -64,6 +64,7 @@ AllOnesCovered.union
 AllOnesCovered.insert
 allOnesCovered_of_firstUncovered_none
 mu_of_allCovered
+mu_of_firstUncovered_none
 allOnesCovered_of_mu_eq
 uncovered_eq_empty_of_allCovered
 uncovered_subset_of_union_singleton
@@ -85,7 +86,7 @@ mu_union_triple_lt
 mu_union_triple_succ_le
 ```
 
-### Not yet ported (32 lemmas)
+### Not yet ported (31 lemmas)
 
 ```
 buildCover_card_bound
@@ -117,7 +118,6 @@ mono_union
 mu_buildCover_le_start
 mu_buildCover_lt_start
 sunflower_step
-mu_of_firstUncovered_none
 mu_union_buildCover_le
 mu_union_buildCover_lt
 ```
@@ -125,7 +125,7 @@ mu_union_buildCover_lt
 ## Next steps
 
 1. Port the remaining combinatorial facts about uncovered inputs and the
-   termination measure (e.g., `mu_of_firstUncovered_none` and related lemmas).
+   termination measure.
 2. Recreate the recursion `buildCover` and its counting bounds,
    replacing each remaining axiom with its full proof.
 3. Once all lemmas are available, `cover2.lean` can replace `cover.lean` in the

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -265,6 +265,31 @@ example :
       (F := ({(fun _ : Point 1 => false)} : BoolFunc.Family 1))
       (Rset := (∅ : Finset (Subcube 1))) hfu)
 
+/-- If `firstUncovered` returns `none`, the measure collapses to `2 * h`. -/
+example :
+    Cover2.mu (n := 1)
+      (∅ : BoolFunc.Family 1) 0 (∅ : Finset (Subcube 1)) = 0 := by
+  -- `firstUncovered` is `none` because the family is empty.
+  have hfu : Cover2.firstUncovered (n := 1)
+      (∅ : BoolFunc.Family 1) (∅ : Finset (Subcube 1)) = none := by
+    -- The uncovered set is empty by definition.
+    have hunc :
+        Cover2.uncovered (n := 1)
+          (∅ : BoolFunc.Family 1) (∅ : Finset (Subcube 1)) =
+          (∅ : Set (Sigma (fun _ => Point 1))) := by
+      ext p; constructor <;> intro hp
+      · rcases hp with ⟨hf, _, _⟩; simpa using hf
+      · cases hp
+    simpa using
+      (Cover2.firstUncovered_none_iff
+        (n := 1) (F := (∅ : BoolFunc.Family 1))
+        (R := (∅ : Finset (Subcube 1)))).2 hunc
+  -- Apply the lemma under test.
+  simpa using
+    Cover2.mu_of_firstUncovered_none
+      (n := 1) (F := (∅ : BoolFunc.Family 1))
+      (Rset := (∅ : Finset (Subcube 1))) (h := 0) hfu
+
 /-- If all `1`-inputs are covered, the measure collapses to `2 * h`. -/
 example :
     Cover2.mu (n := 1)


### PR DESCRIPTION
## Summary
- port `mu_of_firstUncovered_none` lemma into `Cover2`
- document migration progress for the new lemma
- expand tests covering `mu_of_firstUncovered_none`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688be527cc20832bba17aa60759c38ec