### PR TITLE
feat: port buildCover_measure_drop lemma

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1500,5 +1500,19 @@ lemma mu_buildCover_le_start {F : Family n}
   -- Simplify using the stub definition of `buildCover`.
   simpa [buildCover] using this
 
+/--
+`buildCover_measure_drop` bounds the initial measure by `2 * h`.  In the
+current development `buildCover` does not alter the uncovered set, so the
+general lower bound on `μ` suffices.  The statement matches the legacy API
+for downstream compatibility.
+-/
+lemma buildCover_measure_drop {F : Family n} {h : ℕ}
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    2 * h ≤ mu (n := n) F h (∅ : Finset (Subcube n)) := by
+  -- The measure `μ` always dominates `2 * h`, even for the empty rectangle set.
+  simpa using
+    (mu_lower_bound (n := n) (F := F) (h := h)
+      (Rset := (∅ : Finset (Subcube n))))
+
 end Cover2
 

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -18,9 +18,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 71 |
+| Fully migrated | 72 |
 | Axioms | 0 |
-| Pending | 22 |
+| Pending | 21 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -88,6 +88,7 @@ mu_union_triple_lt
 mu_union_triple_succ_le
 mu_union_buildCover_le
 mu_buildCover_le_start
+buildCover_measure_drop
 buildCover_card_bound_base
 buildCover_card_bound_of_none
 buildCover_card_bound
@@ -101,7 +102,7 @@ mono_subset
 mono_union
 ```
 
-### Not yet ported (22 lemmas)
+### Not yet ported (21 lemmas)
 
 ```
 buildCover_card_bound_lowSens
@@ -111,7 +112,6 @@ buildCover_card_lowSens
 buildCover_card_lowSens_with
 buildCover_covers
 buildCover_covers_with
-buildCover_measure_drop
 buildCover_mono_lowSens
 buildCover_mu
 coverFamily_card_bound

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1109,6 +1109,20 @@ example :
   simpa [Fsingle] using
     (Cover2.mu_buildCover_le_start (n := 1) (F := Fsingle) (h := 0) hH')
 
+/-- `buildCover_measure_drop` bounds the initial measure by `2 * h`. -/
+example :
+    2 * (0 : ℕ) ≤
+      Cover2.mu (n := 1) Fsingle 0 (∅ : Finset (Subcube 1)) := by
+  -- Compute the entropy bound for the single-function family.
+  have hcard : Fsingle.card = 1 := by simp [Fsingle]
+  have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+    simpa [hcard] using (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+  have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+  have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by simpa using hH
+  -- Apply the lemma directly.
+  simpa [Fsingle] using
+    (Cover2.buildCover_measure_drop (n := 1) (F := Fsingle) (h := 0) hH')
+
 /-- `buildCover_mono` yields a vacuous monochromaticity condition. -/
 example :
     ∀ R ∈ Cover2.buildCover (n := 1) (F := Fsingle) (h := 0) hH',


### PR DESCRIPTION
### **User description**
## Summary
- port `buildCover_measure_drop` from `cover` into `cover2` with full proof
- document updated migration counts and move lemma to the migrated list
- add regression test for `buildCover_measure_drop`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688d0bce9810832ba9772e13ea70cced


___

### **PR Type**
Enhancement


___

### **Description**
- Port `buildCover_measure_drop` lemma from cover to cover2

- Add regression test for the migrated lemma

- Update migration documentation counts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover.lean lemma"] -- "port" --> B["cover2.lean lemma"]
  B -- "test" --> C["regression test"]
  D["migration docs"] -- "update counts" --> E["updated counts"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add buildCover_measure_drop lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>buildCover_measure_drop</code> lemma with proof<br> <li> Lemma bounds initial measure by <code>2 * h</code><br> <li> Uses <code>mu_lower_bound</code> for implementation<br> <li> Includes comprehensive documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/741/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add buildCover_measure_drop test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add regression test for <code>buildCover_measure_drop</code><br> <li> Test uses single-function family <code>Fsingle</code><br> <li> Verifies measure bound <code>2 * h ≤ mu</code></ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/741/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress counts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 71 to 72<br> <li> Update pending count from 22 to 21<br> <li> Move <code>buildCover_measure_drop</code> to migrated list<br> <li> Remove from not-yet-ported list</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/741/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

