### PR TITLE
feat: pointwise monochromatic cover

### DIFF
--- a/Pnp2/Cover/Measure.lean
+++ b/Pnp2/Cover/Measure.lean
@@ -335,9 +335,15 @@ lemma support_subset_supportUnion {n : ℕ} {F : Family n} {g : BFunc n}
 
 /--
 `extendCover` performs a single covering step.  When `firstUncovered` locates a
-pair `(f, x)` that is not yet covered by `Rset` we add the largest subcube
-around `x` on which every function in `F` is constant.  Coordinates that affect
-any function are frozen while the remaining coordinates stay free.  If no
+pair `(f, x)` that is not yet covered by `Rset` we insert a subcube around `x`
+on which every function in `F` is constant.  To keep the invariant simple we
+freeze all coordinates that occur in the support of some function in `F`.  This
+global choice may over‑approximate the coordinates that actually matter at `x`
+and thus yield a smaller rectangle than a point‑adaptive construction, but it
+still covers the uncovered pair.  The measure arguments below rely only on this
+coverage and therefore remain valid.  The trade‑off is that the cover may
+contain more, smaller rectangles, but termination bounds are unaffected because
+the measure still drops whenever an uncovered point is inserted.  If no
 uncovered pair exists, `Rset` is returned unchanged.
 -/
 noncomputable def extendCover {n : ℕ} (F : Family n)
@@ -345,9 +351,10 @@ noncomputable def extendCover {n : ℕ} (F : Family n)
   match firstUncovered (n := n) F Rset with
   | none => Rset
   | some p =>
-      -- Freeze precisely those coordinates on which some function of the
-      -- family depends.  The resulting subcube is the largest one around the
-      -- uncovered point `p.2` where all functions are constant.
+      -- Freeze all coordinates appearing in the support of some function in
+      -- the family.  The resulting subcube is guaranteed to be constant for
+      -- each `g ∈ F`, although it may be smaller than the maximal one that would
+      -- suffice for the particular point `p.2`.
       let K : Finset (Fin n) := supportUnion (n := n) F
       Rset ∪ {Boolcube.Subcube.fromPoint (n := n) p.2 K}
 
@@ -384,8 +391,10 @@ lemma fromPoint_supportUnion_monoFor_each {n : ℕ} {F : Family n}
     (BoolFunc.eval_eq_of_agree_on_support (f := g) (x := y) (y := x) hagree)
 
 /--
-If `firstUncovered` finds an uncovered pair, `extendCover` inserts the
-corresponding point subcube and the measure drops by at least one.
+If `firstUncovered` finds an uncovered pair, `extendCover` inserts a subcube
+containing that point and the measure drops by at least one.  The argument uses
+only the containment of the uncovered point, so it remains valid even though
+`extendCover` may freeze more coordinates than strictly necessary.
 -/
 lemma mu_extendCover_succ_le {F : Family n} {Rset : Finset (Subcube n)}
     {h : ℕ}

--- a/Pnp2/Cover/Measure.lean
+++ b/Pnp2/Cover/Measure.lean
@@ -304,6 +304,35 @@ lemma mu_union_firstUncovered_singleton_succ_le {F : Family n}
       (R := Boolcube.Subcube.fromPoint (n := n) p.2
         (Finset.univ : Finset (Fin n))) (h := h) hx
 
+/-!
+### Support unions
+
+The following auxiliary definition collects all coordinates that matter for any
+function in a family `F`.  Intuitively, it is the union of the supports of all
+functions.  Freeing only coordinates outside this union guarantees that every
+`g ∈ F` is constant on the resulting subcube.
+-/
+
+/--  The union of the supports of all functions in the family `F`. -/
+noncomputable def supportUnion {n : ℕ} (F : Family n) : Finset (Fin n) :=
+  Finset.univ.filter fun i : Fin n => ∃ g ∈ F, i ∈ BoolFunc.support g
+
+/--  Each individual support is contained in the global `supportUnion`. -/
+lemma support_subset_supportUnion {n : ℕ} {F : Family n} {g : BFunc n}
+    (hg : g ∈ F) :
+    BoolFunc.support g ⊆ supportUnion (n := n) F := by
+  classical
+  intro i hi
+  -- The witness `⟨g, hg, hi⟩` proves membership in the filtered set.
+  have hmem :
+      i ∈ Finset.univ.filter (fun j : Fin n => ∃ g' ∈ F, j ∈ BoolFunc.support g') := by
+    -- First note that `i` ranges over all coordinates.
+    have : i ∈ (Finset.univ : Finset (Fin n)) := by simpa
+    -- Then show that `i` satisfies the predicate of the filter.
+    exact Finset.mem_filter.mpr ⟨this, ⟨g, hg, hi⟩⟩
+  -- Finally unfold the definition of `supportUnion`.
+  simpa [supportUnion] using hmem
+
 /--
 `extendCover` performs a single covering step.  When `firstUncovered` locates a
 pair `(f, x)` that is not yet covered by `Rset` we add the largest subcube
@@ -316,11 +345,43 @@ noncomputable def extendCover {n : ℕ} (F : Family n)
   match firstUncovered (n := n) F Rset with
   | none => Rset
   | some p =>
-      let K : Finset (Fin n) :=
-        Finset.univ.filter fun i : Fin n =>
-          ∃ g ∈ F,
-            g p.2 ≠ g (BoolFunc.Point.update (n := n) p.2 i (!(p.2 i)))
+      -- Freeze precisely those coordinates on which some function of the
+      -- family depends.  The resulting subcube is the largest one around the
+      -- uncovered point `p.2` where all functions are constant.
+      let K : Finset (Fin n) := supportUnion (n := n) F
       Rset ∪ {Boolcube.Subcube.fromPoint (n := n) p.2 K}
+
+/--
+The freshly constructed subcube around a point is pointwise monochromatic for
+each function in the family.  More precisely, every `g ∈ F` is constant on the
+subcube obtained from `supportUnion F`.
+-/
+lemma fromPoint_supportUnion_monoFor_each {n : ℕ} {F : Family n}
+    {x : Boolcube.Point n} :
+    ∀ g ∈ F,
+      Boolcube.Subcube.monochromaticFor
+        (Boolcube.Subcube.fromPoint (n := n) x (supportUnion (n := n) F)) g := by
+  classical
+  intro g hg
+  -- The constant value is simply `g x`.
+  refine ⟨g x, ?_⟩
+  intro y hy
+  -- A point `y` inside the subcube agrees with `x` on all indices from
+  -- `supportUnion F`.
+  have hagree : ∀ i ∈ BoolFunc.support g, y i = x i := by
+    intro i hi
+    -- Membership in the support implies membership in `supportUnion`.
+    have hi' : i ∈ supportUnion (n := n) F :=
+      support_subset_supportUnion (n := n) (F := F) (g := g) hg hi
+    -- Points in `fromPoint` agree with the base point on all coordinates from
+    -- the index set.
+    have hyK :=
+      (Boolcube.Subcube.mem_fromPoint (n := n) (x := x)
+        (K := supportUnion (n := n) F) (y := y)).1 hy
+    exact hyK i hi'
+  -- Agreement on the support forces equal evaluations.
+  simpa using
+    (BoolFunc.eval_eq_of_agree_on_support (f := g) (x := y) (y := x) hagree)
 
 /--
 If `firstUncovered` finds an uncovered pair, `extendCover` inserts the
@@ -343,35 +404,19 @@ lemma mu_extendCover_succ_le {F : Family n} {Rset : Finset (Subcube n)}
         mem_uncovered_of_firstUncovered_some (n := n)
           (F := F) (R := Rset) (p := p) hfu'
       -- The point lies in the newly created subcube.
-      have hpR : p.2 ∈ₛ Boolcube.Subcube.fromPoint (n := n) p.2
-          (Finset.univ.filter fun i : Fin n =>
-            ∃ g ∈ F,
-              g p.2 ≠
-                g (BoolFunc.Point.update (n := n) p.2 i (!(p.2 i)))) := by
-        have :=
-          Boolcube.Subcube.self_mem_fromPoint (n := n) (x := p.2)
-            (K :=
-              Finset.univ.filter fun i : Fin n =>
-                ∃ g ∈ F,
-                  g p.2 ≠
-                    g (BoolFunc.Point.update (n := n) p.2 i (!(p.2 i))))
-        simpa using this
+      have hpR :
+          p.2 ∈ₛ Boolcube.Subcube.fromPoint (n := n) p.2 (supportUnion (n := n) F) := by
+        simpa using
+          (Boolcube.Subcube.self_mem_fromPoint (n := n) (x := p.2)
+            (K := supportUnion (n := n) F))
       -- Package the witness for `mu_union_singleton_succ_le`.
       have hx : ∃ q ∈ uncovered (n := n) F Rset, q.2 ∈ₛ
-          Boolcube.Subcube.fromPoint (n := n) p.2
-            (Finset.univ.filter fun i : Fin n =>
-              ∃ g ∈ F,
-                g p.2 ≠
-                  g (BoolFunc.Point.update (n := n) p.2 i (!(p.2 i)))) :=
+          Boolcube.Subcube.fromPoint (n := n) p.2 (supportUnion (n := n) F) :=
         ⟨p, hpU, hpR⟩
       have hdrop :=
         mu_union_singleton_succ_le (n := n) (F := F) (Rset := Rset)
           (R := Boolcube.Subcube.fromPoint (n := n) p.2
-            (Finset.univ.filter fun i : Fin n =>
-              ∃ g ∈ F,
-                g p.2 ≠
-                  g (BoolFunc.Point.update (n := n) p.2 i (!(p.2 i)))))
-          (h := h) hx
+            (supportUnion (n := n) F)) (h := h) hx
       simpa [extendCover, hfu'] using hdrop
 
 /--
@@ -451,13 +496,44 @@ lemma subset_extendCover {F : Family n} {Rset : Finset (Subcube n)} :
   | some p =>
       -- The result is the union with a freshly constructed subcube.
       have : R ∈ Rset ∪
-          {Boolcube.Subcube.fromPoint (n := n) p.2
-            (Finset.univ.filter fun i : Fin n =>
-              ∃ g ∈ F,
-                g p.2 ≠
-                  g (BoolFunc.Point.update (n := n) p.2 i (!(p.2 i))))} :=
+          {Boolcube.Subcube.fromPoint (n := n) p.2 (supportUnion (n := n) F)} :=
         Finset.mem_union.mpr (Or.inl hR)
       simpa [extendCover, hfu] using this
+
+/--
+Assuming every rectangle in `Rset` is pointwise monochromatic for every
+function in `F`, the same holds after extending the cover by one step.  This is
+the basic inductive invariant used in the construction.
+-/
+lemma extendCover_pointwiseMono {n : ℕ} {F : Family n}
+    {Rset : Finset (Subcube n)} :
+    (∀ R ∈ Rset, ∀ g ∈ F, Boolcube.Subcube.monochromaticFor R g) →
+    (∀ R ∈ extendCover (n := n) F Rset, ∀ g ∈ F,
+        Boolcube.Subcube.monochromaticFor R g) := by
+  classical
+  intro hMono R hR g hg
+  -- Examine the outcome of `firstUncovered`.
+  cases hfu : firstUncovered (n := n) F Rset with
+  | none =>
+      -- No extension occurs; the result equals the original set.
+      have hRset : R ∈ Rset := by simpa [extendCover, hfu] using hR
+      simpa [extendCover, hfu] using hMono R hRset g hg
+  | some p =>
+      -- Membership in the union splits into the old rectangles or the new one.
+      have hmem :
+          R ∈ Rset ∪ {Boolcube.Subcube.fromPoint (n := n) p.2
+            (supportUnion (n := n) F)} := by
+        simpa [extendCover, hfu] using hR
+      have hcases := Finset.mem_union.mp hmem
+      cases hcases with
+      | inl hRset =>
+          -- Old rectangles remain unchanged.
+          exact hMono R hRset g hg
+      | inr hnew =>
+          -- The new rectangle is monochromatic by construction.
+          rcases Finset.mem_singleton.mp hnew with rfl
+          exact fromPoint_supportUnion_monoFor_each (n := n) (F := F)
+            (x := p.2) g hg
 
 /--
 If a rectangle covers two distinct uncovered pairs, the measure drops

--- a/Pnp2/Cover/SubcubeAdapters.lean
+++ b/Pnp2/Cover/SubcubeAdapters.lean
@@ -23,6 +23,14 @@ notation x " ∈ₛ " R => Boolcube.Subcube.Mem R x
 namespace Boolcube.Subcube
 
 /--
+`R` is monochromatic for the function `f` if `f` takes a constant Boolean
+value on all points of the subcube.  This mirrors the corresponding definition
+for the legacy subcube representation used in other parts of the repository.
+-/
+def monochromaticFor {n : ℕ} (R : Subcube n) (f : BoolFunc.BFunc n) : Prop :=
+  ∃ b : Bool, ∀ x, R.Mem x → f x = b
+
+/--
 `R` is jointly monochromatic for the family `F` if every function in `F`
 assumes the same Boolean value on all points of `R`.
 This lightweight wrapper mirrors the corresponding definition for the

--- a/test/Cover2Test.lean
+++ b/test/Cover2Test.lean
@@ -1130,7 +1130,13 @@ example :
   | none => cases (hfu_ne hfu)
   | some p =>
       -- The coordinate filter is empty, yielding the full subcube.
-      simp [Cover2.extendCover, hfu, Boolcube.Subcube.fromPoint, Boolcube.Subcube.full]
+      -- `supportUnion` for the constant-`true` family is empty.
+      have hsup : Cover2.supportUnion
+          (F := ({(fun _ : Point 1 => true)} : BoolFunc.Family 1)) =
+          (∅ : Finset (Fin 1)) := by
+        ext i; simp [Cover2.supportUnion]
+      simp [Cover2.extendCover, hfu, hsup, Boolcube.Subcube.fromPoint,
+        Boolcube.Subcube.full]
 
 /-- When all `1`‑inputs are already covered, `extendCover` is the identity. -/
 example :


### PR DESCRIPTION
### **User description**
## Summary
- add `supportUnion` and update `extendCover` to freeze all supported coordinates
- prove cover construction preserves per-function monochromaticity
- adapt tests to the new `extendCover` behaviour

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6898a2b2a5a8832bb9633f3c32ccefa8


___

### **PR Type**
Enhancement


___

### **Description**
- Add pointwise monochromatic cover construction proof

- Introduce `supportUnion` for function family support

- Update `extendCover` to use global support union

- Prove monochromaticity preservation in cover algorithm


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["supportUnion"] --> B["extendCover"]
  B --> C["buildCoverAux_pointwiseMono"]
  C --> D["buildCover_pointwiseMono"]
  E["monochromaticFor"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildCover.lean</strong><dd><code>Prove pointwise monochromatic cover construction</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/BuildCover.lean

<ul><li>Add <code>buildCoverAux_pointwiseMono</code> lemma proving pointwise <br>monochromaticity preservation<br> <li> Add <code>buildCover_pointwiseMono</code> lemma for top-level cover construction<br> <li> Establish that each rectangle is monochromatic for every function <br>individually</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/849/files#diff-88bbdb540ef91fae992c9cf9ee4327e7a1123aba064a5c223a7e21da44b48be7">+82/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Measure.lean</strong><dd><code>Introduce support union and update cover extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/Measure.lean

<ul><li>Add <code>supportUnion</code> definition collecting all function supports<br> <li> Add <code>support_subset_supportUnion</code> lemma proving containment<br> <li> Update <code>extendCover</code> to use <code>supportUnion</code> instead of dynamic filtering<br> <li> Add <code>fromPoint_supportUnion_monoFor_each</code> proving monochromaticity<br> <li> Add <code>extendCover_pointwiseMono</code> preserving pointwise monochromaticity</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/849/files#diff-729fbd9502f9bc6e52cb4c643b8e5cf5b4936087ecdea70cf9216c82dae9eb3a">+108/-32</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SubcubeAdapters.lean</strong><dd><code>Add pointwise monochromaticity definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/SubcubeAdapters.lean

<ul><li>Add <code>monochromaticFor</code> definition for individual function <br>monochromaticity</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/849/files#diff-5ae514a044015904f088dee8ea738e04e93f5e94f1a6eea608d6c76fc8069afb">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cover2Test.lean</strong><dd><code>Adapt test to new extendCover behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/Cover2Test.lean

<ul><li>Update test to use <code>supportUnion</code> instead of coordinate filtering<br> <li> Add explicit support union computation for constant function</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/849/files#diff-3fccfe2bbce6fc739dcea8bf140b21f200d1d9c38094cb3538067646a5f22092">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

