### PR TITLE
Port buildCover_card_univ_bound

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1318,5 +1318,20 @@ lemma buildCover_card_bound_base {n h : ℕ} (F : Family n)
   have : (0 : ℕ) ≤ mBound n h := mBound_nonneg (n := n) (h := h)
   simpa [buildCover] using this
 
+/--
+`buildCover` always yields a set of rectangles whose cardinality is bounded by
+the universal function `bound_function`.  This is a direct consequence of the
+generic size bound for finite sets of subcubes and does not rely on the
+internal construction of `buildCover`.
+-/
+lemma buildCover_card_univ_bound {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (buildCover (n := n) F h hH).card ≤ bound_function n := by
+  classical
+  -- `size_bounds` provides the universal bound for any finite set of
+  -- rectangles.  Instantiate it with the set produced by `buildCover`.
+  have := size_bounds (n := n) (Rset := buildCover (n := n) F h hH)
+  simpa [size, bound_function] using this
+
 end Cover2
 

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 59 |
+| Fully migrated | 60 |
 | Axioms | 0 |
-| Pending | 29 |
+| Pending | 28 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -86,9 +86,10 @@ mu_union_triple_lt
 mu_union_triple_succ_le
 buildCover_card_bound_base
 buildCover_card_bound_of_none
+buildCover_card_univ_bound
 ```
 
-### Not yet ported (29 lemmas)
+### Not yet ported (28 lemmas)
 
 ```
 buildCover_card_bound
@@ -100,7 +101,6 @@ buildCover_card_linear_bound
 buildCover_card_linear_bound_base
 buildCover_card_lowSens
 buildCover_card_lowSens_with
-buildCover_card_univ_bound
 buildCover_covers
 buildCover_covers_with
 buildCover_measure_drop

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -961,5 +961,30 @@ example :
       hp₁ hp₂ hp₃ hp₄ hx₁R hx₂R hx₃R hx₄R
       hne₁₂ hne₁₃ hne₁₄ hne₂₃ hne₂₄ hne₃₄
 
+/-- A single full rectangle still respects the universal cover bound. -/
+def Fsingle : BoolFunc.Family 1 := {fun _ : Point 1 => true}
+
+/-- `buildCover_card_univ_bound` applies to the stub `buildCover` construction. -/
+example :
+    (Cover2.buildCover (n := 1) (F := Fsingle) (h := 0)
+        (by
+          -- `Fsingle` has collision entropy zero.
+          have hcard : Fsingle.card = 1 := by simp [Fsingle]
+          have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+            simpa [hcard] using
+              (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+          have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+          have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by simpa using hH
+          simpa using hH')).card ≤
+      Cover2.bound_function 1 := by
+  -- Reuse the entropy witness for the main statement.
+  have hcard : Fsingle.card = 1 := by simp [Fsingle]
+  have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+    simpa [hcard] using (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+  have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+  have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by simpa using hH
+  simpa [Fsingle] using
+    (Cover2.buildCover_card_univ_bound (n := 1) (F := Fsingle) (h := 0) hH')
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- add complete proof of `buildCover_card_univ_bound`
- exercise universal bound in Cover2 tests
- update cover migration plan counts

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688c0389a848832b8834d9af97a340c2


___

### **PR Type**
Enhancement


___

### **Description**
- Port `buildCover_card_univ_bound` lemma from Cover to Cover2

- Add comprehensive test exercising universal bound property

- Update migration plan documentation with progress


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cover.lean lemma"] --> B["Cover2.lean port"]
  B --> C["Test validation"]
  C --> D["Documentation update"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add universal bound lemma for buildCover</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>buildCover_card_univ_bound</code> lemma with complete proof<br> <li> Implement universal bound using <code>size_bounds</code> theorem<br> <li> Include detailed documentation explaining the approach</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/724/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add universal bound test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Define <code>Fsingle</code> test family with single boolean function<br> <li> Add comprehensive test for <code>buildCover_card_univ_bound</code><br> <li> Include entropy calculations and bound verification</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/724/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 59 to 60<br> <li> Move <code>buildCover_card_univ_bound</code> to completed section<br> <li> Decrease pending count from 29 to 28</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/724/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

