### PR TITLE
feat: lift restricted monochromaticity with fixed coordinate

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1336,6 +1336,18 @@ lemma lift_mono_of_restrict
   exact this
 
 /--
+When a subcube `R` already forces the `i`-th coordinate to be `b`,
+monochromaticity for the restricted family lifts directly to the original
+family.  This variant mirrors `lift_mono_of_restrict` but packages the
+common situation where the fixed-coordinate condition is immediate. -/
+lemma lift_mono_of_restrict_fixOne
+    {F : Family n} {i : Fin n} {b : Bool} {R : Subcube n}
+    (hfix : ∀ x, R.Mem x → x i = b)
+    (hmono : Subcube.monochromaticForFamily R (F.restrict i b)) :
+    Subcube.monochromaticForFamily R F :=
+  lift_mono_of_restrict (F := F) (i := i) (b := b) (R := R) hfix hmono
+
+/--
 Monochromaticity is preserved when restricting to a subset of rectangles.
 If every rectangle in `R₁` is monochromatic for `F` and `R₂ ⊆ R₁`, then every
 rectangle in `R₂` remains monochromatic. -/

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -18,9 +18,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 72 |
+| Fully migrated | 73 |
 | Axioms | 0 |
-| Pending | 21 |
+| Pending | 20 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -98,11 +98,12 @@ buildCover_card_linear_bound
 buildCover_card_linear_bound_base
 buildCover_mono
 lift_mono_of_restrict
+lift_mono_of_restrict_fixOne
 mono_subset
 mono_union
 ```
 
-### Not yet ported (21 lemmas)
+### Not yet ported (20 lemmas)
 
 ```
 buildCover_card_bound_lowSens
@@ -122,7 +123,6 @@ coverFamily_mono
 coverFamily_spec
 coverFamily_spec_cover
 cover_exists
-lift_mono_of_restrict_fixOne
 mu_buildCover_lt_start
 sunflower_step
 mu_union_buildCover_lt

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1160,6 +1160,36 @@ example :
       (i := 0) (b := true)
       (R := Subcube.fixOne (0 : Fin 1) true) hfix hmono
 
+/-- `lift_mono_of_restrict_fixOne` reuses the fixed-coordinate hypothesis. -/
+example :
+    Subcube.monochromaticForFamily
+      (Subcube.fixOne (0 : Fin 1) true)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+  classical
+  -- The subcube `fixOne` forces coordinate `0` to be `true`.
+  have hfix : ∀ x, (Subcube.fixOne (0 : Fin 1) true).Mem x → x 0 = true := by
+    intro x hx; exact (Subcube.mem_fixOne_iff).1 hx
+  -- The restricted family is monochromatic with colour `true`.
+  have hmono :
+      Subcube.monochromaticForFamily
+        (Subcube.fixOne (0 : Fin 1) true)
+        ((({(fun _ : Point 1 => true)} : BoolFunc.Family 1).restrict (0 : Fin 1) true)) := by
+    refine ⟨true, ?_⟩
+    intro f hf x hx
+    rcases (BoolFunc.Family.mem_restrict.mp hf) with ⟨g, hg, rfl⟩
+    have hgtrue : g = (fun _ : Point 1 => true) := by
+      simpa [Finset.mem_singleton] using hg
+    subst hgtrue
+    simp [BFunc.restrictCoord]
+  -- Apply the packaged lifting lemma.
+  exact
+    Cover2.lift_mono_of_restrict_fixOne
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (i := 0) (b := true)
+      (R := Subcube.fixOne (0 : Fin 1) true)
+      hfix hmono
+
 /-- `mono_subset` preserves monochromaticity under subset inclusion. -/
 example :
     Subcube.monochromaticForFamily Subcube.full


### PR DESCRIPTION
### **User description**
## Summary
- expose `lift_mono_of_restrict_fixOne` to lift monochromaticity when a subcube fixes a coordinate
- exercise the lemma in `Cover2Test`
- document migration progress (73 of 93 lemmas ported)

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688d3fdce1d0832b849559f7c595f159


___

### **PR Type**
Enhancement


___

### **Description**
- Add `lift_mono_of_restrict_fixOne` lemma for lifting monochromaticity

- Include test example demonstrating the new lemma usage

- Update migration progress documentation (73/93 lemmas ported)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["lift_mono_of_restrict"] --> B["lift_mono_of_restrict_fixOne"]
  B --> C["Test example"]
  B --> D["Migration progress update"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add convenience lemma for fixed coordinate lifting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>lift_mono_of_restrict_fixOne</code> lemma as convenience wrapper<br> <li> Packages common case where fixed-coordinate condition is immediate<br> <li> Mirrors existing <code>lift_mono_of_restrict</code> functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/742/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for new lifting lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example demonstrating <code>lift_mono_of_restrict_fixOne</code> usage<br> <li> Shows how the new lemma reuses fixed-coordinate hypothesis<br> <li> Provides concrete proof pattern for the convenience function</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/742/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update migration count from 72 to 73 fully migrated lemmas<br> <li> Move <code>lift_mono_of_restrict_fixOne</code> from pending to migrated section<br> <li> Adjust pending count from 21 to 20 lemmas</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/742/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

