### PR TITLE
Enumerate classical cover as list

### DIFF
--- a/test/CoverComputeTest.lean
+++ b/test/CoverComputeTest.lean
@@ -35,6 +35,7 @@ example :
       ).length ≤ mBound 1 0 :=
 by
   classical
+  -- Obtain the specification for `buildCoverCompute`.
   have hspec := buildCoverCompute_spec
         (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
         (by
@@ -42,21 +43,8 @@ by
           have _hH₂ := BoolFunc.H₂_card_one
               (F := ({trivialFun} : Boolcube.Family 1)) hcard
           simp)
-  -- Bound the length by the number of cube points and relate this to `mBound`.
-  have hlen := hspec.2
-  have hpow : Fintype.card (Boolcube.Point 1) = 2 := by simp
-  have hlen' :
-      (buildCoverCompute (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
-        (by
-          have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
-          have _hH₂ := BoolFunc.H₂_card_one
-              (F := ({trivialFun} : Boolcube.Family 1)) hcard
-          simp)).length ≤ 2 := by
-    simpa [hpow] using hlen
-  have hbound : (2 : ℕ) ≤ mBound 1 0 := by
-    have hn : 0 < (1 : ℕ) := by decide
-    simpa using two_le_mBound (n := 1) (h := 0) hn
-  exact Nat.le_trans hlen' hbound
+  -- The length bound is part of the specification.
+  simpa using hspec.2.2
 
 /-- The list returned by `buildCoverCompute` has no duplicates. -/
 example :


### PR DESCRIPTION
## Summary
- add `buildCoverCompute` wrapper that turns `Cover2.buildCover` into an executable list
- prove that the produced list is nodup, monochromatic and bounded by `mBound`
- adapt tests to the new `buildCoverCompute` specification

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_689289876b98832bbebb27b492b6a08e