### PR TITLE
feat: enumerate buildCover rectangles

### DIFF
--- a/test/CoverComputeTest.lean
+++ b/test/CoverComputeTest.lean
@@ -23,40 +23,26 @@ example : 0 < mBound 1 0 := by
 /-/  `buildCoverCompute` enumerates a small cover for a trivial function. -/
 def trivialFun : BoolFun 1 := fun _ => false
 
-example :
-    (buildCoverCompute (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
-      (by
-        classical
-        -- Collision entropy of a singleton family is zero.
-        have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
-        have _hH₂ := BoolFunc.H₂_card_one
-            (F := ({trivialFun} : Boolcube.Family 1)) hcard
-        simp)
-      ).length ≤ mBound 1 0 :=
-by
-  classical
-  have hspec := buildCoverCompute_spec
-        (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
-        (by
-          have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
-          have _hH₂ := BoolFunc.H₂_card_one
-              (F := ({trivialFun} : Boolcube.Family 1)) hcard
-          simp)
-  -- Bound the length by the number of cube points and relate this to `mBound`.
-  have hlen := hspec.2.2
-  have hpow : Fintype.card (Boolcube.Point 1) = 2 := by simp
-  have hlen' :
+  example :
       (buildCoverCompute (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
         (by
+          classical
+          -- Collision entropy of a singleton family is zero.
           have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
           have _hH₂ := BoolFunc.H₂_card_one
               (F := ({trivialFun} : Boolcube.Family 1)) hcard
-          simp)).length ≤ 2 := by
-    simpa [hpow] using hlen
-  have hbound : (2 : ℕ) ≤ mBound 1 0 := by
-    have hn : 0 < (1 : ℕ) := by decide
-    simpa using two_le_mBound (n := 1) (h := 0) hn
-  exact Nat.le_trans hlen' hbound
+          simp)).length ≤ mBound 1 0 :=
+  by
+    classical
+    have hspec := buildCoverCompute_spec
+          (F := ({trivialFun} : Boolcube.Family 1)) (h := 0)
+          (by
+            have hcard : ({trivialFun} : Boolcube.Family 1).card = 1 := by simp
+            have _hH₂ := BoolFunc.H₂_card_one
+                (F := ({trivialFun} : Boolcube.Family 1)) hcard
+            simp)
+    -- The specification already yields the desired bound.
+    exact hspec.2.2
 
 /-- The list returned by `buildCoverCompute` has no duplicates. -/
 example :


### PR DESCRIPTION
### **User description**
## Summary
- expose an executable `buildCoverCompute` by listing rectangles from `Cover2.buildCover`
- provide specification lemma bounding the list via `mBound`
- simplify cover computation tests to rely on the new specification

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68929284bf08832b8101c47b21a6fddb


___

### **PR Type**
Enhancement


___

### **Description**
- Replace naive search algorithm with direct enumeration of `Cover2.buildCover`

- Simplify specification to use `mBound` instead of point count

- Remove complex recursive search implementation

- Streamline test cases to use new specification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCoverSearch"] --> B["buildCoverCompute"]
  C["searchLoop"] --> B
  D["insertFirstUncovered"] --> B
  B --> E["Cover2.buildCover.toList"]
  F["Complex specification"] --> G["Simplified mBound spec"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Simplify buildCoverCompute with direct enumeration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Remove <code>buildCoverSearch</code>, <code>searchLoop</code>, and <code>insertFirstUncovered</code> <br>functions<br> <li> Replace <code>buildCoverCompute</code> implementation with direct <br><code>Cover2.buildCover.toList</code><br> <li> Simplify specification lemma to use <code>mBound</code> instead of point count <br>bounds<br> <li> Remove 150+ lines of complex recursive search logic</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/813/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+30/-159</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CoverComputeTest.lean</strong><dd><code>Simplify test using new specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/CoverComputeTest.lean

<ul><li>Simplify test case to directly use <code>buildCoverCompute_spec</code><br> <li> Remove manual bound calculations and intermediate steps<br> <li> Streamline proof to rely on new specification</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/813/files#diff-6c5dde12451bd7a341032bb83f2ba7c9397fe572190d7748ce3d3ccf2e04735a">+15/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

