### PR TITLE
refactor: extract subcube utilities

### DIFF
--- a/Pnp2/Cover/SubcubeAdapters.lean
+++ b/Pnp2/Cover/SubcubeAdapters.lean
@@ -1,0 +1,175 @@
+import Pnp2.BoolFunc
+import Pnp2.BoolFunc.Support
+import Pnp2.Boolcube
+import Mathlib.Data.Nat.Basic
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Card
+import Mathlib.Tactic
+
+open Classical
+open Finset
+open BoolFunc (Family BFunc)
+open Boolcube (Point Subcube)
+
+/--
+Local notation for membership in a subcube of the Boolean cube.
+The notation `x ∈ₛ R` should be read as “the point `x` belongs to the
+subcube `R`”.  This mirrors the notation used for the legacy subcube
+structure defined in `BoolFunc`.
+-/
+notation x " ∈ₛ " R => Boolcube.Subcube.Mem R x
+
+namespace Boolcube.Subcube
+
+/--
+`R` is jointly monochromatic for the family `F` if every function in `F`
+assumes the same Boolean value on all points of `R`.
+This lightweight wrapper mirrors the corresponding definition for the
+simplified subcube structure used throughout the `cover2` development.
+-/
+def monochromaticForFamily {n : ℕ} (R : Subcube n) (F : BoolFunc.Family n) : Prop :=
+  ∃ b : Bool, ∀ f ∈ F, ∀ x, R.Mem x → f x = b
+
+/--
+Construct a subcube by *freezing* the coordinates in `K` to match the values
+of a base point `x`.
+
+In our simplified representation a subcube is described by a function that
+assigns to each coordinate either `none` (meaning the coordinate is free) or
+`some b` (meaning the coordinate is fixed to the Boolean value `b`).
+The constructor below freezes exactly the coordinates from the set `K`.
+-/
+def fromPoint {n : ℕ} (x : Point n) (K : Finset (Fin n)) : Subcube n :=
+  ⟨fun i => if _ : i ∈ K then some (x i) else none⟩
+
+/--
+A point `y` belongs to `fromPoint x K` iff it agrees with `x` on every index in `K`.
+-/
+@[simp] lemma mem_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} {y : Point n} :
+    Mem (fromPoint (n := n) x K) y ↔ ∀ i ∈ K, y i = x i := by
+  classical
+  unfold fromPoint Mem
+  constructor
+  · intro h i hi
+    have := h i
+    simpa [hi] using this
+  · intro h i
+    by_cases hiK : i ∈ K
+    · have hx := h i hiK
+      -- Expand the definition of the cube and reduce using the assumed equality.
+      simpa [hiK] using hx
+    · simp [hiK]
+
+/--
+The base point `x` always lies in the subcube obtained by freezing `K`.
+-/
+@[simp] lemma self_mem_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} :
+    x ∈ₛ fromPoint (n := n) x K := by
+  classical
+  -- Each coordinate in `K` obviously matches the corresponding bit of `x`.
+  refine (mem_fromPoint (x := x) (K := K) (y := x)).2 ?_
+  intro i hi; rfl
+
+/--
+The dimension of `fromPoint x K` is `n - |K|` because each frozen coordinate
+reduces the number of degrees of freedom by one.
+-/
+@[simp] lemma dim_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} :
+    (fromPoint (n := n) x K).dim = n - K.card := by
+  classical
+  unfold fromPoint dim support
+  have hset :
+      Finset.univ.filter (fun i : Fin n =>
+        (if h : i ∈ K then some (x i) else none).isSome) = K := by
+    -- Membership in the filtered set coincides with membership in `K`.
+    ext i; by_cases hi : i ∈ K <;> simp [hi]
+  -- The dimension is simply the number of unfixed coordinates.
+  -- The filtered set is exactly `K`, so the dimension drops by `K.card`.
+  simp
+
+/--
+Membership in larger frozen sets implies membership in smaller ones.
+If `L` freezes at least the coordinates of `K` and `y` belongs to `fromPoint x L`
+then `y` also belongs to `fromPoint x K`.
+-/
+@[simp] lemma mem_fromPoint_subset {n : ℕ} {x : Point n}
+    {K L : Finset (Fin n)} {y : Point n}
+    (hKL : K ⊆ L)
+    (hy : y ∈ₛ fromPoint (n := n) x L) :
+    y ∈ₛ fromPoint (n := n) x K := by
+  classical
+  -- Expand membership of `hy` and restrict it along the subset relation.
+  have hL : ∀ i ∈ L, y i = x i :=
+    (mem_fromPoint (x := x) (K := L) (y := y)).1 hy
+  -- Show membership in the smaller cube using the specialised equality.
+  exact
+    (mem_fromPoint (x := x) (K := K) (y := y)).2
+      (by intro i hiK; exact hL i (hKL hiK))
+
+end Boolcube.Subcube
+
+/-!
+### Bridging the legacy `BoolFunc.Subcube` with the simplified `Boolcube.Subcube`
+
+The original development represents subcubes via a pair `(idx, val)` where `idx`
+collects the fixed coordinates and `val` records their Boolean values.  The
+newer `Boolcube.Subcube` structure instead uses an option-valued function and is
+more convenient for constructive manipulations.  The following helpers convert
+between the two representations and establish basic properties.
+-/
+namespace BoolFunc.Subcube
+
+/--
+Convert an old-style subcube (specified by a set of fixed coordinates and their
+Boolean values) into the simplified `Boolcube.Subcube` representation used in
+`cover2`.  Each coordinate in `idx` becomes a fixed bit in the resulting cube,
+while all other coordinates remain free.
+-/
+def toCube {n : ℕ} (R : Subcube n) : Boolcube.Subcube n :=
+  ⟨fun i => if h : i ∈ R.idx then some (R.val i h) else none⟩
+
+/--
+Membership in the converted cube coincides with membership in the original
+subcube.
+-/
+lemma mem_toCube {n : ℕ} (R : Subcube n) (x : Boolcube.Point n) :
+    Boolcube.Subcube.Mem (toCube (n := n) R) x ↔ Subcube.mem (n := n) R x := by
+  classical
+  unfold toCube Boolcube.Subcube.Mem Subcube.mem
+  constructor
+  · intro h i hi
+    have hx := h i
+    -- The `if` branch collapses using the membership assumption `hi`
+    -- and directly yields the desired equality.
+    simpa [hi] using hx
+  · intro h i
+    by_cases hi : i ∈ R.idx
+    · have hx := h i hi
+      -- In the fixed coordinates, `toCube` and `R` agree by definition.
+      simpa [hi] using hx
+    · -- Outside the fixed coordinates the membership predicate is trivially
+      -- satisfied.
+      simp [hi]
+
+/--
+The dimension of the converted cube matches that of the original subcube.
+-/
+lemma dim_toCube {n : ℕ} (R : Subcube n) :
+    (toCube (n := n) R).dim = Subcube.dimension (n := n) R := by
+  classical
+  unfold toCube Boolcube.Subcube.dim Boolcube.Subcube.support
+  unfold Subcube.dimension
+  -- The support of `toCube R` is exactly the set of fixed coordinates `R.idx`.
+  have hset :
+      Finset.univ.filter
+          (fun i : Fin n =>
+            (if h : i ∈ R.idx then some (R.val i h) else none).isSome)
+          = R.idx := by
+    -- Again we unfold the filtered set and identify it with `R.idx`.
+    ext i; by_cases hi : i ∈ R.idx <;> simp [hi]
+  -- The dimension of the cube produced by `toCube` matches that of `R`.
+  simp
+
+end BoolFunc.Subcube
+

--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -6,6 +6,7 @@ import Pnp2.BoolFunc.Support
 import Pnp2.Sunflower.RSpread
 import Pnp2.low_sensitivity_cover
 import Pnp2.Boolcube
+import Pnp2.Cover.SubcubeAdapters -- subcube conversion utilities
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finset.Card
@@ -18,132 +19,6 @@ open Agreement
 open BoolFunc (Family BFunc)
 open Boolcube (Point Subcube)
 open Sunflower
-
--- Local notation for membership in a subcube of the Boolean cube.
-notation x " ∈ₛ " R => Boolcube.Subcube.Mem R x
-
-namespace Boolcube.Subcube
-
-/-- `R` is jointly monochromatic for the family `F` if every function shares a
-constant value on all points of `R`.  This lightweight wrapper mirrors the
-definition from `BoolFunc.lean` for the simplified subcube structure used in
-`cover2`. -/
-def monochromaticForFamily {n : ℕ} (R : Subcube n) (F : BoolFunc.Family n) : Prop :=
-  ∃ b : Bool, ∀ f ∈ F, ∀ x, R.Mem x → f x = b
-
-/-- Construct a subcube by freezing the coordinates in `K` to match the base point `x`. -/
--- In the simplified `Boolcube.Subcube` representation a subcube is specified by
--- giving the value of each coordinate: coordinates mapped to `some b` are
--- fixed to the Boolean value `b` whereas coordinates mapped to `none` are left
--- free.  The constructor below freezes exactly the coordinates from the set
--- `K` to match a given base point `x`.
-def fromPoint {n : ℕ} (x : Point n) (K : Finset (Fin n)) : Subcube n :=
-  ⟨fun i => if _ : i ∈ K then some (x i) else none⟩
-
-@[simp] lemma mem_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} {y : Point n} :
-    Mem (fromPoint (n := n) x K) y ↔ ∀ i ∈ K, y i = x i := by
-  classical
-  unfold fromPoint Mem
-  constructor
-  · intro h i hi
-    have := h i
-    simpa [hi] using this
-  · intro h i
-    by_cases hiK : i ∈ K
-    · have hx := h i hiK
-      -- Expand the definition of the cube and reduce using the assumed equality.
-      simpa [hiK] using hx
-    · simp [hiK]
-
-@[simp] lemma self_mem_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} :
-    x ∈ₛ fromPoint (n := n) x K := by
-  classical
-  -- Each coordinate in `K` obviously matches the corresponding bit of `x`.
-  refine (mem_fromPoint (x := x) (K := K) (y := x)).2 ?_;
-  intro i hi; rfl
-
-@[simp] lemma dim_fromPoint {n : ℕ} {x : Point n} {K : Finset (Fin n)} :
-    (fromPoint (n := n) x K).dim = n - K.card := by
-  classical
-  unfold fromPoint dim support
-  have hset :
-      Finset.univ.filter (fun i : Fin n =>
-        (if h : i ∈ K then some (x i) else none).isSome) = K := by
-    -- Membership in the filtered set coincides with membership in `K`.
-    ext i; by_cases hi : i ∈ K <;> simp [hi]
-  -- The dimension is simply the number of unfixed coordinates.
-  -- The filtered set is exactly `K`, so the dimension drops by `K.card`.
-  simp [hset]
-
-@[simp] lemma mem_fromPoint_subset {n : ℕ} {x : Point n}
-    {K L : Finset (Fin n)} {y : Point n}
-    (hKL : K ⊆ L)
-    (hy : y ∈ₛ fromPoint (n := n) x L) :
-    y ∈ₛ fromPoint (n := n) x K := by
-  classical
-  -- Expand membership of `hy` and restrict it along the subset relation.
-  have hL : ∀ i ∈ L, y i = x i :=
-    (mem_fromPoint (x := x) (K := L) (y := y)).1 hy
-  -- Show membership in the smaller cube using the specialised equality.
-  exact
-    (mem_fromPoint (x := x) (K := K) (y := y)).2
-      (by intro i hiK; exact hL i (hKL hiK))
-
-end Boolcube.Subcube
-
---! ### Bridging the legacy `BoolFunc.Subcube` with the simplified `Boolcube.Subcube`
-
-namespace BoolFunc.Subcube
-
-/-- Convert an old-style subcube (specified by a set of fixed coordinates and
-their Boolean values) into the simplified `Boolcube.Subcube` representation
-used in `cover2`.  Each coordinate in `idx` becomes a fixed bit in the
-resulting cube, while all other coordinates remain free. -/
-def toCube {n : ℕ} (R : Subcube n) : Boolcube.Subcube n :=
-  ⟨fun i => if h : i ∈ R.idx then some (R.val i h) else none⟩
-
-/-- Membership in the converted cube coincides with membership in the original
-subcube. -/
-lemma mem_toCube {n : ℕ} (R : Subcube n) (x : Boolcube.Point n) :
-    Boolcube.Subcube.Mem (toCube (n := n) R) x ↔ Subcube.mem (n := n) R x := by
-  classical
-  unfold toCube Boolcube.Subcube.Mem Subcube.mem
-  constructor
-  · intro h i hi
-    have hx := h i
-    -- The `if` branch collapses using the membership assumption `hi`.
-    -- Simplify the hypothesis using the fact that `i ∈ R.idx`.
-    simp [hi] at hx
-    -- The goal now reduces to a trivial equality on coordinates.
-    simp [hi, hx]
-  · intro h i
-    by_cases hi : i ∈ R.idx
-    · have hx := h i hi
-      -- In the fixed coordinates, `toCube` and `R` agree by definition.
-      simp [hi, hx]
-    · -- Outside the fixed coordinates the membership predicate is trivially
-      -- satisfied.
-      simp [hi]
-
-/-- The dimension of the converted cube matches that of the original
-subcube. -/
-lemma dim_toCube {n : ℕ} (R : Subcube n) :
-    (toCube (n := n) R).dim = Subcube.dimension (n := n) R := by
-  classical
-  unfold toCube Boolcube.Subcube.dim Boolcube.Subcube.support
-  unfold Subcube.dimension
-  -- The support of `toCube R` is exactly the set of fixed coordinates `R.idx`.
-  have hset :
-      Finset.univ.filter
-          (fun i : Fin n =>
-            (if h : i ∈ R.idx then some (R.val i h) else none).isSome)
-          = R.idx := by
-    -- Again we unfold the filtered set and identify it with `R.idx`.
-    ext i; by_cases hi : i ∈ R.idx <;> simp [hi]
-  -- The dimension of the cube produced by `toCube` matches that of `R`.
-  simp [hset]
-
-end BoolFunc.Subcube
 
 namespace Cover2
 


### PR DESCRIPTION
### **User description**
## Summary
- factor out subcube helper functions into `Cover/SubcubeAdapters` with documentation
- simplify `cover2` by importing the new adapters

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688f6b3f31b8832b893f455f8fb8f19d


___

### **PR Type**
Enhancement


___

### **Description**
- Extract subcube utilities into dedicated module

- Add comprehensive documentation for subcube operations

- Simplify cover2 by importing new adapters

- Bridge legacy and simplified subcube representations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover2.lean"] --> B["SubcubeAdapters.lean"]
  B --> C["Subcube utilities"]
  B --> D["Documentation"]
  B --> E["Bridge functions"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SubcubeAdapters.lean</strong><dd><code>New subcube utilities module with documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/SubcubeAdapters.lean

<ul><li>Create new module with subcube utility functions<br> <li> Add comprehensive documentation for all functions<br> <li> Implement bridge between legacy and simplified subcube representations<br> <li> Include lemmas for membership, dimension, and conversion operations</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/773/files#diff-5ae514a044015904f088dee8ea738e04e93f5e94f1a6eea608d6c76fc8069afb">+175/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Simplify by importing subcube adapters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Remove 134 lines of subcube utility code<br> <li> Add import for new SubcubeAdapters module<br> <li> Simplify file structure by delegating to dedicated module</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/773/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+1/-126</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

