### PR TITLE
doc: clarify zero sensitivity lemmas

### DIFF
--- a/Pnp2/BoolFunc/Sensitivity.lean
+++ b/Pnp2/BoolFunc/Sensitivity.lean
@@ -2552,8 +2552,9 @@ Constant Boolean functions have zero sensitivity.
 
 /--
 If a Boolean function has zero sensitivity, then its essential `support` is
-empty.  Any coordinate belonging to the support would witness positive
-sensitivity, contradicting the assumption.
+empty.  The proof proceeds by contradiction: assuming a coordinate lies in the
+support, we exhibit a point where flipping that coordinate changes the function
+value, deriving positive sensitivity and contradicting `h`.
 -/
 lemma support_eq_empty_of_sensitivity_zero (f : BFunc n)
     (h : sensitivity f = 0) :
@@ -2563,6 +2564,8 @@ lemma support_eq_empty_of_sensitivity_zero (f : BFunc n)
   apply Finset.eq_empty_iff_forall_notMem.mpr
   intro i hi
   rcases mem_support_iff.mp hi with ⟨x, hx⟩
+  -- The point `x` demonstrates that flipping coordinate `i` changes `f`.
+  -- This non-trivial change will yield positive sensitivity, contradicting `h`.
   -- The witness `x` certifies that flipping `i` changes the value of `f`.
   have hxpos' :
       0 < (Finset.univ.filter fun j => f (Point.update x j (!x j)) ≠ f x).card := by

--- a/Pnp2/low_sensitivity_cover.lean
+++ b/Pnp2/low_sensitivity_cover.lean
@@ -3265,10 +3265,12 @@ lemma decisionTree_cover_smallS_zero
     (∀ f ∈ F, ∀ x, f x = true → ∃ R ∈ Rset, x ∈ₛ R) ∧
     Rset.card ≤ Nat.pow 2 (coverConst * 0 * Nat.log2 (Nat.succ n)) := by
   classical
+  -- First upgrade the non‑strict bound `sensitivity f ≤ 0` to an equality.
   have Hsens0 : ∀ f ∈ F, sensitivity f = 0 := by
     intro f hf
     have hle := Hsens f hf
     exact le_antisymm hle (Nat.zero_le _)
+  -- A Boolean function with zero sensitivity is constant on all inputs.
   have hconst : ∀ f ∈ F, ∀ x y, f x = f y := by
     intro f hf x y
     have hsupp :=
@@ -3277,8 +3279,10 @@ lemma decisionTree_cover_smallS_zero
       intro i hi
       have : i ∈ (∅ : Finset (Fin n)) := by simpa [hsupp] using hi
       cases this
+    -- With an empty support, the values agree on all points.
     simpa using
       eval_eq_of_agree_on_support (f := f) (x := x) (y := y) hagree
+  -- The specialised constant-family cover provides the desired rectangle set.
   simpa [Nat.mul_comm, Nat.mul_left_comm, Nat.mul_assoc] using
     (decisionTree_cover_of_constFamily (n := n) (F := F) (s := 0) hconst)
 


### PR DESCRIPTION
## Summary
- expand explanation for `support_eq_empty_of_sensitivity_zero`
- add detailed comments to the base-case cover lemma `decisionTree_cover_smallS_zero`

## Testing
- `./scripts/check.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c1cb469ff8832b8643473d900c85a4