### PR TITLE
Add irreflexivity lemma for μRel

### DIFF
--- a/Pnp2/Cover/BuildCover.lean
+++ b/Pnp2/Cover/BuildCover.lean
@@ -44,6 +44,13 @@ lemma μRel_wf (F : Family n) (h : ℕ) :
     (InvImage.wf (f := fun Rset : Finset (Subcube n) => mu (n := n) F h Rset)
       Nat.lt_wfRel.wf)
 
+/--  A rectangle set cannot have a strictly smaller measure than itself. -/
+lemma μRel_irrefl (F : Family n) (h : ℕ) (Rset : Finset (Subcube n)) :
+    ¬ μRel (n := n) (F := F) h Rset Rset := by
+  intro hlt
+  -- The measure `μ` takes values in `ℕ`, where `<` is irreflexive.
+  exact lt_irrefl _ hlt
+
 /-!
 ### Recursive cover construction
 


### PR DESCRIPTION
### **User description**
## Summary
- document that μRel cannot relate a rectangle set to itself
- clarify recursive covering development

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_689530009c30832bae35ac3b7561e421


___

### **PR Type**
Enhancement


___

### **Description**
- Add irreflexivity lemma for μRel relation

- Prove rectangle sets cannot have smaller measure than themselves

- Enhance mathematical documentation for recursive covering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["μRel relation"] --> B["irreflexivity lemma"]
  B --> C["mathematical proof"]
  C --> D["enhanced documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildCover.lean</strong><dd><code>Add irreflexivity lemma for μRel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/BuildCover.lean

<ul><li>Add <code>μRel_irrefl</code> lemma proving relation irreflexivity<br> <li> Document that rectangle sets cannot relate to themselves<br> <li> Provide formal proof using natural number irreflexivity</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/843/files#diff-88bbdb540ef91fae992c9cf9ee4327e7a1123aba064a5c223a7e21da44b48be7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

