### PR TITLE
feat: expose cover set as finset and list

### DIFF
--- a/Pnp2/Cover/Compute.lean
+++ b/Pnp2/Cover/Compute.lean
@@ -95,6 +95,20 @@ This is a direct consequence of enumerating a `Finset` via `toList`.
     (Finset.nodup_toList (Cover2.buildCover (n := n) F h hH))
 
 /--
+The `Finset` of rectangles enumerated by `buildCoverCompute` agrees with
+`Cover2.buildCover`.  This convenience lemma allows translating membership
+statements between the list and the underlying set without manual rewrites.
+-/
+@[simp] lemma buildCoverCompute_toFinset (F : Family n) (h : ℕ)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
+    (buildCoverCompute (F := F) (h := h) hH).toFinset =
+      Cover2.buildCover (n := n) F h hH := by
+  classical
+  -- `Finset.toList` followed by `List.toFinset` yields the original set.
+  ext R
+  simp [buildCoverCompute]
+
+/--
 Basic specification for the stub `buildCoverCompute`: all listed rectangles are
 monochromatic for the family (vacuously, since the list is empty) and the
 enumeration length satisfies the global bound `mBound`.
@@ -117,8 +131,9 @@ lemma buildCoverCompute_spec (F : Family n) (h : ℕ)
       -- Translate membership in the enumerated list back to the underlying set
       -- of rectangles and reuse `buildCover_mono`.
       have hR' : R ∈ Cover2.buildCover (n := n) F h hH := by
-        -- The conversion from list to set preserves membership.
-        simpa [buildCoverCompute] using hR
+        -- The conversion from list to set is handled by
+        -- `buildCoverCompute_toFinset`.
+        simpa [buildCoverCompute_toFinset] using hR
       exact Cover2.buildCover_mono (n := n) (F := F) (h := h) hH R hR'
     ·
       -- The length of the list equals the cardinality of the set, which is

--- a/test/CoverComputeTest.lean
+++ b/test/CoverComputeTest.lean
@@ -4,6 +4,12 @@ open Cover
 open BoolFunc
 open Boolcube
 
+-- Silence stylistic linter warnings in this test file.
+set_option linter.unnecessarySimpa false
+set_option linter.unusedVariables false
+set_option linter.unusedTactic false
+set_option linter.unreachableTactic false
+
 namespace CoverComputeTest
 
 /-- `mBound` expands to the expected arithmetic expression. -/
@@ -58,5 +64,32 @@ by
               (F := ({trivialFun} : Boolcube.Family 1)) hcard
           simp)
   exact hspec.1
+
+open Cover2
+
+/-- `buildCoverCompute` enumerates the same rectangles as `Cover2.buildCover`. -/
+example :
+    (buildCoverCompute (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
+      (by
+        have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
+        simpa [hcard] using
+          (BoolFunc.H₂_card_one
+            (F := ({trivialFun} : Boolcube.Family 1)) hcard))).toFinset =
+      Cover2.buildCover (n := 1) ({trivialFun} : Boolcube.Family 1) 0
+        (by
+          have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
+          simpa [hcard] using
+            (BoolFunc.H₂_card_one
+              (F := ({trivialFun} : Boolcube.Family 1)) hcard)) :=
+by
+  classical
+  simpa using
+    (buildCoverCompute_toFinset
+      (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
+      (by
+        have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
+        simpa [hcard] using
+          (BoolFunc.H₂_card_one
+            (F := ({trivialFun} : Boolcube.Family 1)) hcard)))
 
 end CoverComputeTest


### PR DESCRIPTION
### **User description**
## Summary
- add lemma showing `buildCoverCompute`'s list matches `Cover2.buildCover`
- cover lemma with regression test and tidy test file options

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_689269880914832b9d6e2e0e5031ac98


___

### **PR Type**
Enhancement


___

### **Description**
- Add lemma connecting `buildCoverCompute` list to `Cover2.buildCover` finset

- Improve proof clarity by using new lemma instead of manual rewrites

- Add regression test for list-to-finset conversion

- Configure test file linter options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCoverCompute"] -- "toFinset" --> B["Cover2.buildCover"]
  B -- "new lemma" --> C["buildCoverCompute_toFinset"]
  C -- "simplifies proofs" --> D["buildCoverCompute_spec"]
  C -- "tested by" --> E["regression test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Add finset conversion lemma and improve proofs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Add <code>buildCoverCompute_toFinset</code> lemma proving list-to-finset conversion <br>matches <code>Cover2.buildCover</code><br> <li> Simplify proof in <code>buildCoverCompute_spec</code> using new lemma<br> <li> Replace manual membership conversion with cleaner approach</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/801/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+17/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CoverComputeTest.lean</strong><dd><code>Add regression test and configure linter options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/CoverComputeTest.lean

<ul><li>Add linter option configurations to silence stylistic warnings<br> <li> Add regression test verifying <code>buildCoverCompute</code> list converts to <br>correct finset<br> <li> Import <code>Cover2</code> namespace for test</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/801/files#diff-6c5dde12451bd7a341032bb83f2ba7c9397fe572190d7748ce3d3ccf2e04735a">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

