### PR TITLE
feat: bound low-sensitivity cover with initial rectangles

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1483,6 +1483,26 @@ lemma buildCover_card_lowSens {n h : ℕ} (F : Family n)
   simpa [buildCover] using this
 
 /--
+`buildCover_card_lowSens_with` extends `buildCover_card_lowSens` to the case
+where an initial set of rectangles `Rset` is provided.  The stubbed
+implementation of `buildCover` simply returns `Rset`, so the inequality reduces
+to the trivial bound `Rset.card ≤ Rset.card + …`.
+-/
+lemma buildCover_card_lowSens_with {n h : ℕ} (F : Family n)
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (_hs : ∀ f ∈ F, BoolFunc.sensitivity f < Nat.log2 (Nat.succ n))
+    (Rset : Finset (Subcube n)) :
+    (buildCover (n := n) F h _hH Rset).card ≤
+      Rset.card +
+        Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) := by
+  -- The right-hand side obviously dominates `Rset.card`.
+  have : Rset.card ≤
+      Rset.card +
+        Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) :=
+    Nat.le_add_right _ _
+  simpa [buildCover] using this
+
+/--
 `buildCover_card_bound_lowSens` upgrades the crude exponential bound from
 `buildCover_card_lowSens` to the standard `mBound` function whenever the
 logarithmic threshold `Nat.log2 (n + 1)^2` is at most the entropy budget `h`.

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -18,9 +18,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 75 |
+| Fully migrated | 76 |
 | Axioms | 0 |
-| Pending | 18 |
+| Pending | 17 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -97,6 +97,7 @@ buildCover_card_init_mu
 buildCover_card_linear_bound
 buildCover_card_linear_bound_base
 buildCover_card_lowSens
+buildCover_card_lowSens_with
 buildCover_card_bound_lowSens
 buildCover_mono
 lift_mono_of_restrict
@@ -110,7 +111,6 @@ mono_union
 ```
 buildCover_card_bound_lowSens_or
 buildCover_card_bound_lowSens_with
-buildCover_card_lowSens_with
 buildCover_covers
 buildCover_covers_with
 buildCover_mono_lowSens

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1078,6 +1078,19 @@ example {n h : ℕ} (F : BoolFunc.Family n)
   -- Direct application of the lemma suffices.
   exact Cover2.buildCover_card_lowSens (n := n) (F := F) (h := h) hH hs
 
+/-- Supplying an existing set of rectangles still yields the crude
+exponential bound from `buildCover_card_lowSens_with`. -/
+example {n h : ℕ} (F : BoolFunc.Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hs : ∀ f ∈ F, BoolFunc.sensitivity f < Nat.log2 (Nat.succ n))
+    (Rset : Finset (Subcube n)) :
+    (Cover2.buildCover (n := n) F h hH Rset).card ≤
+      Rset.card +
+        Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) := by
+  -- Again we simply apply the lemma.
+  exact
+    Cover2.buildCover_card_lowSens_with (n := n) (F := F) (h := h) hH hs Rset
+
 /-- The refined bound `buildCover_card_bound_lowSens` specialises to the stubbed
 cover construction. -/
 example {n h : ℕ} (F : BoolFunc.Family n)


### PR DESCRIPTION
## Summary
- extend low-sensitivity cover bound to allow a starting rectangle set via `buildCover_card_lowSens_with`
- document migration progress and update counts
- exercise new lemma in Cover2 test suite

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688d75b3279c832ba12971809a21dfa2