### PR TITLE
Expose canonical cover as list enumerator

### DIFF
--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -2,9 +2,12 @@ import Pnp2.Boolcube
 import Pnp2.BoolFunc
 import Pnp2.entropy
 import Pnp2.Cover.Bounds
+import Pnp2.Cover.Canonical
 
--- The full cover construction is not yet available in this trimmed-down
--- environment, so we avoid importing `Pnp2.cover` here.
+-- The full cover construction lives in `cover2.lean`.  For the
+-- computational wrapper we only need access to the *resulting* cover
+-- packaged by `Cover2.coverFamily`, so we avoid importing the heavy
+-- machinery directly and instead delegate to this canonical wrapper.
 /-!
 This lightweight module provides a purely constructive wrapper around the
 heavy `cover` development.  To keep the test suite compiling we include only
@@ -24,43 +27,77 @@ namespace Cover
 -- Re-export the numeric bounds from `Cover2` for convenience.
 export Cover2 (mBound mBound_pos mBound_zero two_le_mBound mBound_mono_left)
 
-open BoolFunc
+-- We pull in the basic Boolean-cube objects and Boolean-function families.
+open BoolFunc (Family BFunc)
+open Boolcube (Point Subcube)
+open Boolcube.Subcube
 
 variable {n : ℕ}
+
 /--
-`buildCoverCompute` is a constructive cover enumerator used by the SAT procedure.
-It enumerates the rectangles produced by `Cover.coverFamily`, turning the finite set into an explicit list.
+`buildCoverCompute` enumerates the rectangles of the canonical cover.
+
+It simply turns the finite set `Cover2.coverFamily F h hH` into a list.
+This is a thin wrapper whose purpose is to expose a fully constructive
+interface: downstream algorithms can iterate over the list without
+opening the underlying `Finset`.
 -/
-def buildCoverCompute (F : Family n) (h : ℕ)
-    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=
-  []
+noncomputable def buildCoverCompute (F : Family n) (h : ℕ)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) : List (Subcube n) :=
+  (Cover2.coverFamily (n := n) (F := F) (h := h) hH).toList
+
 @[simp] lemma buildCoverCompute_empty (h : ℕ)
     (hH : BoolFunc.H₂ (∅ : Family n) ≤ (h : ℝ)) :
-    buildCoverCompute (F := (∅ : Family n)) (h := h) hH = [] :=
-  rfl
+    buildCoverCompute (F := (∅ : Family n)) (h := h) hH = [] := by
+  classical
+  -- `coverFamily` reduces to the underlying `buildCover`, which returns the
+  -- supplied rectangle set `Rset`.  With the default `Rset = ∅` we obtain an
+  -- empty list.
+  have hcov : Cover2.coverFamily (n := n) (F := (∅ : Family n))
+      (h := h) hH = (∅ : Finset (Subcube n)) := by
+    simpa [Cover2.coverFamily] using
+      (Cover2.buildCover_eq_Rset (n := n) (F := (∅ : Family n))
+        (h := h) hH (Rset := (∅ : Finset (Subcube n))))
+  simpa [buildCoverCompute, hcov]
 
-/-- The length of `buildCoverCompute` is always zero since the current
-implementation merely returns the empty list.  This lemma keeps the
-interface stable while the constructive cover enumeration is unfinished. -/
+/-- The length of the enumeration coincides with the cardinality of the
+underlying canonical cover. -/
 @[simp] lemma buildCoverCompute_length (F : Family n) (h : ℕ)
     (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
-    (buildCoverCompute (F := F) (h := h) hH).length = 0 := by
-  simp [buildCoverCompute]
+    (buildCoverCompute (F := F) (h := h) hH).length =
+      (Cover2.coverFamily (n := n) (F := F) (h := h) hH).card := by
+  classical
+  -- `Finset.length_toList` converts the equality between list length and
+  -- set cardinality.
+  simpa [buildCoverCompute] using
+    (Finset.length_toList (Cover2.coverFamily (n := n) (F := F) (h := h) hH))
 /--
 Basic specification for `buildCoverCompute`. It simply expands `Cover.coverFamily` into a list,
 so the rectangles remain monochromatic and the length bound follows from `coverFamily_card_bound`.
 -/
 lemma buildCoverCompute_spec (F : Family n) (h : ℕ)
-    (_hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
-    (∀ R ∈ (buildCoverCompute (F := F) (h := h) _hH).toFinset,
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (∀ R ∈ (buildCoverCompute (F := F) (h := h) hH).toFinset,
         Subcube.monochromaticForFamily R F) ∧
-    (buildCoverCompute (F := F) (h := h) _hH).length ≤ mBound n h := by
-    classical
-    refine And.intro ?left ?right
-    · intro R hR; cases hR
-    ·
-      -- The stub implementation always returns an empty list, so the goal
-      -- simplifies to `0 ≤ mBound n h`, which holds by `Nat.zero_le`.
-      simp [buildCoverCompute]
+    (buildCoverCompute (F := F) (h := h) hH).length ≤ mBound n h := by
+  classical
+  -- The list is obtained from `coverFamily`, hence its `toFinset` is the
+  -- same set and all properties transfer from the canonical cover.
+  refine And.intro ?mono ?bound
+  · intro R hR
+    -- Unfold `buildCoverCompute` and reduce membership to the canonical
+    -- cover set, then apply `coverFamily_mono`.
+    have hmem' : R ∈
+        ((Cover2.coverFamily (n := n) (F := F) (h := h) hH).toList).toFinset := by
+      simpa [buildCoverCompute] using hR
+    have hmem : R ∈ Cover2.coverFamily (n := n) (F := F) (h := h) hH := by
+      simpa [Finset.toList_toFinset] using hmem'
+    exact Cover2.coverFamily_mono (n := n) (F := F) (h := h) hH R hmem
+  ·
+    -- The length bound follows from the corresponding cardinality bound.
+    have hcard := Cover2.coverFamily_card_bound
+      (n := n) (F := F) (h := h) hH
+    -- Replace the list length by the set cardinality via the previous lemma.
+    simpa [buildCoverCompute, buildCoverCompute_length] using hcard
 
 end Cover


### PR DESCRIPTION
### **User description**
## Summary
- implement `buildCoverCompute` by enumerating rectangles from canonical `coverFamily`
- prove lemmas about empty family, length, and specification with monotonicity and bounds

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68923be20bac832b9308dc9fcf426824


___

### **PR Type**
Enhancement


___

### **Description**
- Implement `buildCoverCompute` using canonical cover enumeration

- Replace stub implementation with actual cover computation

- Add proper proofs for empty family, length, and specification lemmas

- Update documentation to reflect computational wrapper approach


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cover2.coverFamily"] --> B["buildCoverCompute"]
  B --> C["List (Subcube n)"]
  D["Finset.toList"] --> C
  E["Specification Lemmas"] --> F["Monochromatic Property"]
  E --> G["Length Bounds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Implement cover enumeration with canonical cover</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Replace stub <code>buildCoverCompute</code> with actual implementation using <br><code>Cover2.coverFamily</code><br> <li> Add <code>noncomputable</code> qualifier and proper function body<br> <li> Implement complete proofs for <code>buildCoverCompute_empty</code>, <br><code>buildCoverCompute_length</code>, and <code>buildCoverCompute_spec</code><br> <li> Update imports to include <code>Pnp2.Cover.Canonical</code><br> <li> Enhance documentation explaining computational wrapper approach</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/796/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+62/-25</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

