### PR TITLE
Explain coarse bound for uncovered pairs

### DIFF
--- a/Pnp2/Cover/CoarseBound.lean
+++ b/Pnp2/Cover/CoarseBound.lean
@@ -17,52 +17,61 @@ namespace Cover2
 /-!
 ### Coarse bound on the number of uncovered pairs
 
-The lemmas in this file provide a very rough estimate on the size of the set
-of *uncovered pairs*.  An uncovered pair consists of a Boolean function `f`
-from the family and a point `x` of the Boolean cube such that `f x = true` but
-no rectangle in the current rectangle set contains `x`.
+This file isolates a *very* simple counting argument about uncovered points.
+Separating the reasoning into its own module keeps the main construction in
+`cover2.lean` focused on the combinatorics while still providing an easy-to-use
+upper bound on the size of the set of uncovered pairs.
 
-Ignoring the structure of the rectangles gives an immediate bound: there are at
-most `F.card` choices for `f` and `2^n` choices for `x`.  Hence the uncovered
-set cannot contain more than `F.card * 2^n` elements.  Even though the estimate
-is extremely coarse, it suffices for quick sanity checks and keeps the
-combinatorial development in `cover2.lean` uncluttered.
+An uncovered pair consists of a Boolean function `f` from the family and a
+point `x` of the Boolean cube such that `f x = true` but `x` is missing from all
+currently chosen rectangles.  Forgetting all structural information about the
+rectangles, we can simply count the possible choices of `f` and `x`.
+
+There are at most `F.card` options for the function and `2^n` options for the
+point.  Consequently the uncovered set cannot contain more than `F.card * 2^n`
+elements.  While this bound is extremely coarse, it is sufficient for basic
+sanity checks and for establishing termination measures in preliminary
+experiments.
 -/
 
-/--
-Each uncovered pair `(f, x)` comes from a function `f` in the family and a point
-`x` of the cube.  Forgetting that uncovered points satisfy additional
-properties, we embed the uncovered set into the simple product `F × 2^n` and use
-a cardinality argument to derive the coarse upper bound.
+/-
+At the heart of the argument lies the following observation: every element of
+the uncovered set determines a function `f ∈ F` together with a point `x` from
+the Boolean cube.  Disregarding the additional property that `x` is actually
+uncovered, this gives an injection into the simple sigma-type `F × 2^n`.  The
+cardinality of the latter factorises into the product `F.card * 2^n`, which
+immediately bounds the uncovered set.
 -/
 lemma uncovered_card_bound (F : Family n) (Rset : Finset (Subcube n)) :
     (uncovered (n := n) F Rset).toFinset.card ≤ F.card * 2 ^ n := by
   classical
-  -- Map every uncovered pair into the sigma-type of a function and a cube point.
-  have hsubset : (uncovered (n := n) F Rset).toFinset ⊆
+  -- We explicitly construct the embedding described above.  Every uncovered
+  -- pair maps to its function together with the underlying point of the cube.
+  have embed : (uncovered (n := n) F Rset).toFinset ⊆
       F.sigma (fun _ => (Finset.univ : Finset (Point n))) := by
     intro p hp
-    -- Recover the proof that `p` is uncovered to extract information about its
-    -- components.
+    -- `hp` certifies that `p` is uncovered.  From this we read off membership of
+    -- the function component in `F` and that the point lies in the cube.
     have hp' : p ∈ uncovered (n := n) F Rset := by simpa using hp
     rcases hp' with ⟨hf, hx, _⟩
-    -- Every point of the cube lies in `Finset.univ`.
+    -- Every point of the Boolean cube is, tautologically, an element of `univ`.
     have hx' : p.2 ∈ (Finset.univ : Finset (Point n)) := by simp
-    -- Assemble the pair in the sigma-type.
+    -- Package the information in the sigma-type `F × 2^n`.
     exact Finset.mem_sigma.mpr ⟨hf, hx'⟩
-  -- Cardinalities respect subsets: the uncovered set is at most as large as the
-  -- sigma-type it embeds into.
-  have hcard := Finset.card_le_card hsubset
-  -- For a constant fibre the sigma-type cardinality factorises into a product.
+  -- Taking cardinalities, the subset relation yields the desired inequality.
+  have hcard := Finset.card_le_card embed
+  -- For a sigma-type with constant fibre, the cardinality splits into a
+  -- product.  This corresponds to the counting argument "choose `f` and then
+  -- choose `x`".
   have hprod : (F.sigma fun _ => (Finset.univ : Finset (Point n))).card =
       F.card * (Finset.univ : Finset (Point n)).card := by
     classical
     simpa [Finset.card_sigma, Finset.sum_const, Nat.mul_comm,
       Nat.mul_left_comm, Nat.mul_assoc]
-  -- The Boolean cube of dimension `n` has exactly `2^n` points.
+  -- The n-dimensional Boolean cube has exactly `2^n` points.
   have hcube : (Finset.univ : Finset (Point n)).card = 2 ^ n := by
     simpa using (Fintype.card_vector (α := Bool) (n := n))
-  -- Putting the pieces together yields the advertised bound.
+  -- Combine the previous facts and rewrite to obtain the final inequality.
   simpa [hprod, hcube] using hcard
 
 /--
@@ -73,6 +82,9 @@ form for callers concerned with the starting configuration of the algorithm.
 lemma uncovered_init_coarse_bound (F : Family n) :
     (uncovered (n := n) F (∅ : Finset (Subcube n))).toFinset.card ≤
       F.card * 2 ^ n := by
+  -- This is just `uncovered_card_bound` with `Rset = ∅`.  The additional lemma
+  -- exists only for convenience when reasoning about the starting state of the
+  -- cover construction.
   simpa using
     (uncovered_card_bound (n := n) (F := F)
       (Rset := (∅ : Finset (Subcube n))))
@@ -85,11 +97,12 @@ ambient dimension `n` for easy reuse in examples and tests.
 lemma uncovered_init_bound_empty (F : Family n) (hF : F = (∅ : Family n)) :
     (uncovered (n := n) F (∅ : Finset (Subcube n))).toFinset.card ≤ n := by
   classical
-  -- An empty family yields no uncovered pairs, hence the cardinality is zero.
+  -- If the family itself is empty, the uncovered set is obviously empty.  The
+  -- goal therefore reduces to a simple inequality `0 ≤ n`.
   have hcard :
       (uncovered (n := n) F (∅ : Finset (Subcube n))).toFinset.card = 0 := by
     simpa [uncovered, hF]
-  -- Replace the goal with `0 ≤ n` and discharge it using `Nat.zero_le`.
+  -- Rewriting the goal makes the statement immediate.
   have hgoal :
       (uncovered (n := n) F (∅ : Finset (Subcube n))).toFinset.card ≤ n := by
     rw [hcard]


### PR DESCRIPTION
### **User description**
## Summary
- document reasoning behind coarse bound for uncovered pairs
- provide lemma specializations and detailed comments for clarity

## Testing
- `lake build Pnp2.Cover.CoarseBound`
- `./scripts/check.sh`


------
https://chatgpt.com/codex/tasks/task_e_688f85fbbbcc832b9a70f594481a9b61


___

### **PR Type**
Documentation


___

### **Description**
- Enhanced documentation for coarse bound on uncovered pairs

- Added detailed comments explaining the counting argument

- Improved clarity of lemma specializations and proofs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Uncovered pairs (f,x)"] -- "embed into" --> B["Product F × 2^n"]
  B -- "count elements" --> C["Bound: F.card * 2^n"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CoarseBound.lean</strong><dd><code>Enhanced documentation and proof comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/CoarseBound.lean

<ul><li>Rewrote module-level documentation with clearer explanation<br> <li> Added detailed comments explaining the embedding argument<br> <li> Enhanced proof comments for better readability<br> <li> Improved variable naming and comment structure</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/777/files#diff-58f9add3bd1dbbed5b7c7ecd6d0cc8fc1528f4879c6806906ab80dea908a3a60">+41/-28</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

