### PR TITLE
Add lemma for subcube membership in `cover2`

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -31,8 +31,13 @@ def monochromaticForFamily {n : ℕ} (R : Subcube n) (F : BoolFunc.Family n) : P
   ∃ b : Bool, ∀ f ∈ F, ∀ x, R.Mem x → f x = b
 
 /-- Construct a subcube by freezing the coordinates in `K` to match the base point `x`. -/
+-- In the simplified `Boolcube.Subcube` representation a subcube is specified by
+-- giving the value of each coordinate: coordinates mapped to `some b` are
+-- fixed to the Boolean value `b` whereas coordinates mapped to `none` are left
+-- free.  The constructor below freezes exactly the coordinates from the set
+-- `K` to match a given base point `x`.
 def fromPoint {n : ℕ} (x : Point n) (K : Finset (Fin n)) : Subcube n :=
-  ⟨fun i => if h : i ∈ K then some (x i) else none⟩
+  ⟨fun i => if _ : i ∈ K then some (x i) else none⟩
 
 @[simp] lemma mem_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} {y : Point n} :
     Mem (fromPoint (n := n) x K) y ↔ ∀ i ∈ K, y i = x i := by
@@ -45,8 +50,16 @@ def fromPoint {n : ℕ} (x : Point n) (K : Finset (Fin n)) : Subcube n :=
   · intro h i
     by_cases hiK : i ∈ K
     · have hx := h i hiK
-      simpa [fromPoint, hiK] using hx
-    · simp [fromPoint, hiK]
+      -- Expand the definition of the cube and reduce using the assumed equality.
+      simpa [hiK] using hx
+    · simp [hiK]
+
+@[simp] lemma self_mem_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} :
+    x ∈ₛ fromPoint (n := n) x K := by
+  classical
+  -- Each coordinate in `K` obviously matches the corresponding bit of `x`.
+  refine (mem_fromPoint (x := x) (K := K) (y := x)).2 ?_;
+  intro i hi; rfl
 
 @[simp] lemma dim_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} :
     (fromPoint (n := n) x K).dim = n - K.card := by


### PR DESCRIPTION
### **User description**
## Summary
- document subcube constructor `fromPoint` and suppress unused binder
- add lemma `self_mem_fromPoint` showing a point lies in the cube generated from itself

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688eb1dba8e4832b946f824349a9ea00


___

### **PR Type**
Enhancement


___

### **Description**
- Add documentation for `fromPoint` subcube constructor

- Add `self_mem_fromPoint` lemma proving point membership

- Suppress unused binder warning in constructor


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["fromPoint constructor"] --> B["Documentation added"]
  A --> C["Unused binder suppressed"]
  A --> D["self_mem_fromPoint lemma"]
  D --> E["Proves x ∈ fromPoint x K"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Document fromPoint and add self-membership lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Added comprehensive documentation for <code>fromPoint</code> constructor explaining <br>subcube representation<br> <li> Suppressed unused binder warning by replacing <code>h</code> with <code>_</code><br> <li> Added <code>self_mem_fromPoint</code> lemma proving a point belongs to subcube <br>generated from itself<br> <li> Enhanced code comments in existing <code>mem_fromPoint</code> proof</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/766/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

