### PR TITLE
docs: clarify sunflower step axiom

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -1435,11 +1435,15 @@ lemma uncovered_init_bound_empty (F : Family n) (hF : F = (∅ : Family n)) :
   exact hgoal
 
 /--
-`sunflower_step` is currently assumed as an axiom in `cover2`.  It matches the
-combinatorial statement from the legacy development: whenever all functions in
-`F` have the same positive support size `p` and the family of supports is
-large, there exists a subcube `R` of positive dimension such that at least
-`t` functions are constantly `true` on `R`.
+**Sunflower extraction.**  At the current stage of the migration this lemma is
+still posed as an axiom.  It is a direct analogue of the classical
+`sunflower_step` used in the original `cover` module: if all functions in `F`
+share the same non‑zero support size `p` and the family of supports is large
+enough, one can find a subcube `R` of positive dimension on which at least
+`t` functions from the family are identically `true`.
+
+The formal proof has not yet been ported to the simplified `Boolcube.Subcube`
+structure and remains as future work.
 -/
 axiom sunflower_step {n : ℕ} (F : Family n) (p t : ℕ)
     (hp : 0 < p) (ht : 2 ≤ t)


### PR DESCRIPTION
### **User description**
## Summary
- Document the placeholder `sunflower_step` axiom, clarifying its role in the future cover2 migration

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688e9e4ba53c832b989c4402dd47fb65


___

### **PR Type**
Documentation


___

### **Description**
- Enhanced documentation for `sunflower_step` axiom

- Clarified its role in future cover2 migration

- Added context about porting from original cover module


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Enhanced sunflower_step axiom documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Rewrote docstring for <code>sunflower_step</code> axiom with clearer explanation<br> <li> Added context about migration from original cover module<br> <li> Explained current axiom status and future porting work</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/765/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

