### PR TITLE
Normalize complexity notation and theorem references

### DIFF
--- a/Preprint.latex
+++ b/Preprint.latex
@@ -7,9 +7,21 @@
 \usepackage{geometry}
 \usepackage[ruled,linesnumbered]{algorithm2e}
 \geometry{margin=1in}
+% Classes and common operators
+\newcommand{\Pclass}{\mathrm{P}}
+\newcommand{\NP}{\mathrm{NP}}
+\newcommand{\Ppoly}{\mathrm{P}/\mathrm{poly}}
+\newcommand{\PH}{\mathrm{PH}}
+\newcommand{\ACC}{\mathsf{ACC}}
+\newcommand{\poly}{\operatorname{poly}}
+\newcommand{\GapMCSP}{\textsc{Gap-MCSP}}
+\newcommand{\SearchMCSP}{\textsc{search-MCSP}}
 \newcommand{\PHNC}{\textup{PHNC}}
+% Theorem environments
+\newtheorem{theorem}{Theorem}
+\newtheorem{lemma}{Lemma}
 
-\title{Outline of a Proof that $P \neq NP$ via the Family Collision-Entropy Lemma}
+\title{Outline of a Proof that $\Pclass \ne \NP$ via the Family Collision-Entropy Lemma}
 \author{Dmitry Khanukov\\\texttt{thelaprok@gmail.com}\\\emph{Preprint, work in progress}}
 \date{July 2025}
 
@@ -17,23 +29,30 @@
 
 \maketitle
 
-\noindent\textbf{Work-in-Progress Note:} \emph{This manuscript outlines a route to separating $P$ from $NP$ based on the \textbf{Family Collision-Entropy Lemma (FCE-Lemma)}. The lemma has now been fully formalized in Lean, though the broader connection to circuit lower bounds is still being polished. We summarize the approach and highlight the remaining steps.}
+\noindent\textbf{Work-in-Progress Note:} \emph{This manuscript outlines a route to separating $\Pclass$ from $\NP$ based on the \textbf{Family Collision-Entropy Lemma (FCE-Lemma)}. The lemma has now been fully formalized in Lean, though the broader connection to circuit lower bounds is still being polished. We summarize the approach and highlight the remaining steps.}
 
 \begin{abstract}
-We outline the \textbf{Family Collision-Entropy Lemma (FCE-Lemma)}, a combinatorial statement about covering low-entropy families of boolean functions by a small number of monochromatic subcubes. Together with a \emph{hardness magnification} theorem for (variants of) MCSP and the classical simulation $P \subseteq P/\mathrm{poly}$, the FCE-Lemma yields \textbf{an unconditional route} to $NP \not\subseteq P/\mathrm{poly}$ and hence $P \neq NP$. The core lemma and its cover-building algorithm are being fully formalized in Lean; the remaining work is the formal bridge from FCE to explicit MCSP lower bounds under parameters that trigger magnification, and a Lean-level TM$\to$circuits simulation (closing $P \subseteq P/\mathrm{poly}$) for the final step. We summarize the approach and the current formalization status.
+We outline the \textbf{Family Collision-Entropy Lemma (FCE-Lemma)}, a combinatorial
+statement about covering low-entropy families of boolean functions by a small number of
+monochromatic subcubes. Together with a \emph{hardness magnification} theorem for (variants of)
+MCSP and the classical simulation $\Pclass \subseteq \Ppoly$, the FCE-Lemma yields an unconditional
+route to $\NP \not\subseteq \Ppoly$ and hence $\Pclass \ne \NP$. The core lemma and its cover-building algorithm
+are being fully formalized in Lean; the remaining work is the formal bridge from FCE to explicit
+MCSP lower bounds under parameters that trigger magnification, and a Lean-level TM$\to$circuits
+simulation (closing $\Pclass \subseteq \Ppoly$) for the final step.
 \end{abstract}
 
 \section{Introduction}
 
-Determining whether \textbf{$P = NP$ or $P \neq NP$} is a central open problem in theoretical computer science and mathematics. Over the years, many approaches have been explored. The approach in this work follows a \textbf{communication complexity and combinatorics route}: we reduce the question $P \stackrel{?}{=} NP$ to a statement about covering boolean functions with simple combinatorial regions (see \cite{KN97} for background on communication complexity). In particular, prior work showed that to prove $P \neq NP$, it suffices to construct certain \emph{subexponential-size covers} for families of boolean functions arising from NP problems. Most parts of that program have been tackled previously. Here we sketch how the remaining step might be resolved; if successful, this would essentially complete the program under standard complexity assumptions.
+Determining whether \textbf{$\Pclass = \NP$ or $\Pclass \ne \NP$} is a central open problem in theoretical computer science and mathematics. Over the years, many approaches have been explored. The approach in this work follows a \textbf{communication complexity and combinatorics route}: we reduce the question $\Pclass \stackrel{?}{=} \NP$ to a statement about covering boolean functions with simple combinatorial regions (see \cite{KN97} for background on communication complexity). In particular, prior work showed that to prove $\Pclass \ne \NP$, it suffices to construct certain \emph{subexponential-size covers} for families of boolean functions arising from $\NP$ problems. Most parts of that program have been tackled previously. Here we sketch how the remaining step might be resolved; if successful, this would essentially complete the program under standard complexity assumptions.
 
 The last step is captured by what we call the \textbf{Family Collision-Entropy Lemma (FCE-Lemma)}. \emph{Collision entropy} $H_2(F)$, informally, measures how “spread out” or uniform a family $F$ of functions is: low collision entropy means the family has a lot of structure or bias (e.g. the functions might mostly output 0 on most inputs). The FCE-Lemma asserts that if a family of boolean functions has low output entropy, then one can cover all \emph{1-inputs} (true outputs) of all functions in the family with a surprisingly \emph{small collection of subcubes} (combinatorial rectangles). Crucially, the cover is \emph{uniform} for the whole family $F$ – the same set of subcubes works for every function in $F$ simultaneously. This generalizes earlier results on low-sensitivity (``smooth'') boolean functions~\cite{GNSWT16} to entire families. Intuitively, it means that structured (low-entropy) families cannot evade a common simple structure: they \emph{must} have a large monochromatic combinatorial region in common or a small set of such regions that covers all their outputs.
 
 Why is this lemma so significant? In earlier work by researchers like Göös, Lovett, and others, complexity lower bounds were linked to the inability to cover certain function families with few rectangles (a rectangle is essentially a subcube in the boolean hypercube). For example, NP-complete problems are believed to require exponentially many rectangles in any communication protocol or DNF representation \cite{Juk12}. The FCE-Lemma formalizes a combinatorial condition under which \emph{such large covers are unavoidable}. Establishing the FCE-Lemma would show that certain NP-related function families (those with small entropy, arising in hardness reductions) \emph{cannot} be covered by fewer than $2^{n^{c}}$ rectangles for some $c>0$. This yields the desired lower bound in communication or circuit complexity that separates NP from P. In short, the FCE-Lemma would be a central ingredient in this approach.
 
-Our contributions in this preprint are: (1) a formal statement of the FCE-Lemma and an outline of its \emph{constructive proof}, (2) an explanation of how this lemma fits into the larger framework that yields $P \neq NP$, and (3) a report on the status of a full \textbf{formal verification} of this proof in Lean (a proof assistant), underscoring our confidence in its correctness.
+Our contributions in this preprint are: (1) a formal statement of the FCE-Lemma and an outline of its \emph{constructive proof}, (2) an explanation of how this lemma fits into the larger framework that yields $\Pclass \ne \NP$, and (3) a report on the status of a full \textbf{formal verification} of this proof in Lean (a proof assistant), underscoring our confidence in its correctness.
 
-Our route reduces $P$ vs.\ $NP$ to a combinatorial covering statement (FCE) and then leverages recent \emph{hardness magnification} results for (variants of) MCSP to obtain $NP \not\subseteq P/\mathrm{poly}$. Together with the classical $P \subseteq P/\mathrm{poly}$ simulation, this yields $P \neq NP$ without any appeal to the polynomial hierarchy.
+Our route reduces $\Pclass$ vs.\ $\NP$ to a combinatorial covering statement (FCE) and then leverages recent \emph{hardness magnification} results for (variants of) MCSP to obtain $\NP \not\subseteq \Ppoly$. Together with the classical $\Pclass \subseteq \Ppoly$ simulation, this yields $\Pclass \ne \NP$ without any appeal to the polynomial hierarchy.
 
 \section{Main Result: The Family Collision-Entropy Lemma}
 
@@ -57,75 +76,75 @@ Intuitively, $H_2(F) = \log_2 |F|$ if all functions are distinct and equally lik
 \begin{enumerate}
     \item \emph{Each $R_i \in \mathcal{R}$ is monochromatic for every $f \in F$ (all functions in $F$ agree on each subcube).}
     \item \emph{For every function $f \in F$, the union of the subcubes on which $f$ outputs 1 covers \textbf{all} 1-inputs of $f$. (In other words, these rectangles collectively cover the 1-output set of every $f$ in the family.)}
-    \item \emph{The number of subcubes $m$ in the collection is at most $m \le n(h+2)2^{10h}$, which is less than $2^{n/100}$ for sufficiently large $n$. In particular, $m = 2^{o(n)}$ is subexponential in $n$.}
+    \item \emph{The number of subcubes $m$ in the collection is at most $m \le n(h+2)\,2^{10h}$, which is less than $2^{n/100}$ for sufficiently large $n$. In particular, $m = 2^{o(n)}$ is subexponential in $n$.}
 \end{enumerate}
 
 This lemma guarantees a \textbf{subexponential-size covering} of all functions in $F$ by common rectangles, as long as the family’s collision entropy is sublinear in $n$. The exact bound $m < 2^{n/100}$ is not optimized in our sketch (we did not strive for the best constant $1/100$ here), but any $2^{o(n)}$ bound suffices for applications. The condition $h = o(n)$ is very weak – in typical applications $h$ will be a small constant or $O(\log n)$. Thus, intuitively, any family of moderately low entropy functions on $n$ bits can be “tiled” by significantly fewer than $2^n$ monochromatic subcubes.
 
-\textbf{Significance:} Achieving a cover of size $2^{o(n)}$ (where a naive exhaustive cover would have size $2^n$) is critical. It aligns with known thresholds in complexity theory: a cover of size $2^{o(n)}$ for certain NP-related function families is enough to force superpolynomial (often exponential) lower bounds in circuit or communication complexity. The FCE-Lemma would provide an important combinatorial piece in one approach to separating $P$ from $NP$ by yielding the required lower bound in the non-uniform setting (see Section~4).
+\textbf{Significance:} Achieving a cover of size $2^{o(n)}$ (where a naive exhaustive cover would have size $2^n$) is critical. It aligns with known thresholds in complexity theory: a cover of size $2^{o(n)}$ for certain $\NP$-related function families is enough to force superpolynomial (often exponential) lower bounds in circuit or communication complexity. The FCE-Lemma would provide an important combinatorial piece in one approach to separating $\Pclass$ from $\NP$ by yielding the required lower bound in the non-uniform setting (see Section~\ref{sec:ph-free-route}).
 
 \section{Cover--Building Algorithm}
 
 \emph{Our proof of the FCE-Lemma is constructive}, providing an explicit algorithm to build the covering subcubes $\mathcal{R}$. The strategy follows a \textbf{structure-vs-randomness paradigm}: at each step, we either find a structured pattern (a large common intersection among some 1-inputs) or, if no obvious structure is present, we use an entropy argument to fix a bit that reduces the complexity (entropy) of the family. This approach is inspired by sunflower lemmas (to find large intersections) and information-theoretic arguments (to handle pseudo-random behavior). Here is a high-level procedure:
 
 \begin{algorithm}[H]
+\DontPrintSemicolon
 \KwIn{family $F$ with $H_2(F)\le h$}
 \KwOut{subcube cover $\mathcal{R}$}
-initialize $\mathcal{R}\leftarrow\emptyset$ and $\texttt{Pts}\leftarrow\{x\mid f(x)=1 \text{ for some }f\in F\}$\;
+$\mathcal{R}\gets\emptyset$;\quad
+$\texttt{Pts}\gets\{x\in\{0,1\}^n:\exists f\in F,\, f(x)=1\}$\;
 \While{$\texttt{Pts}\neq\emptyset$}{
-  \eIf{a sunflower core $I$ exists in $\texttt{Pts}$}{
-    add the subcube fixing $I$ to $\mathcal{R}$ and remove covered points\;
+  \eIf{\textsc{SunflowerCore}$(\texttt{Pts})$ returns a core $I$}{
+    add subcube fixing $I$ to $\mathcal{R}$;\quad remove covered points from $\texttt{Pts}$\;
   }{
-    choose a coordinate $i$ reducing entropy and restrict $F$ on $x_i$\;
+    choose a coordinate $i$ that lowers $H_2$;\quad restrict $F$ on $x_i$;\quad update $\texttt{Pts}$\;
   }
 }
 \Return{$\mathcal{R}$}
+\caption{Cover builder (structure vs.\ randomness)}
 \end{algorithm}
-This iterative process alternates sunflower extractions and entropy-drop splits. Because $H_2(F)\le h$, there can be at most $h$ entropy-based splits before the family becomes monochromatic. Each sunflower step removes many points at once. The overall number of rectangles produced is bounded by $m \le n(h+2)2^{10h} < 2^{n/100}$ for sufficiently large $n$.
-The above is a high-level sketch. Each step uses a specific lemma: the \emph{Sunflower Lemma} to find common cores, a \emph{Core Agreement Lemma} to ensure that if two inputs have a large common intersection and are 1 for all $f$, then the whole subcube is 1 for all $f$, an \emph{Entropy Drop Lemma} to reduce $H_2$, and a \emph{Low-Sensitivity Cover Lemma} (for a technical case of very ``smooth'' functions) to merge small decision-tree covers. All these pieces are proven or cited in our development. What\'s important is that this constructive procedure will not run for too many steps and will output a correct cover $\mathcal{R}$ meeting the three criteria of the FCE-Lemma. Thus, we have (sketchily) proven the main theorem. The full details of the proof are being formalized in Lean (see Section~6).
-\section{From FCE to Circuit Lower Bounds (PH-free Route)}
+This iterative process alternates sunflower extractions and entropy-drop splits. Because $H_2(F)\le h$, there can be at most $h$ entropy-based splits before the family becomes monochromatic. Each sunflower step removes many points at once. The overall number of rectangles produced is bounded by $m \le n(h+2)\,2^{10h} < 2^{n/100}$ for sufficiently large $n$.
+The above is a high-level sketch. Each step uses a specific lemma: the \emph{Sunflower Lemma} to find common cores, a \emph{Core Agreement Lemma} to ensure that if two inputs have a large common intersection and are 1 for all $f$, then the whole subcube is 1 for all $f$, an \emph{Entropy Drop Lemma} to reduce $H_2$, and a \emph{Low-Sensitivity Cover Lemma} (for a technical case of very ``smooth'' functions) to merge small decision-tree covers. All these pieces are proven or cited in our development. What's important is that this constructive procedure will not run for too many steps and will output a correct cover $\mathcal{R}$ meeting the three criteria of the FCE-Lemma. Thus, we have (sketchily) proven the main theorem. The full details of the proof are being formalized in Lean (see Section~6).
+\section{From FCE to Circuit Lower Bounds (PH-free Route)}\label{sec:ph-free-route}
 
-This section records the exact, PH-free pipeline from the Family Collision-Entropy Lemma to $P \neq NP$. We present two interchangeable targets for the intermediate circuit lower bound (choose one to implement; we recommend the McKay--Murray--Williams path as the primary target).
+This section records the exact, PH-free pipeline from the Family Collision-Entropy Lemma to $\Pclass \ne \NP$. We present two interchangeable targets for the intermediate circuit lower bound (choose one to implement; we recommend the McKay--Murray--Williams path as the primary target).
 
 \paragraph{Target A (MMW'19, recommended).}
 Let $N=2^n$ denote the input length for the tabulated function on $n$ bits. Consider the \emph{search} version of MCSP (find a small circuit or certify none exists) under the usual size parameter $s(n)\ge n$. McKay--Murray--Williams (STOC'19) show, in essence, that if one rules out \emph{oracle circuits} of
 \[
-\text{size } N\cdot \mathrm{poly}(\log N)\quad\text{and}\quad \text{depth } \mathrm{poly}(\log N)
+\text{size } N\cdot \poly(\log N)\quad\text{and}\quad \text{depth } \poly(\log N)
 \]
-(with short queries to a fixed $A\in \mathrm{PH}$), then it already follows that $NP \not\subseteq P/\mathrm{poly}$. Concretely:
+(with short queries to a fixed $A\in \PH$), then it already follows that $\NP \not\subseteq \Ppoly$. Concretely:
 
-\begin{theorem}[MMW'19, informal trigger]
-\label{thm:mmw-trigger}
-If \textup{search-MCSP}$_A[s(\cdot)]$ cannot be computed by oracle circuits of size $N\cdot\mathrm{poly}(\log N)$ and depth $\mathrm{poly}(\log N)$ (for a suitable $s(\cdot)$ and short queries to $A\in \mathrm{PH}$), then $NP \not\subseteq P/\mathrm{poly}$.
+\begin{theorem}[MMW'19, informal trigger]\label{thm:mmw-trigger}
+If $\SearchMCSP_A[s(\cdot)]$ cannot be computed by oracle circuits of size $N\cdot\poly(\log N)$ and depth $\poly(\log N)$ (for a suitable $s(\cdot)$ and short queries to $A\in \PH$), then $\NP \not\subseteq \Ppoly$.
 \end{theorem}
 
-Thus, our job is to derive such a lower bound for \textup{search-MCSP} using FCE.
+Thus, our job is to derive such a lower bound for $\SearchMCSP$ using FCE.
 
 \paragraph{Target B (OPS'19/ToC'21).}
 Oliveira--Pich--Santhanam show a hardness magnification statement for \emph{Gap}-MCSP vs.\ \emph{general} circuits:
 
-\begin{theorem}[OPS'19, informal trigger]
-\label{thm:ops-trigger}
-If \textup{Gap-MCSP} requires circuits of size $N^{1+\varepsilon}$ (for some fixed $\varepsilon>0$) on inputs of length $N$, then $NP \not\subseteq P/\mathrm{poly}$.
+\begin{theorem}[OPS'19, informal trigger]\label{thm:ops-trigger}
+If $\GapMCSP$ requires circuits of size $N^{1+\varepsilon}$ (for some fixed $\varepsilon>0$) on inputs of length $N$, then $\NP \not\subseteq \Ppoly$.
 \end{theorem}
 
 This alternative avoids oracle gates but asks for a superlinear lower bound against all circuits.
 
 \medskip
-In both routes, once $NP \not\subseteq P/\mathrm{poly}$ is obtained, combining with the classical inclusion $P\subseteq P/\mathrm{poly}$ immediately yields $P\neq NP$.
+In both routes, once $\NP \not\subseteq \Ppoly$ is obtained, combining with the classical inclusion $\Pclass\subseteq \Ppoly$ immediately yields $\Pclass\ne \NP$.
 
 \subsection{FCE $\Rightarrow$ lower bounds for (search/Gap-)MCSP}
 
 The FCE-Lemma provides a \emph{subexponential}-size, \emph{family-uniform} cover of the 1-inputs of each $f\in F$ by monochromatic subcubes, whenever the collision entropy $H_2(F)$ is $o(n)$. We now explain how to instantiate $F$ with the distributions that arise in (search/Gap-)MCSP so that small-depth/small-size circuits for MCSP would contradict FCE.
 
-At a high level, suppose \textup{(search/Gap)-MCSP} had circuits under the target model/parameters. Standard rectangle/DNF simulations for such circuits over tabulation inputs yield small covers for the corresponding \emph{families} of acceptance regions. By construction, these families enjoy low collision entropy (they are drawn from tabulations with a structured size promise). Applying FCE collapses these families to a \emph{common} subcube cover of size $2^{o(n)}$, which in turn forces the DNF/rectangle complexity to be $2^{o(n)}$. For MCSP this contradicts the intended behavior (one can separate positive and negative instances only with sufficiently many distinct “shapes”), yielding:
+At a high level, suppose \textup{(search/Gap)-MCSP} had circuits under the target model/parameters. Standard rectangle/DNF simulations for such circuits over tabulation inputs (that is, truth tables of $n$-bit functions with $N=2^n$) yield small covers for the corresponding \emph{families} of acceptance regions. By construction, these families enjoy low collision entropy (they are drawn from tabulations with a structured size promise). Applying FCE collapses these families to a \emph{common} subcube cover of size $2^{o(n)}$, which in turn forces the DNF/rectangle complexity to be $2^{o(n)}$. For MCSP this contradicts the intended behavior (one can separate positive and negative instances only with sufficiently many distinct “shapes”), yielding:
 
-\begin{lemma}[FCE-to-MCSP lower bound, schematic]
-\label{lem:FCE-to-MCSP}
-Assume FCE at parameter $h=o(n)$. Then there exist natural parameterizations of \textup{search-MCSP} or \textup{Gap-MCSP} such that:
+\begin{lemma}[FCE-to-MCSP lower bound, schematic]\label{lem:fce-to-mcsp}
+Assume FCE at parameter $h=o(n)$. Then there exist natural parameterizations of $\SearchMCSP$ or $\GapMCSP$ such that:
 \begin{enumerate}
-  \item either \textup{search-MCSP}$_A[s(\cdot)] \notin$ oracle-circuits of size $N\cdot\mathrm{poly}(\log N)$ and depth $\mathrm{poly}(\log N)$ (MMW trigger),
-  \item or \textup{Gap-MCSP} $\notin$ circuits of size $N^{1+\varepsilon}$ for some fixed $\varepsilon>0$ (OPS trigger).
+  \item either $\SearchMCSP_A[s(\cdot)] \notin$ oracle circuits of size $N\cdot\poly(\log N)$ and depth $\poly(\log N)$ (MMW trigger),
+  \item or $\GapMCSP \notin$ circuits of size $N^{1+\varepsilon}$ for some fixed $\varepsilon>0$ (OPS trigger).
 \end{enumerate}
 \end{lemma}
 
@@ -133,24 +152,24 @@ Assume FCE at parameter $h=o(n)$. Then there exist natural parameterizations of 
 
 \subsection{Magnification step and the final implication}
 
-By Theorems~\ref{thm:mmw-trigger} or \ref{thm:ops-trigger}, Lemma~\ref{lem:FCE-to-MCSP} implies $NP \not\subseteq P/\mathrm{poly}$. Finally, together with the classical simulation $P\subseteq P/\mathrm{poly}$ we conclude $P\neq NP$. Importantly, \emph{no assumption about the polynomial hierarchy is used} in this chain.
+By Theorems~\ref{thm:mmw-trigger} or~\ref{thm:ops-trigger}, Lemma~\ref{lem:fce-to-mcsp} implies $\NP \not\subseteq \Ppoly$. Finally, together with the classical simulation $\Pclass\subseteq \Ppoly$ we conclude $\Pclass\ne \NP$. Importantly, \emph{no assumption about the polynomial hierarchy is used} in this chain.
 
-\section{Unconditional Implications for $P$ vs.\ $NP$}
+\section{Unconditional Implications for $\Pclass$ vs.\ $\NP$}
 
 We summarize the PH-free logical flow:
 
 \begin{enumerate}
   \item \textbf{FCE-Lemma} (proved/being formalized): for any family $F$ with $H_2(F)=o(n)$ there is a subcube cover of size $2^{o(n)}$ that uniformly covers the 1-inputs of all $f\in F$.
-  \item \textbf{FCE $\Rightarrow$ MCSP lower bound} (Lemma~\ref{lem:FCE-to-MCSP}): instantiate $F$ with the acceptance families induced by (search/Gap-)MCSP under the usual promise; conclude either an oracle-circuit lower bound of size $N\cdot\mathrm{polylog}(N)$ and depth $\mathrm{polylog}(N)$ (MMW) \emph{or} a general-circuit lower bound $N^{1+\varepsilon}$ (OPS).
-  \item \textbf{Hardness magnification:} apply MMW'19 or OPS'19 to deduce $NP \not\subseteq P/\mathrm{poly}$.
-  \item \textbf{Classical simulation:} since $P \subseteq P/\mathrm{poly}$, we conclude \textbf{$P \neq NP$}.
+  \item \textbf{FCE $\Rightarrow$ MCSP lower bound} (Lemma~\ref{lem:fce-to-mcsp}): instantiate $F$ with the acceptance families induced by (search/Gap-)MCSP under the usual promise; conclude either an oracle-circuit lower bound of size $N\cdot\poly(\log N)$ and depth $\poly(\log N)$ (MMW) \emph{or} a general-circuit lower bound $N^{1+\varepsilon}$ (OPS).
+  \item \textbf{Hardness magnification:} apply MMW'19 or OPS'19 to deduce $\NP \not\subseteq \Ppoly$.
+  \item \textbf{Classical simulation:} since $\Pclass \subseteq \Ppoly$, we conclude \textbf{$\Pclass \ne \NP$}.
 \end{enumerate}
 
-This route is \emph{unconditional}: it uses only FCE, a concrete MCSP lower bound derived from FCE, a published magnification theorem, and the textbook inclusion $P\subseteq P/\mathrm{poly}$.
+This route is \emph{unconditional}: it uses only FCE, a concrete MCSP lower bound derived from FCE, a published magnification theorem, and the textbook inclusion $\Pclass\subseteq \Ppoly$.
 
 \section{Formalization and Future Work}
 
-Given the historical difficulty of the $P \neq NP$ problem, we have been \textbf{extra cautious}: in parallel with developing the proof on paper, we are formalizing the entire argument in the Lean~4 theorem prover. This helps ensure there are no hidden assumptions or flaws. As of this writing, the formalization confirms the main arguments, and work continues on the remaining connections to circuit lower bounds:
+Given the historical difficulty of the $\Pclass \ne \NP$ problem, we have been \textbf{extra cautious}: in parallel with developing the proof on paper, we are formalizing the entire argument in the Lean~4 theorem prover. This helps ensure there are no hidden assumptions or flaws. As of this writing, the formalization confirms the main arguments, and work continues on the remaining connections to circuit lower bounds:
 
 \begin{itemize}
     \item We have formalized several key components of the proof. The classical \emph{Sunflower Lemma} and the \emph{Core Agreement Lemma} are fully formalized. A cardinal variant of the entropy drop argument, \texttt{exists\_coord\_card\_drop}, is proven, and the FCE-Lemma itself is mechanized in Lean. A recursive cover builder is implemented in \texttt{cover2.lean} and its termination is established.
@@ -163,9 +182,9 @@ The formalization effort not only bolsters confidence in the result but also set
 
 \section{Conclusion}
 
-We have outlined a combinatorial lemma that, together with published hardness-magnification triggers for MCSP and the classical circuit simulation $P \subseteq P/\mathrm{poly}$, may lead to a separation of $P$ and $NP$. The \textbf{Family Collision-Entropy Lemma} suggests that attempts to make NP computations efficient run into an unavoidable combinatorial explosion. This preprint records the current state of the argument and invites feedback while the Lean formalization is still under development.
+We have outlined a combinatorial lemma that, together with published hardness-magnification triggers for MCSP and the classical circuit simulation $\Pclass \subseteq \Ppoly$, may lead to a separation of $\Pclass$ and $\NP$. The \textbf{Family Collision-Entropy Lemma} suggests that attempts to make $\NP$ computations efficient run into an unavoidable combinatorial explosion. This preprint records the current state of the argument and invites feedback while the Lean formalization is still under development.
 
-The claims here remain provisional and will require careful scrutiny. We hope that continued work on the formal proof and feedback from the community will clarify whether this approach can indeed separate $P$ from $NP$.
+The claims here remain provisional and will require careful scrutiny. We hope that continued work on the formal proof and feedback from the community will clarify whether this approach can indeed separate $\Pclass$ from $\NP$.
 
 \section*{Remaining Work and Open Verification Tasks (PH-free)}
 
@@ -173,14 +192,14 @@ The claims here remain provisional and will require careful scrutiny. We hope th
   \item \textbf{Finalize the MCSP connection under a fixed trigger.} 
   Pick one magnification trigger (we recommend MMW'19) and freeze the exact parameters:
   \begin{itemize}
-    \item \emph{MMW’19 path}: formalize oracle-circuit models with size $N\cdot\mathrm{polylog}(N)$ and depth $\mathrm{polylog}(N)$, short queries to $A\in\mathrm{PH}$, and the \textup{search-MCSP} parameter $s(n)$ used in their theorem. Prove the FCE$\to$MCSP lower bound in that model.
-    \item \emph{OPS’19 path (backup)}: formalize \textup{Gap-MCSP} and show a superlinear lower bound $N^{1+\varepsilon}$ vs.\ \emph{general} circuits.
+    \item \emph{MMW’19 path}: formalize oracle-circuit models with size $N\cdot\poly(\log N)$ and depth $\poly(\log N)$, short queries to $A\in\PH$, and the $\SearchMCSP$ parameter $s(n)$ used in their theorem. Prove the FCE$\to$MCSP lower bound in that model.
+    \item \emph{OPS’19 path (backup)}: formalize $\GapMCSP$ and show a superlinear lower bound $N^{1+\varepsilon}$ vs.\ \emph{general} circuits.
   \end{itemize}
 
   \item \textbf{Lean formalization of the trigger theorem.} 
   Either (i) import the MMW/OPS magnification theorem as a trusted reference with a precise statement matching our parameters, or (ii) mechanize its proof (longer-term).
 
-  \item \textbf{Close the TM$\to$circuits simulation in Lean ($P \subseteq P/\mathrm{poly}$).}
+  \item \textbf{Close the TM$\to$circuits simulation in Lean ($\Pclass \subseteq \Ppoly$).}
   Replace the current placeholder with a constructive simulation: from a poly-time TM build a circuit family of polynomial size and prove correctness/size bounds.
 
   \item \textbf{Remove legacy PH mentions from the mainline.}
@@ -190,7 +209,7 @@ The claims here remain provisional and will require careful scrutiny. We hope th
   Tighten constants in the FCE cover bound (any $2^{o(n)}$ suffices for magnification, but better bounds may yield stronger side-results).
 
   \item \textbf{Packaging for review.}
-  Ensure Lean scripts expose (i) FCE, (ii) FCE$\to$MCSP-LB (chosen path), (iii) magnification trigger, (iv) $P\subseteq P/\mathrm{poly}$, and (v) the final lemma \texttt{P\_neq\_NP} with no extraneous assumptions.
+  Ensure Lean scripts expose (i) FCE, (ii) FCE$\to$MCSP-LB (chosen path), (iii) magnification trigger, (iv) $\Pclass\subseteq \Ppoly$, and (v) the final lemma \texttt{P\_neq\_NP} with no extraneous assumptions.
 \end{itemize}
 
 \bibliographystyle{plain}


### PR DESCRIPTION
## Summary
- Introduced macros for standard complexity classes and updated the abstract, introduction, and conclusion to use consistent $\Pclass$, $\NP$, and $\Ppoly$ notation throughout the preprint.
- Restored the cover-building procedure to an `algorithm2e` presentation with proper typography while clarifying the subexponential bounds it achieves.
- Added labeled statements for the MMW and OPS trigger theorems plus the FCE-to-MCSP bridge, and referenced them in the PH-free route discussion with a brief clarification of tabulation inputs.
- Declared explicit theorem and lemma environments and normalized every magnification reference to use $\poly(\log N)$ notation.

## Testing
- not run (latex-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d52416bd50832b8b01909bb1daf987