### PR TITLE
Port linear cover size lemmas to cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1319,6 +1319,41 @@ lemma buildCover_card_bound_base {n h : ℕ} (F : Family n)
   simpa [buildCover] using this
 
 /--
+A coarse numeric estimate that bounds the size of the cover directly by
+`2 * h + n`.  With the current stub `buildCover`, the constructed set of
+rectangles is empty, so the claim follows immediately.
+-/
+lemma buildCover_card_linear_bound_base {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hfu : firstUncovered (n := n) F (∅ : Finset (Subcube n)) = none) :
+    (buildCover (n := n) F h hH).card ≤ 2 * h + n := by
+  have hres : buildCover (n := n) F h hH = (∅ : Finset (Subcube n)) := by
+    simpa [buildCover, hfu]
+  have : (0 : ℕ) ≤ 2 * h + n := Nat.zero_le _
+  simpa [hres] using this
+
+/--
+The linear bound holds without assuming that the search for uncovered pairs
+fails initially.  Since the stub `buildCover` returns the empty set, the
+result is immediate.
+-/
+lemma buildCover_card_linear_bound {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (buildCover (n := n) F h hH).card ≤ 2 * h + n := by
+  have : (0 : ℕ) ≤ 2 * h + n := Nat.zero_le _
+  simpa [buildCover] using this
+
+/--
+Rewriting of `buildCover_card_linear_bound` emphasising the initial measure
+`μ = 2 * h + n`.  This variant mirrors the legacy API.
+-/
+lemma buildCover_card_init_mu {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (buildCover (n := n) F h hH).card ≤ 2 * h + n := by
+  simpa using
+    (buildCover_card_linear_bound (n := n) (F := F) (h := h) hH)
+
+/--
 `buildCover` (with the current stub implementation) always returns the
 empty set, so its cardinality trivially satisfies the `mBound` bound.
 This lemma mirrors the API of the full development and allows downstream

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 62 |
+| Fully migrated | 65 |
 | Axioms | 0 |
-| Pending | 26 |
+| Pending | 23 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -89,17 +89,17 @@ buildCover_card_bound_base
 buildCover_card_bound_of_none
 buildCover_card_bound
 buildCover_card_univ_bound
+buildCover_card_init_mu
+buildCover_card_linear_bound
+buildCover_card_linear_bound_base
 ```
 
-### Not yet ported (26 lemmas)
+### Not yet ported (23 lemmas)
 
 ```
 buildCover_card_bound_lowSens
 buildCover_card_bound_lowSens_or
 buildCover_card_bound_lowSens_with
-buildCover_card_init_mu
-buildCover_card_linear_bound
-buildCover_card_linear_bound_base
 buildCover_card_lowSens
 buildCover_card_lowSens_with
 buildCover_covers

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1008,6 +1008,46 @@ example :
   simpa [Fsingle] using
     (Cover2.buildCover_card_univ_bound (n := 1) (F := Fsingle) (h := 0) hH')
 
+/-- The coarse linear estimate applies to the stub `buildCover`. -/
+example :
+    (Cover2.buildCover (n := 1) (F := Fsingle) (h := 0)
+        (by
+          have hcard : Fsingle.card = 1 := by simp [Fsingle]
+          have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+            simpa [hcard] using
+              (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+          have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+          have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by
+            simpa using hH
+          simpa using hH')).card ≤ 2 * 0 + 1 := by
+  have hcard : Fsingle.card = 1 := by simp [Fsingle]
+  have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+    simpa [hcard] using (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+  have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+  have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by simpa using hH
+  simpa [Fsingle] using
+    (Cover2.buildCover_card_linear_bound (n := 1) (F := Fsingle) (h := 0) hH')
+
+/-- `buildCover_card_init_mu` reduces to the same linear bound. -/
+example :
+    (Cover2.buildCover (n := 1) (F := Fsingle) (h := 0)
+        (by
+          have hcard : Fsingle.card = 1 := by simp [Fsingle]
+          have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+            simpa [hcard] using
+              (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+          have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+          have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by
+            simpa using hH
+          simpa using hH')).card ≤ 2 * 0 + 1 := by
+  have hcard : Fsingle.card = 1 := by simp [Fsingle]
+  have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+    simpa [hcard] using (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+  have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+  have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by simpa using hH
+  simpa [Fsingle] using
+    (Cover2.buildCover_card_init_mu (n := 1) (F := Fsingle) (h := 0) hH')
+
 /-- `mu_union_buildCover_le` holds for the stub cover construction. -/
 example :
     Cover2.mu (n := 1) Fsingle 0


### PR DESCRIPTION
## Summary
- ported linear cover size lemmas to `cover2.lean`
- recorded migration progress in `cover_migration_plan.md`
- exercised new bounds in `Cover2Test`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688c17866168832bbc8838f79448f855