### PR TITLE
Add length bound for buildCoverSearch

### DIFF
--- a/test/CoverComputeTest.lean
+++ b/test/CoverComputeTest.lean
@@ -20,8 +20,19 @@ example : mBound 1 0 = 2 := by
 example : 0 < mBound 1 0 := by
   simp [mBound]
 
+/-- `buildCoverSearch` produces at most as many rectangles as its fuel. -/
 /-/  `buildCoverCompute` enumerates a small cover for a trivial function. -/
 def trivialFun : BoolFun 1 := fun _ => false
+
+/-- `buildCoverSearch` produces at most as many rectangles as its fuel. -/
+example :
+    (buildCoverSearch (F := ({trivialFun} : Boolcube.Family 1))).length ≤
+      ({trivialFun} : Boolcube.Family 1).card *
+        Fintype.card (Boolcube.Point 1) := by
+  classical
+  simpa using
+    (buildCoverSearch_length_le
+      (n := 1) (F := ({trivialFun} : Boolcube.Family 1)))
 
 example :
     (buildCoverCompute (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)


### PR DESCRIPTION
## Summary
- factor out recursive worker for the search-based cover enumerator
- prove `buildCoverSearch_length_le` bounding the number of rectangles produced by the search
- exercise the new lemma in `CoverComputeTest` to check the bound for a trivial family

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_689282bef28c832bafe6ad0a86148750