### PR TITLE
feat: port low-sensitivity bound lemma

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1483,6 +1483,38 @@ lemma buildCover_card_lowSens {n h : ℕ} (F : Family n)
   simpa [buildCover] using this
 
 /--
+`buildCover_card_bound_lowSens` upgrades the crude exponential bound from
+`buildCover_card_lowSens` to the standard `mBound` function whenever the
+logarithmic threshold `Nat.log2 (n + 1)^2` is at most the entropy budget `h`.
+This mirrors the corresponding lemma in `cover.lean` but is trivial for the
+stubbed `buildCover`.
+-/
+lemma buildCover_card_bound_lowSens {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hs : ∀ f ∈ F, BoolFunc.sensitivity f < Nat.log2 (Nat.succ n))
+    (hh : Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n) ≤ h)
+    (hn : 0 < n) :
+    (buildCover (n := n) F h hH).card ≤ mBound n h := by
+  classical
+  -- Start with the exponential estimate from `buildCover_card_lowSens`.
+  have hcard : (buildCover (n := n) F h hH).card ≤
+      Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) :=
+    buildCover_card_lowSens (n := n) (F := F) (h := h) hH hs
+  -- Compare the exponents `10 * log₂(n+1)^2` and `10 * h`.
+  have hexp_mul :
+      10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n) ≤ 10 * h := by
+    have := Nat.mul_le_mul_left 10 hh
+    simpa [Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using this
+  have hpow :
+      Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) ≤
+        Nat.pow 2 (10 * h) :=
+    Nat.pow_le_pow_of_le_right (by decide : 0 < (2 : ℕ)) hexp_mul
+  -- Combine with the main bound `pow_le_mBound`.
+  have hbig := hcard.trans hpow
+  have hbound := hbig.trans (pow_le_mBound (n := n) (h := h) hn)
+  simpa using hbound
+
+/--
 Every rectangle produced by `buildCover` is monochromatic for the family `F`.
 With the current stub implementation, the cover is empty and the claim holds
 vacuously.  This lemma mirrors the API of the full development.

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -18,9 +18,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 74 |
+| Fully migrated | 75 |
 | Axioms | 0 |
-| Pending | 19 |
+| Pending | 18 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -97,6 +97,7 @@ buildCover_card_init_mu
 buildCover_card_linear_bound
 buildCover_card_linear_bound_base
 buildCover_card_lowSens
+buildCover_card_bound_lowSens
 buildCover_mono
 lift_mono_of_restrict
 lift_mono_of_restrict_fixOne
@@ -107,7 +108,6 @@ mono_union
 ### Not yet ported (20 lemmas)
 
 ```
-buildCover_card_bound_lowSens
 buildCover_card_bound_lowSens_or
 buildCover_card_bound_lowSens_with
 buildCover_card_lowSens_with

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1078,6 +1078,19 @@ example {n h : ℕ} (F : BoolFunc.Family n)
   -- Direct application of the lemma suffices.
   exact Cover2.buildCover_card_lowSens (n := n) (F := F) (h := h) hH hs
 
+/-- The refined bound `buildCover_card_bound_lowSens` specialises to the stubbed
+cover construction. -/
+example {n h : ℕ} (F : BoolFunc.Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hs : ∀ f ∈ F, BoolFunc.sensitivity f < Nat.log2 (Nat.succ n))
+    (hh : Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n) ≤ h)
+    (hn : 0 < n) :
+    (Cover2.buildCover (n := n) F h hH).card ≤ Cover2.mBound n h := by
+  -- The lemma applies directly with the given hypotheses.
+  exact
+    Cover2.buildCover_card_bound_lowSens (n := n) (F := F) (h := h)
+      hH hs hh hn
+
 /-- `mu_union_buildCover_le` holds for the stub cover construction. -/
 example :
     Cover2.mu (n := 1) Fsingle 0


### PR DESCRIPTION
### **User description**
## Summary
- port `buildCover_card_bound_lowSens` from `cover.lean` to `cover2.lean`
- exercise new lemma in `Cover2Test` examples
- refresh migration plan to reflect latest ported lemma

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688d68ff71a8832b9d6ca923faead1e1


___

### **PR Type**
Enhancement


___

### **Description**
- Port `buildCover_card_bound_lowSens` lemma from `cover.lean` to `cover2.lean`

- Add refined bound using `mBound` function with logarithmic threshold

- Include test example exercising the new lemma

- Update migration plan documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover.lean"] -- "port lemma" --> B["cover2.lean"]
  B -- "add test" --> C["Cover2Test.lean"]
  B -- "update status" --> D["migration_plan.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add refined low-sensitivity bound lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>buildCover_card_bound_lowSens</code> lemma with detailed documentation<br> <li> Implement refined bound using <code>mBound</code> function<br> <li> Include proof combining exponential estimate with logarithmic <br>threshold</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/744/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for refined bound lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example for <code>buildCover_card_bound_lowSens</code> lemma<br> <li> Demonstrate direct application with required hypotheses</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/744/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 74 to 75<br> <li> Move <code>buildCover_card_bound_lowSens</code> from pending to migrated<br> <li> Decrease pending count from 19 to 18</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/744/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

