### PR TITLE
refactor: simplify cover helper proofs

### DIFF
--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -18,32 +18,38 @@ example : 0 ≤ mBound 1 0 := by
   exact Cover2.mBound_nonneg (n := 1) (h := 0)
 
 /-- Numeric bound specialised to trivial parameters using the positive version. -/
-example : 2 * 0 + 1 ≤ mBound 1 0 := by
-  have hn : 0 < (1 : ℕ) := by decide
-  simp [numeric_bound_pos (n := 1) (h := 0) hn]
+  example : 2 * 0 + 1 ≤ mBound 1 0 := by
+    have hn : 0 < (1 : ℕ) := by decide
+    -- Apply the numeric bound directly.
+    exact numeric_bound_pos (n := 1) (h := 0) hn
 
 /-- `numeric_bound_pos` also holds when `n` is strictly positive. -/
-example : 2 * 0 + 2 ≤ mBound 2 0 := by
-  have hn : 0 < (2 : ℕ) := by decide
-  simp [numeric_bound_pos (n := 2) (h := 0) hn]
+  example : 2 * 0 + 2 ≤ mBound 2 0 := by
+    have hn : 0 < (2 : ℕ) := by decide
+    -- Again we apply the lemma directly.
+    exact numeric_bound_pos (n := 2) (h := 0) hn
 
 /-- Doubling the bound for a smaller budget stays below the next budget. -/
-example : 2 * mBound 1 0 ≤ mBound 1 1 := by
-  simpa using two_mul_mBound_le_succ (n := 1) (h := 0)
+  example : 2 * mBound 1 0 ≤ mBound 1 1 := by
+    -- The statement matches `two_mul_mBound_le_succ` exactly.
+    exact two_mul_mBound_le_succ (n := 1) (h := 0)
 
 /-- `pow_le_mBound_simple` for trivial parameters. -/
-example : 1 ≤ mBound 1 0 := by
-  have hn : 0 < (1 : ℕ) := by decide
-  simp [pow_le_mBound_simple (n := 1) (h := 0) hn]
+  example : 1 ≤ mBound 1 0 := by
+    have hn : 0 < (1 : ℕ) := by decide
+    -- Use the lemma directly instead of a `simp` rewrite.
+    exact pow_le_mBound_simple (n := 1) (h := 0) hn
 
 /-- `two_le_mBound` verifies the bound is at least `2`. -/
-example : 2 ≤ mBound 1 0 := by
-  have hn : 0 < (1 : ℕ) := by decide
-  simp [two_le_mBound (n := 1) (h := 0) hn]
+  example : 2 ≤ mBound 1 0 := by
+    have hn : 0 < (1 : ℕ) := by decide
+    -- Applying `two_le_mBound` directly avoids an unused `simp` argument warning.
+    exact two_le_mBound (n := 1) (h := 0) hn
 
 /-- Doubling the bound for `h = 0` stays below the next budget. -/
-example : 2 * mBound 1 0 ≤ mBound 1 1 := by
-  simpa using two_mul_mBound_le_succ (n := 1) (h := 0)
+  example : 2 * mBound 1 0 ≤ mBound 1 1 := by
+    -- As before, use the lemma directly.
+    exact two_mul_mBound_le_succ (n := 1) (h := 0)
 
 /-- Inserting a single rectangle stays within the next budget. -/
 example :


### PR DESCRIPTION
### **User description**
## Summary
- simplify numeric bound proof using explicit calculation
- streamline buildCoverCompute specification with direct simp
- replace simpa with exact in early Cover2 tests

## Testing
- `lake build Pnp2.Cover.Compute`

------
https://chatgpt.com/codex/tasks/task_e_688c27692e48832b810c21485e8354ec


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `simpa` with explicit `calc` proof in `two_le_mBound`

- Streamline `buildCoverCompute_spec` with direct `simp` approach

- Convert test examples from `simp` to `exact` applications

- Add explanatory comments for linter warning fixes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["simpa usage"] --> B["explicit calc proof"]
  C["simp in tests"] --> D["exact applications"]
  E["buildCoverCompute_spec"] --> F["direct simp approach"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Eliminate simpa usage with explicit proofs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Replace <code>simpa</code> with explicit <code>calc</code> proof in <code>two_le_mBound</code><br> <li> Refactor <code>buildCoverCompute_spec</code> to use direct <code>simp</code> instead of <code>simpa</code><br> <li> Add detailed comments explaining linter warning fixes</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/731/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+18/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Convert test proofs from simp to exact</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Replace <code>simp</code> with <code>exact</code> in multiple test examples<br> <li> Add explanatory comments for each proof change<br> <li> Maintain same logical structure with cleaner syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/731/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+22/-16</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

