### PR TITLE
feat: port coverFamily_mono lemma

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1689,6 +1689,18 @@ noncomputable def coverFamily {n : ℕ} (F : Family n) (h : ℕ)
     (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     coverFamily (n := n) F h _hH = buildCover (n := n) F h _hH := rfl
 
+/-!  Every rectangle in the canonical cover is monochromatic for the family.
+With the current stub `buildCover` the cover is empty, so the statement holds
+vacuously.  This lemma mirrors the eventual behaviour of the full
+construction. -/
+lemma coverFamily_mono {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    ∀ R ∈ coverFamily (n := n) F h hH,
+      Subcube.monochromaticForFamily R F := by
+  -- Unfold `coverFamily` and reuse the corresponding lemma for `buildCover`.
+  simpa [coverFamily] using
+    (buildCover_mono (n := n) (F := F) (h := h) hH)
+
 lemma coverFamily_card_bound {n h : ℕ} (F : Family n)
     (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     (coverFamily (n := n) F h hH).card ≤ mBound n h := by

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -18,9 +18,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 83 |
+| Fully migrated | 84 |
 | Axioms | 0 |
-| Pending | 10 |
+| Pending | 9 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -108,18 +108,18 @@ lift_mono_of_restrict_fixOne
 mono_subset
 mono_union
 coverFamily_eq_buildCover
+coverFamily_mono
 coverFamily_card_bound
 coverFamily_card_linear_bound
 coverFamily_card_univ_bound
 ```
 
-### Not yet ported (10 lemmas)
+### Not yet ported (9 lemmas)
 
 ```
 buildCover_covers
 buildCover_covers_with
 buildCover_mu
-coverFamily_mono
 coverFamily_spec
 coverFamily_spec_cover
 cover_exists

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1051,6 +1051,28 @@ example :
   simpa [Fsingle] using
     (Cover2.coverFamily_card_univ_bound (n := 1) (F := Fsingle) (h := 0) hH')
 
+/-- Every rectangle in the canonical cover is monochromatic. -/
+example :
+    ∀ R ∈ Cover2.coverFamily (n := 1) (F := Fsingle) (h := 0)
+          (by
+            -- `Fsingle` has collision entropy zero.
+            have hcard : Fsingle.card = 1 := by simp [Fsingle]
+            have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+              simpa [hcard] using
+                (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+            have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+            have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by simpa using hH
+            simpa using hH'),
+        Subcube.monochromaticForFamily R Fsingle := by
+  -- Direct application of the lemma `coverFamily_mono`.
+  have hcard : Fsingle.card = 1 := by simp [Fsingle]
+  have hH0 : BoolFunc.H₂ Fsingle = (0 : ℝ) := by
+    simpa [hcard] using (BoolFunc.H₂_card_one (F := Fsingle) hcard)
+  have hH : BoolFunc.H₂ Fsingle ≤ (0 : ℝ) := by exact le_of_eq hH0
+  have hH' : BoolFunc.H₂ Fsingle ≤ ((0 : ℕ) : ℝ) := by simpa using hH
+  simpa [Fsingle] using
+    (Cover2.coverFamily_mono (n := 1) (F := Fsingle) (h := 0) hH')
+
 /-- The coarse linear estimate applies to the stub `buildCover`. -/
 example :
     (Cover2.buildCover (n := 1) (F := Fsingle) (h := 0)


### PR DESCRIPTION
### **User description**
## Summary
- establish that every rectangle in the canonical cover is monochromatic (`coverFamily_mono`)
- exercise the new lemma in a Cover2 test
- update cover migration plan totals and move `coverFamily_mono` to migrated list

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688dfeca6ba0832b8ae654d148f13542


___

### **PR Type**
Enhancement


___

### **Description**
- Port `coverFamily_mono` lemma from cover.lean to cover2.lean

- Add test case demonstrating monochromatic property of cover rectangles

- Update migration plan documentation with progress tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["coverFamily_mono lemma"] --> B["Cover2Test example"]
  A --> C["Migration plan update"]
  B --> D["Monochromatic property verified"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add coverFamily_mono lemma implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>coverFamily_mono</code> lemma proving all cover rectangles are <br>monochromatic<br> <li> Include documentation explaining vacuous truth with current stub <br>implementation<br> <li> Implement proof by delegating to existing <code>buildCover_mono</code> lemma</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/750/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add monochromatic cover test case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example demonstrating <code>coverFamily_mono</code> lemma usage<br> <li> Verify monochromatic property for single-element family <code>Fsingle</code><br> <li> Include collision entropy calculations and proof structure</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/750/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration progress tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update fully migrated count from 83 to 84 lemmas<br> <li> Move <code>coverFamily_mono</code> from pending to migrated section<br> <li> Decrease pending count from 10 to 9 lemmas</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/750/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

