### PR TITLE
feat: prove strict measure drop for extendCover

### DIFF
--- a/Pnp2/Cover/Measure.lean
+++ b/Pnp2/Cover/Measure.lean
@@ -375,6 +375,30 @@ lemma mu_extendCover_succ_le {F : Family n} {Rset : Finset (Subcube n)}
       simpa [extendCover, hfu'] using hdrop
 
 /--
+If an uncovered pair exists, applying `extendCover` causes a strict drop in
+the termination measure `μ`.  This is a convenient reformulation of
+`mu_extendCover_succ_le` that exposes the decrease as a `<` inequality, which
+is often more ergonomic when reasoning about recursive calls.
+-/
+lemma mu_extendCover_lt {F : Family n} {Rset : Finset (Subcube n)}
+    {h : ℕ}
+    (hfu : firstUncovered (n := n) F Rset ≠ none) :
+    mu (n := n) F h (extendCover (n := n) F Rset) <
+      mu (n := n) F h Rset := by
+  classical
+  -- Obtain the quantified decrease from the previous lemma.
+  have hdrop :=
+    mu_extendCover_succ_le (n := n) (F := F) (Rset := Rset)
+      (h := h) hfu
+  -- Interpret `a + 1 ≤ b` as `succ a ≤ b` to derive a strict inequality.
+  have hdrop' :
+      Nat.succ (mu (n := n) F h (extendCover (n := n) F Rset)) ≤
+        mu (n := n) F h Rset := by
+    simpa [Nat.succ_eq_add_one] using hdrop
+  -- Conclude with the standard natural number comparison lemma.
+  exact Nat.lt_of_succ_le hdrop'
+
+/--
 If the search for an uncovered pair fails, `extendCover` leaves the set of
 rectangles unchanged.  This lemma exposes that behaviour for convenient
 rewriting in subsequent proofs.

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1170,8 +1170,48 @@ example :
         (∅ : Finset (Subcube 1)) := by
   classical
   simpa using
-    Cover2.mu_extendCover_le
+      Cover2.mu_extendCover_le
+        (n := 1)
+        (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+        (Rset := (∅ : Finset (Subcube 1))) (h := 0)
+
+/-- If an uncovered pair exists, `extendCover` strictly decreases the
+termination measure `μ`. -/
+example :
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) 0
+        (extendCover (n := 1)
+          ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+          (∅ : Finset (Subcube 1))) <
+    Cover2.mu (n := 1)
+        ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) 0
+        (∅ : Finset (Subcube 1)) := by
+  classical
+  -- Show that `firstUncovered` actually finds a witness pair.
+  have hfu_ne :
+      Cover2.firstUncovered (n := 1)
+          ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)
+          (∅ : Finset (Subcube 1)) ≠ none := by
+    -- The constant-`true` function evaluated at `x` remains uncovered.
+    let f : BFunc 1 := fun _ => true
+    let x : Point 1 := fun _ => false
+    have hf : f ∈ ({(fun _ : Point 1 => true)} : BoolFunc.Family 1) := by
+      simp [f]
+    have hxval : f x = true := by simp [f, x]
+    intro hnone
+    -- From `firstUncovered = none` we obtain full coverage, contradicting `x`.
+    have hcov :=
+      (Cover2.firstUncovered_none_iff_AllOnesCovered
+        (n := 1)
+        (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
+        (Rset := (∅ : Finset (Subcube 1)))).1 hnone
+    have hcontr := hcov f hf x hxval
+    rcases hcontr with ⟨R, hR, _⟩
+    simpa using hR
+  -- Apply the strict decrease lemma.
+  simpa using
+    Cover2.mu_extendCover_lt
       (n := 1)
       (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1))
-      (Rset := (∅ : Finset (Subcube 1))) (h := 0)
+      (Rset := (∅ : Finset (Subcube 1))) (h := 0) hfu_ne
 


### PR DESCRIPTION
### **User description**
## Summary
- prove `mu_extendCover_lt` establishing strict decrease of termination measure when an uncovered pair exists
- add test ensuring measure strictly decreases under a successful `extendCover`

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6893bb4f6d28832bb0a23e4180f1d994


___

### **PR Type**
Enhancement


___

### **Description**
- Add strict inequality lemma `mu_extendCover_lt` for termination measure

- Prove measure strictly decreases when uncovered pairs exist

- Include comprehensive test demonstrating strict decrease behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mu_extendCover_succ_le"] --> B["mu_extendCover_lt"]
  B --> C["Strict inequality μ(extendCover) < μ(Rset)"]
  D["Test case"] --> E["Verify strict decrease"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Measure.lean</strong><dd><code>Add strict inequality lemma for measure decrease</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Measure.lean

<ul><li>Add <code>mu_extendCover_lt</code> lemma proving strict measure decrease<br> <li> Convert <code>succ a ≤ b</code> to <code>a < b</code> using natural number properties<br> <li> Include detailed documentation explaining ergonomic benefits</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/830/files#diff-729fbd9502f9bc6e52cb4c643b8e5cf5b4936087ecdea70cf9216c82dae9eb3a">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Add test for strict measure decrease behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Add comprehensive test for strict measure decrease<br> <li> Prove <code>firstUncovered</code> finds witness when uncovered pairs exist<br> <li> Demonstrate contradiction when assuming full coverage<br> <li> Apply new strict decrease lemma in test</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/830/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+42/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

