### PR TITLE
feat: port mono_union to cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -374,6 +374,26 @@ lemma AllOnesCovered.insert {F : Family n} {Rset : Finset (Subcube n)}
   exact AllOnesCovered.superset (F := F) (R₁ := Rset)
     (R₂ := Insert.insert R Rset) hcov hsub
 
+/-- Monochromaticity is preserved when restricting to a subset of rectangles. -/
+lemma mono_subset {F : Family n}
+    {R₁ R₂ : Finset (BoolFunc.Subcube n)}
+    (h₁ : ∀ R ∈ R₁, BoolFunc.Subcube.monochromaticForFamily R F)
+    (hsub : R₂ ⊆ R₁) :
+    ∀ R ∈ R₂, BoolFunc.Subcube.monochromaticForFamily R F := by
+  intro R hR
+  exact h₁ R (hsub hR)
+
+/-- The union of two monochromatic collections remains monochromatic. -/
+lemma mono_union {F : Family n}
+    {R₁ R₂ : Finset (BoolFunc.Subcube n)}
+    (h₁ : ∀ R ∈ R₁, BoolFunc.Subcube.monochromaticForFamily R F)
+    (h₂ : ∀ R ∈ R₂, BoolFunc.Subcube.monochromaticForFamily R F) :
+    ∀ R ∈ R₁ ∪ R₂, BoolFunc.Subcube.monochromaticForFamily R F := by
+  intro R hR
+  rcases Finset.mem_union.mp hR with h | h
+  · exact h₁ R h
+  · exact h₂ R h
+
 /-- When the set of rectangles is empty, `AllOnesCovered` simply states that
 no function in the family has a `1`‑input.  This handy characterisation is
 often used to initiate cover constructions. -/

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 57 |
+| Fully migrated | 58 |
 | Axioms | 0 |
-| Pending | 31 |
+| Pending | 30 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -84,9 +84,10 @@ mu_union_singleton_triple_succ_le
 mu_union_singleton_quad_succ_le
 mu_union_triple_lt
 mu_union_triple_succ_le
+mono_union
 ```
 
-### Not yet ported (31 lemmas)
+### Not yet ported (30 lemmas)
 
 ```
 buildCover_card_bound
@@ -114,7 +115,6 @@ coverFamily_spec_cover
 cover_exists
 lift_mono_of_restrict
 lift_mono_of_restrict_fixOne
-mono_union
 mu_buildCover_le_start
 mu_buildCover_lt_start
 sunflower_step

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -9,6 +9,13 @@ open Cover2
 
 namespace Cover2Test
 
+/-- The full subcube with no fixed coordinates. -/
+def fullSubcube (n : ℕ) : BoolFunc.Subcube n :=
+  { idx := (∅ : Finset (Fin n)),
+    val := by
+      intro i hi
+      exact False.elim (by simpa using hi) }
+
 /-- `mBound` is computed via the wrapper definition. -/
 example : mBound 1 0 = 2 := by
   simp [mBound]
@@ -109,6 +116,33 @@ example :
   simpa using
     Cover2.AllOnesCovered.union (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
       (R₁ := {Subcube.full}) (R₂ := {Subcube.full}) hcov hcov
+
+/-- `mono_union` combines monochromatic rectangle sets. -/
+  example :
+      ∀ R ∈ ({fullSubcube 1} ∪ {fullSubcube 1} : Finset (BoolFunc.Subcube 1)),
+          BoolFunc.Subcube.monochromaticForFamily R
+            ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+    classical
+    have hmono :
+        ∀ R ∈ ({fullSubcube 1} : Finset (BoolFunc.Subcube 1)),
+            BoolFunc.Subcube.monochromaticForFamily R
+              ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+      intro R hR
+      -- Any member of the singleton must be `fullSubcube 1`.
+      have hR' : R = fullSubcube 1 := by
+        simpa [Finset.mem_singleton] using hR
+      subst hR'
+      -- The constant-true function is monochromatic with colour `true`.
+      refine ⟨true, ?_⟩
+      intro f hf x hx
+      have hf' : f = (fun _ : Point 1 => true) := by simpa using hf
+      subst hf'
+      simp
+    -- Apply `mono_union` to merge the two monochromatic sets.
+    simpa using
+      (Cover2.mono_union
+        (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+        (R₁ := {fullSubcube 1}) (R₂ := {fullSubcube 1}) hmono hmono)
 
 /-- Inserting a rectangle preserves coverage. -/
 example :


### PR DESCRIPTION
### **User description**
## Summary
- port `mono_union` and supporting `mono_subset` lemma to `cover2.lean`
- track migration progress and mark `mono_union` as complete
- add regression test exercising `mono_union`

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688bea0614dc832baed71d41d4d3558e


___

### **PR Type**
Enhancement


___

### **Description**
- Port `mono_union` lemma from `cover.lean` to `cover2.lean`

- Add supporting `mono_subset` lemma for monochromatic collections

- Include regression test exercising `mono_union` functionality

- Update migration progress tracking documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover.lean"] -- "port lemma" --> B["cover2.lean"]
  B -- "add mono_union" --> C["Monochromatic Union"]
  B -- "add mono_subset" --> D["Monochromatic Subset"]
  E["Test Suite"] -- "verify" --> C
  F["Migration Docs"] -- "track progress" --> G["58/88 Complete"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add monochromatic union and subset lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mono_subset</code> lemma for monochromatic subset preservation<br> <li> Add <code>mono_union</code> lemma for combining monochromatic collections<br> <li> Both lemmas handle <code>BoolFunc.Subcube.monochromaticForFamily</code> properties</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/722/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add mono_union regression test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Define <code>fullSubcube</code> helper function for testing<br> <li> Add comprehensive test for <code>mono_union</code> lemma<br> <li> Test combines two monochromatic rectangle sets with constant-true <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/722/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update migration progress from 57 to 58 completed lemmas<br> <li> Move <code>mono_union</code> from pending to fully migrated section<br> <li> Adjust pending count from 31 to 30 lemmas</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/722/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

