### PR TITLE
Fix selection lemma in low sensitivity cover proof

### DIFF
--- a/Pnp2/low_sensitivity_cover.lean
+++ b/Pnp2/low_sensitivity_cover.lean
@@ -3098,8 +3098,16 @@ lemma decisionTree_cover_smallS_pos_n1
               · have : f ∈ F.erase f₀ := by
                   simpa [Finset.mem_erase, hf0, hf] using hf
                 simpa [h] using this
-            · intro hf; simpa using (Finset.mem_singleton.mp hf)
-          obtain ⟨f₁, hf₁, hmem⟩ := Finset.exists_mem_of_ne_empty hErase
+            ·
+              intro hf
+              -- Преобразуем членство `f ∈ {f₀}` в равенство и переписываем.
+              have h := Finset.mem_singleton.mp hf
+              subst h
+              simpa using hf₀
+          -- Получаем элемент из `F.erase f₀` через эквивалентность непустоты.
+          have hNonempty : (F.erase f₀).Nonempty :=
+            Finset.nonempty_iff_ne_empty.mpr hErase
+          obtain ⟨f₁, hf₁⟩ := hNonempty
           refine ⟨f₁, ?_, ?_⟩
           · exact Finset.mem_of_mem_erase hf₁
           · exact Finset.ne_of_mem_erase hf₁


### PR DESCRIPTION
### **User description**
## Summary
- avoid nonexistent `Finset.exists_mem_of_ne_empty` by using `Finset.nonempty_iff_ne_empty`
- correctly derive membership of `f₀` from singleton assumption

## Testing
- `lake build`


------
https://chatgpt.com/codex/tasks/task_e_68b216cc8fc0832bb8751a66d03444aa


___

### **PR Type**
Bug fix


___

### **Description**
- Replace nonexistent `Finset.exists_mem_of_ne_empty` with `Finset.nonempty_iff_ne_empty`

- Fix membership derivation for singleton set case

- Add proper comments explaining the proof steps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Nonexistent function call"] --> B["Replace with nonempty equivalence"]
  C["Incorrect singleton handling"] --> D["Fix membership derivation"]
  B --> E["Working proof"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>low_sensitivity_cover.lean</strong><dd><code>Fix finset operations in cover proof</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/low_sensitivity_cover.lean

<ul><li>Replace <code>Finset.exists_mem_of_ne_empty</code> with <br><code>Finset.nonempty_iff_ne_empty.mpr</code><br> <li> Fix singleton membership handling with proper substitution<br> <li> Add Russian comments explaining proof steps<br> <li> Restructure element extraction from erased finset</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/944/files#diff-e8d6d99e466c27b3b222ce19354e16896d865ecc2224933bcb529e2386b88205">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

