### PR TITLE
feat: port mono lemmas to cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1336,6 +1336,29 @@ lemma lift_mono_of_restrict
   exact this
 
 /--
+Monochromaticity is preserved when restricting to a subset of rectangles.
+If every rectangle in `R₁` is monochromatic for `F` and `R₂ ⊆ R₁`, then every
+rectangle in `R₂` remains monochromatic. -/
+lemma mono_subset {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    (h₁ : ∀ R ∈ R₁, Subcube.monochromaticForFamily R F)
+    (hsub : R₂ ⊆ R₁) :
+    ∀ R ∈ R₂, Subcube.monochromaticForFamily R F := by
+  intro R hR
+  exact h₁ R (hsub hR)
+
+/--
+The union of two collections of monochromatic rectangles is again a collection
+of monochromatic rectangles. -/
+lemma mono_union {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    (h₁ : ∀ R ∈ R₁, Subcube.monochromaticForFamily R F)
+    (h₂ : ∀ R ∈ R₂, Subcube.monochromaticForFamily R F) :
+    ∀ R ∈ R₁ ∪ R₂, Subcube.monochromaticForFamily R F := by
+  intro R hR
+  rcases Finset.mem_union.mp hR with h | h
+  · exact h₁ R h
+  · exact h₂ R h
+
+/--
 A preliminary stub for the cover construction.  For now `buildCover` simply
 returns the accumulated set of rectangles without performing any recursive
 steps.  This suffices for basic cardinality lemmas while the full algorithm is

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -18,9 +18,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 68 |
+| Fully migrated | 70 |
 | Axioms | 0 |
-| Pending | 25 |
+| Pending | 23 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -96,9 +96,11 @@ buildCover_card_init_mu
 buildCover_card_linear_bound
 buildCover_card_linear_bound_base
 lift_mono_of_restrict
+mono_subset
+mono_union
 ```
 
-### Not yet ported (25 lemmas)
+### Not yet ported (23 lemmas)
 
 ```
 buildCover_card_bound_lowSens
@@ -121,8 +123,6 @@ coverFamily_spec
 coverFamily_spec_cover
 cover_exists
 lift_mono_of_restrict_fixOne
-mono_subset
-mono_union
 mu_buildCover_lt_start
 sunflower_step
 mu_union_buildCover_lt

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1138,6 +1138,70 @@ example :
       (i := 0) (b := true)
       (R := Subcube.fixOne (0 : Fin 1) true) hfix hmono
 
+/-- `mono_subset` preserves monochromaticity under subset inclusion. -/
+example :
+    Subcube.monochromaticForFamily Subcube.full
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+  classical
+  -- Each rectangle in `{full}` is monochromatic for the constant family.
+  have h₁ :
+      ∀ R ∈ ({Subcube.full} : Finset (Subcube 1)),
+        Subcube.monochromaticForFamily R
+          ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+    intro R hR
+    have : R = Subcube.full := by simpa [Finset.mem_singleton] using hR
+    subst this
+    refine ⟨true, ?_⟩
+    intro f hf x hx
+    rcases Finset.mem_singleton.mp hf with rfl
+    simp
+  -- Trivial subset relation `{full} ⊆ {full}`.
+  have hsub :
+      ({Subcube.full} : Finset (Subcube 1)) ⊆ {Subcube.full} := by
+    intro R hR; simpa [Finset.mem_singleton] using hR
+  -- Apply the lemma and extract the desired case.
+  have hres :=
+    Cover2.mono_subset
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (R₁ := {Subcube.full}) (R₂ := {Subcube.full}) h₁ hsub
+  simpa using hres Subcube.full (by simp)
+
+/-- `mono_union` combines two monochromatic collections. -/
+example :
+    Subcube.monochromaticForFamily Subcube.full
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+  classical
+  -- As before, `{full}` is monochromatic for the constant family.
+  have hmono :
+      ∀ R ∈ ({Subcube.full} : Finset (Subcube 1)),
+        Subcube.monochromaticForFamily R
+          ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+    intro R hR
+    have : R = Subcube.full := by simpa [Finset.mem_singleton] using hR
+    subst this
+    refine ⟨true, ?_⟩
+    intro f hf x hx
+    rcases Finset.mem_singleton.mp hf with rfl
+    simp
+  -- The empty set yields a vacuous monochromatic collection.
+  have hmono_empty :
+      ∀ R ∈ (∅ : Finset (Subcube 1)),
+        Subcube.monochromaticForFamily R
+          ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+    intro R hR; cases hR
+  -- Apply the union lemma; the union is `{full}`.
+  have hres :=
+    Cover2.mono_union
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (R₁ := {Subcube.full}) (R₂ := (∅ : Finset (Subcube 1)))
+      hmono hmono_empty
+  have hR :
+      Subcube.full ∈ {Subcube.full} ∪ (∅ : Finset (Subcube 1)) := by
+    simp
+  exact hres Subcube.full hR
+
 
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- port `mono_subset` and `mono_union` from `cover` to `cover2`
- expand Cover2 test suite for new lemmas
- update cover migration progress

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688cf8622714832babf165a6e21fcc76


___

### **PR Type**
Enhancement


___

### **Description**
- Port `mono_subset` and `mono_union` lemmas from cover to cover2

- Add comprehensive test cases for new monochromatic lemmas

- Update migration progress documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover.lean"] -- "port lemmas" --> B["cover2.lean"]
  B -- "add tests" --> C["Cover2Test.lean"]
  D["migration docs"] -- "update progress" --> E["70 migrated lemmas"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add monochromatic preservation lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>mono_subset</code> lemma preserving monochromaticity under subset <br>inclusion<br> <li> Add <code>mono_union</code> lemma combining monochromatic rectangle collections</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/738/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add tests for mono lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test case for <code>mono_subset</code> with constant family<br> <li> Add test case for <code>mono_union</code> combining collections<br> <li> Include comprehensive proof examples for both lemmas</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/738/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 68 to 70<br> <li> Move <code>mono_subset</code> and <code>mono_union</code> to migrated section<br> <li> Reduce pending count from 25 to 23</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/738/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

