### PR TITLE
feat: prove buildCoverAux_unfold

### DIFF
--- a/Pnp2/Cover/BuildCover.lean
+++ b/Pnp2/Cover/BuildCover.lean
@@ -79,8 +79,7 @@ noncomputable def buildCoverAux (F : Family n) (h : ℕ)
           rec R' hdrop)
 
 /--  Unfolding equation for `buildCoverAux`.  It exposes the first recursive
-    step and is useful for subsequent reasoning.  The proof is currently a
-    placeholder. -/
+    step and is useful for subsequent reasoning. -/
 lemma buildCoverAux_unfold (F : Family n) (h : ℕ)
     (hH : BoolFunc.H₂ F ≤ (h : ℝ)) (Rset : Finset (Subcube n)) :
     buildCoverAux (n := n) (F := F) (h := h) (_hH := hH) Rset =
@@ -90,32 +89,18 @@ lemma buildCoverAux_unfold (F : Family n) (h : ℕ)
           buildCoverAux (n := n) (F := F) (h := h) (_hH := hH)
             (extendCover (n := n) F Rset) := by
   classical
-  -- Unfold the definition and expose the underlying fixpoint once.  The helper
-  -- theorem `WellFounded.fix_eq` yields an equation that already has the desired
-  -- shape; matching it to the statement requires a few additional rewriting
-  -- steps that are deferred for future work.
   unfold buildCoverAux
-  have hfix :=
-    (WellFounded.fix_eq
-      (C := fun _ : Finset (Subcube n) => Finset (Subcube n))
-      (μRel_wf (n := n) (F := F) h)
-      (fun Rset rec =>
-        match hfu : firstUncovered (n := n) F Rset with
-        | none => Rset
-        | some _ =>
-            let R' := extendCover (n := n) F Rset
-            have hdrop : μRel (n := n) (F := F) h R' Rset := by
-              have hne : firstUncovered (n := n) F Rset ≠ none := by
-                simpa [hfu]
-              simpa [μRel, R'] using
-                (mu_extendCover_lt (n := n) (F := F)
-                  (Rset := Rset) (h := h) hne)
-            rec R' hdrop)
-      Rset)
-  -- The proof will finish by simplifying `hfix` and identifying the recursive
-  -- call `rec R' hdrop` with `buildCoverAux F h hH (extendCover F Rset)`.
-  -- These remaining steps are technical and left as a `sorry` for now.
-  exact sorry
+  rw [WellFounded.fix_eq]
+  cases hfu : firstUncovered (n := n) F Rset with
+  | none =>
+      simp [hfu]
+  | some p =>
+      simp [hfu]
+      have hne : firstUncovered (n := n) F Rset ≠ none := by simp [hfu]
+      have hdrop : μRel (n := n) (F := F) h (extendCover F Rset) Rset := by
+        simpa [μRel] using mu_extendCover_lt (n := n) (F := F)
+          (Rset := Rset) (h := h) hne
+      rfl
 
 /--  If `firstUncovered` finds no witness, the recursive auxiliary function
     `buildCoverAux` leaves the current rectangle set unchanged.  This lemma


### PR DESCRIPTION
### **User description**
## Summary
- add a concrete proof for `buildCoverAux_unfold`

## Testing
- `lake build Pnp2.Cover.BuildCover` *(fails: declaration uses 'sorry')*

------
https://chatgpt.com/codex/tasks/task_e_6895ad969ed4832bb1cc31e034d5d069


___

### **PR Type**
Enhancement


___

### **Description**
- Replace placeholder proof with concrete implementation for `buildCoverAux_unfold`

- Remove sorry statement and provide complete proof

- Update documentation to reflect completed proof


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Placeholder proof with sorry"] --> B["Complete concrete proof"]
  B --> C["Updated documentation"]
  B --> D["Case analysis on firstUncovered"]
  D --> E["Base case: none"]
  D --> F["Recursive case: some p"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildCover.lean</strong><dd><code>Complete buildCoverAux_unfold proof implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/BuildCover.lean

<ul><li>Replace sorry with complete proof using case analysis<br> <li> Remove placeholder documentation comments<br> <li> Implement concrete proof steps with <code>rw</code>, <code>cases</code>, and <code>simp</code><br> <li> Add proper handling for both none and some cases</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/844/files#diff-88bbdb540ef91fae992c9cf9ee4327e7a1123aba064a5c223a7e21da44b48be7">+12/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

