### PR TITLE
chore: clarify plan for buildCoverAux_unfold

### DIFF
--- a/Pnp2/Cover/BuildCover.lean
+++ b/Pnp2/Cover/BuildCover.lean
@@ -178,6 +178,21 @@ lemma buildCoverAux_mono (F : Family n) (h : ℕ)
       -- recursive hypothesis on a strictly smaller measure.  Formalising this
       -- argument is non-trivial and remains future work.
       intro R hR
+      -- First, expose the recursive call of `buildCoverAux` using the unfolding
+      -- lemma.  The assumption `hfu` fixes the branch to the `some` case.
+      have hrec :=
+        buildCoverAux_unfold (n := n) (F := F) (h := h)
+          (hH := hH) (Rset := Rset)
+      -- Replace the membership hypothesis by the result of the recursive call
+      -- on the extended rectangle set.
+      have hR' : R ∈
+          buildCoverAux (n := n) (F := F) (h := h) (_hH := hH)
+            (extendCover (n := n) F Rset) := by
+        simpa [hrec, hfu] using hR
+      -- Showing that the newly added rectangle is monochromatic and invoking
+      -- the induction hypothesis on the smaller measure will complete the
+      -- argument.  These steps require additional lemmas and are left for
+      -- future work.
       exact sorry
 
 /-- Every rectangle returned by `buildCover` is monochromatic for the family.

--- a/Pnp2/Cover/BuildCover.lean
+++ b/Pnp2/Cover/BuildCover.lean
@@ -82,8 +82,11 @@ lemma buildCoverAux_unfold (F : Family n) (h : ℕ)
       | some _ =>
           buildCoverAux (n := n) (F := F) (h := h) (_hH := hH)
             (extendCover (n := n) F Rset) := by
-  -- Proving this lemma requires unfolding the well-founded fixpoint.  The
-  -- argument is technical and postponed.
+  -- Proving this lemma amounts to unfolding the underlying well-founded
+  -- fixpoint once.  A future version will invoke `WellFounded.fix_eq` and
+  -- simplify the resulting expression so that the recursive call is exposed
+  -- explicitly as `buildCoverAux (extendCover F Rset)`.  The technical details
+  -- of that argument are still being worked out, hence the placeholder below.
   exact sorry
 
 /--  If `firstUncovered` finds no witness, the recursive auxiliary function


### PR DESCRIPTION
### **User description**
## Summary
- Add detailed comment outlining future proof strategy for `buildCoverAux_unfold` in `BuildCover.lean`

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_689504ba2e3c832b811164d256541506


___

### **PR Type**
Documentation


___

### **Description**
- Clarify implementation strategy for `buildCoverAux_unfold` lemma

- Add detailed comment about well-founded fixpoint proof approach


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildCover.lean</strong><dd><code>Enhanced documentation for buildCoverAux_unfold proof strategy</code></dd></summary>
<hr>

Pnp2/Cover/BuildCover.lean

<ul><li>Replace brief comment with detailed explanation of proof strategy<br> <li> Outline future approach using <code>WellFounded.fix_eq</code> for recursive call <br>exposure<br> <li> Clarify technical implementation details for well-founded fixpoint <br>unfolding</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/840/files#diff-88bbdb540ef91fae992c9cf9ee4327e7a1123aba064a5c223a7e21da44b48be7">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

