### PR TITLE
refactor: expand cover family utilities

### DIFF
--- a/Pnp2/Cover/Canonical.lean
+++ b/Pnp2/Cover/Canonical.lean
@@ -44,21 +44,60 @@ lemma coverFamily_spec {n h : ℕ} (F : Family n)
       (coverFamily (n := n) F h hH).card ≤ mBound n h := by
   classical
   -- `firstUncovered` reports `none`, hence the cover remains empty.
-  have hfu : firstUncovered (n := n) F (∅ : Finset (Subcube n)) = none := by
-    simpa using
-      (firstUncovered_none_iff_AllOnesCovered (n := n) (F := F)
+  have hfu : firstUncovered (n := n) F (∅ : Finset (Subcube n)) = none :=
+    (firstUncovered_none_iff_AllOnesCovered (n := n) (F := F)
         (Rset := (∅ : Finset (Subcube n)))).2 hcov
-  have hbuild : coverFamily (n := n) F h hH =
+  -- Record the behaviour of `extendCover` under this hypothesis.
+  have hextend : extendCover (n := n) F (∅ : Finset (Subcube n)) =
       (∅ : Finset (Subcube n)) := by
-    simpa [coverFamily, buildCover, extendCover, hfu] using
+    simpa using
       (extendCover_none (n := n) (F := F)
         (Rset := (∅ : Finset (Subcube n))) hfu)
+  -- Consequently the canonical cover is the empty set of rectangles.
+  have hbuild : coverFamily (n := n) F h hH =
+      (∅ : Finset (Subcube n)) := by
+    simp [coverFamily, buildCover, hextend]
   refine ⟨?mono, ?cover, ?card⟩
   · intro R hR
+    -- `hR` asserts membership in the empty cover and is thus impossible.
     have : False := by simpa [hbuild] using hR
     exact this.elim
-  · simpa [hbuild] using hcov
-  · have : (0 : ℕ) ≤ mBound n h := mBound_nonneg (n := n) (h := h)
+  · -- Coverage coincides with the assumption `hcov` for the empty cover.
+    simpa [hbuild] using hcov
+  · -- The cardinality of the empty cover is trivially bounded.
+    have : (0 : ℕ) ≤ mBound n h := mBound_nonneg (n := n) (h := h)
     simpa [hbuild] using this
+
+/--
+Every rectangle returned by `coverFamily` is monochromatic for the input family.
+This lemma unwraps the first component of `coverFamily_spec` for convenient use
+in downstream developments.
+-/
+lemma coverFamily_mono {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hcov : AllOnesCovered (n := n) F (∅ : Finset (Subcube n)))
+    {R : Subcube n} (hR : R ∈ coverFamily (n := n) F h hH) :
+    Subcube.monochromaticForFamily R F :=
+  (coverFamily_spec (n := n) (h := h) (F := F) hH hcov).1 R hR
+
+/--
+The canonical cover produced by `coverFamily` covers every `1`-input of the
+family.  This is the second component of `coverFamily_spec`.
+-/
+lemma coverFamily_spec_cover {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hcov : AllOnesCovered (n := n) F (∅ : Finset (Subcube n))) :
+    AllOnesCovered (n := n) F (coverFamily (n := n) F h hH) :=
+  (coverFamily_spec (n := n) (h := h) (F := F) hH hcov).2.1
+
+/--
+The number of rectangles in `coverFamily` never exceeds `mBound`.  This is the
+third component of `coverFamily_spec`.
+-/
+lemma coverFamily_card_bound {n h : ℕ} (F : Family n)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hcov : AllOnesCovered (n := n) F (∅ : Finset (Subcube n))) :
+    (coverFamily (n := n) F h hH).card ≤ mBound n h :=
+  (coverFamily_spec (n := n) (h := h) (F := F) hH hcov).2.2
 
 end Cover2


### PR DESCRIPTION
### **User description**
## Summary
- clarify `coverFamily_spec` by recording explicit empty-cover behaviour
- add convenience lemmas about monochromaticity, coverage, and size bounds for `coverFamily`

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6893ce4da8b4832b96fd607681c59db4


___

### **PR Type**
Enhancement


___

### **Description**
- Refactor `coverFamily_spec` proof with clearer documentation and structure

- Add three convenience lemmas extracting individual components from `coverFamily_spec`

- Improve code readability with explicit intermediate steps and comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["coverFamily_spec"] --> B["coverFamily_mono"]
  A --> C["coverFamily_spec_cover"]
  A --> D["coverFamily_card_bound"]
  B --> E["Monochromaticity property"]
  C --> F["Coverage property"]
  D --> G["Size bound property"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Canonical.lean</strong><dd><code>Refactor cover family utilities with convenience lemmas</code>&nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Canonical.lean

<ul><li>Refactor <code>coverFamily_spec</code> proof with better documentation and explicit <br>intermediate steps<br> <li> Add <code>coverFamily_mono</code> lemma for extracting monochromaticity property<br> <li> Add <code>coverFamily_spec_cover</code> lemma for extracting coverage property<br> <li> Add <code>coverFamily_card_bound</code> lemma for extracting size bound property</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/833/files#diff-28c884b2f9f2dd00384bd8186714c1223292fcecb81930d20eec935c27363ff3">+46/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

