### PR TITLE
feat: monotonicity for uncovered set

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -474,6 +474,15 @@ lemma uncovered_subset_of_union {F : Family n}
   intro S hS
   exact hnc S (by exact Finset.mem_union.mpr <| Or.inl hS)
 
+lemma uncovered_subset {F : Family n} {R₁ R₂ : Finset (Subcube n)}
+    (hsub : R₁ ⊆ R₂) :
+    uncovered (n := n) F R₂ ⊆ uncovered (n := n) F R₁ := by
+  intro p hp
+  rcases hp with ⟨hf, hx, hnc⟩
+  refine ⟨hf, hx, ?_⟩
+  intro R hR
+  exact hnc R (hsub hR)
+
 /-! ### Simple termination measure
 
 `mu` tracks the remaining entropy budget together with the number of

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -9,8 +9,9 @@ interface for downstream files while gradually re-establishing all results.
 * `cover.lean` contains 93 lemmas supporting the recursive construction of a
   rectangular cover.  The file is self‑contained but heavy.
 * `cover2.lean` reintroduces the key numeric definitions and currently provides
-  only a subset of these lemmas.  It additionally includes a helper
-  `mBound_nonneg` not present in `cover.lean`.
+  only a subset of these lemmas.  It additionally includes helpers such as
+  `mBound_nonneg` and the monotonicity lemma `uncovered_subset` not present in
+  `cover.lean`.
 * Statements required by other modules are temporarily marked as `axiom` until
 their proofs are ported.
 

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -192,6 +192,20 @@ example (R₁ R₂ : Finset (Subcube 1)) :
       (F := {(fun _ : Point 1 => true)})
       (R₁ := R₁) (R₂ := R₂)
 
+/-- The uncovered set shrinks when enlarging the rectangle collection. -/
+example (R₁ R₂ : Finset (Subcube 1))
+    (hsub : R₁ ⊆ R₂) :
+    Cover2.uncovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) R₂ ⊆
+    Cover2.uncovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) R₁ := by
+  classical
+  exact
+    Cover2.uncovered_subset
+      (n := 1)
+      (F := {(fun _ : Point 1 => true)})
+      (R₁ := R₁) (R₂ := R₂) hsub
+
 /-- The coarse cardinality bound on uncovered pairs. -/
 example :
     (Cover2.uncovered (n := 1)


### PR DESCRIPTION
### **User description**
## Summary
- add lemma `uncovered_subset` to capture monotonicity of uncovered pairs under set inclusion
- document new helper in migration notes
- test `uncovered_subset` in `Cover2Test`

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688e03a27560832b8bfdc1c5241a2e2b


___

### **PR Type**
Enhancement


___

### **Description**
- Add monotonicity lemma `uncovered_subset` for uncovered pairs

- Test new lemma in `Cover2Test` with example proof

- Update migration documentation with new helper


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["uncovered_subset lemma"] --> B["Cover2Test example"]
  A --> C["Migration docs update"]
  D["R₁ ⊆ R₂"] --> A
  A --> E["uncovered F R₂ ⊆ uncovered F R₁"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add monotonicity lemma for uncovered pairs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>uncovered_subset</code> lemma proving monotonicity property<br> <li> Shows uncovered pairs decrease when rectangle collection grows<br> <li> Uses subset hypothesis to strengthen coverage constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/751/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Test monotonicity lemma with example proof</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example for <code>uncovered_subset</code> lemma<br> <li> Demonstrate usage with 1-dimensional boolean function family<br> <li> Verify subset relationship holds under rectangle collection inclusion</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/751/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Document new monotonicity helper lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update documentation to mention <code>uncovered_subset</code> helper<br> <li> Add to list of new lemmas not present in original <code>cover.lean</code></ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/751/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

