### PR TITLE
Use family sensitivity bound in Huang step

### DIFF
--- a/Pnp2/low_sensitivity_cover.lean
+++ b/Pnp2/low_sensitivity_cover.lean
@@ -3657,16 +3657,15 @@ lemma exists_common_monochromatic_subcube
             intro hmono; apply hf; intro _; exact hmono
           -- Apply `huang_step` to isolate a new coordinate `i`.
           -- Apply `huang_step` to isolate a new coordinate `i`.
+          -- Convert the global sensitivity hypothesis for the family into a
+          -- concrete bound for the offending function `f`.
+          have hfSens : sensitivity f ≤ s := Hsens f hfF
           have hstep :
               ∃ (i : Fin n) (T : Finset (Point n)),
                 2 ≤ T.card ∧
                 (∀ x ∈ T, f x = f (Point.update x i (!x i))) :=
             huang_step (n := n) (s := s) hnpos (hs_lt_n := hs_lt_n)
-              (f := f) (hf := by
-                -- The sensitivity bound required by `huang_step` follows from
-                -- the assumptions on the family.  The explicit conversion is
-                -- deferred.
-                sorry)
+              (f := f) (hf := hfSens)
           -- Unpack the returned data via classical choice.
           classical
           let i := Classical.choose hstep


### PR DESCRIPTION
### **User description**
## Summary
- derive the concrete sensitivity bound for the offending function from the family-wide hypothesis before applying `huang_step`

## Testing
- not run (Lean proofs not executed in this change)

------
https://chatgpt.com/codex/tasks/task_e_68c895bc34a4832b84d29a215e934c47


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `sorry` placeholder with concrete sensitivity bound derivation

- Use family-wide hypothesis to prove individual function sensitivity

- Complete proof step in Huang algorithm application


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Family sensitivity hypothesis"] --> B["Derive concrete bound for function f"]
  B --> C["Apply huang_step with proven bound"]
  D["Remove sorry placeholder"] --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>low_sensitivity_cover.lean</strong><dd><code>Complete sensitivity bound proof derivation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/low_sensitivity_cover.lean

<ul><li>Add derivation of concrete sensitivity bound from family hypothesis<br> <li> Replace <code>sorry</code> placeholder with proven bound <code>hfSens</code><br> <li> Complete proof step for <code>huang_step</code> application</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/991/files#diff-e8d6d99e466c27b3b222ce19354e16896d865ecc2224933bcb529e2386b88205">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

