### PR TITLE
feat: lemma for empty buildCover

### DIFF
--- a/Pnp2/Cover/BuildCover.lean
+++ b/Pnp2/Cover/BuildCover.lean
@@ -129,6 +129,21 @@ noncomputable def buildCover (F : Family n) (h : ℕ)
     (hH : BoolFunc.H₂ F ≤ (h : ℝ)) : Finset (Subcube n) :=
   buildCoverAux (n := n) (F := F) (h := h) (_hH := hH) ∅
 
+/--  If the initial search finds no uncovered pair, `buildCover` returns the
+    empty rectangle set.  This is an immediate consequence of the base case for
+    `buildCoverAux`. -/
+lemma buildCover_empty_of_none (F : Family n) (h : ℕ)
+    (hH : BoolFunc.H₂ F ≤ (h : ℝ))
+    (hfu : firstUncovered (n := n) F (∅ : Finset (Subcube n)) = none) :
+    buildCover (n := n) F h hH = (∅ : Finset (Subcube n)) := by
+  classical
+  -- Expand the definition and apply the auxiliary lemma specialised to the
+  -- empty starting set.
+  unfold buildCover
+  simpa using
+    (buildCoverAux_none (n := n) (F := F) (h := h)
+      (hH := hH) (Rset := (∅ : Finset (Subcube n))) hfu)
+
 /-!
 ### Specification lemmas
 


### PR DESCRIPTION
### **User description**
## Summary
- add lemma ensuring `buildCover` returns empty set when no uncovered pairs

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_689526659728832b842577d1be759e35


___

### **PR Type**
Enhancement


___

### **Description**
- Add lemma proving `buildCover` returns empty set when no uncovered pairs exist

- Provides formal proof using auxiliary lemma for base case handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildCover function"] --> B["buildCover_empty_of_none lemma"]
  B --> C["Proves empty set return"]
  C --> D["Uses buildCoverAux_none auxiliary lemma"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildCover.lean</strong><dd><code>Add empty buildCover lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/BuildCover.lean

<ul><li>Add <code>buildCover_empty_of_none</code> lemma with formal proof<br> <li> Lemma proves empty set return when <code>firstUncovered</code> returns <code>none</code><br> <li> Uses classical logic and <code>buildCoverAux_none</code> auxiliary lemma</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/842/files#diff-88bbdb540ef91fae992c9cf9ee4327e7a1123aba064a5c223a7e21da44b48be7">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

