### PR TITLE
Add subset lemma for buildCover

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -337,6 +337,16 @@ lemma buildCover_eq_Rset_of_none (F : Family n) (h : ℕ)
   simpa [buildCover, extendCover, hfu] using
     (extendCover_none (n := n) (F := F) (Rset := Rset) hfu)
 
+/-- Every rectangle from the starting set remains present after calling
+`buildCover`.  This simple inclusion lemma will be convenient once the full
+recursive version is implemented. -/
+lemma subset_buildCover {F : Family n} {h : ℕ}
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) (Rset : Finset (Subcube n)) :
+    Rset ⊆ buildCover (n := n) F h hH Rset := by
+  classical
+  simpa [buildCover] using
+    (subset_extendCover (n := n) (F := F) (Rset := Rset))
+
 /-- Adding the rectangles produced by `buildCover` cannot increase the
 termination measure `μ`. -/
 lemma mu_union_buildCover_le {F : Family n} {h : ℕ}


### PR DESCRIPTION
### **User description**
## Summary
- document that rectangles in the initial set remain after a single `buildCover` step

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6893fa8d4b58832ba8378c4d54b06f00


___

### **PR Type**
Enhancement


___

### **Description**
- Add subset lemma for `buildCover` function

- Documents that initial rectangles remain after single step

- Provides convenient inclusion property for future recursive implementation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Rset["Initial Rectangle Set"] --> buildCover["buildCover Function"]
  buildCover --> Result["Extended Rectangle Set"]
  Rset -.-> Result
  Result --> Lemma["subset_buildCover: Rset ⊆ Result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cover2.lean</strong><dd><code>Add subset inclusion lemma for buildCover</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/cover2.lean

<ul><li>Add <code>subset_buildCover</code> lemma proving initial rectangles remain<br> <li> Include comprehensive documentation explaining the lemma's purpose<br> <li> Use classical logic and <code>subset_extendCover</code> for proof implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/836/files#diff-3f8ef83a9aa3b9c18d0972847f7daf5518288388881238b4f374f3330e1367b1">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

