### PR TITLE
feat: add helpers for uncovered unions

### DIFF
--- a/Pnp2/Cover/Uncovered.lean
+++ b/Pnp2/Cover/Uncovered.lean
@@ -74,6 +74,19 @@ lemma NotCovered.union {n : ℕ} {R₁ R₂ : Finset (Subcube n)} {x : Point n} 
     | inl hR1 => exact h.1 R hR1
     | inr hR2 => exact h.2 R hR2
 
+/-- If a point is uncovered by the union `R₁ ∪ R₂` it is in particular
+uncovered by the left component. -/
+lemma NotCovered.union_left {n : ℕ} {R₁ R₂ : Finset (Subcube n)}
+    {x : Point n} (h : NotCovered (n := n) (Rset := R₁ ∪ R₂) x) :
+    NotCovered (n := n) (Rset := R₁) x :=
+  (NotCovered.union (R₁ := R₁) (R₂ := R₂) (x := x)).1 h |> And.left
+
+/-- Symmetric version of `NotCovered.union_left` for the right component. -/
+lemma NotCovered.union_right {n : ℕ} {R₁ R₂ : Finset (Subcube n)}
+    {x : Point n} (h : NotCovered (n := n) (Rset := R₁ ∪ R₂) x) :
+    NotCovered (n := n) (Rset := R₂) x :=
+  (NotCovered.union (R₁ := R₁) (R₂ := R₂) (x := x)).1 h |> And.right
+
 /--
 `NotCovered` for a singleton set simply states that the point misses the lone
 rectangle.  This specialised lemma streamlines arguments that peel off a single


### PR DESCRIPTION
### **User description**
## Summary
- extend uncovered utilities with `NotCovered.union_left/right` helpers

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68951cf19f00832b9f2c2f6397865393


___

### **PR Type**
Enhancement


___

### **Description**
- Add `NotCovered.union_left` and `NotCovered.union_right` helper lemmas

- Extend uncovered utilities for union decomposition

- Enable extraction of uncovered properties from union components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NotCovered (R₁ ∪ R₂) x"] --> B["NotCovered.union_left"]
  A --> C["NotCovered.union_right"]
  B --> D["NotCovered R₁ x"]
  C --> E["NotCovered R₂ x"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Uncovered.lean</strong><dd><code>Add union decomposition helper lemmas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Uncovered.lean

<ul><li>Add <code>NotCovered.union_left</code> lemma to extract left component uncovered <br>property<br> <li> Add <code>NotCovered.union_right</code> lemma for symmetric right component <br>extraction<br> <li> Both lemmas use existing <code>NotCovered.union</code> theorem for decomposition</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/841/files#diff-f84ac6580cc24043357bf5f47e57ac97f91664f9976d13d47a2d23d8f74dbd2c">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

