### PR TITLE
chore: clarify empty cover handling

### DIFF
--- a/Pnp2/Cover/Canonical.lean
+++ b/Pnp2/Cover/Canonical.lean
@@ -60,13 +60,16 @@ lemma coverFamily_spec {n h : ℕ} (F : Family n)
   refine ⟨?mono, ?cover, ?card⟩
   · intro R hR
     -- `hR` asserts membership in the empty cover and is thus impossible.
-    have : False := by simpa [hbuild] using hR
-    exact this.elim
+    -- Rewriting with `hbuild` reveals this contradiction explicitly.
+    have hR' : R ∈ (∅ : Finset (Subcube n)) := by
+      simpa [hbuild] using hR
+    simpa using hR'
   · -- Coverage coincides with the assumption `hcov` for the empty cover.
+    -- After rewriting the goal using `hbuild` it matches the hypothesis `hcov`.
     simpa [hbuild] using hcov
   · -- The cardinality of the empty cover is trivially bounded.
-    have : (0 : ℕ) ≤ mBound n h := mBound_nonneg (n := n) (h := h)
-    simpa [hbuild] using this
+    -- Simplification again reduces the goal to a basic arithmetic fact.
+    simpa [hbuild] using (mBound_nonneg (n := n) (h := h))
 
 /--
 Every rectangle returned by `coverFamily` is monochromatic for the input family.


### PR DESCRIPTION
### **User description**
## Summary
- clarify `coverFamily_spec` elimination of empty cover membership
- document coverage and cardinality reasoning for the empty cover case

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6893fa8d4b58832ba8378c4d54b06f00


___

### **PR Type**
Documentation


___

### **Description**
- Improve comments explaining empty cover case handling

- Clarify proof structure with better variable naming

- Enhance documentation for coverage and cardinality reasoning


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original proof structure"] --> B["Enhanced comments"]
  B --> C["Clearer variable naming"]
  C --> D["Better documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Canonical.lean</strong><dd><code>Improve empty cover proof documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Canonical.lean

<ul><li>Enhanced comments explaining empty cover membership contradiction<br> <li> Improved variable naming from anonymous <code>this</code> to explicit <code>hR'</code><br> <li> Added documentation for coverage and cardinality proof steps<br> <li> Simplified arithmetic expression in cardinality bound proof</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/837/files#diff-28c884b2f9f2dd00384bd8186714c1223292fcecb81930d20eec935c27363ff3">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

