### PR TITLE
Refactor permutation case skeleton in decision tree utilities

### DIFF
--- a/Pnp2/DecisionTree.lean
+++ b/Pnp2/DecisionTree.lean
@@ -2107,14 +2107,15 @@ lemma coloredSubcubesAux_cons_subset_node_same (t₀ t₁ : DecisionTree n)
     intro x hx; simpa using hx
 
 /--
-Placeholder for the permutation case of
-`coloredSubcubesAux_cons_subset`.  When the root coordinate `j` of a
-node already appears inside the tail path `p` and differs from the
-coordinate `i` being removed, the combinatorial bookkeeping becomes
-substantial.  The full proof is deferred; we assume the existence of an
-ancestor subcube provided by reordering assignments inside `p`.
+Permutation case of `coloredSubcubesAux_cons_subset`.  When the root
+coordinate `j` already appears inside the tail path `p` and differs from
+the coordinate `i` being removed at the head, we may reorder the path so
+that the occurrence of `j` is processed first.  This reveals an ancestor
+subcube from the shortened path.  The full combinatorial argument is
+somewhat technical and is postponed – we record the statement here with
+the intended strategy sketched in the comments below.
 -/
-axiom coloredSubcubesAux_cons_subset_node_perm (t₀ t₁ : DecisionTree n)
+lemma coloredSubcubesAux_cons_subset_node_perm (t₀ t₁ : DecisionTree n)
     (i j : Fin n) (b : Bool) (p : List (Fin n × Bool))
     (br : Bool × Subcube n)
     (hmem : br ∈ coloredSubcubesAux (n := n)
@@ -2124,7 +2125,24 @@ axiom coloredSubcubesAux_cons_subset_node_perm (t₀ t₁ : DecisionTree n)
     (hij : i ≠ j) :
     ∃ brRec ∈ coloredSubcubesAux (n := n)
           (DecisionTree.node j t₀ t₁) p,
-        ∀ ⦃x : Point n⦄, Subcube.mem br.2 x → Subcube.mem brRec.2 x
+        ∀ ⦃x : Point n⦄, Subcube.mem br.2 x → Subcube.mem brRec.2 x := by
+  classical
+  -- We first expose the final occurrence of `j` inside `p`.
+  obtain ⟨bj, p₁, p₂, hp, hjtail⟩ :=
+    subcube_of_path_idx_split_last (n := n) (p := p) (j := j) hj
+  subst hp
+  -- After rewriting, the path has shape `(i,b) :: p₁ ++ (j,bj) :: p₂` with
+  -- `j ∉ (subcube_of_path p₂).idx`.
+  -- By swapping assignments inside the prefix we can move `(i,b)` past `p₁`
+  -- and finally behind the occurrence of `j`.
+  -- Reordering does not change membership in `coloredSubcubesAux` thanks to
+  -- `coloredSubcubesAux_cons_swap` and its iteration.  The resulting path has
+  -- form `(j,bj) :: (i,b) :: p₁ ++ p₂`.
+  -- Removing the leading assignment for `j` now falls under
+  -- `coloredSubcubesAux_cons_subset_node_same`, yielding the desired ancestor
+  -- subcube.
+  -- The detailed commutator chain is not yet formalised.
+  sorry
 
 /--
 The helper `coloredSubcubesAux_cons_subset` shows that removing the most


### PR DESCRIPTION
### **User description**
## Summary
- Replace `coloredSubcubesAux_cons_subset_node_perm` axiom with lemma stub and proof plan
- Sketch approach using path splitting and swaps for future completion

## Testing
- `lake exe tests`

------
https://chatgpt.com/codex/tasks/task_e_68c31d958744832bac7e746420dd9776


___

### **PR Type**
Enhancement


___

### **Description**
- Replace axiom with lemma stub for permutation case

- Add detailed proof strategy comments

- Implement classical proof framework with sorry placeholder


___

### Diagram Walkthrough


```mermaid
flowchart LR
  axiom["Axiom: coloredSubcubesAux_cons_subset_node_perm"] -- "refactor" --> lemma["Lemma with proof skeleton"]
  lemma -- "add" --> strategy["Proof strategy comments"]
  lemma -- "implement" --> framework["Classical proof framework"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DecisionTree.lean</strong><dd><code>Refactor permutation axiom to lemma with proof skeleton</code>&nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/DecisionTree.lean

<ul><li>Replace <code>axiom</code> with <code>lemma</code> declaration<br> <li> Add comprehensive proof strategy in comments<br> <li> Implement classical proof framework with <code>sorry</code> placeholder<br> <li> Update documentation to reflect proof approach</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/967/files#diff-c3613b7999cc16eb91df068a303712f6d0727ee152ff137bb622b209064bacd9">+26/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

