### PR TITLE
refactor: extract lifting lemmas

### DIFF
--- a/Pnp2/Cover/Lifting.lean
+++ b/Pnp2/Cover/Lifting.lean
@@ -1,0 +1,65 @@
+import Pnp2.BoolFunc
+import Pnp2.Boolcube
+import Pnp2.Cover.SubcubeAdapters
+import Mathlib.Data.Finset.Basic
+import Mathlib.Tactic
+
+open Classical
+open BoolFunc (Family BFunc)
+open Boolcube (Point Subcube)
+
+namespace Cover2
+
+/-!
+### Lifting monochromaticity through restrictions
+
+The cover construction often restricts a family of Boolean functions to a
+subcube where one coordinate is fixed.  The following lemmas explain how
+monochromaticity of the restricted family can be transferred back to the
+original family.  These results will support the recursion once the full cover
+algorithm is ported.
+-/
+
+/--
+If a subcube `R` fixes coordinate `i` to the value `b`, then every function in a
+family `F` takes the same value on `R` provided that the restricted family
+`F.restrict i b` is monochromatic on `R`.
+-/
+lemma lift_mono_of_restrict
+    {n : ℕ} {F : Family n} {i : Fin n} {b : Bool} {R : Subcube n}
+    (hfix : ∀ x, R.Mem x → x i = b)
+    (hmono : Subcube.monochromaticForFamily R (Family.restrict F i b)) :
+    Subcube.monochromaticForFamily R F := by
+  classical
+  rcases hmono with ⟨c, hc⟩
+  refine ⟨c, ?_⟩
+  intro f hf x hx
+  -- membership in the restricted family comes from restricting a function of `F`
+  have hf0 : BFunc.restrictCoord f i b ∈ Family.restrict F i b :=
+    (Family.mem_restrict).2 ⟨f, hf, rfl⟩
+  -- the point `x` agrees with the fixed value on the `i`‑th coordinate
+  have hxib : x i = b := hfix x hx
+  -- updating `x` at position `i` does not change it because `x i = b`
+  have hxupdate : BoolFunc.Point.update x i b = x := by
+    funext j; by_cases hji : j = i
+    · subst hji; simp [BoolFunc.Point.update, hxib]
+    · simp [BoolFunc.Point.update, hji]
+  -- the restricted function is constant with colour `c` on `R`
+  have htmp := hc (BFunc.restrictCoord f i b) hf0 x hx
+  have : f x = c := by
+    simpa [BFunc.restrictCoord, hxupdate] using htmp
+  exact this
+
+/--
+A convenience wrapper for `lift_mono_of_restrict` that reuses the fixed-coordinate
+hypothesis.
+-/
+lemma lift_mono_of_restrict_fixOne
+    {n : ℕ} {F : Family n} {i : Fin n} {b : Bool} {R : Subcube n}
+    (hfix : ∀ x, R.Mem x → x i = b)
+    (hmono : Subcube.monochromaticForFamily R (Family.restrict F i b)) :
+    Subcube.monochromaticForFamily R F :=
+  lift_mono_of_restrict (F := F) (i := i) (b := b) (R := R) hfix hmono
+
+end Cover2
+

--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -10,6 +10,7 @@ import Pnp2.Cover.SubcubeAdapters -- subcube conversion utilities
 import Pnp2.Cover.Bounds -- numeric bounds for the cover construction
 import Pnp2.Cover.CoarseBound -- rough estimate on uncovered pairs
 import Pnp2.Cover.Uncovered -- predicates about uncovered points
+import Pnp2.Cover.Lifting -- lemmas lifting monochromaticity through restrictions
 import Pnp2.Cover2.Measure -- termination measure and its basic lemmas
 import Mathlib.Data.Nat.Basic
 import Mathlib.Data.Finset.Basic
@@ -231,45 +232,13 @@ lemma sunflower_step {n : ℕ} (F : Family n) (p t : ℕ)
     exact hdim_eq.symm ▸ hdim'
   exact ⟨R, h_filter_ge, h_dim⟩
 
-/-! ### Lifting monochromaticity from restricted families
 
-If a subcube `R` fixes the `i`-th coordinate to `b`, then a family that is
-monochromatic on the restricted version of `F` is also monochromatic on `F`
-itself.  These helper lemmas mirror their counterparts in `cover.lean` and
-will support the recursion once `buildCover` is fully ported. -/
-
-lemma lift_mono_of_restrict
-    {F : Family n} {i : Fin n} {b : Bool} {R : Subcube n}
-    (hfix : ∀ x, R.Mem x → x i = b)
-    (hmono : Subcube.monochromaticForFamily R (F.restrict i b)) :
-    Subcube.monochromaticForFamily R F := by
-  classical
-  rcases hmono with ⟨c, hc⟩
-  refine ⟨c, ?_⟩
-  intro f hf x hx
-  have hf0 : f.restrictCoord i b ∈ F.restrict i b :=
-    (BoolFunc.Family.mem_restrict).2 ⟨f, hf, rfl⟩
-  have hxib : x i = b := hfix x hx
-  have hxupdate : BoolFunc.update x i b = x := by
-    funext j; by_cases hji : j = i
-    · subst hji; simp [BoolFunc.update, hxib]
-    · simp [BoolFunc.update, hji]
-  have htmp := hc (f.restrictCoord i b) hf0 x hx
-  have : f x = c := by
-    simpa [BFunc.restrictCoord, hxupdate] using htmp
-  exact this
-
-/--
-When a subcube `R` already forces the `i`-th coordinate to be `b`,
-monochromaticity for the restricted family lifts directly to the original
-family.  This variant mirrors `lift_mono_of_restrict` but packages the
-common situation where the fixed-coordinate condition is immediate. -/
-lemma lift_mono_of_restrict_fixOne
-    {F : Family n} {i : Fin n} {b : Bool} {R : Subcube n}
-    (hfix : ∀ x, R.Mem x → x i = b)
-    (hmono : Subcube.monochromaticForFamily R (F.restrict i b)) :
-    Subcube.monochromaticForFamily R F :=
-  lift_mono_of_restrict (F := F) (i := i) (b := b) (R := R) hfix hmono
+/-
+Notes:
+Lemmas about transferring monochromaticity from restricted families to the
+original family have been moved to `Pnp2.Cover.Lifting`.
+The following results continue the development using those utilities.
+-/
 
 /--
 Monochromaticity is preserved when restricting to a subset of rectangles.


### PR DESCRIPTION
### **User description**
## Summary
- move monochromaticity lifting utilities into `Cover/Lifting.lean`
- reference the new lemmas from `cover2.lean`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_688f922cae98832bae34c3a8ce91c87b


___

### **PR Type**
Enhancement


___

### **Description**
- Extract monochromaticity lifting lemmas into dedicated module

- Move utility functions from `cover2.lean` to `Cover/Lifting.lean`

- Add comprehensive documentation for lifting operations

- Reference new module from main cover implementation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cover2.lean"] -- "extract lemmas" --> B["Cover/Lifting.lean"]
  B -- "import" --> A
  C["lift_mono_of_restrict"] --> B
  D["lift_mono_of_restrict_fixOne"] --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Lifting.lean</strong><dd><code>New module for monochromaticity lifting lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Lifting.lean

<ul><li>Create new module for monochromaticity lifting utilities<br> <li> Add <code>lift_mono_of_restrict</code> lemma with detailed proof<br> <li> Add <code>lift_mono_of_restrict_fixOne</code> convenience wrapper<br> <li> Include comprehensive documentation explaining lifting operations</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/780/files#diff-6ba45687ca13ae18af0223488cc22ba741b4da380bc62fbd18054682f56ddecd">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Remove extracted lemmas and import new module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Remove <code>lift_mono_of_restrict</code> and <code>lift_mono_of_restrict_fixOne</code> lemmas<br> <li> Add import for new <code>Pnp2.Cover.Lifting</code> module<br> <li> Replace removed code with explanatory comment</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/780/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+7/-38</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

