### PR TITLE
feat: expose nodup property of buildCoverCompute

### DIFF
--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -5,6 +5,9 @@ import Pnp2.Cover.Bounds
 import Pnp2.Cover.SubcubeAdapters
 import Pnp2.cover2
 
+-- Silence linter suggestions about using `simp` instead of `simpa` in this file.
+set_option linter.unnecessarySimpa false
+
 /-!
 This module provides a **lightweight executable wrapper** around the
 non‑computable cover construction in `cover2.lean`.
@@ -80,30 +83,50 @@ cardinality of the underlying set returned by `Cover2.buildCover`.
     (Finset.length_toList (Cover2.buildCover (n := n) F h hH))
 
 /--
+The list produced by `buildCoverCompute` contains each rectangle at most once.
+This is a direct consequence of enumerating a `Finset` via `toList`.
+-/
+@[simp] lemma buildCoverCompute_nodup (F : Family n) (h : ℕ)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (buildCoverCompute (F := F) (h := h) hH).Nodup := by
+  classical
+  -- `Finset.toList` yields a list without duplicates.
+  simpa [buildCoverCompute] using
+    (Finset.nodup_toList (Cover2.buildCover (n := n) F h hH))
+
+/--
 Basic specification for the stub `buildCoverCompute`: all listed rectangles are
 monochromatic for the family (vacuously, since the list is empty) and the
 enumeration length satisfies the global bound `mBound`.
 -/
 lemma buildCoverCompute_spec (F : Family n) (h : ℕ)
     (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (buildCoverCompute (F := F) (h := h) hH).Nodup ∧
     (∀ R ∈ (buildCoverCompute (F := F) (h := h) hH).toFinset,
         Subcube.monochromaticForFamily R F) ∧
     (buildCoverCompute (F := F) (h := h) hH).length ≤ mBound n h := by
-  refine And.intro ?mono ?bound
-  · intro R hR
-    -- Translate membership in the enumerated list back to the underlying set
-    -- of rectangles and reuse `buildCover_mono`.
-    have hR' : R ∈ Cover2.buildCover (n := n) F h hH := by
-      -- The conversion from list to set preserves membership.
-      simpa [buildCoverCompute] using hR
-    exact Cover2.buildCover_mono (n := n) (F := F) (h := h) hH R hR'
+  refine And.intro ?nodup ?mono_bound
   ·
-    -- The length of the list equals the cardinality of the set, which is
-    -- bounded by `mBound` via `buildCover_card_bound`.
-    have hcard := Cover2.buildCover_card_bound
-      (n := n) (F := F) (h := h) hH
-    -- Rewrite the goal using the length/cardinality equality.
-    simpa [buildCoverCompute_length] using hcard
+    -- `buildCoverCompute` enumerates a `Finset`, hence no duplicates occur.
+    simpa using
+      (buildCoverCompute_nodup (F := F) (h := h) hH)
+  ·
+    -- Split the remaining obligations: monochromaticity and cardinality bound.
+    refine And.intro ?mono ?bound
+    · intro R hR
+      -- Translate membership in the enumerated list back to the underlying set
+      -- of rectangles and reuse `buildCover_mono`.
+      have hR' : R ∈ Cover2.buildCover (n := n) F h hH := by
+        -- The conversion from list to set preserves membership.
+        simpa [buildCoverCompute] using hR
+      exact Cover2.buildCover_mono (n := n) (F := F) (h := h) hH R hR'
+    ·
+      -- The length of the list equals the cardinality of the set, which is
+      -- bounded by `mBound` via `buildCover_card_bound`.
+      have hcard := Cover2.buildCover_card_bound
+        (n := n) (F := F) (h := h) hH
+      -- Rewrite the goal using the length/cardinality equality.
+      simpa [buildCoverCompute_length] using hcard
 
 end Cover
 

--- a/test/CoverComputeTest.lean
+++ b/test/CoverComputeTest.lean
@@ -36,6 +36,27 @@ by
           have _hH₂ := BoolFunc.H₂_card_one
               (F := ({trivialFun} : Boolcube.Family 1)) hcard
           simp)
-  exact hspec.2
+  exact hspec.2.2
+
+/-- The list returned by `buildCoverCompute` has no duplicates. -/
+example :
+    (buildCoverCompute (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
+      (by
+        classical
+        -- Collision entropy of a singleton family is zero.
+        have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
+        have _hH₂ := BoolFunc.H₂_card_one
+            (F := ({trivialFun} : Boolcube.Family 1)) hcard
+        simp)).Nodup :=
+by
+  classical
+  have hspec := buildCoverCompute_spec
+        (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
+        (by
+          have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
+          have _hH₂ := BoolFunc.H₂_card_one
+              (F := ({trivialFun} : Boolcube.Family 1)) hcard
+          simp)
+  exact hspec.1
 
 end CoverComputeTest


### PR DESCRIPTION
## Summary
- extend Cover.buildCoverCompute with a lemma showing the enumerated rectangles are duplicate-free
- strengthen the specification to include a nodup guarantee
- add tests for the new nodup property

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_689254917c7c832bb0056e33c15a650a