### PR TITLE
Clean up simpa lint warnings

### DIFF
--- a/Pnp2/Sunflower/Sunflower.lean
+++ b/Pnp2/Sunflower/Sunflower.lean
@@ -306,7 +306,8 @@ lemma unions_card_of_disjoint
       simpa [Finset.unions_insert]
     -- intersection of `A` with the union of `T` is empty
     have hA_disj : A ∩ T.unions = (∅ : Finset α) := by
-      apply Finset.eq_empty_of_forall_not_mem
+      -- Use the modern lemma name avoiding deprecation warnings.
+      apply Finset.eq_empty_of_forall_notMem
       intro x hx
       rcases Finset.mem_inter.mp hx with ⟨hxA, hxU⟩
       rcases Finset.mem_unions.mp hxU with ⟨B, hB, hxB⟩
@@ -338,7 +339,7 @@ lemma unions_card_of_disjoint
       _ = w * (T.card + 1) := (Nat.mul_succ w T.card).symm
       _ = w * (insert A T).card := by
             have hcard_insert : (insert A T).card = T.card + 1 :=
-              Finset.card_insert_of_not_mem hA
+              Finset.card_insert_of_notMem hA
             simpa [hcard_insert, Nat.add_comm]
 
 /-! ### Iterated element erasure -/


### PR DESCRIPTION
### **User description**
## Summary
- simplify entropy lemmas using `simp` instead of `simpa`
- modernize sunflower helper lemma names to avoid deprecations

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a9a6f90b14832bb16ea0bf091d98b7


___

### **PR Type**
Other


___

### **Description**
- Replace `simpa` with `simp` for cleaner proofs

- Update deprecated lemma names to modern versions

- Improve code formatting and comments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["simpa usage"] -- "replace with" --> B["simp usage"]
  C["deprecated lemma names"] -- "update to" --> D["modern lemma names"]
  E["code formatting"] -- "improve" --> F["cleaner structure"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Sunflower.lean</strong><dd><code>Update deprecated Finset lemma names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/Sunflower/Sunflower.lean

<ul><li>Replace deprecated <code>Finset.eq_empty_of_forall_not_mem</code> with <br><code>Finset.eq_empty_of_forall_notMem</code><br> <li> Replace deprecated <code>Finset.card_insert_of_not_mem</code> with <br><code>Finset.card_insert_of_notMem</code><br> <li> Add explanatory comments for modernization</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/931/files#diff-50ab50bf1e1750ed334aa084232c0dd854cab00f5f397a6eeb2c651f34e2874b">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entropy.lean</strong><dd><code>Replace simpa with simp and improve formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/entropy.lean

<ul><li>Replace <code>simpa</code> with <code>simp</code> in multiple entropy lemmas<br> <li> Improve code formatting and indentation consistency<br> <li> Add clarifying comments for proof steps<br> <li> Simplify proof expressions using <code>simp</code> instead of <code>simpa</code></ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/931/files#diff-c9945293d072d5db339314094c1055ce9e959671dc64f147c5509da4830de9c9">+38/-33</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

