### PR TITLE
feat: add measure monotonicity lemma for buildCover

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -359,16 +359,27 @@ lemma mu_union_buildCover_le {F : Family n} {h : ℕ}
   simpa [buildCover, hunion] using
     (mu_extendCover_le (n := n) (F := F) (Rset := Rset) (h := h))
 
+/-- Running `buildCover` alone does not increase the measure `μ`.  This is a
+direct reformulation of `mu_extendCover_le` for the thin wrapper `buildCover`. -/
+lemma mu_buildCover_le {F : Family n} {h : ℕ}
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) (Rset : Finset (Subcube n)) :
+    mu (n := n) F h (buildCover (n := n) F h hH Rset) ≤
+      mu (n := n) F h Rset := by
+  classical
+  -- `buildCover` currently performs just one covering step.
+  simpa [buildCover] using
+    (mu_extendCover_le (n := n) (F := F) (Rset := Rset) (h := h))
+
 /-- Starting from the empty set of rectangles, running `buildCover` cannot
 increase the measure `μ`. -/
 lemma mu_buildCover_le_start {F : Family n} {h : ℕ}
     (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     mu (n := n) F h (buildCover (n := n) F h hH) ≤
       mu (n := n) F h (∅ : Finset (Subcube n)) := by
-  -- Again we reduce the claim to `extendCover` by unfolding `buildCover`.
-  simpa [buildCover] using
-    (mu_extendCover_le (n := n) (F := F)
-      (Rset := (∅ : Finset (Subcube n))) (h := h))
+  -- Specialise `mu_buildCover_le` to the empty starting set.
+  simpa using
+    (mu_buildCover_le (n := n) (F := F) (h := h) (hH := hH)
+      (Rset := (∅ : Finset (Subcube n))))
 
 /-- If an uncovered pair exists, running `buildCover` strictly decreases the
 termination measure `μ`.  This follows directly from the corresponding


### PR DESCRIPTION
### **User description**
## Summary
- add `mu_buildCover_le` lemma showing a single `buildCover` step cannot increase measure
- use the lemma to simplify `mu_buildCover_le_start`

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6893e9bfe774832b8d5c42c64f80b6a3


___

### **PR Type**
Enhancement


___

### **Description**
- Add `mu_buildCover_le` lemma proving measure monotonicity

- Simplify `mu_buildCover_le_start` using new lemma

- Improve code organization and reduce duplication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["mu_extendCover_le"] --> B["mu_buildCover_le"]
  B --> C["mu_buildCover_le_start"]
  B --> D["Simplified proof structure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add monotonicity lemma and refactor proofs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add new <code>mu_buildCover_le</code> lemma with documentation<br> <li> Refactor <code>mu_buildCover_le_start</code> to use new lemma<br> <li> Replace direct proof with lemma specialization<br> <li> Update comments to reflect new proof structure</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/835/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+15/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

