### PR TITLE
feat: characterize uncovered points on unions

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -404,6 +404,34 @@ lemma NotCovered.monotone {R₁ R₂ : Finset (Subcube n)} (hsub : R₁ ⊆ R₂
   intro R hR
   exact hx R (hsub hR)
 
+--!/ A convenient characterisation of uncoveredness for unions of rectangle sets.
+-- Adding more rectangles to the cover can only shrink the set of uncovered
+-- points.  Conversely, to show that a point is uncovered by a union it suffices
+-- to show that it is uncovered by each component separately.
+lemma NotCovered.union {R₁ R₂ : Finset (Subcube n)} {x : Point n} :
+    NotCovered (n := n) (Rset := R₁ ∪ R₂) x ↔
+      NotCovered (n := n) (Rset := R₁) x ∧
+        NotCovered (n := n) (Rset := R₂) x := by
+  classical
+  constructor
+  · intro h
+    refine ⟨?_, ?_⟩
+    · -- Any rectangle from `R₁` is also in the union, hence `x` misses it.
+      intro R hR
+      exact h R (by
+        exact Finset.mem_union.mpr <| Or.inl hR)
+    · -- Symmetric argument for rectangles coming from `R₂`.
+      intro R hR
+      exact h R (by
+        exact Finset.mem_union.mpr <| Or.inr hR)
+  · intro h R hR
+    -- A rectangle in the union lies in either `R₁` or `R₂`, so use the
+    -- corresponding component of the conjunction.
+    have hmem := Finset.mem_union.mp hR
+    cases hmem with
+    | inl hR1 => exact h.1 R hR1
+    | inr hR2 => exact h.2 R hR2
+
 /-! ### Uncovered points and search utilities -/
 
 /-- The set of all uncovered `1`-inputs (paired with their functions). -/


### PR DESCRIPTION
### **User description**
## Summary
- add lemma `NotCovered.union` describing uncovered points for unions of rectangle sets
- provide detailed comments clarifying how uncoveredness splits across unions

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688e94084c74832b9f06f3555e917e30


___

### **PR Type**
Enhancement


___

### **Description**
- Add lemma `NotCovered.union` for characterizing uncovered points on unions

- Provide detailed comments explaining uncoveredness behavior across unions

- Establish bidirectional relationship between union and component uncoveredness


___

### Diagram Walkthrough


```mermaid
flowchart LR
  R1["Rectangle Set R₁"] --> Union["Union R₁ ∪ R₂"]
  R2["Rectangle Set R₂"] --> Union
  Union --> NotCovered["NotCovered Point x"]
  NotCovered --> Equiv["↔"]
  Equiv --> Both["NotCovered in R₁ ∧ NotCovered in R₂"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add union characterization lemma for uncovered points</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>NotCovered.union</code> lemma with bidirectional equivalence proof<br> <li> Include detailed comments explaining uncoveredness splitting behavior<br> <li> Implement classical logic proof with case analysis on union membership</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/762/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

