### PR TITLE
refactor: update cover2 simp and pow lemmas

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -68,8 +68,11 @@ def fromPoint {n : ℕ} (x : Point n) (K : Finset (Fin n)) : Subcube n :=
   have hset :
       Finset.univ.filter (fun i : Fin n =>
         (if h : i ∈ K then some (x i) else none).isSome) = K := by
+    -- Membership in the filtered set coincides with membership in `K`.
     ext i; by_cases hi : i ∈ K <;> simp [hi]
-  simpa [hset]
+  -- The dimension is simply the number of unfixed coordinates.
+  -- The filtered set is exactly `K`, so the dimension drops by `K.card`.
+  simp [hset]
 
 @[simp] lemma mem_fromPoint_subset {n : ℕ} {x : Point n}
     {K L : Finset (Fin n)} {y : Point n}
@@ -108,14 +111,18 @@ lemma mem_toCube {n : ℕ} (R : Subcube n) (x : Boolcube.Point n) :
   · intro h i hi
     have hx := h i
     -- The `if` branch collapses using the membership assumption `hi`.
-    simpa [hi] using hx
+    -- Simplify the hypothesis using the fact that `i ∈ R.idx`.
+    simp [hi] at hx
+    -- The goal now reduces to a trivial equality on coordinates.
+    simp [hi, hx]
   · intro h i
     by_cases hi : i ∈ R.idx
     · have hx := h i hi
-      simpa [hi, hx]
+      -- In the fixed coordinates, `toCube` and `R` agree by definition.
+      simp [hi, hx]
     · -- Outside the fixed coordinates the membership predicate is trivially
       -- satisfied.
-      simpa [hi]
+      simp [hi]
 
 /-- The dimension of the converted cube matches that of the original
 subcube. -/
@@ -130,8 +137,10 @@ lemma dim_toCube {n : ℕ} (R : Subcube n) :
           (fun i : Fin n =>
             (if h : i ∈ R.idx then some (R.val i h) else none).isSome)
           = R.idx := by
+    -- Again we unfold the filtered set and identify it with `R.idx`.
     ext i; by_cases hi : i ∈ R.idx <;> simp [hi]
-  simpa [hset]
+  -- The dimension of the cube produced by `toCube` matches that of `R`.
+  simp [hset]
 
 end BoolFunc.Subcube
 
@@ -1688,7 +1697,8 @@ lemma buildCover_card_bound_lowSens {n h : ℕ} (F : Family n)
   have hpow :
       Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) ≤
         Nat.pow 2 (10 * h) :=
-    Nat.pow_le_pow_of_le_right (by decide : 0 < (2 : ℕ)) hexp_mul
+    -- Use the modern lemma `pow_le_pow_right` for exponent monotonicity.
+    Nat.pow_le_pow_right (by decide : 0 < (2 : ℕ)) hexp_mul
   -- Combine with the main bound `pow_le_mBound`.
   have hbig := hcard.trans hpow
   have hbound := hbig.trans (pow_le_mBound (n := n) (h := h) hn)
@@ -1725,7 +1735,9 @@ lemma buildCover_card_bound_lowSens_with {n h : ℕ} (F : Family n)
   have hpow :
       Nat.pow 2 (10 * Nat.log2 (Nat.succ n) * Nat.log2 (Nat.succ n)) ≤
         mBound n h :=
-    (Nat.pow_le_pow_of_le_right (by decide : 0 < (2 : ℕ)) hexp_mul).trans
+    -- Apply monotonicity of exponentiation in a single step and then
+    -- leverage the existing bound on `mBound`.
+    (Nat.pow_le_pow_right (by decide : 0 < (2 : ℕ)) hexp_mul).trans
       (pow_le_mBound (n := n) (h := h) hn)
   -- Combine with the existing rectangles.
   have hsum :


### PR DESCRIPTION
### **User description**
## Summary
- clarify subcube conversion lemmas with `simp`-based proofs
- replace deprecated `Nat.pow_le_pow_of_le_right` with `Nat.pow_le_pow_right`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_688ebb1156f8832b9d9e4d22471f6c04


___

### **PR Type**
Enhancement


___

### **Description**
- Replace deprecated `Nat.pow_le_pow_of_le_right` with modern `Nat.pow_le_pow_right`

- Add clarifying comments to `simp`-based proofs in subcube conversion lemmas

- Improve code readability with detailed proof explanations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["deprecated pow lemma"] -- "replace with" --> B["modern pow_le_pow_right"]
  C["simp proofs"] -- "add comments" --> D["clarified proofs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Update deprecated lemmas and add proof comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Replace deprecated <code>Nat.pow_le_pow_of_le_right</code> with <br><code>Nat.pow_le_pow_right</code> in two locations<br> <li> Add detailed comments explaining <code>simp</code>-based proofs in subcube <br>conversion lemmas<br> <li> Improve readability of proof steps with explanatory comments<br> <li> Maintain same mathematical logic while updating to modern API</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/767/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+19/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

