### PR TITLE
refactor: drop cover size axiom

### DIFF
--- a/Pnp2/Cover/Canonical.lean
+++ b/Pnp2/Cover/Canonical.lean
@@ -28,7 +28,9 @@ noncomputable def coverFamily {n : ℕ} (F : Family n) (h : ℕ)
 
 /--
 Basic specification for the canonical cover.  Every rectangle is
-monochromatic, all `1`-inputs are covered and the size is bounded by `mBound`.
+monochromatic and all `1`-inputs are covered.  Earlier revisions also
+carried a size bound, but this aspect of the API is postponed and
+therefore omitted here.
 -/
 lemma coverFamily_spec {n h : ℕ} (F : Family n)
     (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
@@ -61,13 +63,5 @@ lemma coverFamily_spec_cover {n h : ℕ} (F : Family n)
     (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
     AllOnesCovered (n := n) F (coverFamily (n := n) F h hH) :=
   (coverFamily_spec (n := n) (h := h) (F := F) hH).2
-
-/--
-Cardinality bound for the canonical cover.  This statement summarises the
-counting argument of the recursive construction and is currently assumed as an
-axiom pending a full port of the original proof. -/
-axiom coverFamily_card_bound {n h : ℕ} (F : Family n)
-    (hH : BoolFunc.H₂ F ≤ (h : ℝ)) :
-    (coverFamily (n := n) F h hH).card ≤ mBound n h
 
 end Cover2

--- a/Pnp2/family_entropy_cover.lean
+++ b/Pnp2/family_entropy_cover.lean
@@ -26,15 +26,17 @@ theorem familyCollisionEntropyCover
 
 /-!
 ### A convenience record for covers returned by `familyEntropyCover`.
-This bundles the list of rectangles together with proofs that each
-is monochromatic for the whole family, that the rectangles cover all
-`1`‑inputs, and that their number is bounded by `mBound`.
+This bundles the list of rectangles together with proofs that each is
+monochromatic for the whole family and that the rectangles cover all
+`1`‑inputs.  Earlier iterations of this project also recorded an explicit
+cardinality bound, but the current development does not rely on this
+additional information.  Dropping the field keeps the interface
+lightweight and avoids depending on the unfinished size analysis.
 -/
 structure FamilyCover {n : ℕ} (F : Family n) (h : ℕ) where
   rects   : Finset (Subcube n)
   mono    : ∀ C ∈ rects, ∀ g ∈ F, Boolcube.Subcube.monochromaticFor C g
   covers  : ∀ f ∈ F, ∀ x, f x = true → ∃ C ∈ rects, x ∈ₛ C
-  bound   : rects.card ≤ mBound n h
 
 /--
 `familyEntropyCover` packages the canonical cover produced by `coverFamily` into
@@ -48,15 +50,13 @@ noncomputable def familyEntropyCover
   classical
   refine
     ⟨Cover2.coverFamily (F := F) (h := h) hH,
-      ?mono, ?covers, ?bound⟩
+      ?mono, ?covers⟩
   · -- Monochromaticity is inherited from `coverFamily`.
     intro C hC g hg
     exact Cover2.coverFamily_pointwiseMono (F := F) (h := h) (hH := hH) hC g hg
   · -- All `1`-inputs are covered by construction.
     intro f hf x hx
     exact Cover2.coverFamily_spec_cover (F := F) (h := h) (hH := hH) f hf x hx
-  · -- The size of the cover is bounded by `mBound` (axiom).
-    exact Cover2.coverFamily_card_bound (F := F) (h := h) (hH := hH)
 
 /-!
 `familyEntropyCover` is defined using `cover_exists`, just like


### PR DESCRIPTION
## Summary
- simplify `FamilyCover` by removing unused cardinality bound
- drop `coverFamily_card_bound` axiom and adjust canonical cover docs

## Testing
- `lake test`

------
https://chatgpt.com/codex/tasks/task_e_6899ea70390c832b88fbce8af8a943ef