### PR TITLE
Clarify documentation about noncomputable cover proofs

### DIFF
--- a/Pnp2/cover2.lean
+++ b/Pnp2/cover2.lean
@@ -173,8 +173,8 @@ lemma sunflower_step {n : ℕ} (F : Family n) (p t : ℕ)
   -- Freeze the sunflower core to obtain a covering subcube.
   let x₀ : Boolcube.Point n := fun _ => false
   let R : Boolcube.Subcube n := Boolcube.Subcube.fromPoint x₀ S.core
-  -- Bounding the cardinality and dimension is the intricate part of the argument.
-  -- We leave the two key properties as placeholders for future work.
+  -- Bounding the cardinality and dimension is the intricate part of the argument;
+  -- the following proof carries out the combinatorial bookkeeping directly.
   have h_filter_ge :
       (F.filter fun g => ∀ x : Boolcube.Point n, R.Mem x → g x = true).card ≥ t := by
     -- We embed the `t` selected functions into the filtered family and count them.

--- a/Pnp2/examples.lean
+++ b/Pnp2/examples.lean
@@ -10,12 +10,12 @@ show how to build tiny test families, and demonstrate automatic facts that
 already follow from the (still partial!) library.
 
 > **Important**
-> Several key lemmas (`EntropyDrop`, `sunflower_exists`, `cover_exists`, …)
-> are still assumed as axioms rather than proved constructively.
-> Consequently any computation depending on them is *opaque* — Lean knows
-> that some object exists but cannot reduce it.  Examples invoking such
-> lemmas are marked `/- non‑computable demo -/` and serve purely as
-> *type‑checking* witnesses rather than concrete data dumps.
+> Several high‑level constructions (such as the collision‑entropy cover or
+> the sunflower step) rely on classical choice.  They now come with full
+> proofs, but the resulting witnesses are *non‑computable*, so Lean cannot
+> reduce them to explicit data.  Examples invoking such lemmas are marked
+> `/- non‑computable demo -/` and serve purely as *type‑checking* witnesses
+> rather than concrete data dumps.
 -/
 
 import Pnp2.BoolFunc


### PR DESCRIPTION
## Summary
- update the examples playground note to explain that the high-level cover lemmas are proven but remain noncomputable because they rely on classical choice
- refresh the `sunflower_step` commentary to reflect that the combinatorial bookkeeping is now implemented instead of deferred

## Testing
- lake build


------
https://chatgpt.com/codex/tasks/task_e_68db18bec87c832b8e8078041dd304f3