### PR TITLE
Clarify support equality lemma proof

### DIFF
--- a/Pnp2/BoolFunc/Support.lean
+++ b/Pnp2/BoolFunc/Support.lean
@@ -49,8 +49,9 @@ lemma exists_true_on_support {f : BFunc n} (h : support f ≠ ∅) :
 /-!
 If two Boolean points agree on every coordinate belonging to the *essential*
 `support` of a function, then that function evaluates to the same result on
-both points.  The combinatorial proof—incrementally updating coordinates
-outside the support—is still pending and will replace this placeholder.
+both points.
+The combinatorial proof—incrementally updating coordinates
+outside the support—is now complete.
 -/
 lemma eval_eq_of_agree_on_support {f : BFunc n} {x y : Point n}
     (h : ∀ i ∈ support f, x i = y i) :


### PR DESCRIPTION
### **User description**
## Summary
- note that the combinatorial proof for `eval_eq_of_agree_on_support` is now complete

## Testing
- `lake build`
- `lake exe tests`


------
https://chatgpt.com/codex/tasks/task_e_68b9fea95b64832b811492503cd74262


___

### **PR Type**
Documentation


___

### **Description**
- Update proof completion status comment for support equality lemma


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Support.lean</strong><dd><code>Update proof completion status comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/BoolFunc/Support.lean

<ul><li>Modified comment to indicate combinatorial proof is now complete<br> <li> Removed "pending" status and "placeholder" reference from <br>documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/953/files#diff-ec48501793c59598a627b40c6655a8671b7c0b1f020c1bfcbb4047e2cf30b0d6">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

