### PR TITLE
feat: add path split-first lemma for decision tree

### DIFF
--- a/Pnp2/DecisionTree.lean
+++ b/Pnp2/DecisionTree.lean
@@ -2362,11 +2362,19 @@ lemma coloredSubcubesAux_cons_subset_node_perm (t₀ t₁ : DecisionTree n)
         (DecisionTree.node j t₀ t₁)
         ((j, bj) :: (i, b) :: (p₁ ++ p₂)) := by
     simpa [hperm, List.cons_append, List.append_assoc] using hmem'
-  -- With the normalised path in hand, applying
-  -- `coloredSubcubesAux_cons_subset_node_same` would yield the desired result.
-  -- The remaining steps are therefore postponed.
-  -- TODO: complete the permutation argument and final application.
-  sorry
+  -- After bubbling `(j, bj)` to the front we can drop this head entry using
+  -- the specialised subset lemma for matching coordinates.
+  obtain ⟨br₁, hbr₁, hsub₁⟩ :=
+    coloredSubcubesAux_cons_subset_node_same (t₀ := t₀) (t₁ := t₁)
+      (i := j) (b := bj) (p := (i, b) :: (p₁ ++ p₂)) (br := br) hmemNorm
+  -- Having removed `(j, bj)` we would next like to delete the `(i, b)`
+  -- assignment and permute the remaining path back to `p`.  These steps
+  -- require additional bookkeeping and are left for future work.
+  refine ⟨br₁, ?_, ?_⟩
+  · -- membership in the target coloured subcube set
+    sorry
+  · -- the subcube inclusion established so far
+    exact hsub₁
 
 /--
 The helper `coloredSubcubesAux_cons_subset` shows that removing the most


### PR DESCRIPTION
### **User description**
## Summary
- introduce bubble lemma skeleton to move a coordinate to the front of a path using swaps

## Testing
- `lake build`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68c409664564832bba3c80f5ff581ef1


___

### **PR Type**
Enhancement


___

### **Description**
- Add path splitting lemma for first occurrence of coordinate

- Introduce bubble lemma skeleton for path permutation

- Refactor decision tree construction for empty support functions

- Extend permutation proof framework for coordinate swapping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["path_split_first"] --> B["subcube_of_path_idx_split_first"]
  B --> C["coloredSubcubesAux_cons_bubble"]
  C --> D["coloredSubcubesAux_cons_subset_node_perm"]
  E["exists_decisionTree_of_support_card_zero"] --> F["exists_decisionTree_depth_le_support_card"]
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DecisionTree.lean</strong><dd><code>Path splitting and permutation lemmas for decision trees</code>&nbsp; </dd></summary>
<hr>

Pnp2/DecisionTree.lean

<ul><li>Add <code>path_split_first</code> lemma to split paths at first coordinate <br>occurrence<br> <li> Implement <code>subcube_of_path_idx_split_first</code> for subcube index splitting<br> <li> Introduce <code>coloredSubcubesAux_cons_bubble</code> skeleton for coordinate <br>permutation<br> <li> Extend <code>coloredSubcubesAux_cons_subset_node_perm</code> with detailed <br>permutation proof framework<br> <li> Extract <code>exists_decisionTree_of_support_card_zero</code> helper for constant <br>functions<br> <li> Refactor <code>exists_decisionTree_depth_le_support_card</code> to use extracted <br>helper</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/975/files#diff-c3613b7999cc16eb91df068a303712f6d0727ee152ff137bb622b209064bacd9">+192/-75</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

