### PR TITLE
Add lemmas for fully frozen subcubes and measure drop

### DIFF
--- a/Pnp2/Agreement.lean
+++ b/Pnp2/Agreement.lean
@@ -66,6 +66,20 @@ def Subcube.fromPoint (x : Point n) (I : Finset (Fin n)) : Subcube n where
     (Subcube.fromPoint x I).dimension = n - I.card := by
   rfl
 
+@[simp] lemma mem_fromPoint_univ
+    {x y : Point n} :
+    (y ∈ₛ Subcube.fromPoint x (Finset.univ : Finset (Fin n))) ↔ y = x := by
+  classical
+  constructor
+  · intro h
+    funext i
+    have hi : i ∈ (Finset.univ : Finset (Fin n)) := by simp
+    exact h i hi
+  · intro h
+    subst h
+    intro i hi
+    rfl
+
 /-! ### Core‑agreement lemma with CoreClosed assumption -/
 
 /-

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1252,6 +1252,17 @@ example (F : BoolFunc.Family 1)
         ≤ Cover2.mu (n := 1) F 0 (∅ : Finset (Subcube 1)) :=
   Cover2.mu_buildCover_lt_start (n := 1) (F := F) (h := 0) hH hfu
 
+/--
+A single `extendCover` step reduces the measure whenever an uncovered pair
+exists.
+-/
+example (F : BoolFunc.Family 1)
+    (hfu : Cover2.firstUncovered (n := 1) F (∅ : Finset (Subcube 1)) ≠ none) :
+    Cover2.mu (n := 1) F 0
+        (Cover2.extendCover (n := 1) F (∅ : Finset (Subcube 1))) + 1
+        ≤ Cover2.mu (n := 1) F 0 (∅ : Finset (Subcube 1)) :=
+  Cover2.mu_extendCover_succ_le (n := 1) (F := F) (Rset := ∅) (h := 0) hfu
+
 /-- `buildCover_measure_drop` bounds the initial measure by `2 * h`. -/
 example :
     2 * (0 : ℕ) ≤


### PR DESCRIPTION
### **User description**
## Summary
- characterize membership in a subcube that fixes all coordinates
- show inserting the point subcube from a `firstUncovered` witness drops the measure by at least one
- add `extendCover` to insert the witness subcube and quantify the resulting measure drop

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68916e1bbea0832ba512f39b987c9480


___

### **PR Type**
Enhancement


___

### **Description**
- Add lemmas for fully frozen subcubes and measure drop

- Introduce `extendCover` function for single covering steps

- Add specialized lemmas for `firstUncovered` witness handling

- Include test examples for new functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["firstUncovered witness"] --> B["extendCover function"]
  B --> C["point subcube insertion"]
  C --> D["measure drop by ≥1"]
  E["fromPoint lemmas"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Agreement.lean</strong><dd><code>Add lemma for fully frozen subcube membership</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Agreement.lean

<ul><li>Add <code>mem_fromPoint_univ</code> lemma for point subcube membership<br> <li> Characterize when a point belongs to a fully frozen subcube</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/794/files#diff-338cb59cc9eb2b11b3befaefe3a90cfc6bccf322442d858018e5383a292bef50">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Measure.lean</strong><dd><code>Add extendCover function and measure drop lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover2/Measure.lean

<ul><li>Add <code>mu_union_firstUncovered_singleton_lt</code> for strict measure decrease<br> <li> Add <code>mu_union_firstUncovered_singleton_succ_le</code> for quantified measure <br>drop<br> <li> Introduce <code>extendCover</code> function for single covering steps<br> <li> Add <code>mu_extendCover_succ_le</code> lemma for measure drop guarantee</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/794/files#diff-5f7716b070c171b41b055ce7045d34e58fc1aac17dcd2ea1cc8e78645fd5ed66">+108/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for extendCover functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add test example for <code>extendCover</code> measure reduction<br> <li> Demonstrate single step covering with measure drop</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/794/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

