### PR TITLE
docs: clarify axiom placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # P≠NP formalization repository
-> **Status (2025-08-06)**: This repository is incomplete; many results rely on axioms or unfinished proofs.
+> **Status (2025-08-06)**: This repository is incomplete; unproven statements are currently marked with `axiom` placeholders while their proofs are developed.
 
 
 This repository collects experimental Lean files that sketch a formal proof of the **Family Collision‑Entropy Lemma (FCE‑Lemma)**.  The lemma aims to cover families of Boolean functions with a subexponential number of monochromatic subcubes and is a building block for a potential proof that `P ≠ NP`.
@@ -13,8 +13,8 @@ The development now happens entirely in the `Pnp2` namespace.  The previous
 development tree is kept only as a historical snapshot and is no longer part of
 the build.
 
-Several files continue to contain `sorry` placeholders and axiomatic
-statements while the formal proofs are completed.  These markers are
+Several files continue to contain axiomatic placeholders
+(`axiom`) while the formal proofs are completed.  These markers are
 tracked in `TODO.md` and will be removed as the project progresses.
 
 ## Layout
@@ -146,7 +146,7 @@ python3 experiments/sunflower_step.py --t 3 0,1 0,2 1,2  # search for a small su
 
 ## Status
 
-This repository is a research prototype. Many central lemmas remain incomplete and are marked with `sorry` or `axiom`. In particular:
+This repository is a research prototype. Many central lemmas remain incomplete and are marked with `axiom`. In particular:
 * `decisionTree_cover` remains an axiom.
 * `NP_separation.lean` derives `P ≠ NP` from unproven assumptions (`magnification_AC0_MCSP`, `karp_lipton`, `FCE_implies_MCSP`).
 * `ComplexityClasses.lean` assumes `P ⊆ P/poly`.


### PR DESCRIPTION
### **User description**
## Summary
- Reword README status to note incomplete proofs are denoted by `axiom`
- Remove outdated references to `sorry`
- Highlight remaining axiomatic statements tracked in `TODO.md`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_689cdfacbba8832bbd7d10270e0c484f


___

### **PR Type**
Documentation


___

### **Description**
- Update README status to clarify `axiom` placeholders usage

- Remove outdated references to `sorry` statements

- Standardize terminology for incomplete proofs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old terminology: 'sorry'"] --> B["Updated terminology: 'axiom'"]
  B --> C["Clarified incomplete proofs status"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Clarify axiom placeholder terminology</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Updated status section to clarify <code>axiom</code> placeholders for unproven <br>statements<br> <li> Removed outdated references to <code>sorry</code> throughout the document<br> <li> Standardized terminology to use <code>axiom</code> consistently for incomplete <br>proofs</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/894/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

