### PR TITLE
feat: bound low-sensitivity covers with mBound

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1534,6 +1534,49 @@ lemma buildCover_card_bound_lowSens {n h : ℕ} (F : Family n)
   have hbound := hbig.trans (pow_le_mBound (n := n) (h := h) hn)
   simpa using hbound
 
+/-!
+`buildCover_card_bound_lowSens_with` upgrades the crude exponential bound from
+`buildCover_card_lowSens_with` to the standard `mBound` function when an
+initial set of rectangles `Rset` is provided.  Under the numeric hypothesis
+`hh`, the additional rectangles introduced by the low-sensitivity cover already
+fit inside `mBound n h`, allowing us to conclude that the final size stays below
+`mBound n (h + 1)` using `two_mul_mBound_le_succ`.
+-/
+lemma buildCover_card_bound_lowSens_with {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hs : ∀ f ∈ F, BoolFunc.sensitivity f < Nat.log2 (Nat.succ n))
+    (hh : Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n) ≤ h)
+    (hn : 0 < n) (Rset : Finset (Subcube n))
+    (hcard : Rset.card ≤ mBound n h) :
+    (buildCover (n := n) F h hH Rset).card ≤ mBound n (h + 1) := by
+  classical
+  -- Cardinality bound from the low-sensitivity cover.
+  have hsize :
+      (buildCover (n := n) F h hH Rset).card ≤
+        Rset.card +
+          Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) :=
+    buildCover_card_lowSens_with (n := n) (F := F) (h := h) hH hs
+      (Rset := Rset)
+  -- Estimate the additional rectangles using `mBound`.
+  have hexp_mul :
+      10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n) ≤ 10 * h := by
+    have := Nat.mul_le_mul_left 10 hh
+    simpa [Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using this
+  have hpow :
+      Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) ≤
+        mBound n h :=
+    (Nat.pow_le_pow_of_le_right (by decide : 0 < (2 : ℕ)) hexp_mul).trans
+      (pow_le_mBound (n := n) (h := h) hn)
+  -- Combine with the existing rectangles.
+  have hsum :
+      (buildCover (n := n) F h hH Rset).card ≤ Rset.card + mBound n h :=
+    hsize.trans <| Nat.add_le_add_left hpow _
+  have hdouble : Rset.card + mBound n h ≤ 2 * mBound n h := by
+    have := add_le_add hcard (le_rfl : mBound n h ≤ mBound n h)
+    simpa [two_mul] using this
+  have hstep := two_mul_mBound_le_succ (n := n) (h := h)
+  exact hsum.trans (hdouble.trans hstep)
+
 /--
 `buildCover_card_bound_lowSens_or` partially bridges the gap towards the
 full counting lemma `buildCover_card_bound`.  When the maximum sensitivity of

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -18,9 +18,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 81 |
+| Fully migrated | 82 |
 | Axioms | 0 |
-| Pending | 12 |
+| Pending | 11 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -98,6 +98,7 @@ buildCover_card_linear_bound
 buildCover_card_linear_bound_base
 buildCover_card_lowSens
 buildCover_card_lowSens_with
+buildCover_card_bound_lowSens_with
 buildCover_card_bound_lowSens
 buildCover_card_bound_lowSens_or
 buildCover_mono
@@ -111,10 +112,9 @@ coverFamily_card_linear_bound
 coverFamily_card_univ_bound
 ```
 
-### Not yet ported (12 lemmas)
+### Not yet ported (11 lemmas)
 
 ```
-buildCover_card_bound_lowSens_with
 buildCover_covers
 buildCover_covers_with
 buildCover_mono_lowSens

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1126,6 +1126,20 @@ example {n h : ℕ} (F : BoolFunc.Family n)
     Cover2.buildCover_card_bound_lowSens (n := n) (F := F) (h := h)
       hH hs hh hn
 
+/-- `buildCover_card_bound_lowSens_with` for the stubbed cover construction. -/
+example {n h : ℕ} (F : BoolFunc.Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hs : ∀ f ∈ F, BoolFunc.sensitivity f < Nat.log2 (Nat.succ n))
+    (hh : Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n) ≤ h)
+    (hn : 0 < n) (Rset : Finset (Subcube n))
+    (hcard : Rset.card ≤ Cover2.mBound n h) :
+    (Cover2.buildCover (n := n) F h hH Rset).card ≤
+      Cover2.mBound n (h + 1) := by
+  -- The lemma applies directly to the given parameters.
+  exact
+    Cover2.buildCover_card_bound_lowSens_with
+      (n := n) (F := F) (h := h) hH hs hh hn (Rset := Rset) hcard
+
 /-- Even without assuming a sensitivity bound, the trivial inequality
 `buildCover_card_bound_lowSens_or` holds for the stubbed cover. -/
 example {n h : ℕ} (F : BoolFunc.Family n)


### PR DESCRIPTION
### **User description**
## Summary
- Add `buildCover_card_bound_lowSens_with` to bound low-sensitivity covers augmented with existing rectangles via `mBound`
- Mark lemma as migrated in `cover_migration_plan.md`
- Extend tests with an example using the new bound

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688d8e5f8a20832baa12571c670c5fef


___

### **PR Type**
Enhancement


___

### **Description**
- Add `buildCover_card_bound_lowSens_with` lemma for bounding low-sensitivity covers with existing rectangles

- Upgrade crude exponential bound to standard `mBound` function

- Update migration tracking documentation

- Add comprehensive test example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCover_card_lowSens_with"] --> B["buildCover_card_bound_lowSens_with"]
  C["Existing rectangles Rset"] --> B
  B --> D["mBound n (h + 1)"]
  E["Migration plan"] --> F["Update count: 82 migrated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add bounded low-sensitivity cover lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add new lemma <code>buildCover_card_bound_lowSens_with</code> with detailed <br>documentation<br> <li> Implement proof using cardinality bounds and <code>mBound</code> function<br> <li> Combine existing rectangles with low-sensitivity cover bounds<br> <li> Use <code>two_mul_mBound_le_succ</code> for final bound calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/748/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+43/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for new bounded cover lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add comprehensive test example for <code>buildCover_card_bound_lowSens_with</code><br> <li> Include all required hypotheses and parameter validation<br> <li> Demonstrate direct application of the new lemma</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/748/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update migration count from 81 to 82 fully migrated lemmas<br> <li> Move <code>buildCover_card_bound_lowSens_with</code> from pending to migrated<br> <li> Decrease pending count from 12 to 11 lemmas</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/748/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

