### PR TITLE
feat: add measure_filter_lt_of_card_le_half

### DIFF
--- a/docs/decisionTree_cover_plan.md
+++ b/docs/decisionTree_cover_plan.md
@@ -18,7 +18,8 @@
   - определение `measure` как `Nat.ceil (H₂ F)` и леммы
     `measure_restrict_le`, `measure_filter_le`, `measure_empty`,
     `measure_singleton`, `measure_pos_of_card_two_le`,
-    `measure_restrict_lt_of_card_le_half` в `entropy.lean`.
+    `measure_restrict_lt_of_card_le_half`,
+    `measure_filter_lt_of_card_le_half` в `entropy.lean`.
 * Недостаёт доказательства существования дерева решений глубины
   `O(s · log (n+1))`, покрывающего все 1‑входы семейства.
 
@@ -97,10 +98,11 @@
    * для выбранного индекса `i` доказать `measure F₀ < measure F` либо
      `measure F₁ < measure F` (хватит строгого уменьшения хотя бы в
      среднем).
-   * сейчас реализована только более слабая `measure_restrict_le` и
-     частичная `measure_restrict_lt_of_card_le_half`, которая гарантирует
-     уменьшение при схлопывании хотя бы половины функций; общий строгий
-     вариант остаётся открытым.
+  * сейчас реализована только более слабая `measure_restrict_le` и
+    частичные версии `measure_restrict_lt_of_card_le_half` и
+    `measure_filter_lt_of_card_le_half`, которые гарантируют уменьшение
+    при схлопывании хотя бы половины функций; общий строгий вариант
+    остаётся открытым.
 
 3. ~~`sensitivity_restrict_le`
    * показать, что ограничение функции по координате не увеличивает


### PR DESCRIPTION
### **User description**
## Summary
- extend entropy measure utilities with `measure_filter_lt_of_card_le_half`
- document new strict-decrease lemma in decisionTree cover plan

## Testing
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_689b63002074832b861d3e3c24e06f22


___

### **PR Type**
Enhancement


___

### **Description**
- Add `measure_filter_lt_of_card_le_half` lemma for strict measure decrease

- Generalize from coordinate restrictions to arbitrary predicates

- Update documentation to reflect new entropy utility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["measure_restrict_lt_of_card_le_half"] --> B["measure_filter_lt_of_card_le_half"]
  B --> C["Generalized filtering"]
  C --> D["Updated documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entropy.lean</strong><dd><code>Add generalized measure filter lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/entropy.lean

<ul><li>Add <code>measure_filter_lt_of_card_le_half</code> lemma with 62 lines of proof<br> <li> Generalize from coordinate restrictions to arbitrary predicates<br> <li> Use real number logarithm calculations for entropy bounds<br> <li> Apply ceiling function properties for integer measure conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/875/files#diff-c9945293d072d5db339314094c1055ce9e959671dc64f147c5509da4830de9c9">+66/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>decisionTree_cover_plan.md</strong><dd><code>Update documentation with new lemma</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/decisionTree_cover_plan.md

<ul><li>Add <code>measure_filter_lt_of_card_le_half</code> to entropy utilities list<br> <li> Update description to mention both partial versions of strict decrease<br> <li> Clarify that both coordinate and general filtering variants exist</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/875/files#diff-f008011b56794742a839633e30de1f3a5e53347b32daa32decfa193f9c3478a2">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

