### PR TITLE
feat: bound sunflower core below petals

### DIFF
--- a/Pnp2/Sunflower/Sunflower.lean
+++ b/Pnp2/Sunflower/Sunflower.lean
@@ -119,6 +119,60 @@ lemma petals_nonempty {S : SunflowerFam n t} (ht : 0 < t) :
   rw [S.tsize]
   exact ht
 
+/--
+When a sunflower family contains two distinct petals, its core is strictly
+smaller than each of those petals.  This basic combinatorial fact is convenient
+when reasoning about dimensions of subcubes extracted from the sunflower.
+-/
+lemma core_card_lt_of_two_petals {S : SunflowerFam n t}
+    {P₁ P₂ : Petal n} (h₁ : P₁ ∈ S.petals) (h₂ : P₂ ∈ S.petals)
+    (hcard : P₂.card = P₁.card) (hne : P₁ ≠ P₂) :
+    S.core.card < P₁.card := by
+  classical
+  -- The core is always contained in any petal.
+  have hsub : S.core ⊆ P₁ := S.sub_core _ h₁
+  -- Hence its cardinality is bounded by that of the petal.
+  have hle : S.core.card ≤ P₁.card := Finset.card_le_card hsub
+  -- Show that equality of cardinalities would force the two petals to coincide.
+  have hneq : S.core.card ≠ P₁.card := by
+    intro hEq
+    -- Convert the inclusion into an equality of sets.
+    have hcore_eq : S.core = P₁ :=
+      Finset.eq_of_subset_of_card_le hsub (by simpa [hEq])
+    -- From the sunflower property we deduce `P₁ ⊆ P₂`.
+    have hsubset : P₁ ⊆ P₂ := by
+      have htmp : P₁ ∩ P₂ = P₁ := by
+        simpa [hcore_eq] using S.pairwise_core P₁ h₁ P₂ h₂ hne
+      have hsubset_inter : P₁ ∩ P₂ ⊆ P₂ := Finset.inter_subset_right
+      simpa [htmp] using hsubset_inter
+    -- Equal cardinalities force the two petals to coincide.
+    have hcardle : P₂.card ≤ P₁.card := by simpa [hcard]
+    have : P₁ = P₂ := Finset.eq_of_subset_of_card_le hsubset hcardle
+    exact hne this
+  exact lt_of_le_of_ne hle hneq
+
+/-
+If a sunflower family contains two distinct petals of equal cardinality,
+then the common core is strictly contained in each of those petals.  This
+reformulation of `core_card_lt_of_two_petals` exposes the set-theoretic
+relationship which is often more convenient to exploit directly.
+-/
+lemma core_ssubset_of_two_petals {S : SunflowerFam n t}
+    {P₁ P₂ : Petal n} (h₁ : P₁ ∈ S.petals) (h₂ : P₂ ∈ S.petals)
+    (hcard : P₂.card = P₁.card) (hne : P₁ ≠ P₂) :
+    S.core ⊂ P₁ := by
+  classical
+  -- The core is contained in any petal by definition.
+  have hsub : S.core ⊆ P₁ := S.sub_core _ h₁
+  -- Cardinality considerations rule out equality of `core` and `P₁`.
+  have hneq : S.core ≠ P₁ := by
+    intro hEq
+    have hlt := core_card_lt_of_two_petals (S := S)
+      (P₁ := P₁) (P₂ := P₂) h₁ h₂ hcard hne
+    simpa [hEq] using hlt
+  -- Together these facts yield the desired strict inclusion.
+  exact (Finset.ssubset_iff_subset_ne).2 ⟨hsub, hneq⟩
+
 end SunflowerFam
 
 end Sunflower

--- a/Pnp2/Sunflower/Sunflower.lean
+++ b/Pnp2/Sunflower/Sunflower.lean
@@ -173,6 +173,24 @@ lemma core_ssubset_of_two_petals {S : SunflowerFam n t}
   -- Together these facts yield the desired strict inclusion.
   exact (Finset.ssubset_iff_subset_ne).2 ⟨hsub, hneq⟩
 
+/--
+A petal strictly larger than the sunflower core must contain a coordinate not
+belonging to the core.  Given two distinct petals of the same cardinality, this
+follows immediately from `core_ssubset_of_two_petals`.
+-/
+lemma exists_coord_not_core_of_two_petals {S : SunflowerFam n t}
+    {P₁ P₂ : Petal n} (h₁ : P₁ ∈ S.petals) (h₂ : P₂ ∈ S.petals)
+    (hcard : P₂.card = P₁.card) (hne : P₁ ≠ P₂) :
+    ∃ i ∈ P₁, i ∉ S.core := by
+  classical
+  -- The core is strictly contained in `P₁` by the preceding lemma.
+  have hssub : S.core ⊂ P₁ :=
+    core_ssubset_of_two_petals (S := S)
+      (P₁ := P₁) (P₂ := P₂) h₁ h₂ hcard hne
+  -- Cardinality comparison provides a witness outside the core.
+  rcases Finset.exists_of_ssubset hssub with ⟨i, hiP₁, hiNot⟩
+  exact ⟨i, hiP₁, hiNot⟩
+
 end SunflowerFam
 
 end Sunflower

--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -674,7 +674,7 @@ general lower bound on `μ` suffices.  The statement matches the legacy API
 for downstream compatibility.
 -/
 lemma buildCover_measure_drop {F : Family n} {h : ℕ}
-    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     2 * h ≤ mu (n := n) F h (∅ : Finset (Subcube n)) := by
   -- The measure `μ` always dominates `2 * h`, even for the empty rectangle set.
   simpa using


### PR DESCRIPTION
### **User description**
## Summary
- prove strict-inclusion lemma `core_ssubset_of_two_petals` for sunflower families
- generalize `eval_agree_on_core` and use new lemma to simplify the dimension argument in `sunflower_step`

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_689092144838832b9d4f10f3afe50388


___

### **PR Type**
Enhancement


___

### **Description**
- Add strict inclusion lemmas for sunflower core below petals

- Generalize `eval_agree_on_core` to work with core subsets

- Simplify dimension argument in `sunflower_step` using new lemmas


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["New core lemmas"] --> B["Generalized eval_agree_on_core"]
  B --> C["Simplified sunflower_step"]
  A --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sunflower.lean</strong><dd><code>Add strict inclusion lemmas for sunflower core</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Sunflower/Sunflower.lean

<ul><li>Add <code>core_card_lt_of_two_petals</code> lemma proving core cardinality is <br>strictly less than petal cardinality<br> <li> Add <code>core_ssubset_of_two_petals</code> lemma proving strict subset <br>relationship between core and petals<br> <li> Both lemmas handle case when sunflower has two distinct petals of <br>equal cardinality</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/789/files#diff-50ab50bf1e1750ed334aa084232c0dd854cab00f5f397a6eeb2c651f34e2874b">+54/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Generalize core evaluation and simplify dimension reasoning</code></dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Generalize <code>eval_agree_on_core</code> to accept any function with support <br>subset of core<br> <li> Remove dependency on specific petal membership in the lemma signature<br> <li> Simplify <code>sunflower_step</code> dimension argument using new <br><code>core_ssubset_of_two_petals</code> lemma<br> <li> Replace manual cardinality reasoning with direct strict subset <br>application</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/789/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+26/-36</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

