### PR TITLE
Add placeholder coverage lemma for buildCover

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1665,6 +1665,32 @@ lemma buildCover_mono {n h : ℕ} (F : Family n)
   have : False := by simpa [buildCover] using hR
   cases this
 
+/--
+If the starting set of rectangles already covers all `1`-inputs of the
+family `F`, then adding the (currently empty) result of `buildCover`
+preserves this property.  This weak variant mirrors the intended lemma
+from `cover.lean` and will be strengthened once the full construction is
+ported.
+-/
+lemma buildCover_covers_with {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) (Rset : Finset (Subcube n))
+    (hcov : AllOnesCovered (n := n) F Rset) :
+    AllOnesCovered (n := n) F
+      (Rset ∪ buildCover (n := n) F h hH Rset) := by
+  -- `buildCover` returns `Rset`, so the union does not change the set of
+  -- rectangles.  The coverage hypothesis therefore transfers directly.
+  simpa [buildCover] using hcov
+
+/--
+Special case of `buildCover_covers_with` starting from the empty set of
+rectangles.
+-/
+lemma buildCover_covers {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hcov : AllOnesCovered (n := n) F (∅ : Finset (Subcube n))) :
+    AllOnesCovered (n := n) F (buildCover (n := n) F h hH) := by
+  simpa [buildCover] using hcov
+
 /-!
 `mu_union_buildCover_le` is a small helper lemma used in termination
 arguments for `buildCover`.  Adding the rectangles produced by one

--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -138,6 +138,10 @@ mu_union_buildCover_lt
 3. Once all lemmas are available, `cover2.lean` can replace `cover.lean` in the
    build and the legacy file will be removed.
 
+Note: `cover2.lean` now contains a weak variant `buildCover_covers_with` that
+assumes the starting rectangle set already covers all `1`-inputs.  The full
+lemma without this hypothesis remains pending.
+
 At this stage the lemma `sunflower_step` still depends on the legacy
 `Subcube` implementation.  To prepare for this port we introduced
 `Boolcube.Subcube.fromPoint` together with basic lemmas on membership and

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1394,6 +1394,29 @@ example :
     Cover2.buildCover_mono_lowSens
       (n := 1) (F := (∅ : BoolFunc.Family 1)) (h := 0) (by simpa) hs
 
+/-- A starting cover that already covers all `1`-inputs remains a cover after
+adding the (empty) result of `buildCover`. -/
+example :
+    Cover2.AllOnesCovered (n := 1)
+      (F := (∅ : BoolFunc.Family 1))
+      (({Subcube.full} : Finset (Subcube 1)) ∪
+        Cover2.buildCover (n := 1)
+          (F := (∅ : BoolFunc.Family 1)) 0 (by simpa)
+          ({Subcube.full} : Finset (Subcube 1))) := by
+  classical
+  -- The initial set `{full}` trivially covers the empty family.
+  have hcov : Cover2.AllOnesCovered (n := 1)
+      (F := (∅ : BoolFunc.Family 1))
+      ({Subcube.full} : Finset (Subcube 1)) := by
+    intro f hf; cases hf
+  -- Applying `buildCover_covers_with` leaves the coverage unchanged.
+  simpa using
+    Cover2.buildCover_covers_with
+      (n := 1)
+      (F := (∅ : BoolFunc.Family 1))
+      (h := 0) (hH := by simpa)
+      ({Subcube.full} : Finset (Subcube 1)) hcov
+
 
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- add `buildCover_covers_with` and `buildCover_covers` to preserve coverage for stubbed `buildCover`
- document weak coverage lemma in migration plan
- extend Cover2 tests for the new coverage lemma

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688e35d190f8832b92cddc2c7d93eae9


___

### **PR Type**
Enhancement


___

### **Description**
- Add placeholder coverage lemmas `buildCover_covers_with` and `buildCover_covers`

- Document weak coverage lemma in migration plan

- Extend Cover2 tests for new coverage functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCover function"] --> B["buildCover_covers_with lemma"]
  A --> C["buildCover_covers lemma"]
  B --> D["Test coverage"]
  C --> D
  E["Migration docs"] --> F["Document weak lemma"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add placeholder coverage preservation lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>buildCover_covers_with</code> lemma preserving coverage when starting set <br>already covers all 1-inputs<br> <li> Add <code>buildCover_covers</code> lemma as special case starting from empty set<br> <li> Include detailed documentation explaining weak variant nature</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/754/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add coverage lemma test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example demonstrating <code>buildCover_covers_with</code> functionality<br> <li> Test coverage preservation with initial set containing <code>Subcube.full</code><br> <li> Verify empty family coverage behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/754/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Document weak coverage lemma status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Document existence of weak variant <code>buildCover_covers_with</code><br> <li> Note assumption about starting rectangle set coverage<br> <li> Clarify that full lemma without hypothesis remains pending</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/754/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

