### PR TITLE
feat: add restrict lifting lemma

### DIFF
--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -17,9 +17,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 66 |
+| Fully migrated | 67 |
 | Axioms | 0 |
-| Pending | 22 |
+| Pending | 21 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -93,9 +93,10 @@ buildCover_card_univ_bound
 buildCover_card_init_mu
 buildCover_card_linear_bound
 buildCover_card_linear_bound_base
+lift_mono_of_restrict
 ```
 
-### Not yet ported (22 lemmas)
+### Not yet ported (21 lemmas)
 
 ```
 buildCover_card_bound_lowSens
@@ -114,7 +115,6 @@ coverFamily_mono
 coverFamily_spec
 coverFamily_spec_cover
 cover_exists
-lift_mono_of_restrict
 lift_mono_of_restrict_fixOne
   mono_union
   mu_buildCover_lt_start

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1109,5 +1109,35 @@ example :
   simpa [Fsingle] using
     (Cover2.mu_buildCover_le_start (n := 1) (F := Fsingle) (h := 0) hH')
 
+/-/ `lift_mono_of_restrict` lifts monochromaticity from a restricted family. -/
+example :
+    Subcube.monochromaticForFamily
+      (Subcube.fixOne (0 : Fin 1) true)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+  classical
+  -- On this subcube the coordinate is fixed to `true`.
+  have hfix : ∀ x, (Subcube.fixOne (0 : Fin 1) true).Mem x → x (0) = true := by
+    intro x hx; exact (Subcube.mem_fixOne_iff).1 hx
+  -- The restricted family remains monochromatic with colour `true`.
+  have hmono :
+      Subcube.monochromaticForFamily
+        (Subcube.fixOne (0 : Fin 1) true)
+        ((({(fun _ : Point 1 => true)} : BoolFunc.Family 1).restrict (0 : Fin 1) true)) := by
+    refine ⟨true, ?_⟩
+    intro f hf x hx
+    rcases (BoolFunc.Family.mem_restrict.mp hf) with ⟨g, hg, rfl⟩
+    have hgtrue : g = (fun _ : Point 1 => true) := by
+      simpa [Finset.mem_singleton] using hg
+    subst hgtrue
+    simp [BFunc.restrictCoord]
+  -- Apply the lifting lemma.
+  exact
+    Cover2.lift_mono_of_restrict
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (i := 0) (b := true)
+      (R := Subcube.fixOne (0 : Fin 1) true) hfix hmono
+
+
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- define `monochromaticForFamily` for simplified `Subcube`
- port `lift_mono_of_restrict` to show restricted families lift monochromaticity
- document migration progress and add regression test

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688cc0b84004832bbfbe2ced81671bac


___

### **PR Type**
Enhancement


___

### **Description**
- Add `monochromaticForFamily` definition for simplified subcube structure

- Port `lift_mono_of_restrict` lemma from cover.lean to cover2.lean

- Update migration documentation and add regression test

- Enable lifting monochromaticity from restricted families


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Subcube.monochromaticForFamily"] --> B["lift_mono_of_restrict"]
  B --> C["Migration Progress"]
  B --> D["Regression Test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add monochromatic family definitions and lifting lemma</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>monochromaticForFamily</code> definition in <code>Boolcube.Subcube</code> namespace<br> <li> Port <code>lift_mono_of_restrict</code> lemma with proof for lifting <br>monochromaticity<br> <li> Add documentation section for lifting monochromaticity from restricted <br>families</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/735/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add regression test for restrict lifting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add comprehensive regression test for <code>lift_mono_of_restrict</code> lemma<br> <li> Test demonstrates lifting monochromaticity from restricted to full <br>family<br> <li> Uses <code>Subcube.fixOne</code> and singleton family for validation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/735/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update migration progress: 66→67 fully migrated lemmas<br> <li> Move <code>lift_mono_of_restrict</code> from pending to migrated section<br> <li> Update pending count from 22 to 21 lemmas</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/735/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

