### PR TITLE
Fill huang_step sensitivity argument

### DIFF
--- a/Pnp2/low_sensitivity_cover.lean
+++ b/Pnp2/low_sensitivity_cover.lean
@@ -3663,10 +3663,11 @@ lemma exists_common_monochromatic_subcube
                 (∀ x ∈ T, f x = f (Point.update x i (!x i))) :=
             huang_step (n := n) (s := s) hnpos (hs_lt_n := hs_lt_n)
               (f := f) (hf := by
-                -- The sensitivity bound required by `huang_step` follows from
-                -- the assumptions on the family.  The explicit conversion is
-                -- deferred.
-                sorry)
+                -- Используем глобальное предположение `Hsens` и факт `hfF`
+                -- о принадлежности `f` семейству `F`, чтобы получить
+                -- требуемое ограничение на чувствительность.
+                have hf : sensitivity f ≤ s := Hsens f hfF
+                exact hf)
           -- Unpack the returned data via classical choice.
           classical
           let i := Classical.choose hstep


### PR DESCRIPTION
### **User description**
## Summary
- derive the sensitivity bound needed by `huang_step` from the global family assumption within `decisionTree_cover_smallS_pos_general`
- replace the placeholder `sorry` by an explicit proof using the membership witness `hfF`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c895bc34a4832b84d29a215e934c47


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `sorry` placeholder with explicit proof

- Derive sensitivity bound from global family assumption

- Use membership witness `hfF` for proof completion


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Global assumption Hsens"] --> B["Membership witness hfF"]
  B --> C["Sensitivity bound proof"]
  C --> D["huang_step argument completed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>low_sensitivity_cover.lean</strong><dd><code>Complete sensitivity argument proof</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Pnp2/low_sensitivity_cover.lean

<ul><li>Replace <code>sorry</code> placeholder with explicit proof using <code>Hsens</code> and <code>hfF</code><br> <li> Add Russian comments explaining the proof derivation<br> <li> Complete sensitivity bound argument for <code>huang_step</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/992/files#diff-e8d6d99e466c27b3b222ce19354e16896d865ecc2224933bcb529e2386b88205">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

