### PR TITLE
feat: add converse lemma for buildCover measure

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -569,6 +569,24 @@ lemma buildCover_mu {n h : ℕ} (F : Family n)
     (mu_of_allCovered (n := n) (F := F)
       (Rset := buildCover (n := n) F h hH) (h := h) hcov')
 
+/--
+The converse direction: if the measure of the set of rectangles returned by
+`buildCover` already equals `2 * h`, then no uncovered pairs remain.  Hence the
+resulting rectangles cover all `1`-inputs of the family `F`.
+-/
+lemma buildCover_covers_of_mu_eq {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hμ : mu (n := n) F h (buildCover (n := n) F h hH) = 2 * h) :
+    AllOnesCovered (n := n) F (buildCover (n := n) F h hH) := by
+  -- The lemma `allOnesCovered_of_mu_eq` already provides the desired
+  -- implication for an arbitrary rectangle set.  Instantiating it with the
+  -- result of `buildCover` yields the statement.
+  exact
+    allOnesCovered_of_mu_eq
+      (n := n) (F := F)
+      (Rset := buildCover (n := n) F h hH)
+      (h := h) hμ
+
 /-!
 `mu_union_buildCover_le` is a small helper lemma used in termination
 arguments for `buildCover`.  Adding the rectangles produced by one

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1443,6 +1443,31 @@ example :
       (n := 1) (F := (∅ : BoolFunc.Family 1)) (h := 0)
       (hH := by simp) hcov
 
+/--
+If the measure of the rectangles returned by `buildCover` equals `2 * h`, then
+the rectangles already cover all `1`-inputs.  This is the converse of
+`buildCover_mu`.
+-/
+example :
+    Cover2.AllOnesCovered (n := 1)
+      (F := (∅ : BoolFunc.Family 1))
+      (Cover2.buildCover (n := 1)
+        (F := (∅ : BoolFunc.Family 1)) 0 (by simp)) := by
+  classical
+  -- Reuse `buildCover_mu` to obtain the required measure equality.
+  have hcov : Cover2.AllOnesCovered (n := 1)
+      (F := (∅ : BoolFunc.Family 1)) (∅ : Finset (Subcube 1)) := by
+    intro f hf; cases hf
+  have hμ :=
+    Cover2.buildCover_mu
+      (n := 1) (F := (∅ : BoolFunc.Family 1)) (h := 0)
+      (hH := by simp) hcov
+  -- Apply the converse lemma to deduce coverage.
+  simpa using
+    Cover2.buildCover_covers_of_mu_eq
+      (n := 1) (F := (∅ : BoolFunc.Family 1)) (h := 0)
+      (hH := by simp) hμ
+
 /-- `cover_exists` constructs a cover when the family has no `1`‑inputs. -/
 example :
     ∃ Rset : Finset (Subcube 1),


### PR DESCRIPTION
### **User description**
## Summary
- add lemma proving `buildCover` covers all `1`-inputs if its measure is `2 * h`
- demonstrate converse lemma in Cover2 tests

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_688fc9245098832b996a62097c6494a0


___

### **PR Type**
Enhancement


___

### **Description**
- Add converse lemma `buildCover_covers_of_mu_eq` for buildCover measure

- Prove coverage when measure equals `2 * h`

- Add test demonstrating converse lemma usage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCover function"] --> B["measure = 2 * h"]
  B --> C["AllOnesCovered property"]
  C --> D["Test validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add converse lemma for buildCover coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add new lemma <code>buildCover_covers_of_mu_eq</code> proving converse direction<br> <li> Show that when buildCover measure equals <code>2 * h</code>, all 1-inputs are <br>covered<br> <li> Use existing <code>allOnesCovered_of_mu_eq</code> lemma for implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/784/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for converse lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example demonstrating the converse lemma<br> <li> Show coverage property when measure condition is met<br> <li> Reuse existing <code>buildCover_mu</code> to establish measure equality</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/784/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+25/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

