### PR TITLE
feat: add Boolcube subcube fromPoint helper

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -30,6 +30,34 @@ definition from `BoolFunc.lean` for the simplified subcube structure used in
 def monochromaticForFamily {n : ℕ} (R : Subcube n) (F : BoolFunc.Family n) : Prop :=
   ∃ b : Bool, ∀ f ∈ F, ∀ x, R.Mem x → f x = b
 
+/-- Construct a subcube by freezing the coordinates in `K` to match the base point `x`. -/
+def fromPoint {n : ℕ} (x : Point n) (K : Finset (Fin n)) : Subcube n :=
+  ⟨fun i => if h : i ∈ K then some (x i) else none⟩
+
+@[simp] lemma mem_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} {y : Point n} :
+    Mem (fromPoint (n := n) x K) y ↔ ∀ i ∈ K, y i = x i := by
+  classical
+  unfold fromPoint Mem
+  constructor
+  · intro h i hi
+    have := h i
+    simpa [hi] using this
+  · intro h i
+    by_cases hiK : i ∈ K
+    · have hx := h i hiK
+      simpa [fromPoint, hiK] using hx
+    · simp [fromPoint, hiK]
+
+@[simp] lemma dim_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} :
+    (fromPoint (n := n) x K).dim = n - K.card := by
+  classical
+  unfold fromPoint dim support
+  have hset :
+      Finset.univ.filter (fun i : Fin n =>
+        (if h : i ∈ K then some (x i) else none).isSome) = K := by
+    ext i; by_cases hi : i ∈ K <;> simp [hi]
+  simpa [hset]
+
 end Boolcube.Subcube
 
 namespace Cover2

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -139,5 +139,8 @@ mu_union_buildCover_lt
    build and the legacy file will be removed.
 
 At this stage the lemma `sunflower_step` still depends on the legacy
-`Subcube` implementation.  Porting it requires reconciling this structure
-with the simplified `Boolcube.Subcube` used throughout `cover2.lean`.
+`Subcube` implementation.  To prepare for this port we introduced
+`Boolcube.Subcube.fromPoint` together with basic lemmas on membership and
+dimension, but the full `sunflower_step` proof remains pending.  Completing the
+lemma still requires reconciling the classical argument with the simplified
+subcube structure used throughout `cover2.lean`.

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -35,10 +35,17 @@ example : 0 ≤ mBound 1 0 := by
     exact two_mul_mBound_le_succ (n := 1) (h := 0)
 
 /-- `pow_le_mBound_simple` for trivial parameters. -/
-  example : 1 ≤ mBound 1 0 := by
+example : 1 ≤ mBound 1 0 := by
     have hn : 0 < (1 : ℕ) := by decide
     -- Use the lemma directly instead of a `simp` rewrite.
     exact pow_le_mBound_simple (n := 1) (h := 0) hn
+
+/-- Freezing a coordinate with `fromPoint` fixes membership. -/
+example :
+    (Subcube.fromPoint (n := 1) (fun _ : Fin 1 => true) (∅ : Finset (Fin 1))).Mem
+      (fun _ : Fin 1 => true) := by
+  simp [Subcube.fromPoint]
+
 
 /-- `two_le_mBound` verifies the bound is at least `2`. -/
   example : 2 ≤ mBound 1 0 := by


### PR DESCRIPTION
### **User description**
## Summary
- add `Boolcube.Subcube.fromPoint` with membership and dimension lemmas
- note groundwork for `sunflower_step` in migration plan
- test new helper in Cover2 tests

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688e275a983c832b83d29bc693d73247


___

### **PR Type**
Enhancement


___

### **Description**
- Add `Boolcube.Subcube.fromPoint` helper function with membership and dimension lemmas

- Update migration plan documentation for `sunflower_step` porting

- Add test case for new subcube helper


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Point x and Finset K"] --> B["fromPoint helper"] --> C["Subcube with frozen coordinates"]
  B --> D["mem_fromPoint lemma"]
  B --> E["dim_fromPoint lemma"]
  C --> F["Test verification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add fromPoint helper with membership and dimension lemmas</code></dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>fromPoint</code> function to construct subcube by freezing coordinates<br> <li> Add <code>mem_fromPoint</code> simp lemma for membership characterization<br> <li> Add <code>dim_fromPoint</code> simp lemma for dimension calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/753/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add fromPoint test case and fix formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test case for <code>fromPoint</code> helper with empty coordinate set<br> <li> Fix indentation for existing test example</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/753/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration plan for sunflower_step porting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update documentation about <code>sunflower_step</code> migration status<br> <li> Note introduction of <code>fromPoint</code> helper as preparation step</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/753/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

