### PR TITLE
Document Stage B completion and update atlas docs

### DIFF
--- a/docs/FullPlan.md
+++ b/docs/FullPlan.md
@@ -1,0 +1,250 @@
+# Proof Roadmap for `pnp3`
+
+This document records the complete roadmap for the `pnp3` project, structured
+around the four major proof stages A → B → C → D.  Each subsection lists the
+current status, dependencies, difficulty estimates, and definition-of-done
+criteria.  The goal is to replace every standing axiom by a fully formalized
+Lean proof while keeping the existing high-level architecture intact.
+
+## 0. Global picture
+
+### 0.1 Idea
+
+1. **SAL (Switching-Atlas Lemma).**  From a shrinkage certificate (a shallow
+   PDT approximating an entire function family) we synthesize a bounded atlas
+   whose dictionary of subcubes approximates every member with error ≤ ε and a
+   uniform leaf budget `k`.
+2. **Covering-Power.**  Using combinatorial counting (binomial bounds and
+   Hamming-ball estimates) we upper-bound the number of functions that any such
+   atlas can approximate.  This provides a capacity barrier.
+3. **Anti-checker.**  Assuming a small GapMCSP solver, we construct a rich
+   subfamily `Y` with cardinality strictly exceeding the capacity barrier,
+   contradicting Covering-Power and ruling out the solver.
+4. **Magnification.**  The established lower bound for GapMCSP triggers hardness
+   magnification theorems (OPS/JACM), giving `NP ⊄ P/poly`.  Together with the
+   trivial `P ⊆ P/poly` we conclude `P ≠ NP`.
+
+### 0.2 Dependency DAG
+
+```
+Shrinkage facts ──► SAL_from_Shrinkage ──► BoundedAtlasScenario
+                 │
+Leaf budget ◄────┘                                        │
+                                                         ▼
+Counting bounds (binomial + Hamming) ──► Covering-Power  │
+                                                         ▼
+Anti-checker existence ──► LB cores (AC⁰ / local) ──► False
+                                                         │
+Magnification triggers (OPS/JACM) ────────────────────────┘
+                                                         ▼
+P ⊆ P/poly + NP ⊄ P/poly ──► Final theorem `P ≠ NP`
+```
+
+### 0.3 Ultimate target
+
+Replace every axiom in this pipeline with constructive Lean proofs so that the
+final theorem `P_ne_NP_final` holds unconditionally.
+
+## 1. Stage A — SAL and shrinkage
+
+### 1.1 Core SAL machinery (status: **done**, difficulty 2/10)
+
+* **Files:** `Core/SAL_Core.lean`, `Core/Atlas.lean`, `ThirdPartyFacts/Facts_Switching.lean`.
+* **Scope:** definitions of shrinkage certificates, atlases, and the conversion
+  `SAL_from_Shrinkage`.  Current smoke tests (`Tests/LB_Smoke_Scenario.lean`)
+  verify the pipeline.
+* **Recent progress:** `Core/BooleanBasics.subcube_card_pow` теперь доказана
+  конструктивно: мощности подкубов вычисляются через количество свободных
+  координат, а не постулируются аксиоматически.
+* **DoD:** `SAL_from_Shrinkage` produces a valid atlas for any shrinkage input;
+  regression tests remain green.
+
+### 1.2 Leaf budget uniformization (status: **done (dedup/leaf bound)**, difficulty 3/10)
+
+* **File:** `ThirdPartyFacts/LeafBudget.lean` (`leaf_budget_from_shrinkage`).
+* **Goal:** derive a global leaf bound `k` for all functions in the family from
+  the shrinkage data (ultimately aiming for the textbook `O(t · log(1/ε))`).
+  The current Lean proof removes duplicate leaves from every selector, proves
+  that the cleaned lists inject into the PDT leaf set, and instantiates `k` with
+  the explicit dictionary size `|leaves(tree)|` (hence ≤ `2^t`).
+* **DoD:** constructive `k` together with regression tests confirming the SAL →
+  counting pipeline operates on the deduplicated lists.  Remaining work focuses
+  on sharpening the quantitative bound via multi-switching analytics.
+
+### 1.3 Shrinkage for AC⁰/local circuits (status: **axiom**, difficulty 8/10)
+
+* **File:** `ThirdPartyFacts/Facts_Switching.lean` (`shrinkage_for_AC0` and its
+  local analogue).
+* **Goal:** formalize the multi-switching lemma to obtain shallow PDTs with
+  controlled error.  Early milestones can target depth-2 formulas before moving
+  to the full `d`-layer setting.
+* **DoD:** fully proved shrinkage lemmas matching the current interface
+  (parameter bounds on depth `t` and error `ε`).
+
+## 2. Stage B — Covering-Power and counting
+
+### 2.1 Union/approximation classes (status: **done**, difficulty 2/10)
+
+* **File:** `Counting/Atlas_to_LB_Core.lean`.
+* **Scope:** definitions of union classes, approximation classes, distance
+  metrics, and the incompatibility lemma bridging SAL scenarios with capacity
+  bounds.  The incompatibility result is now fully constructive (`incompatibility`),
+  so any finite `Y` of ε-approximable functions automatically satisfies the
+  capacity bound.
+* **DoD:** definitions remain stable; tests around scenario incompatibility
+  continue to pass.
+
+### 2.2 Capacity bounds (status: **done**, difficulty 3/10)
+
+* **File:** `Counting/BinomialBounds.lean`.
+* **Scope:** все биномиальные и хамминговые оценки доказаны конструктивно, к ним
+  добавлены леммы монотонности (`unionBound_mono_left/right`,
+  `hammingBallBound_mono`).  Эти результаты напрямую кормят теорему
+  `covering_power_bound`, так что во всём шаге B больше не осталось аксиом или
+  незакрытых заготовок.
+* **DoD:** `capacityBound` выражена через явные функции от `D`, `k`, `N` и ε,
+  все вспомогательные оценки доказаны, sanity-тесты (например,
+  `Tests/Atlas_Count_Sanity.lean`) подтверждают корректность на малых
+  примерах.  Дополнительных задач на шаге B не запланировано; дальнейшие
+  улучшения (при желании) могут рассматриваться как отдельные исследования,
+  не входящие в основной план.
+
+## 3. Stage C — GapMCSP lower bounds
+
+### 3.1 Model primitives (status: **done**, difficulty 2/10)
+
+* **File:** `Models/Model_GapMCSP.lean` defines `GapMCSPParams` and basic
+  derived data.
+* **DoD:** type-level parameters remain consistent across the pipeline.
+
+### 3.2 Anti-checker construction (status: **axiom**, difficulty 9/10)
+
+* **File:** `LowerBounds/AntiChecker.lean`.
+* **Goal:** construct the `F` and `Y` witnesses from any small solver, formalize
+  solver correctness predicates, and apply counting bounds to yield a
+  contradiction.
+* **DoD:** Lean proofs of `antiChecker_exists_large_Y` and its local-circuit
+  variant; `LB_Formulas_core` and `LB_LocalCircuits_core` compile without
+  axioms.
+
+### 3.3 LB cores (status: **done modulo axioms**, difficulty 2/10)
+
+* **Files:** `LowerBounds/LB_Formulas_Core.lean`,
+  `LowerBounds/LB_LocalCircuits.lean`.
+* **DoD:** once the anti-checker and counting lemmas are proved, these cores
+  should close without further modification.
+
+## 4. Stage D — Magnification bridge and final separation
+
+### 4.1 Magnification triggers (status: **axiom**, difficulty 6/10)
+
+* **File:** `Magnification/Facts_Magnification.lean`.
+* **Goal:** formalize the OPS'20 and JACM'22 hardness magnification theorems so
+  that GapMCSP lower bounds imply `NP ⊄ P/poly`.  At minimum, document precise
+  parameter requirements; ideally, provide full proofs.
+* **DoD:** the triggers accept the outputs of Stage C and yield
+  `NP_not_subset_Ppoly` without axioms.
+
+### 4.2 Bridge and final theorem (status: **done**, difficulty 2/10)
+
+* **Files:** `Magnification/Bridge_to_Magnification.lean`,
+  `Magnification/FinalResult.lean`, `Complexity/Interfaces.lean`.
+* **DoD:** remains consistent once earlier stages are de-axiomatized; tests in
+  `Tests/Magnification_Core_Contradiction.lean` stay green.
+
+## 5. Source map
+
+* `Core/` — shrinkage, SAL, atlases.
+* `ThirdPartyFacts/` — external shrinkage and leaf-budget facts.
+* `Counting/` — combinatorial capacity bounds.
+* `Models/` — GapMCSP parameters.
+* `LowerBounds/` — anti-checker interfaces and core contradictions.
+* `Magnification/` — hardness magnification triggers and the final bridge.
+* `Complexity/` — interfaces for non-uniform complexity classes.
+* `Tests/` — smoke tests and contradiction checks (always run `lake test`).
+
+## 6. Risk tracking
+
+* **Parity and FCE barriers:** SAL relies on shrinkage; parity lacks shrinkage,
+  so the framework avoids trivial counterexamples.
+* **Relativization/natural proofs/locality:** handled explicitly via shrinkage
+  assumptions and dedicated locality triggers.
+* **Hidden assumptions:** all external inputs are isolated as named axioms with
+  references; `#print axioms` audits keep the dependency surface explicit.
+
+## 7. Definition-of-done checklist
+
+| Stage | Task | Difficulty | DoD snapshot |
+|-------|------|------------|--------------|
+| A | Prove shrinkage lemmas | 8/10 | `shrinkage_for_AC0`/`..._local` proven, tests green |
+| A | Leaf budget bound | 3/10 | `leaf_budget_from_shrinkage` deduplicates selectors and bounds them by `|leaves(tree)|` |
+| B | Binomial & Hamming bounds | 3/10 | `covering_power_bound` + monotonicity lemmas proved |
+| C | Anti-checker | 9/10 | `antiChecker_exists_large_Y[_local]` proven |
+| D | Magnification triggers | 6/10 | OPS/JACM triggers formalized |
+
+Each completed DoD removes one major axiom, steadily converting the current
+conditional proof into an unconditional Lean development.
+
+## 8. Immediate action items
+
+1. Прописать интерфейс корректности для `SmallAC0Solver` и начать формализацию
+   античекера (включая явные описания слоёв YES/NO).
+2. Усилить оценку leaf-budget через мульти-switching аналитику, чтобы добиться
+   классического `O(t · log(1/ε))` вместо грубого `|leaves(tree)|`.
+3. Постепенно деаксиоматизировать `shrinkage_for_AC0`/`..._local`, начиная с
+   малых глубин и аккуратно отслеживая параметры.
+4. Задокументировать требования к триггерам OPS/JACM и спланировать их
+   формализацию (включая перевод параметров из шага C).
+
+Regularly run `lake test` after each milestone and re-examine the assumptions
+for potential counterexamples or parameter misalignments.
+
+## 9. Остаточные задачи и связь с `pnp2`
+
+### 9.1 Что ещё предстоит сделать в `pnp3`
+
+* **Шаг A — shrinkage.**  Требуется заменить аксиомы `shrinkage_for_AC0` и
+  `shrinkage_for_localCircuit` на доказательства многоступенчатой switching lemma.
+  Ближайший подэтап — доказать версию для глубины 2 и зафиксировать все
+  численные константы (глубина PDT, порог ошибки).
+* **Шаг B — ёмкостные оценки.**  Комбинаторные границы полностью доказаны:
+  `unionBound`, `hammingBallBound` и связанные с ними леммы монотонности
+  обеспечивают окончательный вариант теоремы `covering_power_bound`.  Ранее
+  использовавшаяся заглушка `count_small_circuits_bound` заменена на
+  конструктивную границу `2^{2^n}`, поэтому никаких открытых пунктов на шаге B
+  не осталось — его инфраструктура зафиксирована и готова к использованию в
+  последующих этапах.
+* **Шаг C — античекер.**  Основная работа впереди: формализовать корректность
+  абстрактного решателя GapMCSP и построить свидетелей `F` и `Y`, превосходящих
+  ёмкость SAL-сценария.  После закрытия этого шага ядро `LB_Formulas_core` и
+  `LB_LocalCircuits_core` автоматически перестанут зависеть от аксиом.
+* **Шаг D — триггеры магнификации.**  В `Magnification/Facts_Magnification.lean`
+  пока остаются аксиомы, формализующие результаты OPS’20 и JACM’22.  Нужно
+  уточнить их предпосылки, задокументировать перевод параметров и, по
+  возможности, заменить интерфейсы на прямые доказательства.
+
+Выполнение этих четырёх пунктов последовательно снимает последние оставшиеся
+аксиомы и превращает `P_ne_NP_final` в безусловный результат.
+
+### 9.2 Что переносить из `pnp2`
+
+* **Уже используется.**  В `pnp3/Complexity/Interfaces.lean` мы напрямую опираемся
+  на доказанный в `pnp2` факт `P ⊆ P/poly` (`PsubsetPpoly.lean`) и на классический
+  вывод `P ≠ NP` из несравнимости `NP` и `P/poly` (`NP_separation.lean`).  Эти
+  модули трогать не нужно: они служат готовым «чёрным ящиком» для шага D.
+* **Что можно переиспользовать.**  Если для шага B понадобится более сильная
+  энтропийная техника, стоит заглянуть в `Pnp2/family_entropy_cover.lean` и
+  соседние файлы: там уже есть формализованные оценки мощности подсемейств и
+  биномиальных сумм.  Переносить их целиком необязательно, но можно импортировать
+  соответствующие леммы или переписать их в облегченном виде под SAL.
+* **Что переносить не требуется.**  Старый FCE-конвейер (`Pnp2/Cover/`,
+  `Pnp2/fce_lemma_proof.md`) не участвует в текущем проекте: SAL полностью
+  заменяет FCE, и дублировать эти доказательства нет необходимости.  Аналогично,
+  многочисленные конструкты для симуляции Тьюринговых машин уже интегрированы в
+  `pnp2` и подцеплены через интерфейс, поэтому их миграция в `pnp3` не даёт
+  дополнительной выгоды.
+
+Итого, `pnp3` сейчас нуждается не в переносе старых фрагментов, а в
+  последовательной деаксиоматизации собственных блоков.  `pnp2` остаётся
+  «библиотекой справочных фактов», из которой мы берём только те результаты,
+  которые уже полностью формализованы и не требуют адаптации.

--- a/pnp3/Counting/BinomialBounds.lean
+++ b/pnp3/Counting/BinomialBounds.lean
@@ -1,27 +1,33 @@
+import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Data.Int.Basic
+import Mathlib.Algebra.Order.Floor.Defs
+import Mathlib.Algebra.Order.Floor.Ring
+import Mathlib.Data.Rat.Floor
+import Mathlib.Data.Nat.Choose.Bounds
+import Mathlib.Data.Nat.Choose.Sum
 import Mathlib.Data.Rat.Init
 
 /-!
   pnp3/Counting/BinomialBounds.lean
 
-  В этом файле мы фиксируем стандартные комбинаторные оценки,
-  которые понадобятся при анализе ёмкости «атласов» (словари
-  подкубов и их покрытия).  В текущей версии проекта мы не
-  выводим эти факты строго внутри Lean, а оформляем их в виде
-  аксиом с подробными комментариями.  Это позволяет построить
-  логическую связку частей B и C, а при необходимости позже
-  заменить аксиомы на доказанные леммы или импорт из mathlib.
+  В этом файле собраны стандартные комбинаторные оценки для шага B.  Теперь
+  все необходимые неравенства выводятся строго внутри Lean, поэтому атласные
+  ёмкости, используемые в anti-checker, опираются на проверенные подсчёты.
 
-  Конкретно нам нужны две оценки:
+  Основные блоки:
 
-  * Верхняя граница на число различных объединений ≤ k подкубов
-    из словаря размера D.  Комбинаторно это суммарная биномиальная
-    сумма `∑_{i=0}^k C(D,i)`.
-  * Оценка размера хаммингового шара вокруг функции g: число функций f,
-    отличающихся от g не более чем на ε⋅|X| точек.
+  * биномиальные суммы `∑_{i=0}^k C(D,i)` и их грубая оценка `(k+1)·(max 1 D)^k`;
+  * верхняя граница на мощность хаммингового шара через инъекцию в множество
+    подмножеств пространства входов;
+  * леммы монотонности по размеру словаря и по бюджету ошибок ε, полезные как
+    для поиска контрпримеров, так и для аккуратного переноса параметров.
 
-  Эти факты приводят к понятию "ёмкости" словаря, которая позже
-  используется в части C для вывода нижних оценок.
+  На основе этих результатов определяется функция `capacityBound` и получаются
+  численные ограничения, задействованные в теореме `Counting.covering_power_bound`.
 -/
+
+open scoped BigOperators
 
 namespace Pnp3
 namespace Counting
@@ -37,54 +43,435 @@ namespace Counting
 
 /--
   Суммарная верхняя оценка на число подмножеств словаря размера `D`,
-  состоящих не более чем из `k` элементов.  Классический ответ — биномиальная
-  сумма `∑_{i=0}^k C(D,i)`, для которой используется приблизительная
-  оценка `(k+1) * (eD/k)^k`.  Здесь мы фиксируем лишь тот факт, что
-  подобная конечная граница существует и зависит только от `(D,k)`.
-
-  В дальнейшем (при развитии математической части проекта) эту аксиому
-  планируется заменить на строго доказанную лемму.  Пока же важно иметь
-  возможность ссылаться на существование такой оценки.
+  состоящих не более чем из `k` элементов.  Мы работаем с грубой, но
+  полностью формальной границей: суммарная биномиальная сумма не превосходит
+  полного числа подмножеств `2^D`.  Более точные оценки (например,
+  `(k+1) * (eD/k)^k`) можно будет добавить позже, но уже эта версия
+  позволяет заменить прежнюю аксиому на честное доказательство.
 -/
-axiom sum_binom_upper_eD_over_k (D k : Nat) : ∃ _Bound : Nat, True
+lemma sum_choose_le_pow (D k : Nat) :
+    (∑ i ∈ Finset.range (k.succ), Nat.choose D i) ≤ 2 ^ D :=
+  by
+    classical
+    by_cases h : k ≤ D
+    · -- В случае `k ≤ D` ограничиваем сумму более длинной суммой `0 ≤ i ≤ D`.
+      have hsubset : Finset.range (k.succ) ⊆ Finset.range (D.succ) := by
+        intro i hi
+        have hi' := Finset.mem_range.mp hi
+        exact Finset.mem_range.mpr <| lt_of_lt_of_le hi' (Nat.succ_le_succ h)
+      have hmono :
+          (∑ i ∈ Finset.range (k.succ), Nat.choose D i)
+              ≤ (∑ i ∈ Finset.range (D.succ), Nat.choose D i) :=
+        Finset.sum_le_sum_of_subset_of_nonneg hsubset (by
+          intro i _hi _; exact Nat.zero_le _)
+      have hsum_eq : (∑ i ∈ Finset.range (D.succ), Nat.choose D i) = 2 ^ D := by
+        -- `Nat.sum_range_choose` уже даёт нужное равенство; раскрываем определение `Nat.succ`.
+        simpa [Nat.succ_eq_add_one] using (Nat.sum_range_choose (n := D))
+      exact hmono.trans hsum_eq.le
+    · -- Если `k > D`, то хвост суммы обнуляется, и мы получаем точное равенство.
+      push_neg at h
+      have hx :
+          ∀ i ∈ Finset.Ico (D.succ) (k.succ), Nat.choose D i = 0 :=
+        by
+          intro i hi
+          rcases Finset.mem_Ico.mp hi with ⟨hi₁, _⟩
+          have hx : D < i := lt_of_lt_of_le (Nat.lt_succ_self _) hi₁
+          simp [Nat.choose_eq_zero_of_lt hx]
+      have htail :
+          (∑ i ∈ Finset.Ico (D.succ) (k.succ), Nat.choose D i) = 0 :=
+        Finset.sum_eq_zero hx
+      have hsplit :=
+        Finset.sum_range_add_sum_Ico (f := fun i ↦ Nat.choose D i)
+          (m := D.succ) (n := k.succ) (Nat.succ_le_succ h.le)
+      have : (∑ i ∈ Finset.range (k.succ), Nat.choose D i)
+          = (∑ i ∈ Finset.range (D.succ), Nat.choose D i) :=
+        by
+          have : (∑ i ∈ Finset.range (D.succ), Nat.choose D i)
+              = (∑ i ∈ Finset.range (k.succ), Nat.choose D i) := by
+            simpa [htail, Nat.succ_eq_add_one, add_comm] using hsplit
+          exact this.symm
+      have hsum_eq : (∑ i ∈ Finset.range (D.succ), Nat.choose D i) = 2 ^ D := by
+        simpa [Nat.succ_eq_add_one] using (Nat.sum_range_choose (n := D))
+      have hsum_le : (∑ i ∈ Finset.range (k.succ), Nat.choose D i) ≤ 2 ^ D := by
+        simpa [this, hsum_eq]
+      exact hsum_le
 
 /--
-  Оценка размера хаммингового шара.  Для фиксированной функции `g` на
-  пространстве `X` мощности `N` и параметра ошибки `ε ∈ [0, 1/2]` число
-  функций `f`, отличающихся от `g` не более чем на `ε⋅N` позиций, не
-  превышает `2^{H(ε) N}`.  Здесь мы оставляем только заявление о существовании
-  соответствующей конечной границы `Bound`.
+  Более точная оценка для биномиальной суммы.  Мы отделяем зависимость от
+  конкретного размера словаря, оценивая его через `max 1 D`, что автоматически
+  обеспечивает положительность базы степени.  Такая форма удобна для дальнейших
+  аналитических преобразований, поскольку она не приводит к нулевым степеням
+  при `D = 0`.
 -/
-axiom hamming_ball_entropy_bound
-  (N : Nat) (ε : Rat) (h0 : (0 : Rat) ≤ ε) (h1 : ε ≤ (1 : Rat) / 2) :
-  ∃ _Bound : Nat, True
+lemma choose_le_pow_max (D i : Nat) :
+    Nat.choose D i ≤ (Nat.max 1 D) ^ i :=
+  by
+    have hmono : D ≤ Nat.max 1 D := by
+      exact le_max_of_le_right (le_rfl)
+    exact (Nat.choose_le_pow D i).trans (Nat.pow_le_pow_left hmono i)
 
 /--
-  Удобное обозначение для произведения двух верхних оценок: количества
-  возможных объединений и размера хаммингового шара.  Это «ёмкость» словаря,
-  которая будет использоваться в частях B и C.  Поскольку конкретные
-  численные значения нас сейчас не волнуют, определение даёт абстрактную
-  функцию.
+  Удобное обозначение для счётной части словаря: мы просто рассматриваем
+  суммарное количество объединений не более чем `k` подкубов из набора длины
+  `D`.  Эта величина играет роль верхней оценки для «словаря» в сценариях SAL.
 -/
 noncomputable def unionBound (D k : Nat) : Nat :=
-  Classical.choose (sum_binom_upper_eD_over_k D k)
+  ∑ i ∈ Finset.range (k.succ), Nat.choose D i
 
-/-- Свойство, сопровождающее `unionBound`: это действительно корректная граница. -/
-lemma unionBound_spec (D k : Nat) : True :=
-  (Classical.choose_spec (sum_binom_upper_eD_over_k D k))
+/-- Свойство, сопровождающее `unionBound`: извлечённая сумма ограничена числом `2^D`. -/
+theorem unionBound_le_pow (D k : Nat) : unionBound D k ≤ 2 ^ D :=
+  sum_choose_le_pow D k
 
 /--
-  Абстрактная верхняя оценка на размер хаммингового шара.  Мы извлекаем
-  её из аксиомы `hamming_ball_entropy_bound` при фиксированных параметрах.
+  Если перебрать все подмножества размером ≤ `k`, то их количество ограничено
+  грубой, но полностью конструктивной границей `(k+1) * (max 1 D)^k`.  Эта оценка
+  усиливает предыдущую тривиальную границу `2^D` и важна при поиске реальных
+  контрпримеров: мы можем быстро проверять, что словарь недостаточно велик,
+  используя лишь арифметику по натуральным числам.
+-/
+lemma unionBound_le_pow_mul (D k : Nat) :
+    unionBound D k ≤ (k.succ) * (Nat.max 1 D) ^ k :=
+  by
+    classical
+    -- Удобное обозначение для положительной базы степени.
+    set M := Nat.max 1 D with hMdef
+    have hM_pos : 0 < M := by
+      -- Из `1 ≤ M` следует положительность.
+      have hM_ge : 1 ≤ M := by
+        simpa [hMdef] using (le_max_left (1 : Nat) D)
+      have : 0 < (1 : Nat) := by decide
+      exact lt_of_lt_of_le this hM_ge
+    -- Каждая отдельная биномиальная компонента ограничена сверху `M^k`.
+    have hterm :
+        ∀ i ∈ Finset.range (k.succ), Nat.choose D i ≤ M ^ k :=
+      by
+        intro i hi
+        -- Из принадлежности диапазону получаем `i ≤ k`.
+        have hi_le : i ≤ k := Nat.lt_succ_iff.mp (Finset.mem_range.mp hi)
+        -- Сначала применяем оценку `choose ≤ M^i`.
+        have hchoose : Nat.choose D i ≤ M ^ i := by
+          simpa [hMdef] using choose_le_pow_max D i
+        -- Затем используем монотонность степени по показателю.
+        have hmono := Nat.pow_le_pow_right hM_pos hi_le
+        exact hchoose.trans hmono
+    -- Складываем ограничения по всем `i`.
+    have hsum :=
+      Finset.sum_le_sum fun i hi => hterm i hi
+    -- Сумма констант `M^k` равна `(k+1) * M^k`.
+    have hsum_const :
+        ∑ _i ∈ Finset.range (k.succ), M ^ k = k.succ * M ^ k :=
+      by
+        classical
+        have hconst :
+            ∀ x ∈ Finset.range (k.succ), (fun _ : Nat => M ^ k) x = M ^ k := by
+          intro _ _; simp
+        have := Finset.sum_const_nat
+          (s := Finset.range (k.succ)) (m := M ^ k)
+          (f := fun _ : Nat => M ^ k) hconst
+        simpa [Finset.card_range] using this
+    -- Финальный вывод — переписать исходные обозначения.
+    simpa [unionBound, hMdef, hsum_const] using hsum
+
+
+/--
+  Перенумеровка суммирования по `Fin (k+1)` и по диапазону `0..k`.
+  Этот вспомогательный результат удобно применять для переиндексации
+  биномиальных сумм и других комбинаторных выражений.
+-/
+lemma sum_fin_eq_sum_range {β : Type*} [AddCommMonoid β]
+    (f : ℕ → β) (k : ℕ) :
+    (∑ i : Fin (k.succ), f i) =
+      ∑ i ∈ Finset.range (k.succ), f i :=
+  by
+    classical
+    refine
+      Finset.sum_bij (fun (i : Fin (k.succ)) (_ : i ∈ (Finset.univ : Finset _)) => (i : ℕ))
+        (fun i _ => Finset.mem_range.mpr i.isLt)
+        (fun i _ j _ h => by
+          ext; simpa using h)
+        ?_ (fun i _ => rfl)
+    intro j hj
+    refine ⟨⟨j, Finset.mem_range.mp hj⟩, ?_, rfl⟩
+    simp
+
+/--
+  Вспомогательный подсчёт: точное количество подмножеств мощности `i`
+  конечного множества `α` равно биномиальному коэффициенту.
+-/
+lemma card_subsets_exact_choose (α : Type*) [Fintype α] [DecidableEq α]
+    (i : Nat) :
+    Fintype.card {S : Finset α // S.card = i}
+      = Nat.choose (Fintype.card α) i :=
+  by
+    classical
+    have hcard :
+        Fintype.card {S : Finset α // S.card = i} =
+          (Finset.univ.filter fun (S : Finset α) => S.card = i).card := by
+      simpa using
+        (Fintype.card_subtype (fun (S : Finset α) => S.card = i))
+    have hfilter_eq :
+        (Finset.univ.filter fun (S : Finset α) => S.card = i)
+          = (Finset.univ : Finset α).powersetCard i := by
+      apply Finset.ext
+      intro S; constructor <;> intro hS
+      · rcases Finset.mem_filter.1 hS with ⟨-, hcardS⟩
+        have hsubset : S ⊆ (Finset.univ : Finset α) := by
+          intro x _hx; simp
+        simpa [Finset.mem_powersetCard, hsubset, hcardS]
+      · have hcardS : S.card = i :=
+          (Finset.mem_powersetCard.1 hS).2
+        simp [Finset.mem_filter, hcardS]
+    have hpow := Finset.card_powersetCard i (Finset.univ : Finset α)
+    simpa [hcard, hfilter_eq, Finset.card_univ] using hpow
+
+/--
+  Разделяем семейство всех подмножеств мощности ≤ `k` по точной мощности
+  и суммируем полученные биномиальные числа.
+-/
+lemma card_subsets_le_unionBound (α : Type*) [Fintype α] [DecidableEq α]
+    (k : Nat) :
+    Fintype.card {S : Finset α // S.card ≤ k}
+      = unionBound (Fintype.card α) k :=
+  by
+    classical
+    let toSigma : {S : Finset α // S.card ≤ k} →
+        Σ i : Fin (k.succ), {S : Finset α // S.card = (i : Nat)} :=
+      fun S => ⟨⟨S.1.card, Nat.lt_succ_of_le S.2⟩, ⟨S.1, rfl⟩⟩
+    let fromSigma : (Σ i : Fin (k.succ), {S : Finset α // S.card = (i : Nat)}) →
+        {S : Finset α // S.card ≤ k} :=
+      fun x =>
+        ⟨x.2.1, by
+          have hx : (x.1 : Nat) ≤ k := Nat.lt_succ_iff.mp x.1.isLt
+          simpa [x.2.2] using hx⟩
+    have hleft : Function.LeftInverse fromSigma toSigma := by
+      intro S
+      rcases S with ⟨S, hS⟩
+      rfl
+    have hright : Function.RightInverse fromSigma toSigma := by
+      intro x
+      rcases x with ⟨i, ⟨S, hS⟩⟩
+      ext <;> simp [toSigma, fromSigma, hS, Nat.lt_succ_iff]
+    let e : {S : Finset α // S.card ≤ k} ≃
+        Σ i : Fin (k.succ), {S : Finset α // S.card = (i : Nat)} :=
+      ⟨toSigma, fromSigma, hleft, hright⟩
+    have hcard_equiv := Fintype.card_congr e
+    have hsigma :
+        Fintype.card (Σ i : Fin (k.succ), {S : Finset α // S.card = (i : Nat)}) =
+          ∑ i : Fin (k.succ), Fintype.card {S : Finset α // S.card = (i : Nat)} := by
+      classical
+      simpa using
+        (Fintype.card_sigma (fun i : Fin (k.succ) =>
+          {S : Finset α // S.card = (i : Nat)}))
+    have hsum_range :
+        (∑ i : Fin (k.succ),
+            Fintype.card {S : Finset α // S.card = (i : Nat)})
+          = ∑ i ∈ Finset.range (k.succ),
+              Fintype.card {S : Finset α // S.card = i} :=
+      by
+        classical
+        simpa using
+          (sum_fin_eq_sum_range
+            (fun i => Fintype.card {S : Finset α // S.card = i}) k)
+    have hchoose :
+        ∑ i ∈ Finset.range (k.succ),
+            Fintype.card {S : Finset α // S.card = i}
+          = unionBound (Fintype.card α) k :=
+      by
+        simp [unionBound, card_subsets_exact_choose]
+    refine
+      (calc
+        Fintype.card {S : Finset α // S.card ≤ k}
+            = Fintype.card (Σ i : Fin (k.succ),
+                {S : Finset α // S.card = (i : Nat)}) := by
+                simpa using hcard_equiv
+        _ = ∑ i : Fin (k.succ),
+              Fintype.card {S : Finset α // S.card = (i : Nat)} := hsigma
+        _ = ∑ i ∈ Finset.range (k.succ),
+              Fintype.card {S : Finset α // S.card = i} := hsum_range
+        _ = unionBound (Fintype.card α) k := hchoose)
+
+/--
+  Добавление одного элемента в словарь не уменьшает число допустимых
+  объединений.  Формулируем это как монотонность `unionBound` по первой
+  переменной при переходе от `D` к `D.succ`.
+-/
+lemma unionBound_le_succ (D k : Nat) :
+    unionBound D k ≤ unionBound D.succ k :=
+  by
+    classical
+    -- Переписываем обе стороны через точное количество подмножеств множества `Fin D`.
+    have hcardD :
+        unionBound D k =
+          Fintype.card {S : Finset (Fin D) // S.card ≤ k} := by
+      have :=
+        (card_subsets_le_unionBound (α := Fin D) (k := k))
+      -- Учитываем, что `|Fin D| = D`.
+      simpa [Finset.card_fin] using this.symm
+    have hcardSucc :
+        unionBound D.succ k =
+          Fintype.card {S : Finset (Fin D.succ) // S.card ≤ k} := by
+      have :=
+        (card_subsets_le_unionBound (α := Fin D.succ) (k := k))
+      simpa [Finset.card_fin] using this.symm
+    -- Инъективно расширяем каждое множество `S ⊆ Fin D` до `Fin (D.succ)` через `Fin.castSucc`.
+    let lift (S : {S : Finset (Fin D) // S.card ≤ k}) :
+        {T : Finset (Fin D.succ) // T.card ≤ k} :=
+      ⟨Finset.map ⟨Fin.castSucc, Fin.castSucc_injective _⟩ S.1,
+        by
+          -- `Finset.map` по вложению сохраняет кардинальность.
+          simpa [Finset.card_map] using S.2⟩
+    -- Отображение `lift` является инъекцией.
+    have h_inj : Function.Injective lift := by
+      intro S₁ S₂ hS
+      -- Сравниваем образы подмножеств и переходим к базовым элементам.
+      have hsets :
+          Finset.map ⟨Fin.castSucc, Fin.castSucc_injective _⟩ S₁.1 =
+            Finset.map ⟨Fin.castSucc, Fin.castSucc_injective _⟩ S₂.1 := by
+        simpa [lift] using congrArg Subtype.val hS
+      -- Проверяем, что каждое `x` принадлежит `S₁` тогда и только тогда, когда принадлежит `S₂`.
+      ext x; constructor <;> intro hx
+      · -- Используем соответствие через `Fin.castSucc` и равенство образов.
+        have hx' : Fin.castSucc x ∈
+            Finset.map ⟨Fin.castSucc, Fin.castSucc_injective _⟩ S₁.1 :=
+          Finset.mem_map.mpr ⟨x, hx, rfl⟩
+        have hx'' : Fin.castSucc x ∈
+            Finset.map ⟨Fin.castSucc, Fin.castSucc_injective _⟩ S₂.1 := by
+          simpa [hsets] using hx'
+        rcases Finset.mem_map.1 hx'' with ⟨y, hy, hyx⟩
+        have : y = x := Fin.castSucc_injective _ hyx
+        simpa [this] using hy
+      · -- Аналогично, но меняем роли `S₁` и `S₂`.
+        have hx' : Fin.castSucc x ∈
+            Finset.map ⟨Fin.castSucc, Fin.castSucc_injective _⟩ S₂.1 :=
+          Finset.mem_map.mpr ⟨x, hx, rfl⟩
+        have hx'' : Fin.castSucc x ∈
+            Finset.map ⟨Fin.castSucc, Fin.castSucc_injective _⟩ S₁.1 := by
+          simpa [hsets] using hx'
+        rcases Finset.mem_map.1 hx'' with ⟨y, hy, hyx⟩
+        have : y = x := Fin.castSucc_injective _ hyx
+        simpa [this] using hy
+    -- Сравниваем мощности подмножеств при помощи полученной инъекции.
+    have hcard_le :=
+      Fintype.card_le_of_injective lift h_inj
+    -- Возвращаемся к выражению через `unionBound`.
+    simpa [hcardD, hcardSucc, lift]
+      using hcard_le
+
+/--
+  Монотонность `unionBound` по размеру словаря: если `D₁ ≤ D₂`, то и
+  `unionBound D₁ k ≤ unionBound D₂ k`.
+-/
+lemma unionBound_mono_left {D₁ D₂ k : Nat}
+    (h : D₁ ≤ D₂) :
+    unionBound D₁ k ≤ unionBound D₂ k :=
+  by
+    classical
+    have haux : ∀ d, unionBound D₁ k ≤ unionBound (D₁ + d) k := by
+      intro d
+      induction d with
+      | zero => simpa
+      | succ d ih =>
+          have hstep := unionBound_le_succ (D₁ + d) k
+          have hnext := le_trans ih hstep
+          simpa [Nat.add_comm, Nat.add_left_comm, Nat.add_assoc,
+            Nat.succ_eq_add_one] using hnext
+    have hplus : D₁ + (D₂ - D₁) = D₂ := Nat.add_sub_of_le h
+    simpa [hplus] using haux (D₂ - D₁)
+
+/-- Монотонность `unionBound` по бюджету `k`: разрешая больше подкубов,
+мы не уменьшаем число возможных объединений. -/
+lemma unionBound_mono_right {D k₁ k₂ : Nat}
+    (hk : k₁ ≤ k₂) :
+    unionBound D k₁ ≤ unionBound D k₂ :=
+  by
+    classical
+    have hsubset : Finset.range (k₁.succ) ⊆ Finset.range (k₂.succ) := by
+      intro i hi
+      have hi' := Finset.mem_range.mp hi
+      exact Finset.mem_range.mpr
+        (lt_of_lt_of_le hi' (Nat.succ_le_succ hk))
+    have hmono :
+        (∑ i ∈ Finset.range (k₁.succ), Nat.choose D i)
+          ≤ (∑ i ∈ Finset.range (k₂.succ), Nat.choose D i) :=
+      Finset.sum_le_sum_of_subset_of_nonneg hsubset (by
+        intro i _ _; exact Nat.zero_le _)
+    simpa [unionBound] using hmono
+
+/--
+  Натуральный бюджет ошибок `⌈ε ⋅ N⌉`, измеряющий допустимое число
+  рассогласований в хамминговом шаре.  Он является целочисленным аналогом
+  дробного ограничения `ε`, используемого в анализе SAL.
+-/
+noncomputable def hammingBallBudget (N : Nat) (ε : Rat) : Nat :=
+  Int.toNat (Int.ceil (ε * N))
+
+/--
+  Верхняя оценка на число функций в хамминговом шаре радиуса `ε`.  Любую
+  функцию внутри шара можно задать набором точек рассогласования, так что
+  достаточно пересчитать подмножества мощности ≤ `hammingBallBudget`.
 -/
 noncomputable def hammingBallBound
-  (N : Nat) (ε : Rat) (h0 : (0 : Rat) ≤ ε) (h1 : ε ≤ (1 : Rat) / 2) : Nat :=
-  Classical.choose (hamming_ball_entropy_bound N ε h0 h1)
+  (N : Nat) (ε : Rat) (_h0 : (0 : Rat) ≤ ε) (_h1 : ε ≤ (1 : Rat) / 2) : Nat :=
+  unionBound N (hammingBallBudget N ε)
 
-/-- Свойство, сопровождающее `hammingBallBound`. -/
+/-- Раскрываем определение `hammingBallBound` для последующих переписок. -/
 lemma hammingBallBound_spec
-  (N : Nat) (ε : Rat) (h0 : (0 : Rat) ≤ ε) (h1 : ε ≤ (1 : Rat) / 2) : True :=
-  (Classical.choose_spec (hamming_ball_entropy_bound N ε h0 h1))
+  (N : Nat) (ε : Rat) (_h0 : (0 : Rat) ≤ ε) (_h1 : ε ≤ (1 : Rat) / 2) :
+    hammingBallBound N ε _h0 _h1 =
+      unionBound N (hammingBallBudget N ε) :=
+  rfl
+
+/-- Увеличение допустимой ошибки `ε` не уменьшает натуральный бюджет
+рассогласований.  Лемма напрямую следует из монотонности потолка и
+положительности множителя `N`. -/
+lemma hammingBallBudget_mono
+    (N : Nat) {ε ε' : Rat}
+    (hε0 : (0 : Rat) ≤ ε) (hε'0 : (0 : Rat) ≤ ε') (hε : ε ≤ ε') :
+    hammingBallBudget N ε ≤ hammingBallBudget N ε' :=
+  by
+    classical
+    have hN_nonneg : (0 : Rat) ≤ (N : Rat) := by
+      exact_mod_cast (Nat.zero_le N)
+    have hceil_le :
+        Int.ceil (ε * (N : Rat)) ≤ Int.ceil (ε' * (N : Rat)) := by
+      have hmul : ε * (N : Rat) ≤ ε' * (N : Rat) :=
+        mul_le_mul_of_nonneg_right hε hN_nonneg
+      simpa using (Int.ceil_le_ceil hmul)
+    have hceil_nonneg :
+        (0 : ℤ) ≤ Int.ceil (ε' * (N : Rat)) := by
+      have hmul_nonneg : (0 : Rat) ≤ ε' * (N : Rat) :=
+        mul_nonneg hε'0 hN_nonneg
+      simpa using (Int.ceil_nonneg hmul_nonneg)
+    have htarget :
+        Int.ceil (ε * (N : Rat)) ≤
+          (Int.toNat (Int.ceil (ε' * (N : Rat))) : ℤ) := by
+      simpa [Int.toNat_of_nonneg hceil_nonneg] using hceil_le
+    exact (Int.toNat_le.mpr htarget)
+
+/-- Монотонность оценки хаммингового шара по параметру ошибки. -/
+lemma hammingBallBound_mono
+    (N : Nat) {ε ε' : Rat}
+    (hε0 : (0 : Rat) ≤ ε) (hε'0 : (0 : Rat) ≤ ε')
+    (hε1 : ε ≤ (1 : Rat) / 2) (hε'1 : ε' ≤ (1 : Rat) / 2)
+    (hε : ε ≤ ε') :
+    hammingBallBound N ε hε0 hε1 ≤
+      hammingBallBound N ε' hε'0 hε'1 :=
+  by
+    classical
+    have hbudget := hammingBallBudget_mono (N := N) hε0 hε'0 hε
+    simpa [hammingBallBound_spec] using
+      (unionBound_mono_right (D := N)
+        (k₁ := hammingBallBudget N ε)
+        (k₂ := hammingBallBudget N ε') hbudget)
+
+/-- Даже уточнённая оценка не превосходит полного числа подмножеств `2^N`. -/
+lemma hammingBallBound_le_pow
+  (N : Nat) (ε : Rat) (_h0 : (0 : Rat) ≤ ε) (_h1 : ε ≤ (1 : Rat) / 2) :
+    hammingBallBound N ε _h0 _h1 ≤ 2 ^ N :=
+by
+  classical
+  simpa [hammingBallBound_spec] using
+    (unionBound_le_pow N (hammingBallBudget N ε))
 
 /--
   Главная сводная величина — произведение двух оценок.  Именно она
@@ -96,6 +483,27 @@ noncomputable def capacityBound
   (D k N : Nat) (ε : Rat)
   (h0 : (0 : Rat) ≤ ε) (h1 : ε ≤ (1 : Rat) / 2) : Nat :=
   unionBound D k * hammingBallBound N ε h0 h1
+
+/--
+  Комбинируя оценку `unionBound_le_pow_mul` с неравенством
+  `hammingBallBound ≤ 2^N`, получаем удобную верхнюю границу для всей ёмкости.
+-/
+lemma capacityBound_le_pow_mul
+    (D k N : Nat) (ε : Rat)
+    (h0 : (0 : Rat) ≤ ε) (h1 : ε ≤ (1 : Rat) / 2) :
+    capacityBound D k N ε h0 h1 ≤
+      (k.succ) * (Nat.max 1 D) ^ k * 2 ^ N :=
+  by
+    have hmul :=
+      Nat.mul_le_mul_right (unionBound N (hammingBallBudget N ε))
+        (unionBound_le_pow_mul D k)
+    have hball :=
+      Nat.mul_le_mul_left ((k.succ) * (Nat.max 1 D) ^ k)
+        (unionBound_le_pow N (hammingBallBudget N ε))
+    have hchain := le_trans hmul hball
+    -- Переписываем обе стороны через определения `capacityBound` и `hammingBallBound`.
+    simpa [capacityBound, hammingBallBound_spec, Nat.mul_assoc,
+      Nat.mul_left_comm] using hchain
 
 end Counting
 end Pnp3

--- a/pnp3/Tests/Atlas_Count_Sanity.lean
+++ b/pnp3/Tests/Atlas_Count_Sanity.lean
@@ -249,5 +249,23 @@ lemma approx_zero_eq_union_sample :
   classical
   simpa using approx_zero_eq_union (R := sampleDict) (k := 1)
 
+/-- Простая проверка монотонности `unionBound` по бюджету подкубов. -/
+lemma unionBound_mono_sample : unionBound 3 1 ≤ unionBound 3 2 := by
+  simpa using
+    (Counting.unionBound_mono_right (D := 3) (k₁ := 1) (k₂ := 2)
+      (by decide : (1 : Nat) ≤ 2))
+
+/-- Проверка на конкретном примере: увеличение ε расширяет хамминговый шар. -/
+lemma hammingBallBound_mono_sample :
+    hammingBallBound 4 ((1 : ℚ) / 8) (by norm_num) (by norm_num) ≤
+      hammingBallBound 4 ((1 : ℚ) / 4) (by norm_num) (by norm_num) := by
+  have hε : (1 : ℚ) / 8 ≤ (1 : ℚ) / 4 := by norm_num
+  simpa using
+    (Counting.hammingBallBound_mono (N := 4)
+      (ε := (1 : ℚ) / 8) (ε' := (1 : ℚ) / 4)
+      (hε0 := by norm_num) (hε'0 := by norm_num)
+      (hε1 := by norm_num) (hε'1 := by norm_num)
+      (hε := hε))
+
 end Tests
 end Pnp3

--- a/pnp3/ThirdPartyFacts/LeafBudget.lean
+++ b/pnp3/ThirdPartyFacts/LeafBudget.lean
@@ -1,19 +1,22 @@
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.List.Dedup
 import Core.SAL_Core
+import Core.BooleanBasics
 
 /-!
   pnp3/ThirdPartyFacts/LeafBudget.lean
 
-  В этом модуле мы фиксируем "внешний" факт о равномерной границе
-  на число листьев, используемых в Shrinkage-конструкции.  Multi-switching
-  леммы (Servedio–Tan, Håstad и др.) гарантируют, что существует глобальное
-  число `k`, ограничивающее длину списков `Rsel f` для всех функций из
-  семейства.  Нам достаточно интерфейса этого факта, поэтому формализуем его
-  как Lean-аксиому: позднее её можно заменить на доказательство или импорт
-  из полноценной библиотеки.
+  Этот модуль отвечает за извлечение **единой** верхней границы на число листьев,
+  используемых для аппроксимации каждой функции из shrinkage-семейства.  В новой
+  версии мы делаем два ключевых улучшения по сравнению с предыдущей итерацией:
 
-  Эта граница служит ключевым мостиком между SAL и ёмкостными оценками:
-  зная общий `k`, мы сможем автоматически строить `BoundedAtlasScenario`
-  и запускать Covering-Power.
+  * убираем повторы листьев в выборе `Rsel f` (через `List.dedup`), не меняя
+    при этом ошибку аппроксимации;
+  * ограничиваем длину очищенных списков простым и прозрачным числом —
+    `|leaves(tree)|`, то есть количеством листьев PDT.
+
+  Благодаря этому сценарии SAL → Covering-Power могут оперировать конкретной
+  численной оценкой `k`, а не абстрактным максимумом по семейству.
 -/
 
 namespace Pnp3
@@ -21,15 +24,103 @@ namespace ThirdPartyFacts
 
 open Core
 
+namespace Aux
+
+variable {α : Type*}
+
 /--
-  Внешний факт (аксиома): для любого сертификата shrinkage существует
-  одно и то же натуральное число `k`, ограничивающее длину списков `Rsel f`
-  для всех `f ∈ S.F`.  На практике `k = O(t * log(1/ε))`, но для конвейера
-  нижних оценок нам важно лишь само существование такого ограничения.
+  Если каждый элемент списка `xs` встречается в `ys`, то после удаления
+  дубликатов длина `xs` не превосходит длину `ys`.  Доказательство основано на
+  переводе обоих списков в `Finset`: включение множеств даёт оценку кардиналов,
+  а `List.dedup` гарантирует, что кардинал `xs.toFinset` совпадает с длиной
+  очищенного списка `xs.dedup`.
 -/
-axiom leaf_budget_from_shrinkage {n : Nat} [DecidableEq (Subcube n)]
+lemma dedup_length_le_of_subset [DecidableEq α]
+    {xs ys : List α} (h : Core.listSubset xs ys) :
+    xs.dedup.length ≤ ys.length := by
+  classical
+  have hsubset : xs.toFinset ⊆ ys.toFinset := by
+    intro a ha
+    have hmem : a ∈ xs := by
+      simpa [List.mem_toFinset] using ha
+    have hcontains : xs.contains a = true :=
+      Core.contains_of_mem (xs := xs) hmem
+    have hycontains := h a hcontains
+    have hymem : a ∈ ys := Core.mem_of_contains (xs := ys) hycontains
+    simpa [List.mem_toFinset] using hymem
+  have hcard_le : xs.toFinset.card ≤ ys.toFinset.card :=
+    Finset.card_le_card hsubset
+  have hxcard : xs.toFinset.card = xs.dedup.length := by
+    change xs.toFinset.1.card = xs.dedup.length
+    simpa [List.toFinset_val]
+  have hycard : ys.toFinset.card = ys.dedup.length := by
+    change ys.toFinset.1.card = ys.dedup.length
+    simpa [List.toFinset_val]
+  have hy_le : ys.dedup.length ≤ ys.length :=
+    (List.dedup_sublist (l := ys)).length_le
+  have hx_le : xs.dedup.length ≤ ys.toFinset.card := by
+    simpa [hxcard] using hcard_le
+  have hy_bound : ys.toFinset.card ≤ ys.length := by
+    simpa [hycard] using hy_le
+  exact hx_le.trans hy_bound
+
+end Aux
+
+/--
+  Для любого shrinkage сертификата можно выбрать единую границу `k`, равную
+  количеству листьев PDT, так что очищенные (без дубликатов) списки листьев не
+  длиннее `k`.
+-/
+theorem leaf_budget_from_shrinkage {n : Nat}
+    [DecidableEq (Subcube n)] (S : Core.Shrinkage n) :
+    ∃ k : Nat,
+      k ≤ (Core.PDT.leaves S.tree).length ∧
+      ∀ {f : Core.BitVec n → Bool},
+        f ∈ S.F → ((S.Rsel f).dedup).length ≤ k := by
+  classical
+  refine ⟨(Core.PDT.leaves S.tree).length, ?_⟩
+  refine And.intro ?_ ?_
+  · exact le_rfl
+  · intro f hf
+    have hsubset := S.Rsel_sub f hf
+    have hbound := Aux.dedup_length_le_of_subset (xs := S.Rsel f)
+      (ys := Core.PDT.leaves S.tree) hsubset
+    simpa using hbound
+
+/--
+  Очищение списка листьев не ухудшает ошибку аппроксимации.  Удобная форма для
+  дальнейших сценариев: можно заменить `S.Rsel f` на `S.Rsel f`.dedup, сохранив
+  ту же погрешность.
+-/
+lemma err_le_of_dedup {n : Nat} [DecidableEq (Subcube n)]
+    (S : Core.Shrinkage n) {f : Core.BitVec n → Bool} (hf : f ∈ S.F) :
+  Core.errU f ((S.Rsel f).dedup) ≤ S.ε := by
+  classical
+  -- Сравниваем ошибки напрямую через цепочку равенств/неравенств.
+  have h := S.err_le f hf
+  calc
+    Core.errU f ((S.Rsel f).dedup)
+        = Core.errU f (S.Rsel f) := Core.errU_dedup (f := f) (R := S.Rsel f)
+    _ ≤ S.ε := h
+
+/--
+  Корреляция с оценкой на число листьев: полученную границу можно сразу
+  переписать через глубину PDT, применив стандартную оценку `|leaves| ≤ 2^t`.
+-/
+lemma leaf_budget_le_pow_depth {n : Nat} [DecidableEq (Subcube n)]
     (S : Core.Shrinkage n) :
-    ∃ k : Nat, ∀ {f : Core.BitVec n → Bool}, f ∈ S.F → (S.Rsel f).length ≤ k
+    ∀ {f : Core.BitVec n → Bool},
+      f ∈ S.F →
+        ((S.Rsel f).dedup).length ≤ Nat.pow 2 S.t := by
+  classical
+  intro f hf
+  obtain ⟨k, hk⟩ := leaf_budget_from_shrinkage (n := n) S
+  have hlen' := hk.2 hf
+  have hdepth :
+      (Core.PDT.leaves S.tree).length ≤ Nat.pow 2 S.t := by
+    exact (Core.leaves_count_bound (t := S.tree)).trans
+      (Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) S.depth_le)
+  exact hlen'.trans (hk.1.trans hdepth)
 
 end ThirdPartyFacts
 end Pnp3


### PR DESCRIPTION
### **User description**
## Summary
- clarify in the Stage B roadmap that all counting lemmas are now fully proved and no tasks remain for that step
- refresh the Stage B status notes in the outstanding-work section so the remaining todo list only covers stages A, C, and D
- update the atlas counting module header comment to explain that it depends solely on constructive lemmas from `BinomialBounds`

## Testing
- lake test

------
https://chatgpt.com/codex/tasks/task_e_68e10eaac180832bab0ddc63e8e814f4


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
• **Major milestone**: Completed Stage B of the P=NP proof by replacing all axioms with constructive proofs
• **Counting bounds**: Implemented explicit constructive proofs for binomial bounds, Hamming ball estimates, and union bounds in `BinomialBounds.lean`
• **Atlas core**: Replaced counting axioms with complete proofs including `incompatibility` theorem and explicit numerical bounds
• **Deduplication support**: Added comprehensive deduplication handling across boolean basics, leaf budgets, and atlas utilities
• **Circuit counting**: Replaced axiom with explicit `2^{2^n}` bound for all boolean functions
• **Testing**: Extended test suite with monotonicity property verification for new constructive bounds
• **Documentation**: Added comprehensive 250-line proof roadmap documenting completion of Stage B and remaining tasks for stages A, C, and D


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Axioms in counting modules"] -- "replaced with" --> B["Constructive proofs"]
  B --> C["BinomialBounds.lean"]
  B --> D["Atlas_to_LB_Core.lean"] 
  B --> E["Count_EasyFuncs.lean"]
  F["Deduplication support"] --> G["BooleanBasics.lean"]
  F --> H["LeafBudget.lean"]
  F --> I["Atlas.lean"]
  J["Stage B completion"] --> K["Updated roadmap docs"]
  L["New bounds"] --> M["Extended test suite"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>BinomialBounds.lean</strong><dd><code>Replace axioms with constructive proofs for counting bounds</code></dd></summary>
<hr>

pnp3/Counting/BinomialBounds.lean

• Replaced axioms with fully constructive proofs for binomial bounds <br>and Hamming ball estimates<br> • Added lemmas for monotonicity properties <br>of <code>unionBound</code> and <code>hammingBallBound</code><br> • Implemented explicit capacity <br>bounds with concrete arithmetic formulas<br> • Added helper functions like <br><code>hammingBallBudget</code> and supporting theorems


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/1032/files#diff-5692f8554a736570d206301a1deaaefea6e4c25093daf7583406f8f0baaf734d">+456/-48</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Atlas_to_LB_Core.lean</strong><dd><code>Replace counting axioms with constructive proofs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnp3/Counting/Atlas_to_LB_Core.lean

• Replaced axioms <code>unionClass_card_bound</code> and <code>hammingBall_card_bound</code> <br>with complete proofs<br> • Added helper functions <code>mismatchSet</code>, <code>flipOn</code> for <br>Hamming ball analysis<br> • Implemented <code>incompatibility</code> theorem with <br>explicit contradiction proof<br> • Added explicit numerical bounds and <br>subset cardinality theorems


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/1032/files#diff-33f2e429208d3fea00a72defb0a4a93582ae206e7191e0c2185ecfabf3ed3727">+363/-30</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>BooleanBasics.lean</strong><dd><code>Add deduplication support and prove subcube cardinality</code>&nbsp; &nbsp; </dd></summary>
<hr>

pnp3/Core/BooleanBasics.lean

• Added lemmas for handling duplicate removal in subcube lists <br>(<code>covered_dedup</code>, <code>coveredB_dedup</code>)<br> • Implemented <code>subcube_card_pow</code> theorem <br>with explicit bijection construction<br> • Added helper functions for list <br>equivalence and error computation with deduplication<br> • Enhanced <br>coverage analysis with <code>toFinset</code> equivalence lemmas


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/1032/files#diff-cbcb8424ccf28d727488adefdd6bb434acd4dfc3f5c6ff8b6099be6b87cd7e06">+303/-8</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LeafBudget.lean</strong><dd><code>Replace leaf budget axiom with constructive proof</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnp3/ThirdPartyFacts/LeafBudget.lean

• Replaced axiom with constructive proof using PDT leaf count as <br>budget bound<br> • Added deduplication support for leaf lists without <br>changing approximation error<br> • Implemented explicit bounds through <br>tree depth using <code>2^t</code> estimate<br> • Added helper lemmas for subset <br>relationships with deduplication


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/1032/files#diff-c01e6da86b541d6366bac82cbc01791d192630d5c8f9c10208ae1e84c5476df1">+108/-17</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LB_Formulas.lean</strong><dd><code>Update shrinkage scenarios for deduplication support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnp3/LowerBounds/LB_Formulas.lean

• Updated shrinkage scenario construction to use deduplicated leaf <br>lists<br> • Modified function signatures to work with <code>dedup</code> operations<br> • <br>Updated error bounds to account for deduplication preserving <br>approximation quality


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/1032/files#diff-67697477b3e9ac244d6d600e5c59a74e9d286cc27bfa17be68f38d420bb67f62">+17/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Atlas.lean</strong><dd><code>Add deduplication and finset conversion utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnp3/Core/Atlas.lean

• Added support functions for list deduplication (<code>listSubset_dedup</code>)<br> • <br>Implemented finset conversion utilities <br>(<code>toList_mapSubtype_val_toFinset</code>)<br> • Added cardinality bounds for <br>list-to-finset operations<br> • Enhanced subset relationship handling with <br>deduplication


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/1032/files#diff-07e82db66039c73eebea2ce4c482731a3944672f8bacd485086cb03371bec50a">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Count_EasyFuncs.lean</strong><dd><code>Replace circuit counting axiom with explicit bounds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnp3/Counting/Count_EasyFuncs.lean

• Replaced axiom with explicit bound <code>2^{2^n}</code> for all boolean functions<br> <br>• Added constructive proofs for function family cardinality bounds<br> • <br>Implemented <code>allBooleanFunctionsBound</code> with supporting lemmas<br> • Provided <br>concrete bounds instead of existential statements


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/1032/files#diff-51ad01c728fb32de085531822e3f1e6c1fcb587fc11f7bd1151b9208da3a5699">+67/-12</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Atlas_Count_Sanity.lean</strong><dd><code>Add tests for new monotonicity properties</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pnp3/Tests/Atlas_Count_Sanity.lean

• Added test cases for monotonicity properties of <code>unionBound</code><br> • Added <br>verification of <code>hammingBallBound</code> monotonicity with concrete examples<br> • <br>Extended test suite to cover new constructive bounds


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/1032/files#diff-be522017278d4f16e049ddffea894cd8f28f6907101904a867e745fb89f28bed">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>FullPlan.md</strong><dd><code>Complete proof roadmap documentation for pnp3 project stages</code></dd></summary>
<hr>

docs/FullPlan.md

• Added comprehensive 250-line proof roadmap document for the <code>pnp3</code> <br>project<br> • Structured the roadmap around four major proof stages (A → B <br>→ C → D) with detailed status, dependencies, and difficulty estimates<br> <br>• Documented completion of Stage B counting lemmas and binomial bounds <br>with constructive proofs<br> • Included detailed action items, risk <br>tracking, and remaining tasks for each stage


</details>


  </td>
  <td><a href="https://github.com/khanukov/p-np2/pull/1032/files#diff-c043b51ebcccc370467921598e59b6517cf68b48e788a2858899e322a1f07690">+250/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

