### PR TITLE
feat: add cover family wrapper

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1614,5 +1614,38 @@ lemma buildCover_measure_drop {F : Family n} {h : ℕ}
     (mu_lower_bound (n := n) (F := F) (h := h)
       (Rset := (∅ : Finset (Subcube n))))
 
+/-! ### Canonical cover family
+
+`coverFamily` wraps the `buildCover` construction to provide a single
+canonical set of rectangles.  With the current stubbed `buildCover` this
+definition simply returns the same set, but the API mirrors the legacy
+development to ease future porting. -/
+
+noncomputable def coverFamily {n : ℕ} (F : Family n) (h : ℕ)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) : Finset (Subcube n) :=
+  buildCover (n := n) F h hH
+
+@[simp] lemma coverFamily_eq_buildCover {n : ℕ} (F : Family n) {h : ℕ}
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    coverFamily (n := n) F h _hH = buildCover (n := n) F h _hH := rfl
+
+lemma coverFamily_card_bound {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (coverFamily (n := n) F h hH).card ≤ mBound n h := by
+  simpa [coverFamily] using
+    (buildCover_card_bound (n := n) (F := F) (h := h) hH)
+
+lemma coverFamily_card_linear_bound {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (coverFamily (n := n) F h hH).card ≤ 2 * h + n := by
+  simpa [coverFamily] using
+    (buildCover_card_linear_bound (n := n) (F := F) (h := h) hH)
+
+lemma coverFamily_card_univ_bound {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (coverFamily (n := n) F h hH).card ≤ bound_function n := by
+  simpa [coverFamily] using
+    (buildCover_card_univ_bound (n := n) (F := F) (h := h) hH)
+
 end Cover2
 

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -18,9 +18,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 77 |
+| Fully migrated | 81 |
 | Axioms | 0 |
-| Pending | 16 |
+| Pending | 12 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -105,9 +105,13 @@ lift_mono_of_restrict
 lift_mono_of_restrict_fixOne
 mono_subset
 mono_union
+coverFamily_eq_buildCover
+coverFamily_card_bound
+coverFamily_card_linear_bound
+coverFamily_card_univ_bound
 ```
 
-### Not yet ported (16 lemmas)
+### Not yet ported (12 lemmas)
 
 ```
 buildCover_card_bound_lowSens_with
@@ -115,10 +119,6 @@ buildCover_covers
 buildCover_covers_with
 buildCover_mono_lowSens
 buildCover_mu
-coverFamily_card_bound
-coverFamily_card_linear_bound
-coverFamily_eq_buildCover
-coverFamily_card_univ_bound
 coverFamily_mono
 coverFamily_spec
 coverFamily_spec_cover

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1029,6 +1029,28 @@ example :
   simpa [Fsingle] using
     (Cover2.buildCover_card_univ_bound (n := 1) (F := Fsingle) (h := 0) hH')
 
+/-- `coverFamily` inherits the universal bound from `buildCover`. -/
+example :
+    (Cover2.coverFamily (n := 1) (F := Fsingle) (h := 0)
+        (by
+          -- `Fsingle` has collision entropy zero.
+          have hcard : Fsingle.card = 1 := by simp [Fsingle]
+          have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+            simpa [hcard] using
+              (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+          have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+          have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by simpa using hH
+          simpa using hH')).card ≤
+      Cover2.bound_function 1 := by
+  -- Reuse the entropy witness for the main statement.
+  have hcard : Fsingle.card = 1 := by simp [Fsingle]
+  have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+    simpa [hcard] using (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+  have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+  have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by simpa using hH
+  simpa [Fsingle] using
+    (Cover2.coverFamily_card_univ_bound (n := 1) (F := Fsingle) (h := 0) hH')
+
 /-- The coarse linear estimate applies to the stub `buildCover`. -/
 example :
     (Cover2.buildCover (n := 1) (F := Fsingle) (h := 0)


### PR DESCRIPTION
### **User description**
## Summary
- expose a canonical `coverFamily` wrapper around the stubbed `buildCover`
- provide cardinality bounds for `coverFamily` matching legacy API
- record migration progress for the newly ported lemmas

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688d8931dac8832b94a3f47209a3dfc5


___

### **PR Type**
Enhancement


___

### **Description**
- Add canonical `coverFamily` wrapper around `buildCover`

- Provide cardinality bounds matching legacy API

- Update migration progress documentation

- Add test coverage for new wrapper


___

### Diagram Walkthrough


```mermaid
flowchart LR
  buildCover["buildCover (existing)"] --> coverFamily["coverFamily (new wrapper)"]
  coverFamily --> bounds["Cardinality bounds"]
  bounds --> tests["Test coverage"]
  migration["Migration docs"] --> updated["Updated progress"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add coverFamily wrapper with bounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>coverFamily</code> noncomputable definition wrapping <code>buildCover</code><br> <li> Add simp lemma showing equivalence to <code>buildCover</code><br> <li> Implement three cardinality bound lemmas<br> <li> Add documentation explaining canonical wrapper purpose</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/747/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add coverFamily test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example for <code>coverFamily_card_univ_bound</code><br> <li> Verify cardinality bound inheritance from <code>buildCover</code><br> <li> Include entropy witness setup for test case</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/747/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 77 to 81<br> <li> Move 4 coverFamily lemmas from pending to migrated<br> <li> Update pending count from 16 to 12</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/747/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

