### PR TITLE
feat: strengthen buildCoverCompute spec

### DIFF
--- a/test/CoverComputeTest.lean
+++ b/test/CoverComputeTest.lean
@@ -43,7 +43,7 @@ by
               (F := ({trivialFun} : Boolcube.Family 1)) hcard
           simp)
   -- Bound the length by the number of cube points and relate this to `mBound`.
-  have hlen := hspec.2
+  have hlen := hspec.2.2
   have hpow : Fintype.card (Boolcube.Point 1) = 2 := by simp
   have hlen' :
       (buildCoverCompute (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)


### PR DESCRIPTION
### **User description**
## Summary
- Extend `buildCoverCompute_spec` to assert every returned rectangle is a point subcube
- Prove auxiliary lemma ensuring the cover loop only inserts point cubes
- Adjust tests to new specification structure

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_689289876b98832bbebb27b492b6a08e


___

### **PR Type**
Enhancement


___

### **Description**
- Strengthen `buildCoverCompute_spec` to assert point subcube property

- Add auxiliary lemma proving cover loop only inserts point cubes

- Update test to handle new specification structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCoverCompute_spec"] --> B["Add point subcube assertion"]
  B --> C["Auxiliary lemma hpoint_aux"]
  C --> D["Updated test structure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Strengthen specification with point subcube property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Add assertion that every returned rectangle is a point subcube<br> <li> Implement auxiliary lemma <code>hpoint_aux</code> proving loop only inserts point <br>cubes<br> <li> Restructure proof to handle new conjunctive specification<br> <li> Update proof structure from <code>And.intro ?nodup ?length</code> to <code>And.intro </code><br><code>?nodup ?rest</code></ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/811/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+48/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CoverComputeTest.lean</strong><dd><code>Update test for new specification structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/CoverComputeTest.lean

<ul><li>Update test to access length property via <code>hspec.2.2</code> instead of <code>hspec.2</code><br> <li> Adapt to new specification structure with additional conjunct</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/811/files#diff-6c5dde12451bd7a341032bb83f2ba7c9397fe572190d7748ce3d3ccf2e04735a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

