### PR TITLE
feat: plug buildCoverCompute into naive enumerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ tracked in `TODO.md` and will be removed as the project progresses.
   the coverage proof.
 * `Cover/Compute.lean` – lightweight wrapper exposing a constructive
   variant `buildCoverCompute` that enumerates the rectangles as a list.
-  The current implementation still returns an empty list, serving as a
-  placeholder for the future recursive procedure.  Its specification is
-  proven and the file is used by `Algorithms/SatCover` for basic SAT
+  The current implementation reuses the naive exhaustive scan of the Boolean
+  cube, so it is exponentially slow but fully constructive.  Its specification
+  is proven and the file is used by `Algorithms/SatCover` for basic SAT
   experimentation.
 * `bound.lean` – arithmetic bounds deriving the subexponential size estimate;
   the main inequality `mBound_lt_subexp` is now fully proved in the

--- a/docs/lemma_B_plan.md
+++ b/docs/lemma_B_plan.md
@@ -31,9 +31,10 @@ all circuits of size `≤ n^c` admit a joint monochromatic cover of at
 most `2^{(2^n)/100}` rectangles.  The proof relies on the `family_collision_entropy_lemma_table`
 for general families and instantiates it with the circuit family.
 
-What remains open is a **computable** enumeration of these rectangles
-via `Cover.buildCoverCompute`.  The current stub always returns an
-empty list, so the algorithmic applications are still hypothetical.
+What remains open is a **practical** enumeration of these rectangles
+via `Cover.buildCoverCompute`.  The current implementation simply
+enumerates all points of the Boolean cube one by one, which is
+exponentially slow and therefore limits algorithmic applications.
 
 An alternative presentation is given by the lemma
 `Bound.lemmaB_circuit_cover_delta`.  It reformulates the subexponential


### PR DESCRIPTION
### **User description**
## Summary
- implement `buildCoverCompute` via existing naive enumerator
- document the current naive behaviour in README and lemma B notes

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6892b169c0a0832ba9e254037d9e7f0d


___

### **PR Type**
Enhancement


___

### **Description**
- Replace stubbed `buildCoverCompute` with naive enumerator implementation

- Update documentation to reflect current exponential behavior

- Simplify proof by delegating to existing `buildCoverNaive_spec`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCoverCompute"] --> B["buildCoverNaive"]
  B --> C["Exhaustive Boolean cube scan"]
  D["Cover2.buildCover stub"] -.-> A
  style D stroke-dasharray: 5 5
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Compute.lean</strong><dd><code>Replace stubbed implementation with naive enumerator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Compute.lean

<ul><li>Replace <code>buildCoverCompute</code> implementation from <code>Cover2.buildCover</code> stub <br>to <code>buildCoverNaive</code><br> <li> Update documentation to describe current naive enumeration behavior<br> <li> Simplify proof by delegating to <code>buildCoverNaive_spec</code><br> <li> Remove unused <code>Cover2</code> import and references</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/818/files#diff-041553a0fd27510fed37cc33e53ee7f56cc9bd3fe6548580e52ef43d5a8c7776">+24/-46</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to reflect naive implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Update description of <code>Cover/Compute.lean</code> to reflect current naive <br>implementation<br> <li> Change from "returns empty list" to "exponentially slow but fully <br>constructive"</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/818/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lemma_B_plan.md</strong><dd><code>Update lemma B documentation for naive behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/lemma_B_plan.md

<ul><li>Update description from "stub returns empty list" to "exponentially <br>slow enumeration"<br> <li> Clarify that algorithmic applications are limited by performance, not <br>missing implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/818/files#diff-e9d0bd6d17194563d60193cd801d91945277c1aec3c0054e3ce161f9b8b60c57">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

