### PR TITLE
Add explicit 2-sunflower lemma and integrate into sunflower utilities

### DIFF
--- a/Pnp2/Cover/Uncovered.lean
+++ b/Pnp2/Cover/Uncovered.lean
@@ -111,6 +111,17 @@ noncomputable def firstUncovered {n : ℕ} (F : Family n)
       intro p hp; exact h ⟨p, hp⟩
     simp [Set.nonempty_iff_ne_empty]
 
+/-- If `firstUncovered` returns `some p`, then `p` indeed belongs to the uncovered set. -/
+lemma mem_uncovered_of_firstUncovered_some {n : ℕ} {F : Family n} {R : Finset (Subcube n)}
+    {p : Σ _ : BFunc n, Point n}
+    (hp : firstUncovered (n := n) F R = some p) :
+    p ∈ uncovered (n := n) F R := by
+  classical
+  unfold firstUncovered at hp
+  split_ifs at hp with h
+  · cases hp
+    exact Classical.choose_spec h
+
 /-- Every `1`-input of every `f ∈ F` lies inside some rectangle of `Rset`. -/
 @[simp] def AllOnesCovered {n : ℕ} (F : Family n)
     (Rset : Finset (Subcube n)) : Prop :=

--- a/Pnp2/sunflower.lean
+++ b/Pnp2/sunflower.lean
@@ -7,4 +7,4 @@ This module simply re-exports `Pnp2.Sunflower.Sunflower` under the shorter
 path `Pnp2.sunflower`.
 -/
 
-export Sunflower (IsSunflower HasSunflower sunflower_exists)
+export Sunflower (IsSunflower HasSunflower sunflower_exists sunflower_exists_two)

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -264,6 +264,13 @@ example :
       (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
       (R := (∅ : Finset (Subcube 1))))
 
+/-- If `firstUncovered` yields a witness, that witness lies in the uncovered set. -/
+example (F : BoolFunc.Family 1) (R : Finset (Subcube 1))
+    {p : Sigma (fun _ => Point 1)}
+    (hp : Cover2.firstUncovered (n := 1) F R = some p) :
+    p ∈ Cover2.uncovered (n := 1) F R :=
+  Cover2.mem_uncovered_of_firstUncovered_some (n := 1) (F := F) (R := R) hp
+
 /-- If `firstUncovered` returns `none`, all `1`‑inputs are covered. -/
 example :
     Cover2.AllOnesCovered (n := 1)

--- a/test/SunflowerTest.lean
+++ b/test/SunflowerTest.lean
@@ -30,4 +30,22 @@ example :
       (n := 2) (w := 1) (t := 2) (F := F)
       hw ht hcard hbig
 
+/-- The specialised `sunflower_exists_two` also witnesses a sunflower
+    in this basic family. -/
+example :
+    let F : Finset (Petal 2) := { {0}, {1} }
+    HasSunflower F 1 2 := by
+  classical
+  intro F
+  have hw : 0 < (1 : ℕ) := by decide
+  have hlarge : 1 < F.card := by simp [F]
+  have hcard : ∀ S ∈ F, S.card = 1 := by
+    intro S hS
+    have hS' := by simpa [F] using hS
+    rcases hS' with h0 | h1
+    · simp [h0]
+    · simp [h1]
+  simpa [F] using
+    sunflower_exists_two (𝓢 := F) (w := 1) hw hlarge hcard
+
 end SunflowerTest


### PR DESCRIPTION
### **User description**
## Summary
- Proved a concrete `sunflower_exists_two` lemma showing any two distinct sets form a 2‑sunflower.
- Updated `SunflowerFam.exists_of_large_family` to avoid relying on the axiom when `t = 2`, and re-exported the new lemma.
- Added tests demonstrating both the general and specialised sunflower lemmas.

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68912abe9ecc832b8fa5220916d5291e


___

### **PR Type**
Enhancement


___

### **Description**
- Add explicit `sunflower_exists_two` lemma for 2-sunflower case

- Optimize `exists_of_large_family` to avoid axiom when `t = 2`

- Export new lemma and add comprehensive tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["sunflower_exists_two lemma"] --> B["exists_of_large_family optimization"]
  B --> C["Export in sunflower.lean"]
  A --> D["Test cases"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sunflower.lean</strong><dd><code>Add 2-sunflower lemma and optimize main function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Sunflower/Sunflower.lean

<ul><li>Add <code>Mathlib.Data.Finset.Card</code> import<br> <li> Implement <code>sunflower_exists_two</code> lemma with direct proof<br> <li> Optimize <code>exists_of_large_family</code> to use new lemma when <code>t = 2</code><br> <li> Add case analysis to avoid axiom dependency for 2-sunflower case</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/791/files#diff-50ab50bf1e1750ed334aa084232c0dd854cab00f5f397a6eeb2c651f34e2874b">+72/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sunflower.lean</strong><dd><code>Export new 2-sunflower lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/sunflower.lean

- Export `sunflower_exists_two` alongside existing exports


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/791/files#diff-26951b13f0f811f37dfb1a6706328588815ec16bf31b0240c2d1e0c2e9108435">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SunflowerTest.lean</strong><dd><code>Add tests for 2-sunflower lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/SunflowerTest.lean

<ul><li>Add test case demonstrating <code>sunflower_exists_two</code> usage<br> <li> Test with basic 2-element family <code>{ {0}, {1} }</code><br> <li> Verify sunflower property with cardinality constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/791/files#diff-ab9d2a6e2e8f5bb3d069f4f26965b7989cbd440ce2e1191f140103c32cc202b1">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

