### PR TITLE
feat: add low-sensitivity bound lemma to cover2

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1467,6 +1467,22 @@ lemma buildCover_card_univ_bound {n h : ℕ} (F : Family n)
   simpa [size, bound_function] using this
 
 /--
+When all functions in the family have sensitivity below the logarithmic
+threshold, the (stubbed) cover remains empty and hence satisfies the crude
+exponential bound.  This lemma mirrors the statement from `cover.lean` while
+the full algorithm is being ported. -/
+lemma buildCover_card_lowSens {n h : ℕ} (F : Family n)
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (_hs : ∀ f ∈ F, BoolFunc.sensitivity f < Nat.log2 (Nat.succ n)) :
+    (buildCover (n := n) F h _hH).card ≤
+      Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) := by
+  -- The stubbed `buildCover` returns the empty set, whose cardinality is `0`.
+  have : (0 : ℕ) ≤
+      Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) :=
+    Nat.zero_le _
+  simpa [buildCover] using this
+
+/--
 Every rectangle produced by `buildCover` is monochromatic for the family `F`.
 With the current stub implementation, the cover is empty and the claim holds
 vacuously.  This lemma mirrors the API of the full development.

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -18,9 +18,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 73 |
+| Fully migrated | 74 |
 | Axioms | 0 |
-| Pending | 20 |
+| Pending | 19 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -96,6 +96,7 @@ buildCover_card_univ_bound
 buildCover_card_init_mu
 buildCover_card_linear_bound
 buildCover_card_linear_bound_base
+buildCover_card_lowSens
 buildCover_mono
 lift_mono_of_restrict
 lift_mono_of_restrict_fixOne
@@ -109,7 +110,6 @@ mono_union
 buildCover_card_bound_lowSens
 buildCover_card_bound_lowSens_or
 buildCover_card_bound_lowSens_with
-buildCover_card_lowSens
 buildCover_card_lowSens_with
 buildCover_covers
 buildCover_covers_with

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1069,6 +1069,15 @@ example :
   simpa [Fsingle] using
     (Cover2.buildCover_card_init_mu (n := 1) (F := Fsingle) (h := 0) hH')
 
+/-- Even the specialised low-sensitivity bound holds for the stub cover. -/
+example {n h : ℕ} (F : BoolFunc.Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hs : ∀ f ∈ F, BoolFunc.sensitivity f < Nat.log2 (Nat.succ n)) :
+    (Cover2.buildCover (n := n) F h hH).card ≤
+      Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) := by
+  -- Direct application of the lemma suffices.
+  exact Cover2.buildCover_card_lowSens (n := n) (F := F) (h := h) hH hs
+
 /-- `mu_union_buildCover_le` holds for the stub cover construction. -/
 example :
     Cover2.mu (n := 1) Fsingle 0


### PR DESCRIPTION
## Summary
- port `buildCover_card_lowSens` from `cover.lean` and prove bound for current stub
- document migration progress and counts
- add regression test exercising low-sensitivity bound

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688d4cac2040832b978c56b31aba1971