### PR TITLE
Clarify BuildCover pointwise specification

### DIFF
--- a/Pnp2/Cover/BuildCover.lean
+++ b/Pnp2/Cover/BuildCover.lean
@@ -181,8 +181,10 @@ lemma buildCover_empty_of_none (F : Family n) (h : ℕ)
 
 In this section we establish that the cover construction preserves the weaker
 invariant that each rectangle is monochromatic for every function of the family
-individually.  The colours may differ between functions, but each function is
-constant on every rectangle produced by the algorithm.
+individually.  Earlier drafts aimed for the stronger predicate
+`Subcube.monochromaticForFamily`, but the current algorithm only guarantees the
+pointwise version: the colours may differ between functions, yet each function is
+constant on every rectangle produced by the construction.
 -/
 
 /--


### PR DESCRIPTION
### **User description**
## Summary
- Clarify BuildCover comments to note the algorithm guarantees only pointwise monochromatic rectangles, not the stronger `Subcube.monochromaticForFamily` property.

## Testing
- `lake build Pnp2.Cover.BuildCover`

------
https://chatgpt.com/codex/tasks/task_e_6899052c3b74832b9b05a9e549028256


___

### **PR Type**
Documentation


___

### **Description**
- Clarify BuildCover algorithm specification comments

- Update documentation to reflect pointwise monochromatic guarantees

- Remove reference to stronger `Subcube.monochromaticForFamily` property


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildCover.lean</strong><dd><code>Update BuildCover algorithm specification comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Cover/BuildCover.lean

<ul><li>Updated section comment to clarify algorithm guarantees only pointwise <br>monochromatic rectangles<br> <li> Added note about earlier drafts targeting stronger <br><code>Subcube.monochromaticForFamily</code> predicate<br> <li> Emphasized current algorithm provides weaker pointwise version where <br>colors may differ between functions</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/852/files#diff-88bbdb540ef91fae992c9cf9ee4327e7a1123aba064a5c223a7e21da44b48be7">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

