### PR TITLE
Generalize restriction mass identity

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -32,6 +32,7 @@ lean_lib PnP3 where
     `Magnification.Facts_Magnification,
     `Magnification.Bridge_to_Magnification,
     `Magnification.FinalResult,
+    `ThirdPartyFacts.BaseSwitching,
     `ThirdPartyFacts.Facts_Switching,
     `ThirdPartyFacts.LeafBudget
   ]
@@ -44,5 +45,6 @@ lean_lib PnP3Tests where
     `Atlas_Counterexample_Search,
     `LB_Smoke_Scenario,
     `LB_Core_Contradiction,
-    `Magnification_Core_Contradiction
+    `Magnification_Core_Contradiction,
+    `Switching_Basics
   ]

--- a/pnp3/Core/BooleanBasics.lean
+++ b/pnp3/Core/BooleanBasics.lean
@@ -13,7 +13,24 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.List.Basic
 import Mathlib.Data.List.FinRange
+import Mathlib.Data.List.Nodup
 import Mathlib.Tactic
+
+namespace List
+
+/--
+`flatMap` по одноэлементным спискам совпадает с обычным `map`.
+-/
+lemma flatMap_singleton_eq_map {α β : Type _} (f : α → β) :
+    ∀ L : List α, L.flatMap (fun x => [f x]) = L.map f
+  | [] => by simp
+  | x :: L => by
+      simpa [List.flatMap_cons, List.map_cons,
+        flatMap_singleton_eq_map (f := f) (L := L)]
+
+end List
+
+open scoped BigOperators
 
 namespace Pnp3
 namespace Core
@@ -693,7 +710,1457 @@ theorem subcube_card_pow {n : Nat} (β : Subcube n) :
             = Fintype.card (FreeIndex → Bool) := hcube_card
         _ = 2 ^ Fintype.card FreeIndex := hfun_card
         _ = 2 ^ (n - t) := by simpa [hfreeIndex_card, Fintype.card_bool]
+
     exact ⟨t, ht_le, hfinal⟩
+
+/--
+## Булевы формулы ограниченной ширины и частичные ограничения
+
+В прикладных леммах о switching нам потребуются явные структуры, описывающие
+литералы, клаузы, формулы в КНФ/ДНФ и операции применения случайных
+ограничений.  Ранее эти определения жили во вспомогательном модуле в разделе
+`ThirdPartyFacts`.  После обсуждения мы переместили их в ядро `Core`, чтобы
+использовать уже готовую инфраструктуру подкубов (`Subcube`) и облегчить
+дальнейшую интеграцию с остальными частями SAL.
+
+Ниже собраны:
+
+* структура `Literal`, представляющая требование `xᵢ = b`;
+* клаузы `CnfClause` и формулы `CNF` ограниченной ширины;
+* термы `DnfTerm` и формулы `DNF`;
+* структура `Restriction`, расширяющая `Subcube` операциями `override` и
+  `assign`;
+* базовые технические леммы о применении ограничения и подсчёте вероятности
+  неудачи.
+
+Большая часть доказательств — аккуратная «арифметика списков» на уровне Lean;
+они тщательно документированы, чтобы позднее использоваться в формализации
+switching-лемм более высоких уровней.
+-/
+
+/- ### Литералы и клаузы -/
+
+/- Литерал булевой формулы: пара «индекс, требуемое значение». -/
+structure Literal (n : Nat) where
+  idx   : Fin n
+  value : Bool
+  deriving DecidableEq, Repr
+
+namespace Literal
+
+@[simp] lemma mk_eta {n : Nat} (ℓ : Literal n) :
+    Literal.mk ℓ.idx ℓ.value = ℓ := by cases ℓ <;> rfl
+
+/-- Булева оценка литерала на точке `x`. -/
+@[simp] def eval {n : Nat} (ℓ : Literal n) (x : BitVec n) : Bool :=
+  if x ℓ.idx = ℓ.value then true else false
+
+/-- Пропозиционное представление истиности литерала. -/
+@[simp] def holds {n : Nat} (ℓ : Literal n) (x : BitVec n) : Prop :=
+  x ℓ.idx = ℓ.value
+
+lemma eval_eq_true_iff {n : Nat} (ℓ : Literal n) (x : BitVec n) :
+    ℓ.eval x = true ↔ ℓ.holds x := by
+  unfold eval holds
+  by_cases hx : x ℓ.idx = ℓ.value
+  · simp [hx]
+  · simp [hx]
+
+lemma eval_eq_false_iff {n : Nat} (ℓ : Literal n) (x : BitVec n) :
+    ℓ.eval x = false ↔ x ℓ.idx ≠ ℓ.value := by
+  unfold eval
+  by_cases hx : x ℓ.idx = ℓ.value
+  · simp [hx]
+  · simp [hx]
+
+lemma holds_of_eval_true {n : Nat} {ℓ : Literal n} {x : BitVec n}
+    (h : ℓ.eval x = true) : ℓ.holds x :=
+  (ℓ.eval_eq_true_iff x).1 h
+
+lemma eval_true_of_holds {n : Nat} {ℓ : Literal n} {x : BitVec n}
+    (h : ℓ.holds x) : ℓ.eval x = true :=
+  (ℓ.eval_eq_true_iff x).2 h
+
+end Literal
+
+/--
+Дизъюнктивная клауза (для КНФ): список литералов без повторов по индексам.
+Условие `nodupIdx` предотвращает одновременное присутствие противоположных
+литералов одной переменной.
+-/
+structure CnfClause (n : Nat) where
+  literals : List (Literal n)
+  nodupIdx : (literals.map (·.idx)).Nodup
+  deriving Repr
+
+namespace CnfClause
+
+/-- Ширина клаузы — длина списка литералов. -/
+@[simp] def width {n : Nat} (C : CnfClause n) : Nat :=
+  C.literals.length
+
+/-- Дизъюнктивная оценка клаузы. -/
+@[simp] def eval {n : Nat} (C : CnfClause n) (x : BitVec n) : Bool :=
+  C.literals.any (fun ℓ => Literal.eval ℓ x)
+
+/-- Пропозиционное описание истинности клаузы. -/
+@[simp] def holds {n : Nat} (C : CnfClause n) (x : BitVec n) : Prop :=
+  ∃ ℓ ∈ C.literals, Literal.holds ℓ x
+
+lemma eval_eq_true_iff {n : Nat} (C : CnfClause n) (x : BitVec n) :
+    C.eval x = true ↔ C.holds x := by
+  classical
+  unfold eval holds
+  constructor
+  · intro h
+    rcases List.any_eq_true.mp h with ⟨ℓ, hmem, hval⟩
+    exact ⟨ℓ, hmem, Literal.holds_of_eval_true hval⟩
+  · intro h
+    rcases h with ⟨ℓ, hmem, hholds⟩
+    exact List.any_eq_true.mpr ⟨ℓ, hmem, Literal.eval_true_of_holds hholds⟩
+
+lemma eval_eq_false_iff {n : Nat} (C : CnfClause n) (x : BitVec n) :
+    C.eval x = false ↔ ∀ ℓ ∈ C.literals, Literal.eval ℓ x = false := by
+  classical
+  unfold eval
+  simpa using List.any_eq_false
+
+lemma holds_of_mem_eval_true {n : Nat} {C : CnfClause n} {x : BitVec n}
+    {ℓ : Literal n} (hmem : ℓ ∈ C.literals) (hval : Literal.eval ℓ x = true) :
+    C.eval x = true := by
+  classical
+  unfold eval
+  exact List.any_eq_true.mpr ⟨ℓ, hmem, hval⟩
+
+end CnfClause
+
+/--
+Конъюнктивная нормальная форма ширины `w`: набор клауз, каждая из которых не
+длиннее `w`.
+-/
+structure CNF (n w : Nat) where
+  clauses : List (CnfClause n)
+  width_le : ∀ C ∈ clauses, C.width ≤ w
+  deriving Repr
+
+namespace CNF
+
+/-- Вычисление КНФ: конъюнкция клауз. -/
+@[simp] def eval {n w : Nat} (F : CNF n w) (x : BitVec n) : Bool :=
+  F.clauses.all (fun C => C.eval x)
+
+/-- Пропозиционное описание истинности КНФ. -/
+@[simp] def holds {n w : Nat} (F : CNF n w) (x : BitVec n) : Prop :=
+  ∀ C ∈ F.clauses, C.holds x
+
+lemma eval_eq_true_iff {n w : Nat} (F : CNF n w) (x : BitVec n) :
+    F.eval x = true ↔ F.holds x := by
+  classical
+  unfold eval holds
+  constructor
+  · intro h
+    intro C hC
+    have hall := List.all_eq_true.mp h
+    have hval : C.eval x = true := hall C hC
+    exact (CnfClause.eval_eq_true_iff (C := C) (x := x)).1 hval
+  · intro h
+    refine List.all_eq_true.mpr ?_
+    intro C hC
+    have hholds : C.holds x := h C hC
+    exact (CnfClause.eval_eq_true_iff (C := C) (x := x)).2 hholds
+
+lemma eval_eq_false_iff {n w : Nat} (F : CNF n w) (x : BitVec n) :
+    F.eval x = false ↔ ∃ C ∈ F.clauses, C.eval x = false := by
+  classical
+  unfold eval
+  simpa using List.all_eq_false
+
+end CNF
+
+/- ### Термы и формулы ДНФ -/
+
+/-- Термы ДНФ переиспользуют `CnfClause`, трактуя список литералов как
+конъюнкцию. -/
+abbrev DnfTerm (n : Nat) := CnfClause n
+
+namespace DnfTerm
+
+/-- Оценка терма: все литералы должны быть истинны. -/
+@[simp] def eval {n : Nat} (T : DnfTerm n) (x : BitVec n) : Bool :=
+  T.literals.all (fun ℓ => Literal.eval ℓ x)
+
+/-- Пропозиционное описание истинности терма. -/
+@[simp] def holds {n : Nat} (T : DnfTerm n) (x : BitVec n) : Prop :=
+  ∀ ℓ ∈ T.literals, Literal.holds ℓ x
+
+lemma eval_eq_true_iff {n : Nat} (T : DnfTerm n) (x : BitVec n) :
+    T.eval x = true ↔ T.holds x := by
+  classical
+  unfold eval holds
+  constructor
+  · intro h
+    have hall := List.all_eq_true.mp h
+    intro ℓ hℓ
+    exact Literal.holds_of_eval_true (hall ℓ hℓ)
+  · intro h
+    refine List.all_eq_true.mpr ?_
+    intro ℓ hℓ
+    exact Literal.eval_true_of_holds (h ℓ hℓ)
+
+lemma eval_eq_false_iff {n : Nat} (T : DnfTerm n) (x : BitVec n) :
+    T.eval x = false ↔ ∃ ℓ ∈ T.literals, Literal.eval ℓ x = false := by
+  classical
+  unfold eval
+  simpa using List.all_eq_false
+
+end DnfTerm
+
+/-- ДНФ ширины `w`: дизъюнкция термов ограниченной длины. -/
+structure DNF (n w : Nat) where
+  terms : List (DnfTerm n)
+  width_le : ∀ T ∈ terms, T.width ≤ w
+  deriving Repr
+
+namespace DNF
+
+@[simp] def eval {n w : Nat} (F : DNF n w) (x : BitVec n) : Bool :=
+  F.terms.any (fun T => T.eval x)
+
+@[simp] def holds {n w : Nat} (F : DNF n w) (x : BitVec n) : Prop :=
+  ∃ T ∈ F.terms, T.holds x
+
+lemma eval_eq_true_iff {n w : Nat} (F : DNF n w) (x : BitVec n) :
+    F.eval x = true ↔ F.holds x := by
+  classical
+  unfold eval holds
+  constructor
+  · intro h
+    obtain ⟨T, hmem, hval⟩ := List.any_eq_true.mp h
+    exact ⟨T, hmem, (DnfTerm.eval_eq_true_iff (T := T) (x := x)).1 hval⟩
+  · intro h
+    rcases h with ⟨T, hmem, hholds⟩
+    exact List.any_eq_true.mpr ⟨T, hmem, (DnfTerm.eval_eq_true_iff (T := T) (x := x)).2 hholds⟩
+
+lemma eval_eq_false_iff {n w : Nat} (F : DNF n w) (x : BitVec n) :
+    F.eval x = false ↔ ∀ T ∈ F.terms, T.eval x = false := by
+  classical
+  unfold eval
+  simpa using List.any_eq_false
+
+end DNF
+
+/- ### Состояния литералов и клауз под ограничениями -/
+
+/--
+`LiteralStatus` фиксирует воздействие ограничения на отдельный литерал.
+-/
+inductive LiteralStatus
+  | satisfied
+  | falsified
+  | unassigned
+  deriving DecidableEq, Repr
+
+namespace LiteralStatus
+
+@[simp] lemma eq_satisfied_or_eq_falsified_or_eq_unassigned
+    (s : LiteralStatus) :
+    s = satisfied ∨ s = falsified ∨ s = unassigned := by
+  cases s <;> simp
+
+end LiteralStatus
+
+/- ### Частичные ограничения `Restriction`
+
+Ограничение реализуется через подкуб `Subcube n`, но снабжено удобными
+операциями `override` и `assign`, которые активно используются в рассуждениях
+о решающих деревьях.
+-/
+
+structure Restriction (n : Nat) where
+  mask : Subcube n
+  deriving Repr
+
+namespace Restriction
+
+variable {n : Nat}
+
+/-- Полностью свободное ограничение. -/
+@[simp] def free (n : Nat) : Restriction n :=
+  { mask := fun _ => none }
+
+/-- Три варианта для каждой координаты: `*`, `0`, `1`. -/
+@[simp] def optionChoices : List (Option Bool) := [none, some false, some true]
+
+/-- Применение ограничения к вектору: зафиксированные координаты затираются. -/
+@[simp] def override (ρ : Restriction n) (x : BitVec n) : BitVec n :=
+  fun i => match ρ.mask i with
+    | none => x i
+    | some b => b
+
+/-- Проверяем, совместима ли точка `x` с ограничением `ρ`. -/
+@[simp] def compatible (ρ : Restriction n) (x : BitVec n) : Bool :=
+  memB ρ.mask x
+
+@[simp] lemma compatible_iff {ρ : Restriction n} {x : BitVec n} :
+    ρ.compatible x = true ↔ mem ρ.mask x := Iff.rfl
+
+/-- Расширенная точка всегда удовлетворяет ограничению. -/
+lemma override_mem (ρ : Restriction n) (x : BitVec n) :
+    mem ρ.mask (ρ.override x) := by
+  classical
+  apply (mem_iff (β := ρ.mask) (x := ρ.override x)).mpr
+  intro i b hβ
+  unfold override
+  cases hρ : ρ.mask i with
+  | none => simpa [hρ] using hβ
+  | some b' =>
+      have hb : b' = b := by
+        have hsome : some b' = some b := by simpa [hρ] using hβ
+        exact Option.some.inj hsome
+      simp [hρ, hb]
+
+/-- Если `x` удовлетворяет ограничению, `override` не меняет вектор. -/
+lemma override_eq_of_mem {ρ : Restriction n} {x : BitVec n}
+    (h : mem ρ.mask x) : ρ.override x = x := by
+  classical
+  funext i
+  unfold override
+  cases hρ : ρ.mask i with
+  | none => rfl
+  | some b =>
+      have hx := (mem_iff (β := ρ.mask) (x := x)).1 h i b ?_
+      · simpa [hρ, hx]
+      · simpa [hρ]
+
+/-- Совместимость эквивалентна тождественности `override`. -/
+lemma compatible_iff_override_eq {ρ : Restriction n} {x : BitVec n} :
+    ρ.compatible x = true ↔ ρ.override x = x := by
+  constructor
+  · intro hcompat
+    have hmem : mem ρ.mask x := hcompat
+    simpa using ρ.override_eq_of_mem hmem
+  · intro hover
+    have hmem : mem ρ.mask (ρ.override x) := ρ.override_mem x
+    simpa [hover] using hmem
+
+/-- Повторное применение `override` стабилизируется. -/
+lemma override_idem (ρ : Restriction n) (x : BitVec n) :
+    ρ.override (ρ.override x) = ρ.override x :=
+  ρ.override_eq_of_mem (ρ.override_mem x)
+
+/-- Фиксируем координату `i` значением `b`. -/
+@[simp] def assign (ρ : Restriction n) (i : Fin n) (b : Bool) :
+    Option (Restriction n) :=
+  match Subcube.assign ρ.mask i b with
+  | none => none
+  | some β => some ⟨β⟩
+
+lemma assign_mask_eq {ρ : Restriction n} {i : Fin n} {b : Bool}
+    {ρ' : Restriction n} (h : ρ.assign i b = some ρ') :
+    ∀ j : Fin n, ρ'.mask j = (if j = i then some b else ρ.mask j) := by
+  classical
+  dsimp [assign] at h
+  cases hassign : Subcube.assign ρ.mask i b with
+  | none => simp [hassign] at h
+  | some β =>
+      have hβ : Restriction.mk β = ρ' := by
+        simpa [assign, hassign] using h
+      subst hβ
+      cases hmask : ρ.mask i with
+      | none =>
+          intro j
+          have hβeq : β = fun j => if j = i then some b else ρ.mask j := by
+            apply Option.some.inj
+            simpa [Subcube.assign, hmask] using hassign.symm
+          subst hβeq
+          simp
+      | some bOld =>
+          have hb : b = bOld := by
+            by_contra hbneq
+            have : none = some β := by
+              simpa [Subcube.assign, hmask, hbneq] using hassign.symm
+            cases this
+          intro j
+          have hβeq : β = ρ.mask := by
+            apply Option.some.inj
+            simpa [Subcube.assign, hmask, hb] using hassign.symm
+          subst hβeq
+          by_cases hij : j = i
+          · subst hij; simp [hmask, hb]
+          · simp [hij]
+
+lemma assign_override_eq {ρ : Restriction n} {i : Fin n} {b : Bool}
+    {ρ' : Restriction n} (h : ρ.assign i b = some ρ') (x : BitVec n) :
+    ρ'.override x = fun j : Fin n => if j = i then b else ρ.override x j := by
+  classical
+  funext j
+  have hmask := assign_mask_eq (ρ := ρ) (ρ' := ρ') (i := i) (b := b) h j
+  by_cases hij : j = i
+  · subst hij; simp [Restriction.override, hmask]
+  · simp [Restriction.override, hmask, hij]
+
+lemma mask_eq_some_of_not_none {ρ : Restriction n} {i : Fin n}
+    (h : ρ.mask i ≠ none) : ∃ b : Bool, ρ.mask i = some b := by
+  cases hmask : ρ.mask i with
+  | none => cases h <| by simpa [hmask]
+  | some b => exact ⟨b, rfl⟩
+
+/-/
+Список свободных координат (там, где маска равна `none`).
+-/
+def freeIndicesList (ρ : Restriction n) : List (Fin n) :=
+  (List.finRange n).filter (fun i => decide (ρ.mask i = none))
+
+@[simp] lemma mem_freeIndicesList {ρ : Restriction n} {i : Fin n} :
+    i ∈ ρ.freeIndicesList ↔ ρ.mask i = none := by
+  classical
+  unfold freeIndicesList
+  constructor
+  · intro hi
+    have hi' : decide (ρ.mask i = none) = true := (List.mem_filter.mp hi).2
+    exact of_decide_eq_true hi'
+  · intro hnone
+    refine List.mem_filter.mpr ?_
+    exact ⟨List.mem_finRange _, (decide_eq_true_iff (p := ρ.mask i = none)).mpr hnone⟩
+
+/-/
+Число свободных координат.
+-/
+@[simp] def freeCount (ρ : Restriction n) : Nat := ρ.freeIndicesList.length
+
+lemma freeCount_le (ρ : Restriction n) : ρ.freeCount ≤ n := by
+  classical
+  unfold freeCount freeIndicesList
+  have := List.length_filter_le (l := List.finRange n)
+    (p := fun i => decide (ρ.mask i = none))
+  simpa using this
+
+lemma freeCount_pos_of_mem_freeIndicesList {ρ : Restriction n} {i : Fin n}
+    (hmem : i ∈ ρ.freeIndicesList) : 0 < ρ.freeCount := by
+  classical
+  unfold freeCount at *
+  exact List.length_pos_of_mem hmem
+
+lemma freeIndicesList_nodup (ρ : Restriction n) : ρ.freeIndicesList.Nodup := by
+  classical
+  unfold freeIndicesList
+  simpa using (List.nodup_finRange n).filter
+    (fun i => decide (ρ.mask i = none))
+
+lemma assign_some_of_mem_freeIndicesList {ρ : Restriction n} {i : Fin n}
+    {b : Bool} (hmem : i ∈ ρ.freeIndicesList) :
+    ∃ ρ' : Restriction n, ρ.assign i b = some ρ' := by
+  classical
+  have hmask : ρ.mask i = none := (Restriction.mem_freeIndicesList (ρ := ρ) (i := i)).1 hmem
+  refine ⟨⟨fun j => if j = i then some b else ρ.mask j⟩, ?_⟩
+  simp [Restriction.assign, Subcube.assign, hmask]
+
+/--
+Добавляем новую координату в ограничение: значение `choice` назначается
+нулевой позиции, а остальные индексы копируются из исходного `ρ`.
+-/
+@[simp] def cons (choice : Option Bool) (ρ : Restriction n) :
+    Restriction (Nat.succ n) :=
+  { mask := fun i => Fin.cases choice (fun j => ρ.mask j) i }
+
+@[simp] lemma cons_mask_zero (choice : Option Bool) (ρ : Restriction n) :
+    (Restriction.cons choice ρ).mask 0 = choice := rfl
+
+@[simp] lemma cons_mask_succ (choice : Option Bool) (ρ : Restriction n)
+    (i : Fin n) :
+    (Restriction.cons choice ρ).mask i.succ = ρ.mask i := rfl
+
+/--
+Хвост ограничения: отбрасываем нулевую координату и сдвигаем индексы вниз.
+-/
+@[simp] def tail (ρ : Restriction (Nat.succ n)) : Restriction n :=
+  { mask := fun i => ρ.mask i.succ }
+
+@[simp] lemma tail_mask (ρ : Restriction (Nat.succ n)) (i : Fin n) :
+    ρ.tail.mask i = ρ.mask i.succ := rfl
+
+@[simp] lemma tail_cons (choice : Option Bool) (ρ : Restriction n) :
+    (Restriction.cons choice ρ).tail = ρ := by
+  cases ρ
+  simp [tail, Restriction.cons]
+
+/-- Применяем ограничение к булевой функции, не изменяя размерность входа. -/
+@[simp] def restrict (ρ : Restriction n) (f : BitVec n → Bool) :
+    BitVec n → Bool :=
+  fun x => f (ρ.override x)
+
+lemma restrict_agree_of_compatible (ρ : Restriction n)
+    (f : BitVec n → Bool) {x : BitVec n}
+    (h : ρ.compatible x = true) :
+    ρ.restrict f x = f x := by
+  unfold restrict
+  have hover := (ρ.compatible_iff_override_eq).mp h
+  simpa [hover]
+
+lemma restrict_override (ρ : Restriction n) (f : BitVec n → Bool)
+    (x : BitVec n) : ρ.restrict f (ρ.override x) = f (ρ.override x) := by
+  unfold restrict
+  simp [override_idem]
+
+/-- Проверяем, стала ли функция константной после ограничения. -/
+@[simp] def isConstantOn (ρ : Restriction n) (f : BitVec n → Bool) : Bool :=
+  decide (∀ x y : BitVec n, ρ.restrict f x = ρ.restrict f y)
+
+lemma isConstantOn_iff {ρ : Restriction n} {f : BitVec n → Bool} :
+    ρ.isConstantOn f = true ↔
+      (∀ x y : BitVec n, ρ.restrict f x = ρ.restrict f y) := by
+  classical
+  unfold isConstantOn
+  simpa using (decide_eq_true_iff
+    (p := ∀ x y : BitVec n, ρ.restrict f x = ρ.restrict f y))
+
+lemma isConstantOn_of_no_free (ρ : Restriction n) (f : BitVec n → Bool)
+    (hfree : ∀ i : Fin n, ρ.mask i ≠ none) : ρ.isConstantOn f = true := by
+  classical
+  have hover : ∀ x y : BitVec n, ρ.override x = ρ.override y := by
+    intro x y; funext i
+    obtain ⟨b, hb⟩ := mask_eq_some_of_not_none (ρ := ρ) (i := i) (h := hfree i)
+    simp [Restriction.override, hb]
+  have hconst : ∀ x y : BitVec n, ρ.restrict f x = ρ.restrict f y := by
+    intro x y
+    unfold Restriction.restrict
+    simpa using congrArg f (hover x y)
+  have := (Restriction.isConstantOn_iff (ρ := ρ) (f := f)).mpr hconst
+  simpa using this
+
+lemma isConstantOn_of_freeCount_eq_zero (ρ : Restriction n)
+    (f : BitVec n → Bool) (hcount : ρ.freeCount = 0) : ρ.isConstantOn f = true := by
+  classical
+  have hfree : ∀ i : Fin n, ρ.mask i ≠ none := by
+    intro i
+    by_contra hnone
+    have hi : i ∈ ρ.freeIndicesList :=
+      (Restriction.mem_freeIndicesList (ρ := ρ) (i := i)).2 hnone
+    have hpos : 0 < ρ.freeCount :=
+      freeCount_pos_of_mem_freeIndicesList (ρ := ρ) hi
+    have hneq : ρ.freeCount ≠ 0 := Nat.pos_iff_ne_zero.mp hpos
+    exact hneq hcount
+  exact isConstantOn_of_no_free (ρ := ρ) (f := f) hfree
+
+/-- Рекурсивная проверка существования PDT глубины ≤ `t`. -/
+def hasDecisionTreeOfDepth
+    (ρ : Restriction n) (f : BitVec n → Bool) (t : Nat) : Bool :=
+  match t with
+  | 0 => ρ.isConstantOn f
+  | Nat.succ t' =>
+      if ρ.isConstantOn f = true then
+        true
+      else
+        (ρ.freeIndicesList).any (fun i =>
+          match ρ.assign i false, ρ.assign i true with
+          | some ρ0, some ρ1 =>
+              hasDecisionTreeOfDepth ρ0 f t' && hasDecisionTreeOfDepth ρ1 f t'
+          | _, _ => false)
+
+@[simp] lemma hasDecisionTreeOfDepth_zero
+    (ρ : Restriction n) (f : BitVec n → Bool) :
+    hasDecisionTreeOfDepth ρ f 0 = ρ.isConstantOn f := by
+  unfold hasDecisionTreeOfDepth
+  simp
+
+/-- Вес ограничения в распределении `𝓡_p`. -/
+@[simp] def weight (ρ : Restriction n) (p : Q) : Q :=
+  ∏ i : Fin n,
+    match ρ.mask i with
+    | none => p
+    | some _ => ((1 : Q) - p) / 2
+
+lemma weight_cons (choice : Option Bool) (ρ : Restriction n) (p : Q) :
+    (Restriction.cons choice ρ).weight p =
+      (match choice with
+        | none => p
+        | some _ => ((1 : Q) - p) / 2) * ρ.weight p := by
+  classical
+  cases choice with
+  | none =>
+      simp [weight, Fin.prod_univ_succ, cons_mask_zero, cons_mask_succ]
+  | some b =>
+      simp [weight, Fin.prod_univ_succ, cons_mask_zero, cons_mask_succ]
+
+/--
+Вес ограничения всегда неотрицателен при условии `0 ≤ p ≤ 1`.  В каждой точке
+перемножаются либо `p`, либо `(1 - p) / 2`, и обе величины неотрицательны при
+таких ограничениях на `p`.
+-/
+lemma weight_nonneg (ρ : Restriction n) {p : Q}
+    (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
+    0 ≤ ρ.weight p := by
+  classical
+  unfold weight
+  refine Finset.prod_nonneg ?_
+  intro i _
+  cases hmask : ρ.mask i with
+  | none =>
+      simpa [hmask, hp₀]
+  | some _ =>
+      have hsub : 0 ≤ (1 - p) := sub_nonneg.mpr hp₁
+      have : 0 ≤ (1 - p) / 2 := by
+        have htwo : (0 : Q) ≤ 2 := by norm_num
+        exact div_nonneg hsub htwo
+      simpa [hmask] using this
+
+/-- Суммарный вес трёх продолжений (`свободный`, `0`, `1`) выражается через вес исходного ограничения. -/
+lemma weight_cons_sum (ρ : Restriction n) (p : Q) :
+    (Restriction.cons none ρ).weight p
+      + (Restriction.cons (some false) ρ).weight p
+      + (Restriction.cons (some true) ρ).weight p
+        = (p + (1 - p)) * ρ.weight p := by
+  classical
+  set w := ρ.weight p
+  have hnone : (Restriction.cons none ρ).weight p = p * w := by
+    simpa [w] using (weight_cons (choice := none) (ρ := ρ) (p := p))
+  have hfalse : (Restriction.cons (some false) ρ).weight p = ((1 - p) / 2) * w := by
+    simpa [w] using (weight_cons (choice := some false) (ρ := ρ) (p := p))
+  have htrue : (Restriction.cons (some true) ρ).weight p = ((1 - p) / 2) * w := by
+    simpa [w] using (weight_cons (choice := some true) (ρ := ρ) (p := p))
+  have hhalves : ((1 - p) / 2 + (1 - p) / 2) = (1 - p) := by
+    ring
+  have hsum :
+      (Restriction.cons none ρ).weight p
+        + (Restriction.cons (some false) ρ).weight p
+        + (Restriction.cons (some true) ρ).weight p
+          = p * w + ((1 - p) / 2) * w + ((1 - p) / 2) * w := by
+    calc
+      (Restriction.cons none ρ).weight p
+          + (Restriction.cons (some false) ρ).weight p
+          + (Restriction.cons (some true) ρ).weight p
+        = p * w + (Restriction.cons (some false) ρ).weight p
+            + (Restriction.cons (some true) ρ).weight p := by
+              simpa [hnone]
+      _ = p * w + ((1 - p) / 2) * w + (Restriction.cons (some true) ρ).weight p := by
+              simpa [hfalse]
+      _ = p * w + ((1 - p) / 2) * w + ((1 - p) / 2) * w := by
+              simpa [htrue]
+  calc
+    (Restriction.cons none ρ).weight p
+        + (Restriction.cons (some false) ρ).weight p
+        + (Restriction.cons (some true) ρ).weight p
+          = p * w + ((1 - p) / 2) * w + ((1 - p) / 2) * w := hsum
+    _ = (p + ((1 - p) / 2 + (1 - p) / 2)) * w := by
+            ring
+    _ = (p + (1 - p)) * w := by
+            simpa [hhalves]
+    _ = (p + (1 - p)) * ρ.weight p := by
+            simpa [w]
+
+/-- Полный список всех ограничений размера `n`. -/
+@[simp] def enumerate : (n : Nat) → List (Restriction n)
+  | 0 =>
+      [{ mask := fun i => False.elim (Fin.elim0 i) }]
+  | Nat.succ n =>
+      List.flatMap
+        (fun (ρ : Restriction n) =>
+          [Restriction.cons none ρ,
+           Restriction.cons (some false) ρ,
+           Restriction.cons (some true) ρ])
+        (enumerate n)
+
+/--
+Полная масса распределения `𝓡_p` на уровне `n` — сумма весов всех ограничений.
+Мы реализуем её через свёртку по списку `enumerate`, чтобы удобно рассуждать
+индукцией по `n`.
+-/
+@[simp] def totalWeight (n : Nat) (p : Q) : Q :=
+  ((enumerate n).map (fun ρ => ρ.weight p)).sum
+
+/-- Помощник: выносим общий множитель из суммы по списку. -/
+lemma sum_map_mul_left {α : Type _} (c : Q) (f : α → Q) :
+    ∀ L : List α, ((L.map fun x => c * f x).sum) = c * (L.map f).sum
+  | [] => by simp
+  | x :: L =>
+      -- Выпишем обе суммы явно и применим индуктивную гипотезу.
+      calc
+        (( (x :: L).map fun y => c * f y).sum)
+            = c * f x + ((L.map fun y => c * f y).sum) := by
+                simp [List.map_cons, List.sum_cons]
+        _ = c * f x + c * (L.map f).sum := by
+                simpa using sum_map_mul_left (c := c) (f := f) (L := L)
+        _ = c * (f x + (L.map f).sum) := by ring
+        _ = c * ((x :: L).map f).sum := by
+                simp [List.map_cons, List.sum_cons, mul_add]
+
+/-- Базовый случай: в нулевой размерности единственное ограничение имеет вес 1. -/
+lemma totalWeight_zero (p : Q) : totalWeight 0 p = 1 := by
+  simp [totalWeight]
+
+/--
+Рекурсивное соотношение: при добавлении новой координаты суммарная масса
+умножается на нормировочный фактор `p + (1 - p)`.
+
+Интуитивно, каждому ограничению на первых `n` координатах соответствуют три
+продолжения (`*`, `0`, `1`), чьи веса складываются в точности в соответствии с
+леммой `weight_cons_sum`.
+-/
+lemma totalWeight_succ (n : Nat) (p : Q) :
+    totalWeight (Nat.succ n) p = (p + (1 - p)) * totalWeight n p := by
+  classical
+  -- Вспомогательная функция: тройка продолжений каждой маски.
+  let g : Restriction n → List (Restriction (Nat.succ n)) := fun ρ =>
+    [Restriction.cons none ρ,
+     Restriction.cons (some false) ρ,
+     Restriction.cons (some true) ρ]
+  -- Покажем, что сумма весов после `flatMap` масштабируется на `(p + (1 - p))`.
+  have haux : ∀ L : List (Restriction n),
+      ((L.flatMap g).map (fun τ => τ.weight p)).sum =
+        (p + (1 - p)) * (L.map fun ρ => ρ.weight p).sum := by
+    intro L
+    induction L with
+    | nil =>
+        simp [g]
+    | cons ρ L ih =>
+        have hρlist :
+            ((g ρ).map (fun τ => τ.weight p)).sum
+              = (Restriction.cons none ρ).weight p
+                  + (Restriction.cons (some false) ρ).weight p
+                  + (Restriction.cons (some true) ρ).weight p := by
+          simp [g, List.map_cons, List.sum_cons, add_comm, add_left_comm,
+            add_assoc]
+        have hρ :
+            ((g ρ).map (fun τ => τ.weight p)).sum
+              = (p + (1 - p)) * ρ.weight p := by
+          calc
+            ((g ρ).map (fun τ => τ.weight p)).sum
+                = (Restriction.cons none ρ).weight p
+                    + (Restriction.cons (some false) ρ).weight p
+                    + (Restriction.cons (some true) ρ).weight p := hρlist
+            _ = (p + (1 - p)) * ρ.weight p :=
+                weight_cons_sum (ρ := ρ) (p := p)
+        have hflat :
+            ((List.flatMap g (ρ :: L)).map (fun τ => τ.weight p)).sum
+              = ((g ρ).map (fun τ => τ.weight p)).sum
+                  + ((List.flatMap g L).map (fun τ => τ.weight p)).sum := by
+          -- Свёртка по `flatMap`: для списка `(ρ :: L)` получаем конкатенацию.
+          change (((g ρ ++ List.flatMap g L).map fun τ => τ.weight p).sum)
+              = _
+          simpa [List.map_append, List.sum_append]
+        have hmap_cons :
+            ((ρ :: L).map fun ρ => ρ.weight p).sum
+              = ρ.weight p + (L.map fun ρ => ρ.weight p).sum := by
+          simp [List.map_cons, List.sum_cons]
+        have htail :
+            ((g ρ).map (fun τ => τ.weight p)).sum
+              + ((List.flatMap g L).map (fun τ => τ.weight p)).sum
+                = (p + (1 - p)) *
+                    (ρ.weight p + (L.map fun ρ => ρ.weight p).sum) := by
+          calc
+            ((g ρ).map (fun τ => τ.weight p)).sum
+                  + ((List.flatMap g L).map (fun τ => τ.weight p)).sum
+                = (p + (1 - p)) * ρ.weight p
+                    + ((List.flatMap g L).map (fun τ => τ.weight p)).sum := by
+                      rw [hρ]
+            _ = (p + (1 - p)) * ρ.weight p
+                    + (p + (1 - p)) * (L.map fun ρ => ρ.weight p).sum := by
+                      rw [ih]
+            _ = (p + (1 - p)) *
+                    (ρ.weight p + (L.map fun ρ => ρ.weight p).sum) := by
+                      ring
+        calc
+          ((List.flatMap g (ρ :: L)).map (fun τ => τ.weight p)).sum
+              = ((g ρ).map (fun τ => τ.weight p)).sum
+                  + ((List.flatMap g L).map (fun τ => τ.weight p)).sum := hflat
+          _ = (p + (1 - p)) *
+                (ρ.weight p + (L.map fun ρ => ρ.weight p).sum) := htail
+          _ = (p + (1 - p)) * ((ρ :: L).map fun ρ => ρ.weight p).sum := by
+                    rw [hmap_cons]
+  -- Применяем результат к списку `enumerate n`.
+  have hfold := haux (Restriction.enumerate n)
+  -- Преобразуем обе части к определению `totalWeight`.
+  change (((Restriction.enumerate n).flatMap g).map (fun τ => τ.weight p)).sum
+      = (p + (1 - p)) * ((Restriction.enumerate n).map fun ρ => ρ.weight p).sum
+  exact hfold
+
+  /-- Явная формула для суммы весов: она образует геометрическую прогрессию. -/
+  lemma totalWeight_closed_form (n : Nat) (p : Q) :
+      totalWeight n p = (p + (1 - p)) ^ n := by
+  induction n with
+  | zero =>
+      simp [totalWeight_zero]
+  | succ n ih =>
+      calc
+        totalWeight (Nat.succ n) p
+            = (p + (1 - p)) * totalWeight n p :=
+                totalWeight_succ (n := n) (p := p)
+        _ = (p + (1 - p)) * (p + (1 - p)) ^ n := by
+                rw [ih]
+        _ = (p + (1 - p)) ^ n * (p + (1 - p)) := by
+                simpa [mul_comm]
+        _ = (p + (1 - p)) ^ Nat.succ n := by
+                simpa [pow_succ] using (pow_succ (p + (1 - p)) n).symm
+
+/-- Полная масса распределения равна 1: `𝓡_p` корректно нормирована. -/
+lemma totalWeight_eq_one (n : Nat) (p : Q) : totalWeight n p = 1 := by
+  have hnorm : p + (1 - p) = (1 : Q) := by ring
+  have hclosed := totalWeight_closed_form n p
+  have hone : (p + (1 - p)) ^ n = 1 := by
+    simpa [hnorm] using (one_pow n : (1 : Q) ^ n = 1)
+  exact hclosed.trans hone
+
+/--
+Масса всех ограничений, которые оставляют нулевую координату свободной,
+равна `p` умножить на общую массу ограничений меньшей размерности.
+-/
+lemma sum_weights_mask_none_zero (n : Nat) (p : Q) :
+    (((enumerate (Nat.succ n)).filter
+        (fun ρ => ρ.mask 0 = none)).map (fun ρ => ρ.weight p)).sum
+      = p * totalWeight n p := by
+  classical
+  -- Удобные сокращения: фильтр по свободной первой координате и тройка продолжений.
+  let P : Restriction (Nat.succ n) → Bool := fun ρ => decide (ρ.mask 0 = none)
+  let g : Restriction n → List (Restriction (Nat.succ n)) :=
+    fun ρ => [cons none ρ, cons (some false) ρ, cons (some true) ρ]
+  -- Расписываем перечисление через `flatMap`.
+  have henum :
+      enumerate (Nat.succ n) = (enumerate n).flatMap g := by
+    simp [enumerate, g]
+  -- Отфильтрованный список — это просто продолжения с `*` на нулевой позиции.
+  have hfiltered_flat :
+      List.filter P ((enumerate n).flatMap g)
+        = (enumerate n).map (cons none) := by
+    classical
+    have haux :
+        ∀ L : List (Restriction n),
+          List.filter P (L.flatMap g)
+            = L.map (cons none) := by
+      intro L; induction L with
+      | nil => simp
+      | cons ρ L ih =>
+          have hhead : List.filter P (g ρ) = [cons none ρ] := by
+            simp [P, g]
+          calc
+            List.filter P ((ρ :: L).flatMap g)
+                = List.filter P (g ρ ++ L.flatMap g) := by
+                    simp [g, List.flatMap_cons]
+            _ = List.filter P (g ρ)
+                  ++ List.filter P (L.flatMap g) := by
+                    simp [List.filter_append]
+            _ = [cons none ρ]
+                  ++ List.filter P (L.flatMap g) := by
+                    simpa [hhead]
+            _ = cons none ρ :: List.filter P (L.flatMap g) := by
+                    simp
+            _ = cons none ρ :: L.map (cons none) := by
+                    simpa [P, g, ih]
+            _ = List.map (cons none) (ρ :: L) := by
+                    simp
+    simpa using haux (enumerate n)
+  have hfiltered :
+      (enumerate (Nat.succ n)).filter P
+        = (enumerate n).map (cons none) := by
+    simpa [henum] using hfiltered_flat
+  -- Сумма весов по этому списку.
+  have hsum :
+      (((enumerate (Nat.succ n)).filter P).map (fun ρ => ρ.weight p)).sum
+        = ((enumerate n).map fun ρ => (cons none ρ).weight p).sum := by
+    have := congrArg (List.map (fun ρ => ρ.weight p)) hfiltered
+    simpa using congrArg List.sum this
+  have hweight :
+      ∀ ρ : Restriction n,
+        (cons none ρ).weight p = p * ρ.weight p := by
+    intro ρ
+    simpa using (weight_cons (choice := none) (ρ := ρ) (p := p))
+  have hsum' :
+      ((enumerate n).map
+          (fun ρ => (cons none ρ).weight p)).sum
+        = ((enumerate n).map fun ρ => p * ρ.weight p).sum := by
+    induction enumerate n with
+    | nil => simp [hweight]
+    | cons ρ L ih =>
+        have hw := hweight ρ
+        calc
+          ((ρ :: L).map (fun ρ => (cons none ρ).weight p)).sum
+              = (cons none ρ).weight p + (L.map (fun ρ => (cons none ρ).weight p)).sum := by
+                  simp [List.map_cons, List.sum_cons]
+          _ = p * ρ.weight p + (L.map (fun ρ => (cons none ρ).weight p)).sum := by
+                  simpa using congrArg (fun x => x + (L.map (fun ρ => (cons none ρ).weight p)).sum) hw
+          _ = p * ρ.weight p + (L.map fun ρ => p * ρ.weight p).sum := by
+                  simpa [List.map_cons, List.sum_cons, add_comm,
+                    add_left_comm, add_assoc]
+                    using congrArg (fun s => p * ρ.weight p + s) ih
+          _ = ((ρ :: L).map fun ρ => p * ρ.weight p).sum := by
+                  simp [List.map_cons, List.sum_cons]
+  calc
+    (((enumerate (Nat.succ n)).filter P).map (fun ρ => ρ.weight p)).sum
+        = ((enumerate n).map
+            (fun ρ => (cons none ρ).weight p)).sum := hsum
+    _ = ((enumerate n).map fun ρ => p * ρ.weight p).sum := hsum'
+    _ = p * ((enumerate n).map fun ρ => ρ.weight p).sum := by
+            exact sum_map_mul_left
+              (L := enumerate n) (c := p)
+              (f := fun ρ => ρ.weight p)
+    _ = p * totalWeight n p := rfl
+
+/-
+Фильтрация списка, полученного через `flatMap`, может быть перенесена на
+исходный список, если результат фильтрации каждой «ветки» зависит только от
+самого элемента, а не от конкретного продолжения.
+-/
+lemma filter_flatMap_eq_flatMap_filter {α β : Type _}
+    (L : List α) (g : α → List β)
+    (P : β → Prop) [DecidablePred P]
+    (Q : α → Prop) [DecidablePred Q]
+    (hcond : ∀ a, List.filter P (g a) = if Q a then g a else []) :
+    List.filter P (L.flatMap g)
+      = (L.filter Q).flatMap g := by
+  classical
+  induction L with
+  | nil =>
+      simp
+  | cons a L ih =>
+      have hhead := hcond a
+      by_cases hQa : Q a
+      · have hfilter_head : List.filter P (g a) = g a := by
+          simpa [hQa] using hhead
+        simp [List.flatMap_cons, List.filter_append, hfilter_head,
+          ih, hQa]
+      · have hfilter_head : List.filter P (g a) = [] := by
+          simpa [hQa] using hhead
+        simp [List.flatMap_cons, List.filter_append, hfilter_head,
+          ih, hQa]
+
+/-
+Сумма весов по множеству ограничений, оставляющих свободной любую фиксированную
+координату `i`, совпадает с `p` умножить на суммарный вес ограничений меньшей
+размерности.
+-/
+lemma sum_weights_mask_none (n : Nat) :
+    ∀ (i : Fin (Nat.succ n)) (p : Q),
+      (((enumerate (Nat.succ n)).filter
+          (fun ρ => ρ.mask i = none)).map (fun ρ => ρ.weight p)).sum
+        = p * totalWeight n p := by
+  classical
+  induction n with
+  | zero =>
+      intro i p
+      cases i using Fin.cases with
+      | zero =>
+          -- Единственный индекс — нулевой, используем предыдущую лемму.
+          simpa using sum_weights_mask_none_zero (n := 0) (p := p)
+      | succ j => exact False.elim (Fin.elim0 j)
+  | succ n ih =>
+      intro i p
+      cases i using Fin.cases with
+      | zero =>
+          -- Нулевая координата сведена к исходному утверждению.
+          simpa using sum_weights_mask_none_zero (n := Nat.succ n) (p := p)
+      | succ i' =>
+        -- Рассматриваем ограничение вида `cons choice ρ` и изучаем фильтр.
+        let P : Restriction (Nat.succ (Nat.succ n)) → Prop :=
+          fun ρ => ρ.mask i'.succ = none
+        let Q : Restriction (Nat.succ n) → Prop :=
+          fun ρ => ρ.mask i' = none
+        let g : Restriction (Nat.succ n) → List (Restriction (Nat.succ (Nat.succ n))) :=
+          fun ρ => [Restriction.cons none ρ,
+            Restriction.cons (some false) ρ,
+            Restriction.cons (some true) ρ]
+        have henum :
+            enumerate (Nat.succ (Nat.succ n))
+              = (enumerate (Nat.succ n)).flatMap g := by
+          simp [enumerate, g]
+        have hbranch :
+            ∀ ρ : Restriction (Nat.succ n),
+              List.filter P (g ρ)
+                = if Q ρ then g ρ else [] := by
+          intro ρ
+          classical
+          by_cases hnone : Q ρ
+          · have hmask : ρ.mask i' = none := hnone
+            simp [g, P, Q, hmask, Restriction.cons_mask_succ, hnone]
+          · have hmask : ρ.mask i' ≠ none := hnone
+            obtain ⟨b, hb⟩ := Restriction.mask_eq_some_of_not_none
+              (ρ := ρ) (i := i') hmask
+            simp [g, P, Q, Restriction.cons_mask_succ, hb, hnone]
+        -- Переносим фильтрацию с расширенного списка на исходный.
+        have hfiltered :
+            List.filter P (enumerate (Nat.succ (Nat.succ n)))
+              = ((enumerate (Nat.succ n)).filter Q).flatMap g := by
+          simpa [henum]
+            using filter_flatMap_eq_flatMap_filter
+              (L := enumerate (Nat.succ n))
+              (g := g) (P := P) (Q := Q) hbranch
+        -- Оценим сумму весов через вспомогательную формулу для `flatMap`.
+        have hflat_sum :
+            (((((enumerate (Nat.succ n)).filter Q).flatMap g).map
+                (fun ρ => ρ.weight p)).sum)
+              = (p + (1 - p))
+                  * (((enumerate (Nat.succ n)).filter Q).map
+                      (fun ρ => ρ.weight p)).sum := by
+          -- Доказательство идентично шагу в `totalWeight_succ`.
+          let L := (enumerate (Nat.succ n)).filter Q
+          have haux :
+              ((L.flatMap g).map (fun ρ => ρ.weight p)).sum
+                = (p + (1 - p)) * (L.map fun ρ => ρ.weight p).sum := by
+            revert L
+            intro L
+            induction L with
+            | nil =>
+                simp [g]
+            | cons ρ L ih =>
+                have hρsum :
+                    ((g ρ).map (fun τ => τ.weight p)).sum
+                      = (Restriction.cons none ρ).weight p
+                          + (Restriction.cons (some false) ρ).weight p
+                          + (Restriction.cons (some true) ρ).weight p := by
+                  simp [g, List.map_cons, List.sum_cons, List.sum_nil,
+                    add_comm, add_left_comm, add_assoc]
+                have hρ :
+                    ((g ρ).map (fun τ => τ.weight p)).sum
+                      = (p + (1 - p)) * ρ.weight p :=
+                  hρsum.trans (weight_cons_sum (ρ := ρ) (p := p))
+                calc
+                  (( (ρ :: L).flatMap g).map (fun τ => τ.weight p)).sum
+                      = ((g ρ ++ L.flatMap g).map (fun τ => τ.weight p)).sum := by
+                          simp [List.flatMap_cons]
+                  _ = ((g ρ).map (fun τ => τ.weight p)).sum
+                        + ((L.flatMap g).map (fun τ => τ.weight p)).sum := by
+                          simp [List.map_append, List.sum_append]
+                  _ = (p + (1 - p)) * ρ.weight p
+                        + (p + (1 - p)) * (L.map fun ρ => ρ.weight p).sum := by
+                          rw [hρ, ih]
+                  _ = (p + (1 - p))
+                        * (ρ.weight p + (L.map fun ρ => ρ.weight p).sum) := by
+                          have := mul_add (p + (1 - p)) (ρ.weight p)
+                            ((L.map fun ρ => ρ.weight p).sum)
+                          simpa [add_comm, add_left_comm, add_assoc] using this.symm
+                  _ = (p + (1 - p))
+                        * ((ρ :: L).map fun ρ => ρ.weight p).sum := by
+                          simp [List.map_cons, List.sum_cons, add_comm,
+                            add_left_comm, add_assoc]
+          simpa [L] using haux
+        -- Теперь собираем все вычисления вместе.
+        calc
+          (((enumerate (Nat.succ (Nat.succ n))).filter
+                (fun ρ => ρ.mask i'.succ = none)).map
+              (fun ρ => ρ.weight p)).sum
+              = (((((enumerate (Nat.succ n)).filter Q).flatMap g).map
+                  (fun ρ => ρ.weight p)).sum) := by
+                  have := congrArg (List.map (fun ρ => ρ.weight p)) hfiltered
+                  simpa [P] using congrArg List.sum this
+          _ = (p + (1 - p))
+                * (((enumerate (Nat.succ n)).filter Q).map
+                    (fun ρ => ρ.weight p)).sum := hflat_sum
+          _ = (p + (1 - p)) *
+                (p * totalWeight n p) := by
+                  -- Индукционная гипотеза применима к индексу `i'`.
+                  simpa [Q]
+                    using ih i' p
+          _ = p * (p + (1 - p)) * totalWeight n p := by
+                  simp [mul_comm, mul_left_comm, mul_assoc]
+          _ = p * ((p + (1 - p)) * totalWeight n p) := by
+                  simp [mul_comm, mul_left_comm, mul_assoc]
+          _ = p * totalWeight (Nat.succ n) p := by
+                  -- Используем рекуррентное равенство для суммарного веса.
+                  have htot := totalWeight_succ (n := n) (p := p)
+                  rw [htot]
+/- Если на каждом элементе списка `f x ≤ g x`, то и суммы `map f` и `map g`
+сохраняют это неравенство. -/
+lemma sum_map_le_sum_map {α : Type _} (L : List α)
+    (f g : α → Q) (h : ∀ x ∈ L, f x ≤ g x) :
+    ((L.map f).sum) ≤ ((L.map g).sum) := by
+  classical
+  induction L with
+  | nil => simp
+  | cons x xs ih =>
+      have hx : f x ≤ g x := h x (by simp)
+      have hxs : ∀ y ∈ xs, f y ≤ g y := by
+        intro y hy
+        exact h y (by simp [hy])
+      have ih' := ih hxs
+      simpa [List.map_cons, List.sum_cons, add_comm, add_left_comm, add_assoc]
+        using add_le_add hx ih'
+
+lemma foldl_select_sum_aux {α : Type _} (L : List α) (f : α → Q)
+    (P : α → Prop) [DecidablePred P] (acc : Q) :
+    (L.foldl (fun acc x => if P x then acc + f x else acc) acc)
+      = acc + ((L.map fun x => if P x then f x else (0 : Q)).sum) := by
+  classical
+  induction L generalizing acc with
+  | nil => simp
+  | cons x xs ih =>
+      by_cases hx : P x
+      · have := ih (acc := acc + f x)
+        simp [hx, ih, add_comm, add_left_comm, add_assoc]
+      · have := ih (acc := acc)
+        simp [hx, ih]
+
+lemma foldl_select_sum {α : Type _} (L : List α) (f : α → Q) (P : α → Prop)
+    [DecidablePred P] :
+    (L.foldl (fun acc x => if P x then acc + f x else acc) 0)
+      = ((L.map fun x => if P x then f x else (0 : Q)).sum) := by
+  simpa using (foldl_select_sum_aux (L := L) (f := f) (P := P) (acc := (0 : Q)))
+
+lemma if_add_else (b : Bool) (a x : Q) :
+    (if b then a + x else a) = a + (if b then x else 0) := by
+  cases b <;> simp
+
+/--
+Сумма по списку с «усечённой» функцией (`if P x then f x else 0`) совпадает с
+суммой по отфильтрованному списку.  Это удобная форма для переписывания
+вероятностных выражений через явное множество «плохих» ограничений.-/
+  lemma sum_map_filter_eq {α : Type _} (L : List α) (f : α → Q)
+      (P : α → Prop) [DecidablePred P] :
+      ((L.map fun x => if P x then f x else (0 : Q)).sum)
+        = ((L.filter P).map f).sum := by
+    classical
+    induction L with
+    | nil => simp
+    | cons x xs ih =>
+        by_cases hx : P x
+        · simp [hx, ih]
+        · simp [hx, ih]
+
+/--
+Состояние литерала относительно маски ограничения.
+-/
+@[simp] def literalStatus {n : Nat} (ρ : Restriction n)
+    (ℓ : Literal n) : LiteralStatus :=
+  match ρ.mask ℓ.idx with
+  | none      => LiteralStatus.unassigned
+  | some b    => if b = ℓ.value then LiteralStatus.satisfied
+                  else LiteralStatus.falsified
+
+lemma literalStatus_eq_satisfied {n : Nat} {ρ : Restriction n}
+    {ℓ : Literal n} :
+    ρ.literalStatus ℓ = LiteralStatus.satisfied ↔ ρ.mask ℓ.idx = some ℓ.value := by
+  classical
+  unfold literalStatus
+  cases hmask : ρ.mask ℓ.idx with
+  | none => simp [hmask]
+  | some b =>
+      by_cases hb : b = ℓ.value
+      · subst hb; simp [hmask]
+      · have hb' : b ≠ ℓ.value := hb
+        simp [hmask, hb, hb']
+
+lemma literalStatus_eq_unassigned {n : Nat} {ρ : Restriction n}
+    {ℓ : Literal n} :
+    ρ.literalStatus ℓ = LiteralStatus.unassigned ↔ ρ.mask ℓ.idx = none := by
+  classical
+  unfold literalStatus
+  cases hmask : ρ.mask ℓ.idx with
+  | none => simp [hmask]
+  | some b =>
+      by_cases hb : b = ℓ.value
+      · simp [hmask, hb]
+      · simp [hmask, hb]
+
+lemma literalStatus_eq_falsified {n : Nat} {ρ : Restriction n}
+    {ℓ : Literal n} :
+    ρ.literalStatus ℓ = LiteralStatus.falsified ↔
+      ∃ b : Bool, ρ.mask ℓ.idx = some b ∧ b ≠ ℓ.value := by
+  classical
+  unfold literalStatus
+  cases hmask : ρ.mask ℓ.idx with
+  | none => simp [hmask]
+  | some b =>
+      by_cases hb : b = ℓ.value
+      · simp [hmask, hb]
+      · constructor
+        · intro _
+          exact ⟨b, rfl, hb⟩
+        · rintro ⟨b', hb', hbneq⟩
+          have hb_eq' : some b = some b' := by
+            simpa [hmask] using hb'
+          have hb_eq : b = b' := Option.some.inj hb_eq'
+          have hbne : b ≠ ℓ.value := by
+            simpa [hb_eq] using hbneq
+          simpa [hmask, hbne]
+
+/-- Список литералов, оставшихся свободными после применения ограничения. -/
+@[simp] def freeLiterals {n : Nat} (ρ : Restriction n) (C : CnfClause n) :
+    List (Literal n) :=
+  C.literals.filter
+    (fun ℓ => decide (ρ.literalStatus ℓ = LiteralStatus.unassigned))
+
+lemma mem_freeLiterals {n : Nat} {ρ : Restriction n} {C : CnfClause n}
+    {ℓ : Literal n} :
+    ℓ ∈ ρ.freeLiterals C ↔ ℓ ∈ C.literals ∧
+      ρ.literalStatus ℓ = LiteralStatus.unassigned := by
+  classical
+  unfold freeLiterals
+  constructor
+  · intro hmem
+    have h := List.mem_filter.mp hmem
+    exact ⟨h.1, (decide_eq_true_iff
+      (p := ρ.literalStatus ℓ = LiteralStatus.unassigned)).1 h.2⟩
+  · intro hmem
+    obtain ⟨hC, hstatus⟩ := hmem
+    refine List.mem_filter.mpr ?_
+    exact ⟨hC, (decide_eq_true_iff
+      (p := ρ.literalStatus ℓ = LiteralStatus.unassigned)).2 hstatus⟩
+
+/-- Список `freeLiterals` пуст тогда и только тогда, когда в клаузе не осталось свободных литералов. -/
+lemma freeLiterals_eq_nil_iff {n : Nat} {ρ : Restriction n}
+    {C : CnfClause n} :
+    ρ.freeLiterals C = [] ↔
+      ∀ ℓ ∈ C.literals, ρ.literalStatus ℓ ≠ LiteralStatus.unassigned := by
+  classical
+  constructor
+  · intro hfree ℓ hℓ hstatus
+    have hmem : ℓ ∈ ρ.freeLiterals C :=
+      (mem_freeLiterals (ρ := ρ) (C := C) (ℓ := ℓ)).2 ⟨hℓ, hstatus⟩
+    have heq := congrArg (fun l => ℓ ∈ l) hfree
+    have hnil : ℓ ∈ ([] : List (Literal n)) := Eq.mp heq hmem
+    cases hnil
+  · intro hnone
+    classical
+    cases hfree : ρ.freeLiterals C with
+    | nil => simpa [hfree]
+    | cons ℓ₀ free =>
+        have heq := congrArg (fun l => ℓ₀ ∈ l) hfree.symm
+        have hmem : ℓ₀ ∈ ρ.freeLiterals C :=
+          Eq.mp heq (List.mem_cons_self (l := free) (a := ℓ₀))
+        obtain ⟨hℓC, hstatus⟩ :=
+          (mem_freeLiterals (ρ := ρ) (C := C) (ℓ := ℓ₀)).1 hmem
+        exact False.elim ((hnone ℓ₀ hℓC) hstatus)
+
+structure ClausePendingWitness {n : Nat}
+    (ρ : Restriction n) (C : CnfClause n) where
+  free : List (Literal n)
+  subset : ∀ ℓ ∈ free, ℓ ∈ C.literals
+  unassigned : ∀ ℓ ∈ free, ρ.literalStatus ℓ = LiteralStatus.unassigned
+  nonempty : free ≠ []
+  noSatisfied : ∀ ℓ ∈ C.literals, ρ.literalStatus ℓ ≠ LiteralStatus.satisfied
+  deriving Repr
+
+inductive ClauseStatus {n : Nat} (ρ : Restriction n) (C : CnfClause n)
+  | satisfied
+  | falsified
+  | pending (w : ClausePendingWitness ρ C)
+  deriving Repr
+
+@[simp] def clauseStatus {n : Nat} (ρ : Restriction n) (C : CnfClause n) :
+    ClauseStatus ρ C :=
+  if hsat : ∃ ℓ ∈ C.literals, ρ.literalStatus ℓ = LiteralStatus.satisfied then
+    ClauseStatus.satisfied
+  else
+    let free := ρ.freeLiterals C
+    if hfree : free = [] then
+      ClauseStatus.falsified
+    else
+      ClauseStatus.pending
+        { free := free
+          , subset := by
+              intro ℓ hℓ
+              have := (mem_freeLiterals (ρ := ρ) (C := C) (ℓ := ℓ)).1 hℓ
+              exact this.1
+          , unassigned := by
+              intro ℓ hℓ
+              have := (mem_freeLiterals (ρ := ρ) (C := C) (ℓ := ℓ)).1 hℓ
+              exact this.2
+          , nonempty := by
+              simpa using hfree
+          , noSatisfied := by
+              intro ℓ hℓ hstat
+              exact hsat ⟨ℓ, hℓ, hstat⟩ }
+
+lemma ClausePendingWitness.exists_unassigned
+    {n : Nat} {ρ : Restriction n} {C : CnfClause n}
+    (w : ClausePendingWitness ρ C) :
+    ∃ ℓ ∈ C.literals, ρ.literalStatus ℓ = LiteralStatus.unassigned := by
+  classical
+  obtain ⟨ℓ, freeTail, hfree⟩ := List.exists_cons_of_ne_nil w.nonempty
+  have hℓmem : ℓ ∈ w.free := by
+    simpa [hfree] using List.mem_cons_self ℓ freeTail
+  exact ⟨ℓ, w.subset _ hℓmem, w.unassigned _ hℓmem⟩
+
+lemma clauseStatus_pending_exists_literal {n : Nat} {ρ : Restriction n}
+    {C : CnfClause n} {w : ClausePendingWitness ρ C} :
+    ρ.clauseStatus C = ClauseStatus.pending w →
+      ∃ ℓ ∈ C.literals, ρ.literalStatus ℓ = LiteralStatus.unassigned := by
+  intro _; exact ClausePendingWitness.exists_unassigned w
+
+end Restriction
+
+namespace CNF
+
+/-- Вероятность (по `𝓡_p`) того, что глубина PDT после ограничения больше `t`. -/
+@[simp] def failureProbability
+    {n w : Nat} (F : CNF n w) (p : Q) (t : Nat) : Q :=
+  ((Restriction.enumerate n).foldl
+    (fun acc ρ =>
+      if Restriction.hasDecisionTreeOfDepth ρ F.eval t = false then
+        acc + ρ.weight p
+      else
+        acc)
+    0)
+
+/--
+Множество (список) «плохих» ограничений, на которых глубина PDT превышает
+`t`.  Мы реализуем его через фильтрацию полного перечисления ограничений.
+-/
+@[simp] def failureSet {n w : Nat} (F : CNF n w) (t : Nat) :
+    List (Restriction n) :=
+  (Restriction.enumerate n).filter
+    (fun ρ => Restriction.hasDecisionTreeOfDepth ρ F.eval t = false)
+
+lemma mem_failureSet {n w : Nat} {F : CNF n w} {t : Nat} {ρ : Restriction n} :
+    ρ ∈ F.failureSet t ↔
+      ρ ∈ Restriction.enumerate n ∧
+        Restriction.hasDecisionTreeOfDepth ρ F.eval t = false := by
+  classical
+  unfold failureSet
+  constructor
+  · intro hρ
+    obtain ⟨hmem, hbool⟩ := List.mem_filter.mp hρ
+    have hfail : Restriction.hasDecisionTreeOfDepth ρ F.eval t = false := by
+      have := of_decide_eq_true (p :=
+        Restriction.hasDecisionTreeOfDepth ρ F.eval t = false) hbool
+      exact this
+    exact ⟨hmem, hfail⟩
+  · intro hρ
+    rcases hρ with ⟨hmem, hfail⟩
+    have hbool : decide (Restriction.hasDecisionTreeOfDepth ρ F.eval t = false)
+        = true := by
+      exact (decide_eq_true_iff
+        (p := Restriction.hasDecisionTreeOfDepth ρ F.eval t = false)).2 hfail
+    exact List.mem_filter.mpr ⟨hmem, hbool⟩
+
+/--
+Переписываем определение `failureProbability` как сумму по всем ограничениям,
+где вклад равен весу ограничения или нулю в зависимости от того, провалилась ли
+проверка глубины.
+-/
+lemma failureProbability_eq_sum
+    {n w : Nat} (F : CNF n w) (p : Q) (t : Nat) :
+    failureProbability F p t =
+      ((Restriction.enumerate n).map
+        (fun ρ =>
+          if Restriction.hasDecisionTreeOfDepth ρ F.eval t = false then
+            ρ.weight p
+          else
+            0)).sum := by
+  classical
+  unfold failureProbability
+  simpa using
+    Restriction.foldl_select_sum (L := Restriction.enumerate n)
+      (f := fun ρ => ρ.weight p)
+      (P := fun ρ => Restriction.hasDecisionTreeOfDepth ρ F.eval t = false)
+
+/--
+Вероятность неудачи — это сумма весов по множеству «плохих» ограничений.
+-/
+lemma failureProbability_eq_failureSet_sum
+    {n w : Nat} (F : CNF n w) (p : Q) (t : Nat) :
+    failureProbability F p t =
+      ((F.failureSet t).map fun ρ => ρ.weight p).sum := by
+  classical
+  have hsum := failureProbability_eq_sum (F := F) (p := p) (t := t)
+  have hfilter := Restriction.sum_map_filter_eq
+    (L := Restriction.enumerate n)
+    (f := fun ρ => ρ.weight p)
+    (P := fun ρ => Restriction.hasDecisionTreeOfDepth ρ F.eval t = false)
+  calc
+    failureProbability F p t
+        = ((Restriction.enumerate n).map
+            (fun ρ =>
+              if Restriction.hasDecisionTreeOfDepth ρ F.eval t = false then
+                ρ.weight p
+              else
+                0)).sum := hsum
+    _ = (((Restriction.enumerate n).filter
+            (fun ρ =>
+              Restriction.hasDecisionTreeOfDepth ρ F.eval t = false)).map
+              (fun ρ => ρ.weight p)).sum := by
+            simpa using hfilter
+    _ = ((F.failureSet t).map fun ρ => ρ.weight p).sum := by
+            simpa [failureSet]
+
+/--
+Вероятность неудачи не превосходит полной массы распределения случайных
+ограничений `𝓡_p`.
+-/
+lemma failureProbability_le_totalWeight
+    {n w : Nat} (F : CNF n w) {p : Q} (t : Nat)
+    (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
+    failureProbability F p t ≤ Restriction.totalWeight n p := by
+  classical
+  have hpointwise : ∀ ρ ∈ Restriction.enumerate n,
+      (if Restriction.hasDecisionTreeOfDepth ρ F.eval t = false then
+        ρ.weight p
+      else
+        0)
+        ≤ ρ.weight p := by
+    intro ρ hρ
+    by_cases hfail : Restriction.hasDecisionTreeOfDepth ρ F.eval t = false
+    · simp [hfail]
+    · have hnonneg : 0 ≤ ρ.weight p :=
+        Restriction.weight_nonneg (ρ := ρ) hp₀ hp₁
+      simpa [hfail] using hnonneg
+  have hsum :=
+    Restriction.sum_map_le_sum_map (Restriction.enumerate n)
+      (fun ρ =>
+        if Restriction.hasDecisionTreeOfDepth ρ F.eval t = false then
+          ρ.weight p
+        else
+          0)
+      (fun ρ => ρ.weight p) hpointwise
+  have hf := failureProbability_eq_sum (F := F) (p := p) (t := t)
+  have ht : ((Restriction.enumerate n).map fun ρ => ρ.weight p).sum
+      = Restriction.totalWeight n p := by rfl
+  -- После подстановки определений получаем требуемое неравенство.
+  calc
+    failureProbability F p t
+        = ((Restriction.enumerate n).map
+            (fun ρ =>
+              if Restriction.hasDecisionTreeOfDepth ρ F.eval t = false then
+                ρ.weight p
+              else
+                0)).sum := hf
+    _ ≤ ((Restriction.enumerate n).map fun ρ => ρ.weight p).sum := hsum
+    _ = Restriction.totalWeight n p := ht
+
+/-- Вероятность неудачи не может быть отрицательной: каждый вклад неотрицателен. -/
+lemma failureProbability_nonneg
+    {n w : Nat} (F : CNF n w) {p : Q} (t : Nat)
+    (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
+    0 ≤ failureProbability F p t := by
+  classical
+  have hsum := failureProbability_eq_sum (F := F) (p := p) (t := t)
+  -- Все слагаемые в явной сумме неотрицательны.
+  have hterms :
+      ∀ ρ ∈ Restriction.enumerate n,
+        0 ≤
+          (if Restriction.hasDecisionTreeOfDepth ρ F.eval t = false then
+            ρ.weight p
+          else
+            0) := by
+    intro ρ _
+    by_cases hfail : Restriction.hasDecisionTreeOfDepth ρ F.eval t = false
+    · have hnonneg : 0 ≤ ρ.weight p :=
+        Restriction.weight_nonneg (ρ := ρ) hp₀ hp₁
+      simpa [hfail]
+    · simp [hfail]
+  have hlist :
+      0 ≤ ((Restriction.enumerate n).map
+        (fun ρ =>
+          if Restriction.hasDecisionTreeOfDepth ρ F.eval t = false then
+            ρ.weight p
+          else
+            0)).sum := by
+    refine List.sum_nonneg ?_
+    intro x hx
+    obtain ⟨ρ, hρ, rfl⟩ := List.mem_map.1 hx
+    exact hterms ρ hρ
+  -- Переписываем цель через эту сумму и применяем результат выше.
+  refine hsum.symm ▸ ?_
+  exact hlist
+
+/-- Вероятность неудачи всегда ≤ 1 при стандартных ограничениях на `p`. -/
+lemma failureProbability_le_one
+    {n w : Nat} (F : CNF n w) {p : Q} (t : Nat)
+    (hp₀ : 0 ≤ p) (hp₁ : p ≤ 1) :
+    failureProbability F p t ≤ 1 := by
+  have hle :=
+    failureProbability_le_totalWeight (F := F) (p := p) (t := t) hp₀ hp₁
+  have htotal := Restriction.totalWeight_eq_one n p
+  rwa [htotal] at hle
+
+end CNF
 
 end Core
 end Pnp3

--- a/pnp3/Tests/Switching_Basics.lean
+++ b/pnp3/Tests/Switching_Basics.lean
@@ -1,0 +1,218 @@
+import Core.BooleanBasics
+import Mathlib.Data.Fin.Basic
+
+open Pnp3
+open Core
+open scoped Classical
+
+namespace Pnp3.Tests
+
+/-- Простейший тест: CNF из одной клаузы `x₀ = true`. -/
+private def literal₀ : Literal 2 :=
+  { idx := ⟨0, by decide⟩, value := true }
+
+private def clause₀ : CnfClause 2 :=
+  { literals := [literal₀],
+    nodupIdx := by
+      simpa using (List.nodup_singleton (literal₀.idx)) }
+
+private def cnf₀ : CNF 2 1 :=
+  { clauses := [clause₀],
+    width_le := by
+      intro C hC
+      rcases List.mem_singleton.mp hC with rfl
+      simp [CnfClause.width, clause₀] }
+
+/-- Две точки на кубе: совместимая и несовместимая с клаузой. -/
+private def xTrue : Core.BitVec 2 := fun i => Fin.cases true (fun _ => false) i
+private def xFalse : Core.BitVec 2 := fun _ => false
+
+@[simp] lemma clause₀_eval_true : clause₀.eval xTrue = true := by
+  classical
+  refine
+    (CnfClause.eval_eq_true_iff (C := clause₀) (x := xTrue)).2 ?_
+  refine ⟨literal₀, ?_, ?_⟩
+  · simp [clause₀]
+  · simp [Literal.holds, literal₀, xTrue, Fin.cases]
+
+@[simp] lemma clause₀_eval_false : clause₀.eval xFalse = false := by
+  classical
+  refine
+    (CnfClause.eval_eq_false_iff (C := clause₀) (x := xFalse)).2 ?_
+  intro ℓ hℓ
+  have hℓ' : ℓ = literal₀ := by
+    simpa [clause₀] using hℓ
+  subst hℓ'
+  simp [Literal.eval, literal₀, xFalse]
+
+@[simp] lemma cnf₀_eval_true : cnf₀.eval xTrue = true := by
+  classical
+  refine (CNF.eval_eq_true_iff (F := cnf₀) (x := xTrue)).2 ?_
+  intro C hC
+  rcases List.mem_singleton.mp hC with rfl
+  simpa using (CnfClause.eval_eq_true_iff (C := clause₀) (x := xTrue)).1 clause₀_eval_true
+
+@[simp] lemma cnf₀_eval_false : cnf₀.eval xFalse = false := by
+  classical
+  refine (CNF.eval_eq_false_iff (F := cnf₀) (x := xFalse)).2 ?_
+  refine ⟨clause₀, ?_, ?_⟩
+  · simp [cnf₀]
+  · simpa using clause₀_eval_false
+
+/-- Пример ограничения: фиксируем `x₀ := true`, `x₁` оставляем свободным. -/
+private def restriction₀ : Restriction 2 :=
+  { mask := fun
+      | ⟨0, _⟩ => some true
+      | ⟨1, _⟩ => none }
+
+/-- Ограничения, дополнительно фиксирующие второй бит. -/
+private def restriction₀_fix (b : Bool) : Restriction 2 :=
+  { mask := fun
+      | ⟨0, _⟩ => some true
+      | ⟨1, _⟩ => some b }
+
+/-- Ограничение, фиксирующее оба бита. -/
+private def restriction_all_fixed : Restriction 2 :=
+  { mask := fun
+      | ⟨0, _⟩ => some true
+      | ⟨1, _⟩ => some false }
+
+lemma restriction_all_fixed_freeCount :
+    restriction_all_fixed.freeCount = 0 := by
+  classical
+  unfold Restriction.freeCount Restriction.freeIndicesList restriction_all_fixed
+  decide
+
+lemma restriction_all_fixed_constant :
+    restriction_all_fixed.isConstantOn cnf₀.eval = true := by
+  classical
+  refine Restriction.isConstantOn_of_freeCount_eq_zero
+    (ρ := restriction_all_fixed) (f := cnf₀.eval) ?_
+  simpa using restriction_all_fixed_freeCount
+
+/-- Ограничение совместимо с точкой `xTrue`. -/
+lemma restriction₀_compatible_true :
+    restriction₀.compatible xTrue = true := by
+  classical
+  have hover : restriction₀.override xTrue = xTrue := by
+    funext i
+    fin_cases i <;> simp [Restriction.override, restriction₀, xTrue, Fin.cases]
+  exact
+    (Restriction.compatible_iff_override_eq (ρ := restriction₀) (x := xTrue)).2 hover
+
+/-- Ограничение не совместимо с `xFalse`. -/
+lemma restriction₀_not_compatible_false :
+    restriction₀.compatible xFalse = false := by
+  classical
+  have hover : restriction₀.override xFalse ≠ xFalse := by
+    intro h
+    have hx := congrArg (fun f => f ⟨0, by decide⟩) h
+    simpa [Restriction.override, restriction₀, xFalse, Fin.cases] using hx
+  have hx : restriction₀.compatible xFalse = true → False := by
+    intro hcompat
+    have :=
+      (Restriction.compatible_iff_override_eq (ρ := restriction₀) (x := xFalse)).1 hcompat
+    exact hover this
+  cases hbool : restriction₀.compatible xFalse
+  · simpa [hbool]
+  · exact (hx (by simpa [hbool])).elim
+
+/-- При совместимой точке `restrict` оставляет значение функции. -/
+lemma restriction₀_preserves_eval :
+    restriction₀.restrict cnf₀.eval xTrue = cnf₀.eval xTrue := by
+  have h := restriction₀_compatible_true
+  simpa using Restriction.restrict_agree_of_compatible restriction₀ cnf₀.eval h
+
+/-- После применения `restriction₀` формула `cnf₀` становится константой. -/
+lemma restriction₀_constant :
+    restriction₀.isConstantOn cnf₀.eval = true := by
+  classical
+  have htrue : ∀ x : Core.BitVec 2,
+      restriction₀.restrict cnf₀.eval x = true := by
+    intro x
+    simp [Restriction.restrict, cnf₀, CNF.eval, clause₀, CnfClause.eval,
+      Literal.eval, restriction₀, Restriction.override, literal₀]
+  have hprop : ∀ x y : Core.BitVec 2,
+      restriction₀.restrict cnf₀.eval x = restriction₀.restrict cnf₀.eval y := by
+    intro x y
+    have hx := htrue x
+    have hy := htrue y
+    simpa [hx, hy]
+  simpa [Restriction.isConstantOn, hprop]
+
+/-- Следовательно, PDT глубины ноль уже достаточен. -/
+lemma restriction₀_depth_zero :
+    Restriction.hasDecisionTreeOfDepth restriction₀ cnf₀.eval 0 = true := by
+  classical
+  -- По лемме `hasDecisionTreeOfDepth_zero` достаточно установить константность.
+  simpa using
+    (restriction₀_constant : restriction₀.isConstantOn cnf₀.eval = true)
+
+/-- Попытка зафиксировать `x₀ := false` приводит к конфликту с маской. -/
+@[simp] lemma restriction₀_assign_index0_false :
+    restriction₀.assign ⟨0, by decide⟩ false = (none : Option (Restriction 2)) := by
+  classical
+  simp [Restriction.assign, restriction₀, Core.Subcube.assign]
+
+/-- Проверяем, что глубины один достаточно для всех ограничений. -/
+def checkAllRestrictionsDepthOne : Bool :=
+  ((Restriction.enumerate 2).map
+      (fun ρ => Restriction.hasDecisionTreeOfDepth ρ cnf₀.eval 1)).all
+    (fun b => b)
+
+-- Контролируем, что суммарная масса распределения `𝓡_p` действительно равна 1.
+#eval Restriction.totalWeight 2 (1 / 2 : Rat)
+
+#eval checkAllRestrictionsDepthOne
+
+#eval
+  (((Restriction.enumerate 2).filter
+        (fun ρ => ρ.mask 0 = none)).map
+      (fun ρ => ρ.weight (1 / 2 : Rat))).sum
+
+-- Проверка новой леммы: свободная координата `1` в трёхмерном случае даёт ту же массу.
+#eval
+  (((Restriction.enumerate 3).filter
+        (fun ρ => ρ.mask ⟨1, by decide⟩ = none)).map
+      (fun ρ => ρ.weight (1 / 2 : Rat))).sum
+
+#eval (1 / 2 : Rat) * Restriction.totalWeight 2 (1 / 2 : Rat)
+
+-- Контрольное вычисление вероятности провала при `t = 0` и `p = 1/2`.
+#eval CNF.failureProbability cnf₀ (1 / 2 : Rat) 0
+
+/-- Уточняем: формула из леммы `failureProbability_eq_failureSet_sum` совпадает с прямым вычислением. -/
+lemma cnf₀_failureProbability_eq_failureSet_sum :
+    CNF.failureProbability cnf₀ (1 / 2 : Rat) 0 =
+      ((cnf₀.failureSet 0).map fun ρ => ρ.weight (1 / 2 : Rat)).sum := by
+  simpa using
+    (CNF.failureProbability_eq_failureSet_sum
+      (F := cnf₀) (p := (1 / 2 : Rat)) (t := 0))
+
+/-- Илллюстрация общей оценки: вероятность неудачи не превосходит 1. -/
+lemma cnf₀_failureProbability_le_one :
+    CNF.failureProbability cnf₀ (1 / 2 : Rat) 0 ≤ 1 := by
+  have hp₀ : 0 ≤ (1 / 2 : Rat) := by norm_num
+  have hp₁ : (1 / 2 : Rat) ≤ 1 := by norm_num
+  simpa using
+    (CNF.failureProbability_le_one (F := cnf₀) (p := (1 / 2 : Rat))
+      (t := 0) hp₀ hp₁)
+
+/-- Проверяем и нижнюю границу: вероятность не опускается ниже нуля. -/
+lemma cnf₀_failureProbability_nonneg :
+    0 ≤ CNF.failureProbability cnf₀ (1 / 2 : Rat) 0 := by
+  have hp₀ : 0 ≤ (1 / 2 : Rat) := by norm_num
+  have hp₁ : (1 / 2 : Rat) ≤ 1 := by norm_num
+  simpa using
+    (CNF.failureProbability_nonneg (F := cnf₀) (p := (1 / 2 : Rat))
+      (t := 0) hp₀ hp₁)
+
+/-- Проверяем формулу суммы весов при `choice = none`. -/
+lemma sum_weights_mask_none_zero_example :
+    (((Restriction.enumerate 1).filter
+        (fun ρ => ρ.mask 0 = none)).map (fun ρ => ρ.weight (1 / 3 : Rat))).sum
+      = (1 / 3 : Rat) := by
+  simpa using
+    (Restriction.sum_weights_mask_none_zero (n := 0) (p := (1 / 3 : Rat)))
+
+end Pnp3.Tests

--- a/pnp3/ThirdPartyFacts/BaseSwitching.lean
+++ b/pnp3/ThirdPartyFacts/BaseSwitching.lean
@@ -1,0 +1,59 @@
+import Core.BooleanBasics
+
+/-!
+  pnp3/ThirdPartyFacts/BaseSwitching.lean
+
+  После реструктуризации определения для switching-леммы живут в ядре проекта
+  (`Core.BooleanBasics`).  Этот модуль оставлен как совместимый фасад: он
+  импортирует `Core` и переэкспортирует базовые определения/леммы в пространстве
+  имён `ThirdPartyFacts`, чтобы остальной код, опирающийся на прежние имена,
+  продолжал компилироваться.  По мере появления доказательства базовой
+  switching-леммы именно здесь будет сформулировано итоговое утверждение.
+-/
+
+namespace Pnp3
+namespace ThirdPartyFacts
+
+open Core
+
+abbrev Literal := Core.Literal
+namespace Literal
+  export Core.Literal
+    (eval holds eval_eq_true_iff eval_eq_false_iff holds_of_eval_true
+      eval_true_of_holds)
+end Literal
+
+abbrev CnfClause := Core.CnfClause
+namespace CnfClause
+  export Core.CnfClause
+    (width eval holds eval_eq_true_iff eval_eq_false_iff holds_of_mem_eval_true)
+end CnfClause
+
+abbrev CNF := Core.CNF
+namespace CNF
+  export Core.CNF (eval holds eval_eq_true_iff eval_eq_false_iff failureProbability)
+end CNF
+
+abbrev DnfTerm := Core.DnfTerm
+namespace DnfTerm
+  export Core.DnfTerm (eval holds eval_eq_true_iff eval_eq_false_iff)
+end DnfTerm
+
+abbrev DNF := Core.DNF
+namespace DNF
+  export Core.DNF (eval holds eval_eq_true_iff eval_eq_false_iff)
+end DNF
+
+abbrev Restriction := Core.Restriction
+namespace Restriction
+  export Core.Restriction
+    (free optionChoices override compatible compatible_iff override_mem
+      override_eq_of_mem compatible_iff_override_eq override_idem assign
+      assign_mask_eq assign_override_eq freeIndicesList mem_freeIndicesList
+      freeCount freeCount_le restrict restrict_agree_of_compatible
+      restrict_override isConstantOn isConstantOn_iff hasDecisionTreeOfDepth
+      hasDecisionTreeOfDepth_zero weight enumerate)
+end Restriction
+
+end ThirdPartyFacts
+end Pnp3


### PR DESCRIPTION
## Summary
- add a reusable lemma for commuting filters across `flatMap` to streamline restriction enumerations
- generalize the restriction mass identity to any free coordinate using the new helper
- extend the switching basics diagnostics to exercise the generalized lemma on concrete inputs

## Testing
- `lake build PnP3`
- `lake test`


------
https://chatgpt.com/codex/tasks/task_e_68e1b4500be8832bb09068750dcdcc27