### PR TITLE
feat: link uncovered search to coverage

### DIFF
--- a/Pnp2/Cover/Uncovered.lean
+++ b/Pnp2/Cover/Uncovered.lean
@@ -327,6 +327,25 @@ lemma allOnesCovered_of_firstUncovered_none {n : ℕ} {F : Family n}
   have hx_mem_empty := Eq.mp hx_eq hx_mem_set
   cases hx_mem_empty
 
+/--
+`firstUncovered` yields `none` exactly when every `1`‑input of the family is
+already covered.  This bundles the two implications into a single convenient
+equivalence.
+-/
+lemma firstUncovered_none_iff_AllOnesCovered {n : ℕ} (F : Family n)
+    (Rset : Finset (Subcube n)) :
+    firstUncovered (n := n) F Rset = none ↔
+      AllOnesCovered (n := n) F Rset := by
+  classical
+  constructor
+  · intro h
+    exact allOnesCovered_of_firstUncovered_none
+      (n := n) (F := F) (Rset := Rset) h
+  · intro hcov
+    have hempty := uncovered_eq_empty_of_allCovered
+      (n := n) (F := F) (Rset := Rset) hcov
+    exact (firstUncovered_none_iff (n := n) (F := F) (R := Rset)).2 hempty
+
 /-- Adding rectangles can only reduce the uncovered set. -/
 lemma uncovered_subset_of_union_singleton {n : ℕ} {F : Family n}
     {Rset : Finset (Subcube n)} {R : Subcube n} :

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -269,6 +269,21 @@ example :
       (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
       (R := (∅ : Finset (Subcube 1))))
 
+/-- `firstUncovered` returns `none` exactly when every `1`‑input is covered. -/
+example :
+    Cover2.firstUncovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      ({Subcube.full} : Finset (Subcube 1)) = none ↔
+    Cover2.AllOnesCovered (n := 1)
+      ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+      ({Subcube.full} : Finset (Subcube 1)) := by
+  -- The dedicated lemma proves the equivalence directly.
+  exact
+    (Cover2.firstUncovered_none_iff_AllOnesCovered
+      (n := 1)
+      (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+      (Rset := ({Subcube.full} : Finset (Subcube 1))))
+
 /-- If `firstUncovered` yields a witness, that witness lies in the uncovered set. -/
 example (F : BoolFunc.Family 1) (R : Finset (Subcube 1))
     {p : Sigma (fun _ => Point 1)}


### PR DESCRIPTION
### **User description**
## Summary
- show that `firstUncovered` fails exactly when all ones are covered
- add regression test for `firstUncovered_none_iff_AllOnesCovered`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_68933c943d20832b9736c8ce1b6aa743


___

### **PR Type**
Enhancement


___

### **Description**
- Add bidirectional equivalence lemma linking `firstUncovered` to coverage

- Provide regression test demonstrating the equivalence relationship

- Establish formal connection between uncovered search and coverage properties


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["firstUncovered = none"] <--> B["AllOnesCovered"]
  C["New lemma"] --> A
  C --> B
  D["Regression test"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Uncovered.lean</strong><dd><code>Add bidirectional equivalence lemma for coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Uncovered.lean

<ul><li>Add <code>firstUncovered_none_iff_AllOnesCovered</code> lemma establishing <br>bidirectional equivalence<br> <li> Combine existing one-way implications into single convenient <br>equivalence<br> <li> Include comprehensive documentation explaining the relationship</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/823/files#diff-f84ac6580cc24043357bf5f47e57ac97f91664f9976d13d47a2d23d8f74dbd2c">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add regression test for coverage equivalence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add regression test demonstrating <br><code>firstUncovered_none_iff_AllOnesCovered</code> equivalence<br> <li> Test with concrete example using full subcube coverage<br> <li> Verify the new lemma works correctly in practice</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/823/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

