### PR TITLE
feat: add unions and slice double-counting lemma

### DIFF
--- a/test/SunflowerTest.lean
+++ b/test/SunflowerTest.lean
@@ -1,10 +1,27 @@
 import Pnp2.Sunflower.Sunflower
 
 open Sunflower
+open scoped BigOperators
 
 namespace SunflowerTest
 
 open Finset
+
+/-- Simple check of the double-counting lemma on a tiny family of two
+    singletons. -/
+example :
+    let 𝓢 : Finset (Finset ℕ) := { {0}, {1} }
+    ∑ x ∈ 𝓢.unions, (slice 𝓢 x).card = 1 * 𝓢.card := by
+  classical
+  intro 𝓢
+  have h_w : ∀ A ∈ 𝓢, A.card = 1 := by
+    intro A hA
+    have hA' := by simpa [𝓢] using hA
+    rcases hA' with h0 | h1
+    · simp [h0]
+    · simp [h1]
+  simpa using
+    (Sunflower.sum_card_slices_eq_w_mul_card (𝓢 := 𝓢) (w := 1) h_w)
 
 /-- A simple family of two singletons forms a sunflower.
     We verify that `exists_of_large_family_classic` can produce the structure


### PR DESCRIPTION
## Summary
- define Finset.unions as the sup of a family and provide membership lemma
- prove a double-counting lemma for slice sizes in uniform families
- add a simple test for the new lemma and update existing sunflower threshold tests

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_6899196a5868832b88855e86b2695cf1