### PR TITLE
chore: reduce lint warnings

### DIFF
--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -82,7 +82,9 @@ lemma buildCoverCompute_spec (F : Family n) (h : ℕ)
   classical
   constructor
   · intro R hR; cases hR
-  · simpa [buildCoverCompute] using
+  ·
+    -- `simp` is sufficient here; no need for the more elaborate `simpa`.
+    simp [buildCoverCompute] using
       buildCoverCompute_length (F := F) (h := h) (hH := _hH)
 
 end Cover


### PR DESCRIPTION
### **User description**
## Summary
- simplify proofs to use `simp` and remove redundant arguments
- eliminate unused variables and placeholder binders in cover utilities
- rework coverage helper lemma to use assumptions and clean up `simp` calls
## Testing
- `lake test` (attempted, but did not complete within the time limit)

------
https://chatgpt.com/codex/tasks/task_e_688c27692e48832b810c21485e8354ec


___

### **PR Type**
Other


___

### **Description**
- Simplify proof tactics by replacing `simpa` with `simp`

- Remove redundant arguments from `simp` calls

- Replace unused variable names with placeholder binders

- Clean up proof structure and comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Lint warnings"] --> B["Simplify simp calls"]
  A --> C["Remove unused variables"]
  A --> D["Clean up proofs"]
  B --> E["Cleaner code"]
  C --> E
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Simplify proof tactic usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Replace <code>simpa</code> with <code>simp</code> in proof<br> <li> Add explanatory comment about simplification choice</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/730/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Remove unused variables and simplify proofs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Remove redundant <code>Nat.mul_left_comm</code> from <code>simp</code> calls<br> <li> Replace unused variable <code>f</code> with placeholder <code>_</code> in type signatures<br> <li> Clean up proof structure and remove unnecessary assumptions<br> <li> Add clarifying comments in proof steps</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/730/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+38/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

