### PR TITLE
feat: port cover existence lemma

### DIFF
--- a/docs/cover_migration_plan.md
+++ b/docs/cover_migration_plan.md
@@ -19,9 +19,9 @@ their proofs are ported.
 
 | Category | Lemmas |
 |---------|--------|
-| Fully migrated | 89 |
+| Fully migrated | 90 |
 | Axioms | 0 |
-| Pending | 4 |
+| Pending | 3 |
 
 The lists below group the lemmas by status.  Names exactly match those in
 `cover.lean`.
@@ -107,6 +107,7 @@ buildCover_card_bound_lowSens
 buildCover_card_bound_lowSens_or
 buildCover_mono_lowSens
 buildCover_mono
+cover_exists
 lift_mono_of_restrict
 lift_mono_of_restrict_fixOne
 mono_subset
@@ -120,10 +121,9 @@ coverFamily_card_linear_bound
 coverFamily_card_univ_bound
 ```
 
-### Not yet ported (4 lemmas)
+### Not yet ported (3 lemmas)
 
 ```
-cover_exists
 mu_buildCover_lt_start
 sunflower_step
 mu_union_buildCover_lt

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1433,6 +1433,26 @@ example :
       (n := 1) (F := (∅ : BoolFunc.Family 1)) (h := 0)
       (hH := by simp) hcov
 
+/-- `cover_exists` constructs a cover when the family has no `1`‑inputs. -/
+example :
+    ∃ Rset : Finset (Subcube 1),
+      Rset.card ≤ mBound 1 0 := by
+  classical
+  -- Family consisting of the constant false function.
+  let F : BoolFunc.Family 1 := { (fun _ : Point 1 => false) }
+  have hcard : F.card = 1 := by simp [F]
+  have hH : BoolFunc.H₂ F ≤ (0 : ℝ) := by
+    simp [BoolFunc.H₂, hcard]
+  have hcov : Cover2.AllOnesCovered (n := 1) F (∅ : Finset (Subcube 1)) := by
+    intro f hf x hx
+    have hf' : f = (fun _ : Point 1 => false) := by simpa [F] using hf
+    have : False := by simpa [hf'] using hx
+    exact this.elim
+  obtain ⟨Rset, _, _, hbound⟩ :=
+    Cover2.cover_exists (n := 1) (F := F) (h := 0)
+      (hH := by simpa using hH) (hcov := hcov)
+  exact ⟨Rset, hbound⟩
+
 
 end Cover2Test
 


### PR DESCRIPTION
### **User description**
## Summary
- port `cover_exists` to `cover2.lean`, bundling cover properties into a single lemma
- document migration status and move `cover_exists` to fully-migrated list
- add regression test exercising the new lemma on a trivial family

## Testing
- `lake test` *(warnings only)*


------
https://chatgpt.com/codex/tasks/task_e_688e4d50479c832bb0d8bce667bf6e8b


___

### **PR Type**
Enhancement


___

### **Description**
- Port `cover_exists` lemma from original cover module

- Update documentation to reflect migration progress

- Add regression test for new lemma functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original cover.lean"] -- "port lemma" --> B["cover2.lean"]
  B -- "add test" --> C["Cover2Test.lean"]
  B -- "update status" --> D["migration_plan.md"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Port cover existence lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>cover_exists</code> lemma that packages <code>buildCover</code> properties<br> <li> Update module documentation to reflect migration status<br> <li> Provide existence statement for cover construction</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/757/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+24/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add cover existence test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add regression test for <code>cover_exists</code> lemma<br> <li> Test with trivial family (constant false function)<br> <li> Verify cover construction and cardinality bounds</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/757/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover_migration_plan.md</strong><dd><code>Update migration status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/cover_migration_plan.md

<ul><li>Update migration counters (90 fully migrated, 3 pending)<br> <li> Move <code>cover_exists</code> from pending to fully migrated list<br> <li> Reflect current porting progress</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/757/files#diff-6b7ac73b582205435ec9072577ac51d37670666733318686db4c7b4632e64359">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

