### PR TITLE
Add shrinkage-derived bounds for SAL scenarios

### DIFF
--- a/pnp3/Core/Atlas.lean
+++ b/pnp3/Core/Atlas.lean
@@ -77,6 +77,50 @@ lemma listSubset.mem {α} [DecidableEq α]
   have hcontains' := h a hcontains
   exact mem_of_contains (xs := ys) hcontains'
 
+/--
+  Если каждый элемент `xs` принадлежит `ys` (в обычном смысле списочного
+  членства), то выполняется и отношение `listSubset`.  Эта вспомогательная
+  лемма позволяет работать с привычными "математическими" включениями, не
+  заботясь о том, какая конкретная реализация `DecidableEq` используется для
+  функций `contains`.
+-/
+lemma listSubset_of_mem {α} [DecidableEq α]
+    {xs ys : List α} (h : ∀ ⦃a : α⦄, a ∈ xs → a ∈ ys) :
+    listSubset xs ys := by
+  intro a ha
+  classical
+  have hmem : a ∈ xs := mem_of_contains (xs := xs) ha
+  have hy : a ∈ ys := h hmem
+  exact contains_of_mem (xs := ys) hy
+
+/-- Эквивалентность между определением `listSubset` и привычным включением. -/
+lemma listSubset_iff_mem {α} [DecidableEq α] (xs ys : List α) :
+    listSubset xs ys ↔ ∀ ⦃a : α⦄, a ∈ xs → a ∈ ys := by
+  constructor
+  · intro h a ha
+    exact listSubset.mem h ha
+  · intro h
+    exact listSubset_of_mem h
+
+/--
+  От выбранной реализации `DecidableEq` значение `listSubset` не зависит.  Мы
+  переводим утверждение через обычное включение множеств, где доказательство не
+  использует конкретные решения равенства.
+-/
+lemma listSubset_congr_decEq {α} (inst₁ inst₂ : DecidableEq α)
+    (xs ys : List α) :
+    @listSubset α inst₁ xs ys ↔ @listSubset α inst₂ xs ys := by
+  classical
+  -- Эквивалентность достигается через промежуточную форму "каждый элемент xs
+  -- содержится в ys".
+  have h₁ : @listSubset α inst₁ xs ys ↔ ∀ ⦃a : α⦄, a ∈ xs → a ∈ ys := by
+    letI := inst₁
+    exact listSubset_iff_mem (xs := xs) (ys := ys)
+  have h₂ : @listSubset α inst₂ xs ys ↔ ∀ ⦃a : α⦄, a ∈ xs → a ∈ ys := by
+    letI := inst₂
+    exact listSubset_iff_mem (xs := xs) (ys := ys)
+  exact h₁.trans h₂.symm
+
 
 /-- Добавление элемента, уже содержащегося в `ys`, сохраняет отношение `listSubset`. -/
 lemma listSubset_cons_of_mem {α} [DecidableEq α]

--- a/pnp3/Core/SAL_Core.lean
+++ b/pnp3/Core/SAL_Core.lean
@@ -16,6 +16,75 @@ namespace Core
 /-- Семейство функций как список (для удобства перебора). -/
 abbrev Family (n : Nat) := List (BitVec n → Bool)
 
+/--
+`CommonPDT F` описывает единое частичное решающее дерево, которое
+аппроксимирует каждую функцию семейства `F` с одной и той же глубиной и
+погрешностью.  Структура хранит:
+
+* само дерево `tree` и допустимую верхнюю границу `depthBound` на его глубину;
+* общую ошибку аппроксимации `epsilon`;
+* функцию `selectors`, которая каждой функции сопоставляет подсписок листьев;
+* доказательства, что выбранные листья действительно содержатся в `tree` и
+  что ошибка не превосходит `epsilon`.
+
+Такая запись удобна тем, что отделяет «конструктивную» часть shrinkage
+сертификата (конкретное дерево) от последующей работы с атласами.  В дальнейшем
+мы будем явно превращать `CommonPDT` в атлас и показывать, что он работает для
+всего семейства.
+-/
+structure CommonPDT (n : Nat) [DecidableEq (Subcube n)]
+    (F : Family n) where
+  tree        : PDT n
+  depthBound  : Nat
+  epsilon     : Q
+  depth_le    : PDT.depth tree ≤ depthBound
+  selectors   : (BitVec n → Bool) → List (Subcube n)
+  selectors_sub :
+    ∀ {f : BitVec n → Bool} {β : Subcube n},
+      f ∈ F → β ∈ selectors f → β ∈ PDT.leaves tree
+  err_le :
+    ∀ {f : BitVec n → Bool}, f ∈ F →
+      errU f (selectors f) ≤ epsilon
+
+namespace CommonPDT
+
+variable {n : Nat} [DecidableEq (Subcube n)] {F : Family n}
+
+/-- Атлас, полученный из общего PDT.  Словарь совпадает со списком листьев,
+а допустимая погрешность равна `epsilon`. -/
+def toAtlas (C : CommonPDT n F) : Atlas n :=
+  Atlas.ofPDT C.tree C.epsilon
+
+/-- Сценарий SAL: общий PDT автоматически задаёт атлас, работающий для всего
+семейства функций.  Доказательство напрямую распаковывает поля структуры. -/
+theorem worksFor (C : CommonPDT n F) : WorksFor C.toAtlas F := by
+  intro f hf
+  refine ⟨C.selectors f, ?_, ?_⟩
+  · have hmem : ∀ β ∈ C.selectors f, β ∈ PDT.leaves C.tree := by
+      intro β hβ
+      exact C.selectors_sub (F := F) (f := f) (β := β) hf hβ
+    have hmem' : ∀ β ∈ C.selectors f, β ∈ C.toAtlas.dict := by
+      simpa [CommonPDT.toAtlas, Atlas.ofPDT] using hmem
+    classical
+    -- Сначала строим доказательство `listSubset` относительно текущего экземпляра
+    -- `DecidableEq`.  Далее переведём его к каноническому, который ожидает
+    -- определение `WorksFor`.
+    let inst₁ : DecidableEq (Subcube n) := inferInstance
+    have hsubset_inst :
+        @listSubset (Subcube n) inst₁ (C.selectors f) (C.toAtlas.dict) := by
+      letI := inst₁
+      exact
+        (listSubset_iff_mem (xs := C.selectors f) (ys := C.toAtlas.dict)).2 hmem'
+    -- Переходим к каноническому экземпляру `DecidableEq`.
+    exact
+      ((listSubset_congr_decEq (inst₁ := inst₁)
+            (inst₂ := fun a b => Fintype.decidablePiFintype a b)
+            (C.selectors f) (C.toAtlas.dict)).1 hsubset_inst)
+  · simpa [CommonPDT.toAtlas, Atlas.ofPDT] using
+      C.err_le (F := F) hf
+
+end CommonPDT
+
 /-- Абстрактная "усадка" (Shrinkage):
     существует ОБЩЕЕ PDT глубины ≤ t и для каждого f ∈ F задан поднабор листьев (Rf),
     дающий ошибку ≤ ε. -/
@@ -29,17 +98,52 @@ structure Shrinkage (n : Nat) [DecidableEq (Subcube n)] where
   Rsel_sub : ∀ f, f ∈ F → listSubset (Rsel f) (PDT.leaves tree)
   err_le   : ∀ f, f ∈ F → errU f (Rsel f) ≤ ε
 
+/-- Любой shrinkage-сертификат содержит в себе явный `CommonPDT`. -/
+def Shrinkage.commonPDT {n : Nat} [DecidableEq (Subcube n)]
+    (S : Shrinkage n) : CommonPDT n S.F where
+  tree := S.tree
+  depthBound := S.t
+  epsilon := S.ε
+  depth_le := S.depth_le
+  selectors := S.Rsel
+  selectors_sub := by
+    intro f β hf hβ
+    have hsubset := S.Rsel_sub f hf
+    exact listSubset.mem hsubset hβ
+  err_le := by
+    intro f hf
+    simpa using S.err_le f hf
+
+@[simp] lemma Shrinkage.commonPDT_tree {n : Nat} [DecidableEq (Subcube n)]
+    (S : Shrinkage n) : S.commonPDT.tree = S.tree := rfl
+
+@[simp] lemma Shrinkage.commonPDT_depthBound {n : Nat}
+    [DecidableEq (Subcube n)] (S : Shrinkage n) :
+    S.commonPDT.depthBound = S.t := rfl
+
+@[simp] lemma Shrinkage.commonPDT_epsilon {n : Nat}
+    [DecidableEq (Subcube n)] (S : Shrinkage n) :
+    S.commonPDT.epsilon = S.ε := rfl
+
+@[simp] lemma Shrinkage.commonPDT_selectors {n : Nat}
+    [DecidableEq (Subcube n)] (S : Shrinkage n) (f : BitVec n → Bool) :
+    S.commonPDT.selectors f = S.Rsel f := rfl
+
+/-- Формулировка из плана проекта: из shrinkage следует существование общего PDT. -/
+def shrinkage_to_commonPDT {n : Nat} [DecidableEq (Subcube n)]
+    (S : Shrinkage n) : CommonPDT n S.F := S.commonPDT
+
+/-- Вспомогательная лемма из плана: общий PDT сразу даёт атлас. -/
+theorem commonPDT_to_atlas {n : Nat} [DecidableEq (Subcube n)]
+    {F : Family n} (C : CommonPDT n F) : WorksFor C.toAtlas F :=
+  C.worksFor
+
 /-- SAL: из Shrinkage строим атлас с dict = листья PDT, ε = заданное, который "работает" для F. -/
 theorem SAL_from_Shrinkage {n : Nat} [DecidableEq (Subcube n)]
   (S : Shrinkage n) :
   WorksFor (Atlas.ofPDT S.tree S.ε) S.F := by
-  intro f hf
-  -- Возьмём R_f как предписано shrinkage'ем
-  refine ⟨S.Rsel f, ?subset, ?err⟩
-  · -- R_f ⊆ leaves(tree)
-    simpa [Atlas.ofPDT, listSubset] using S.Rsel_sub f hf
-  · -- errU f R_f ≤ ε
-    exact S.err_le f hf
+  simpa [CommonPDT.toAtlas, Atlas.ofPDT] using
+    (commonPDT_to_atlas (C := S.commonPDT))
 
 /-- Удобная оболочка: сам атлас из Shrinkage. -/
 def Atlas.fromShrinkage {n : Nat} [DecidableEq (Subcube n)]

--- a/pnp3/LowerBounds/LB_Formulas.lean
+++ b/pnp3/LowerBounds/LB_Formulas.lean
@@ -153,68 +153,225 @@ theorem no_bounded_atlas_of_large_family
     exact (Nat.lt_irrefl _ hcontr)
 
 /--
-  ### От shrinkage к сценарию ограниченного атласа
+  ### От общего PDT к сценарию ограниченного атласа
 
-  В практических применениях SAL выдаёт «сырой» сертификат вида `Shrinkage`: у нас
-  есть PDT небольшой глубины, и для каждой функции из семейства задан набор листьев,
-  обеспечивающий малую ошибку.  Чтобы воспользоваться счётными результатами части B,
-  удобно упаковать эти данные в `BoundedAtlasScenario`.  Следующая конструкция
-  выполняет именно это преобразование, если заранее известна граница `k` на число
-  листьев, используемых для каждой функции.
+  В практических применениях SAL (и родственных конструкций) мы часто получаем
+  не только готовый атлас, но и общий частичный решающий дерево `CommonPDT`.  Это
+  более гибкий интерфейс по сравнению с голым `Shrinkage`: он содержит дерево,
+  допускающее совместное использование листьев несколькими функциями, и явно
+  хранит списки листьев для каждой функции.  Следующая конструкция преобразует
+  такие данные в `BoundedAtlasScenario`, если известна граница `k` на длину
+  очищенных (`dedup`) списков селекторов.
 -/
+noncomputable def BoundedAtlasScenario.ofCommonPDT
+    {n : Nat}
+    {F : Core.Family n}
+    (C : Core.CommonPDT n F) (k : Nat)
+    (hlen : ∀ f ∈ F, ((C.selectors f).dedup).length ≤ k)
+    (hε0 : (0 : Core.Q) ≤ C.epsilon)
+    (hε1 : C.epsilon ≤ (1 : Core.Q) / 2) :
+    BoundedAtlasScenario n :=
+  by
+    classical
+    refine
+      { atlas := C.toAtlas
+        family := F
+        k := k
+        hε0 := hε0
+        hε1 := hε1
+        works := C.worksFor
+        bounded := by
+          intro f hf
+          refine ⟨(C.selectors f).dedup, hlen f hf, ?_, ?_⟩
+          ·
+            have hsubset_mem :
+                ∀ β : Subcube n,
+                  β ∈ (C.selectors f).dedup → β ∈ C.toAtlas.dict := by
+              intro β hβ
+              have hsel : β ∈ C.selectors f := List.mem_dedup.mp hβ
+              have hleaf : β ∈ Core.PDT.leaves C.tree :=
+                C.selectors_sub (F := F) (f := f) (β := β) hf hsel
+              simpa [Core.CommonPDT.toAtlas, Core.Atlas.ofPDT] using hleaf
+            exact
+              ((Core.listSubset_iff_mem
+                    (xs := (C.selectors f).dedup)
+                    (ys := C.toAtlas.dict)).2)
+                hsubset_mem
+          ·
+            simpa using
+              (ThirdPartyFacts.err_le_of_dedup_commonPDT
+                (n := n) (F := F) (C := C) (f := f) hf) }
+
 noncomputable def BoundedAtlasScenario.ofShrinkage
-    {n : Nat} [DecidableEq (Core.Subcube n)]
+    {n : Nat}
     (S : Core.Shrinkage n) (k : Nat)
     (hlen : ∀ f ∈ S.F, ((S.Rsel f).dedup).length ≤ k)
     (hε0 : (0 : Core.Q) ≤ S.ε) (hε1 : S.ε ≤ (1 : Core.Q) / 2) :
     BoundedAtlasScenario n :=
-  { atlas := Core.Atlas.fromShrinkage S
-    family := S.F
-    k := k
-    hε0 := hε0
-    hε1 := hε1
-    works := by
-      -- Конструкция SAL непосредственно показывает, что полученный атлас
-      -- работает для семейства `S.F`.
-      simpa [Core.Atlas.fromShrinkage] using Core.SAL_from_Shrinkage S
-    bounded := by
-      -- Используем данные shrinkage: список `S.Rsel f` подмножеством словаря,
-      -- имеет ограниченную длину и даёт требуемую ошибку.
+  by
+    classical
+    refine BoundedAtlasScenario.ofCommonPDT (C := S.commonPDT) k ?hlen ?hε0 ?hε1
+    · intro f hf
+      simpa [Core.Shrinkage.commonPDT_selectors] using hlen f hf
+    · simpa [Core.Shrinkage.commonPDT_epsilon] using hε0
+    · simpa [Core.Shrinkage.commonPDT_epsilon] using hε1
+
+/-
+  ### От shrinkage к сценарию ограниченного атласа
+
+  Специализация предыдущего шага: SAL обычно возвращает `Shrinkage`, который можно
+  рассматривать как частный случай `CommonPDT`.  Поэтому дальнейшие конструкции
+  могут работать с общим интерфейсом, а `ofShrinkage` лишь аккуратно упаковывает
+  преобразование.
+-/
+
+/--
+  Общий вариант построения ограниченного сценария по данному `CommonPDT`.
+  Используем внешнюю оценку `leaf_budget_from_commonPDT`, чтобы выбрать
+  подходящее число `k` листьев, после чего применяем `ofCommonPDT`.
+-/
+noncomputable def scenarioFromCommonPDT
+    {n : Nat} {F : Core.Family n}
+    (C : Core.CommonPDT n F)
+    (hε0 : (0 : Core.Q) ≤ C.epsilon)
+    (hε1 : C.epsilon ≤ (1 : Core.Q) / 2) :
+    Σ' _ : Nat, BoundedAtlasScenario n :=
+  by
+    classical
+    let witness :=
+      ThirdPartyFacts.leaf_budget_from_commonPDT (n := n) (F := F) (C := C)
+    let k := Classical.choose witness
+    have hkSpec := Classical.choose_spec witness
+    have hlen : ∀ f ∈ F, ((C.selectors f).dedup).length ≤ k := by
       intro f hf
-      refine ⟨(S.Rsel f).dedup, ?_, ?_, ?_⟩
-      · exact hlen f hf
-      · -- После удаления дубликатов отношение подмножества сохраняется.
-        have hsubset := S.Rsel_sub f hf
-        have hsubset' := Core.listSubset_dedup (h := hsubset)
-        convert hsubset' using 1 <;>
-          simp [Core.listSubset, Core.Atlas.fromShrinkage, Core.Atlas.ofPDT]
-      · -- Ошибка не возрастает: `dedup` лишь убирает повторы листьев.
-        simpa using ThirdPartyFacts.err_le_of_dedup (S := S) hf }
+      have hkLen := hkSpec.2 hf
+      simpa using hkLen
+    exact ⟨k, BoundedAtlasScenario.ofCommonPDT (C := C) k hlen hε0 hε1⟩
+
+/--
+  Полезная граница на параметр `k`, возвращаемый конструкцией
+  `scenarioFromCommonPDT`.  Он не превышает `2^{depthBound}` — число, которое
+  ограничивает количество листьев исходного PDT.  Именно это значение
+  появляется в дальнейших оценках ёмкости.
+-/
+lemma scenarioFromCommonPDT_k_le_pow
+    {n : Nat} {F : Core.Family n}
+    (C : Core.CommonPDT n F)
+    (hε0 : (0 : Core.Q) ≤ C.epsilon)
+    (hε1 : C.epsilon ≤ (1 : Core.Q) / 2) :
+    (scenarioFromCommonPDT (n := n) (F := F) (C := C) hε0 hε1).1
+      ≤ Nat.pow 2 C.depthBound := by
+  classical
+  -- Теперь определение `scenarioFromCommonPDT` доступно — раскрываем его.
+  unfold scenarioFromCommonPDT
+  set witness :=
+      ThirdPartyFacts.leaf_budget_from_commonPDT
+        (n := n) (F := F) (C := C)
+    with hwitness
+  set k := Classical.choose witness with hk
+  change k ≤ Nat.pow 2 C.depthBound
+  have hk_spec := Classical.choose_spec witness
+  have hk_leaves : k ≤ (Core.PDT.leaves C.tree).length := by
+    simpa [hk] using hk_spec.1
+  have hlen_bound :
+      (Core.PDT.leaves C.tree).length ≤ Nat.pow 2 (Core.PDT.depth C.tree) :=
+    Core.leaves_count_bound (t := C.tree)
+  have hdepth_bound :
+      Nat.pow 2 (Core.PDT.depth C.tree) ≤ Nat.pow 2 C.depthBound :=
+    Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) C.depth_le
+  exact hk_leaves.trans (hlen_bound.trans hdepth_bound)
 
 /--
   Для shrinkage-сертификата полезно знать, что словарь полученного атласа
   не длиннее `2^{t}`, где `t` — заявленная глубина PDT.  Эта оценка напрямую
   следует из стандартной границы на число листьев дерева решений.
 -/
+lemma dictLen_fromCommonPDT_le_pow
+    {n : Nat} {F : Core.Family n} (C : Core.CommonPDT n F) :
+    Counting.dictLen C.toAtlas.dict ≤ Nat.pow 2 C.depthBound :=
+  by
+    classical
+    have hLeaves :
+        (Core.PDT.leaves C.tree).length ≤ Nat.pow 2 (Core.PDT.depth C.tree) :=
+      Core.leaves_count_bound (t := C.tree)
+    have hDepth :
+        Nat.pow 2 (Core.PDT.depth C.tree) ≤ Nat.pow 2 C.depthBound :=
+      Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) C.depth_le
+    have hDict :
+        Counting.dictLen C.toAtlas.dict =
+          (Core.PDT.leaves C.tree).length := rfl
+    exact (hDict ▸ hLeaves).trans hDepth
+
+/--
+  Специализация предыдущей оценки на случай shrinkage.  Граница выражается
+  через параметр `t`, управляющий глубиной PDT.
+-/
 lemma dictLen_fromShrinkage_le_pow
     {n : Nat} (S : Core.Shrinkage n) :
     Counting.dictLen (Core.Atlas.fromShrinkage S).dict ≤ Nat.pow 2 S.t :=
   by
-    have hLeaves :
-        (Core.PDT.leaves S.tree).length ≤ Nat.pow 2 (Core.PDT.depth S.tree) :=
-      Core.leaves_count_bound (t := S.tree)
-    have hDepth :
-        Nat.pow 2 (Core.PDT.depth S.tree) ≤ Nat.pow 2 S.t :=
-      Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) S.depth_le
-    have hDict :
-        Counting.dictLen (Core.Atlas.fromShrinkage S).dict =
-          (Core.PDT.leaves S.tree).length := rfl
-    exact (hDict ▸ hLeaves).trans hDepth
+    classical
+    have :=
+      dictLen_fromCommonPDT_le_pow
+        (n := n) (F := S.F) (C := S.commonPDT)
+    simpa [Core.Atlas.fromShrinkage, Core.Atlas.ofPDT,
+      Core.CommonPDT.toAtlas, Core.Shrinkage.commonPDT_depthBound,
+      Core.Shrinkage.commonPDT_tree]
+      using this
+
+/-- У `scenarioFromCommonPDT` семейство во втором компоненте равно исходному `F`. -/
+@[simp]
+lemma scenarioFromCommonPDT_family
+    {n : Nat} {F : Core.Family n}
+    (C : Core.CommonPDT n F)
+    (hε0 : (0 : Core.Q) ≤ C.epsilon)
+    (hε1 : C.epsilon ≤ (1 : Core.Q) / 2) :
+    (scenarioFromCommonPDT (n := n) (F := F) (C := C) hε0 hε1).2.family = F := by
+  rfl
+
+lemma scenarioFromCommonPDT_dictLen_le_pow
+    {n : Nat} {F : Core.Family n}
+    (C : Core.CommonPDT n F)
+    (hε0 : (0 : Core.Q) ≤ C.epsilon)
+    (hε1 : C.epsilon ≤ (1 : Core.Q) / 2) :
+    Counting.dictLen
+        (scenarioFromCommonPDT (n := n) (F := F) (C := C) hε0 hε1).2.atlas.dict
+      ≤ Nat.pow 2 C.depthBound := by
+  classical
+  have hbound := dictLen_fromCommonPDT_le_pow (n := n) (F := F) (C := C)
+  -- В полученном сценарии атлас совпадает с `C.toAtlas`, поэтому оценка
+  -- на длину словаря переносится напрямую.
+  simpa [scenarioFromCommonPDT, BoundedAtlasScenario.ofCommonPDT,
+    Core.CommonPDT.toAtlas]
+    using hbound
 
 /--
   Версия критерия несовместимости, заточенная под shrinkage: если для
   построенного из него сценария существует большое подсемейство функций,
   то получить такой shrinkage невозможно.
+-/
+theorem no_commonPDT_of_large_family
+    {n : Nat} {F : Core.Family n}
+    (C : Core.CommonPDT n F) (k : Nat)
+    (hlen : ∀ f ∈ F, ((C.selectors f).dedup).length ≤ k)
+    (hε0 : (0 : Core.Q) ≤ C.epsilon) (hε1 : C.epsilon ≤ (1 : Core.Q) / 2)
+    (Y : Finset (Core.BitVec n → Bool))
+    (hYsubset :
+      Y ⊆ familyFinset (sc := BoundedAtlasScenario.ofCommonPDT (C := C) k hlen hε0 hε1))
+    (hLarge :
+      scenarioCapacity
+          (sc := BoundedAtlasScenario.ofCommonPDT (C := C) k hlen hε0 hε1) < Y.card) :
+    False :=
+  by
+    classical
+    exact
+      no_bounded_atlas_of_large_family
+        (sc := BoundedAtlasScenario.ofCommonPDT (C := C) k hlen hε0 hε1)
+        (Y := Y) hYsubset hLarge
+
+/--
+  Версия критерия для shrinkage-сертификата.  Следует из общей формы, применённой
+  к `S.commonPDT`.
 -/
 theorem no_shrinkage_of_large_family
     {n : Nat} (S : Core.Shrinkage n) (k : Nat)
@@ -229,33 +386,69 @@ theorem no_shrinkage_of_large_family
     False :=
   by
     classical
-    -- Применяем общий критерий к специально построенному сценарию.
+    have hsubset' :
+        Y ⊆
+          familyFinset
+            (sc := BoundedAtlasScenario.ofCommonPDT
+              (C := S.commonPDT) k
+              (hlen := by
+                intro f hf
+                simpa [Core.Shrinkage.commonPDT_selectors] using hlen f hf)
+              (hε0 := by
+                simpa [Core.Shrinkage.commonPDT_epsilon] using hε0)
+              (hε1 := by
+                simpa [Core.Shrinkage.commonPDT_epsilon] using hε1)) :=
+      by
+        simpa using hYsubset
+    have hLarge' :
+        scenarioCapacity
+            (sc := BoundedAtlasScenario.ofCommonPDT
+              (C := S.commonPDT) k
+              (hlen := by
+                intro f hf
+                simpa [Core.Shrinkage.commonPDT_selectors] using hlen f hf)
+              (hε0 := by
+                simpa [Core.Shrinkage.commonPDT_epsilon] using hε0)
+              (hε1 := by
+                simpa [Core.Shrinkage.commonPDT_epsilon] using hε1))
+          < Y.card :=
+      by
+        simpa using hLarge
     exact
-      no_bounded_atlas_of_large_family
-        (sc := BoundedAtlasScenario.ofShrinkage S k hlen hε0 hε1)
-        (Y := Y) hYsubset hLarge
+      no_commonPDT_of_large_family
+        (C := S.commonPDT) (k := k)
+        (hlen := by
+          intro f hf
+          simpa [Core.Shrinkage.commonPDT_selectors] using hlen f hf)
+        (hε0 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε0)
+        (hε1 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε1)
+        (Y := Y)
+        hsubset' hLarge'
 
 /--
   ### Автоматический переход от Shrinkage к ограниченному сценарию
 
-  Комбинируем SAL и внешний факт о бюджете листьев, получая готовый
-  объект `BoundedAtlasScenario` и общую границу `k`.  Это базовый клей
-  между частями A и B: дальше можно напрямую применять Covering-Power.
+  Комбинируем SAL и внешний факт о бюджете листьев (теперь сформулированный на
+  уровне `CommonPDT`), получая готовый объект `BoundedAtlasScenario` и общую
+  границу `k`.  Это базовый клей между частями A и B: дальше можно напрямую
+  применять Covering-Power.
 -/
 noncomputable def scenarioFromShrinkage
-    {n : Nat} [DecidableEq (Core.Subcube n)]
+    {n : Nat}
     (S : Core.Shrinkage n)
     (hε0 : (0 : Core.Q) ≤ S.ε) (hε1 : S.ε ≤ (1 : Core.Q) / 2) :
-    Σ' k : Nat, BoundedAtlasScenario n :=
+    Σ' _ : Nat, BoundedAtlasScenario n :=
   by
     classical
-    let witness := ThirdPartyFacts.leaf_budget_from_shrinkage S
-    let k := Classical.choose witness
-    have hkSpec := Classical.choose_spec witness
-    have hk : ∀ f ∈ S.F, ((S.Rsel f).dedup).length ≤ k := by
-      intro f hf
-      simpa using hkSpec.2 hf
-    exact ⟨k, BoundedAtlasScenario.ofShrinkage S k hk hε0 hε1⟩
+    exact
+      scenarioFromCommonPDT
+        (n := n) (F := S.F) (C := S.commonPDT)
+        (hε0 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε0)
+        (hε1 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε1)
 
 /--
   Специализация к случаю AC⁰: из shrinkage-конструкции, предоставленной
@@ -266,10 +459,9 @@ noncomputable def scenarioFromShrinkage
 noncomputable def scenarioFromAC0
     (params : ThirdPartyFacts.AC0Parameters)
     (F : Core.Family params.n) :
-    Σ' k : Nat, BoundedAtlasScenario params.n :=
+    Σ' _ : Nat, BoundedAtlasScenario params.n :=
   by
     classical
-    letI := inferInstanceAs (DecidableEq (Core.Subcube params.n))
     let shrinkWitness := ThirdPartyFacts.shrinkage_for_AC0 params F
     let t := Classical.choose shrinkWitness
     let rest₁ := Classical.choose_spec shrinkWitness
@@ -277,37 +469,66 @@ noncomputable def scenarioFromAC0
     let rest₂ := Classical.choose_spec rest₁
     let S := Classical.choose rest₂
     have hspec := Classical.choose_spec rest₂
-    rcases hspec with ⟨hF, hchain⟩
-    rcases hchain with ⟨ht, hchain⟩
-    rcases hchain with ⟨hε, hchain⟩
-    rcases hchain with ⟨htBound, hchain⟩
-    rcases hchain with ⟨hε0, hεBound⟩
+    have hF : S.F = F := hspec.1
+    have hchain := hspec.2
+    have ht : S.t = t := hchain.1
+    have hchain' := hchain.2
+    have hε : S.ε = ε := hchain'.1
+    have hchain'' := hchain'.2
+    have htBound : t ≤ Nat.pow (Nat.log2 (params.M + 2)) (params.d + 1) := hchain''.1
+    have hchain''' := hchain''.2
+    have hε0 : (0 : Core.Q) ≤ ε := hchain'''.1
+    have hεBound : ε ≤ (1 : Core.Q) / (params.n + 2) := hchain'''.2
     let hε' : ε = S.ε := hε.symm
     have hε_le_half_base :=
       ThirdPartyFacts.eps_le_half_of_eps_le_inv_nplus2
         params.n (ε := ε) hεBound
     have hε_le_half : S.ε ≤ (1 : Core.Q) / 2 := hε' ▸ hε_le_half_base
     have hε_nonneg : (0 : Core.Q) ≤ S.ε := hε' ▸ hε0
-    let leafWitness := ThirdPartyFacts.leaf_budget_from_shrinkage S
-    let k := Classical.choose leafWitness
-    have hkSpec := Classical.choose_spec leafWitness
-    have hkLen : ∀ f ∈ S.F, ((S.Rsel f).dedup).length ≤ k := by
-      intro f hf
-      simpa using hkSpec.2 hf
     let base :=
-      BoundedAtlasScenario.ofShrinkage S k hkLen hε_nonneg hε_le_half
-    have hFamily : base.family = S.F := rfl
-    refine ⟨k, { base with family := F, works := ?_, bounded := ?_ }⟩
+      scenarioFromCommonPDT
+        (n := params.n) (F := S.F) (C := S.commonPDT)
+        (hε0 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε_nonneg)
+        (hε1 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε_le_half)
+    have base_family : base.2.family = S.F := by
+      simp [base, scenarioFromCommonPDT, BoundedAtlasScenario.ofCommonPDT]
+    refine ⟨base.1, { base.2 with family := F, works := ?_, bounded := ?_ }⟩
     ·
-      have hworksBase : WorksFor base.atlas S.F := by
-        simpa [hFamily] using base.works
+      have hworksBase : WorksFor base.2.atlas S.F := by
+        simpa [base_family] using base.2.works
       exact hF ▸ hworksBase
     · intro f hf
       have hfS : f ∈ S.F := hF ▸ hf
-      have hfBase : f ∈ base.family := by
-        simpa [hFamily] using hfS
-      have hbounded := base.bounded f hfBase
-      simpa [hFamily] using hbounded
+      have hfBase : f ∈ base.2.family := by
+        simpa [base_family] using hfS
+      have hbounded := base.2.bounded f hfBase
+      simpa [base_family] using hbounded
+
+/-- Семейство функций в сценарии, построенном из факта `AC⁰ → shrinkage`,
+  совпадает с исходным списком `F`.  Это удобное переписывание для дальнейших
+  аргументов о подсемействах и мощностях. -/
+@[simp]
+lemma scenarioFromAC0_family_eq
+    (params : ThirdPartyFacts.AC0Parameters)
+    (F : Core.Family params.n) :
+    (scenarioFromAC0 params F).2.family = F := by
+  classical
+  unfold scenarioFromAC0
+  set shrinkWitness := ThirdPartyFacts.shrinkage_for_AC0 params F
+  set t := Classical.choose shrinkWitness
+  set rest₁ := Classical.choose_spec shrinkWitness
+  set ε := Classical.choose rest₁
+  set rest₂ := Classical.choose_spec rest₁
+  set S := Classical.choose rest₂
+  have hspec := Classical.choose_spec rest₂
+  rcases hspec with ⟨hF, hchain⟩
+  rcases hchain with ⟨ht, hchain⟩
+  rcases hchain with ⟨hε, hchain⟩
+  rcases hchain with ⟨htBound, hchain⟩
+  rcases hchain with ⟨hε0, hεBound⟩
+  simp
 
 /--
   Аналог конструкции `scenarioFromAC0`, но для shrinkage факта о
@@ -317,10 +538,9 @@ noncomputable def scenarioFromAC0
 noncomputable def scenarioFromLocalCircuit
     (params : ThirdPartyFacts.LocalCircuitParameters)
     (F : Core.Family params.n) :
-    Σ' k : Nat, BoundedAtlasScenario params.n :=
+    Σ' _ : Nat, BoundedAtlasScenario params.n :=
   by
     classical
-    letI := inferInstanceAs (DecidableEq (Core.Subcube params.n))
     let shrinkWitness := ThirdPartyFacts.shrinkage_for_localCircuit params F
     let t := Classical.choose shrinkWitness
     let rest₁ := Classical.choose_spec shrinkWitness
@@ -328,38 +548,267 @@ noncomputable def scenarioFromLocalCircuit
     let rest₂ := Classical.choose_spec rest₁
     let S := Classical.choose rest₂
     have hspec := Classical.choose_spec rest₂
-    rcases hspec with ⟨hF, hchain⟩
-    rcases hchain with ⟨ht, hchain⟩
-    rcases hchain with ⟨hε, hchain⟩
-    rcases hchain with ⟨htBound, hchain⟩
-    rcases hchain with ⟨hε0, hεBound⟩
+    have hF : S.F = F := hspec.1
+    have hchain := hspec.2
+    have ht : S.t = t := hchain.1
+    have hchain' := hchain.2
+    have hε : S.ε = ε := hchain'.1
+    have hchain'' := hchain'.2
+    have htBound : t ≤ params.ℓ * (Nat.log2 (params.M + 2) + params.depth + 1) := hchain''.1
+    have hchain''' := hchain''.2
+    have hε0 : (0 : Core.Q) ≤ ε := hchain'''.1
+    have hεBound : ε ≤ (1 : Core.Q) / (params.n + 2) := hchain'''.2
     let hε' : ε = S.ε := hε.symm
     have hε_le_half_base :=
       ThirdPartyFacts.eps_le_half_of_eps_le_inv_nplus2
         params.n (ε := ε) hεBound
     have hε_le_half : S.ε ≤ (1 : Core.Q) / 2 := hε' ▸ hε_le_half_base
     have hε_nonneg : (0 : Core.Q) ≤ S.ε := hε' ▸ hε0
-    let leafWitness := ThirdPartyFacts.leaf_budget_from_shrinkage S
-    let k := Classical.choose leafWitness
-    have hkSpec := Classical.choose_spec leafWitness
-    have hkLen : ∀ f ∈ S.F, ((S.Rsel f).dedup).length ≤ k := by
-      intro f hf
-      simpa using hkSpec.2 hf
     let base :=
-      BoundedAtlasScenario.ofShrinkage S k hkLen hε_nonneg hε_le_half
-    have hFamily : base.family = S.F := rfl
-    refine ⟨k, { base with family := F, works := ?_, bounded := ?_ }⟩
+      scenarioFromCommonPDT
+        (n := params.n) (F := S.F) (C := S.commonPDT)
+        (hε0 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε_nonneg)
+        (hε1 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε_le_half)
+    have base_family : base.2.family = S.F := by
+      simp [base, scenarioFromCommonPDT, BoundedAtlasScenario.ofCommonPDT]
+    refine ⟨base.1, { base.2 with family := F, works := ?_, bounded := ?_ }⟩
     ·
-      have hworksBase : WorksFor base.atlas S.F := by
-        simpa [hFamily] using base.works
+      have hworksBase : WorksFor base.2.atlas S.F := by
+        simpa [base_family] using base.2.works
       exact hF ▸ hworksBase
     · intro f hf
       have hfS : f ∈ S.F := hF ▸ hf
-      have hfBase : f ∈ base.family := by
-        simpa [hFamily] using hfS
-      have hbounded := base.bounded f hfBase
-      simpa [hFamily] using hbounded
+      have hfBase : f ∈ base.2.family := by
+        simpa [base_family] using hfS
+      have hbounded := base.2.bounded f hfBase
+      simpa [base_family] using hbounded
 
+/-- Семейство в сценарии для локальных схем совпадает с исходным списком `F`. -/
+@[simp]
+lemma scenarioFromLocalCircuit_family_eq
+    (params : ThirdPartyFacts.LocalCircuitParameters)
+    (F : Core.Family params.n) :
+    (scenarioFromLocalCircuit params F).2.family = F := by
+  classical
+  unfold scenarioFromLocalCircuit
+  set shrinkWitness := ThirdPartyFacts.shrinkage_for_localCircuit params F
+  set t := Classical.choose shrinkWitness
+  set rest₁ := Classical.choose_spec shrinkWitness
+  set ε := Classical.choose rest₁
+  set rest₂ := Classical.choose_spec rest₁
+  set S := Classical.choose rest₂
+  have hspec := Classical.choose_spec rest₂
+  rcases hspec with ⟨hF, hchain⟩
+  rcases hchain with ⟨ht, hchain⟩
+  rcases hchain with ⟨hε, hchain⟩
+  rcases hchain with ⟨htBound, hchain⟩
+  rcases hchain with ⟨hε0, hεBound⟩
+  simp
 
+/--
+  Для сценария, построенного из shrinkage, параметр `k` не превышает числа
+  листьев PDT, то есть `2^{t}`.  Это прямое следствие определения
+  `scenarioFromShrinkage` через `scenarioFromCommonPDT`.
+-/
+lemma scenarioFromShrinkage_k_le_pow
+    {n : Nat} (S : Core.Shrinkage n)
+    (hε0 : (0 : Core.Q) ≤ S.ε) (hε1 : S.ε ≤ (1 : Core.Q) / 2) :
+    (scenarioFromShrinkage (n := n) S hε0 hε1).1 ≤ Nat.pow 2 S.t := by
+  classical
+  simpa [scenarioFromShrinkage, Core.Shrinkage.commonPDT_depthBound,
+    Core.Shrinkage.commonPDT_epsilon]
+    using
+      scenarioFromCommonPDT_k_le_pow
+        (n := n) (F := S.F) (C := S.commonPDT)
+        (hε0 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε0)
+        (hε1 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε1)
+
+/--
+  Аналогичная оценка для длины словаря: `scenarioFromShrinkage` наследует
+  границу `|dict| ≤ 2^{t}` от общего PDT.
+-/
+lemma scenarioFromShrinkage_dictLen_le_pow
+    {n : Nat} (S : Core.Shrinkage n)
+    (hε0 : (0 : Core.Q) ≤ S.ε) (hε1 : S.ε ≤ (1 : Core.Q) / 2) :
+    Counting.dictLen
+        (scenarioFromShrinkage (n := n) S hε0 hε1).2.atlas.dict
+      ≤ Nat.pow 2 S.t := by
+  classical
+  simpa [scenarioFromShrinkage, Core.Shrinkage.commonPDT_depthBound,
+    Core.Shrinkage.commonPDT_epsilon]
+    using
+      scenarioFromCommonPDT_dictLen_le_pow
+        (n := n) (F := S.F) (C := S.commonPDT)
+        (hε0 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε0)
+        (hε1 := by
+          simpa [Core.Shrinkage.commonPDT_epsilon] using hε1)
+
+/--
+  Параметр `k` в сценарии AC⁰ не превышает `2^{(log₂(M+2))^{d+1}}`.  Получаем
+  его из границы `t ≤ (log₂(M+2))^{d+1}`, предоставленной внешним фактом.
+-/
+lemma scenarioFromAC0_k_le_pow
+    (params : ThirdPartyFacts.AC0Parameters)
+    (F : Core.Family params.n) :
+    (scenarioFromAC0 params F).1
+      ≤ Nat.pow 2 (Nat.pow (Nat.log2 (params.M + 2)) (params.d + 1)) := by
+  classical
+  unfold scenarioFromAC0
+  set shrinkWitness := ThirdPartyFacts.shrinkage_for_AC0 params F with hwit
+  let t := Classical.choose shrinkWitness
+  set rest₁ := Classical.choose_spec shrinkWitness with hrest₁
+  let ε := Classical.choose rest₁
+  set rest₂ := Classical.choose_spec rest₁ with hrest₂
+  let S := Classical.choose rest₂
+  have hspec := Classical.choose_spec rest₂
+  rcases hspec with ⟨hF, hchain⟩
+  rcases hchain with ⟨ht_eq, hchain⟩
+  rcases hchain with ⟨hε_eq, hchain⟩
+  rcases hchain with ⟨htBound, hchain⟩
+  rcases hchain with ⟨hε0, hεBound⟩
+  have hε_nonneg : (0 : Core.Q) ≤ S.ε := by
+    simpa using (hε_eq ▸ hε0)
+  have hε_half : S.ε ≤ (1 : Core.Q) / 2 :=
+    (hε_eq ▸
+      ThirdPartyFacts.eps_le_half_of_eps_le_inv_nplus2
+        params.n (ε := ε) hεBound)
+  have hk_base :=
+    scenarioFromShrinkage_k_le_pow
+      (n := params.n) (S := S)
+      (hε0 := hε_nonneg)
+      (hε1 := hε_half)
+  have hbound_pow :
+      Nat.pow 2 S.t ≤ Nat.pow 2 (Nat.pow (Nat.log2 (params.M + 2)) (params.d + 1)) := by
+    have : S.t ≤ Nat.pow (Nat.log2 (params.M + 2)) (params.d + 1) := by
+      simpa using (ht_eq.symm ▸ htBound)
+    exact Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) this
+  exact hk_base.trans hbound_pow
+
+/--
+  Оценка на длину словаря в AC⁰-сценарии: она не превосходит того же `2^{(log₂(M+2))^{d+1}}`.
+-/
+lemma scenarioFromAC0_dictLen_le_pow
+    (params : ThirdPartyFacts.AC0Parameters)
+    (F : Core.Family params.n) :
+    Counting.dictLen (scenarioFromAC0 params F).2.atlas.dict
+      ≤ Nat.pow 2 (Nat.pow (Nat.log2 (params.M + 2)) (params.d + 1)) := by
+  classical
+  unfold scenarioFromAC0
+  set shrinkWitness := ThirdPartyFacts.shrinkage_for_AC0 params F with hwit
+  let t := Classical.choose shrinkWitness
+  set rest₁ := Classical.choose_spec shrinkWitness with hrest₁
+  let ε := Classical.choose rest₁
+  set rest₂ := Classical.choose_spec rest₁ with hrest₂
+  let S := Classical.choose rest₂
+  have hspec := Classical.choose_spec rest₂
+  rcases hspec with ⟨hF, hchain⟩
+  rcases hchain with ⟨ht_eq, hchain⟩
+  rcases hchain with ⟨hε_eq, hchain⟩
+  rcases hchain with ⟨htBound, hchain⟩
+  rcases hchain with ⟨hε0, hεBound⟩
+  have hε_nonneg : (0 : Core.Q) ≤ S.ε := by
+    simpa using (hε_eq ▸ hε0)
+  have hε_half : S.ε ≤ (1 : Core.Q) / 2 :=
+    (hε_eq ▸
+      ThirdPartyFacts.eps_le_half_of_eps_le_inv_nplus2
+        params.n (ε := ε) hεBound)
+  have hdict_base :=
+    scenarioFromShrinkage_dictLen_le_pow
+      (n := params.n) (S := S)
+      (hε0 := hε_nonneg)
+      (hε1 := hε_half)
+  have hbound_pow :
+      Nat.pow 2 S.t ≤ Nat.pow 2 (Nat.pow (Nat.log2 (params.M + 2)) (params.d + 1)) := by
+    have : S.t ≤ Nat.pow (Nat.log2 (params.M + 2)) (params.d + 1) := by
+      simpa using (ht_eq.symm ▸ htBound)
+    exact Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) this
+  exact hdict_base.trans hbound_pow
+
+/--
+  Локальные схемы дают аналогичную границу: `k ≤ 2^{ℓ · (log₂(M+2) + depth + 1)}`.
+-/
+lemma scenarioFromLocalCircuit_k_le_pow
+    (params : ThirdPartyFacts.LocalCircuitParameters)
+    (F : Core.Family params.n) :
+    (scenarioFromLocalCircuit params F).1
+      ≤ Nat.pow 2 (params.ℓ * (Nat.log2 (params.M + 2) + params.depth + 1)) := by
+  classical
+  unfold scenarioFromLocalCircuit
+  set shrinkWitness := ThirdPartyFacts.shrinkage_for_localCircuit params F with hwit
+  let t := Classical.choose shrinkWitness
+  set rest₁ := Classical.choose_spec shrinkWitness with hrest₁
+  let ε := Classical.choose rest₁
+  set rest₂ := Classical.choose_spec rest₁ with hrest₂
+  let S := Classical.choose rest₂
+  have hspec := Classical.choose_spec rest₂
+  rcases hspec with ⟨hF, hchain⟩
+  rcases hchain with ⟨ht_eq, hchain⟩
+  rcases hchain with ⟨hε_eq, hchain⟩
+  rcases hchain with ⟨htBound, hchain⟩
+  rcases hchain with ⟨hε0, hεBound⟩
+  have hε_nonneg : (0 : Core.Q) ≤ S.ε := by
+    simpa using (hε_eq ▸ hε0)
+  have hε_half : S.ε ≤ (1 : Core.Q) / 2 :=
+    (hε_eq ▸
+      ThirdPartyFacts.eps_le_half_of_eps_le_inv_nplus2
+        params.n (ε := ε) hεBound)
+  have hk_base :=
+    scenarioFromShrinkage_k_le_pow
+      (n := params.n) (S := S)
+      (hε0 := hε_nonneg)
+      (hε1 := hε_half)
+  have hbound_pow :
+      Nat.pow 2 S.t ≤ Nat.pow 2 (params.ℓ * (Nat.log2 (params.M + 2) + params.depth + 1)) := by
+    have : S.t ≤ params.ℓ * (Nat.log2 (params.M + 2) + params.depth + 1) := by
+      simpa using (ht_eq.symm ▸ htBound)
+    exact Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) this
+  exact hk_base.trans hbound_pow
+
+/--
+  И для длины словаря в локальных схемах действует та же оценка.
+-/
+lemma scenarioFromLocalCircuit_dictLen_le_pow
+    (params : ThirdPartyFacts.LocalCircuitParameters)
+    (F : Core.Family params.n) :
+    Counting.dictLen (scenarioFromLocalCircuit params F).2.atlas.dict
+      ≤ Nat.pow 2 (params.ℓ * (Nat.log2 (params.M + 2) + params.depth + 1)) := by
+  classical
+  unfold scenarioFromLocalCircuit
+  set shrinkWitness := ThirdPartyFacts.shrinkage_for_localCircuit params F with hwit
+  let t := Classical.choose shrinkWitness
+  set rest₁ := Classical.choose_spec shrinkWitness with hrest₁
+  let ε := Classical.choose rest₁
+  set rest₂ := Classical.choose_spec rest₁ with hrest₂
+  let S := Classical.choose rest₂
+  have hspec := Classical.choose_spec rest₂
+  rcases hspec with ⟨hF, hchain⟩
+  rcases hchain with ⟨ht_eq, hchain⟩
+  rcases hchain with ⟨hε_eq, hchain⟩
+  rcases hchain with ⟨htBound, hchain⟩
+  rcases hchain with ⟨hε0, hεBound⟩
+  have hε_nonneg : (0 : Core.Q) ≤ S.ε := by
+    simpa using (hε_eq ▸ hε0)
+  have hε_half : S.ε ≤ (1 : Core.Q) / 2 :=
+    (hε_eq ▸
+      ThirdPartyFacts.eps_le_half_of_eps_le_inv_nplus2
+        params.n (ε := ε) hεBound)
+  have hdict_base :=
+    scenarioFromShrinkage_dictLen_le_pow
+      (n := params.n) (S := S)
+      (hε0 := hε_nonneg)
+      (hε1 := hε_half)
+  have hbound_pow :
+      Nat.pow 2 S.t ≤ Nat.pow 2 (params.ℓ * (Nat.log2 (params.M + 2) + params.depth + 1)) := by
+    have : S.t ≤ params.ℓ * (Nat.log2 (params.M + 2) + params.depth + 1) := by
+      simpa using (ht_eq.symm ▸ htBound)
+    exact Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) this
+  exact hdict_base.trans hbound_pow
+
+-- Дополнительные оценки будут добавлены ниже при необходимости.
 end LowerBounds
 end Pnp3

--- a/pnp3/Tests/LB_Smoke_Scenario.lean
+++ b/pnp3/Tests/LB_Smoke_Scenario.lean
@@ -44,10 +44,11 @@ by
         -- Глубина листа равна нулю, потому условие выполнено автоматически.
         simp [trivialTree, PDT.depth]
       Rsel := fun _ => []
-      Rsel_sub := ?subset
+      Rsel_sub := by
+        intro f β hf hβ
+        -- Пустой список листьев: предположение `β ∈ []` невозможно.
+        simpa using hβ
       err_le := ?err } <;> intro f hf
-  · -- Пустой список всегда является подсписком словаря.
-    simp [Core.listSubset_nil, trivialTree, PDT.leaves]
   · -- В семействе лишь функция `f₀`, для неё ошибка равна нулю.
     have hf' : f = f₀ := by
       simpa using hf
@@ -113,6 +114,111 @@ by
       change Core.errU (fun _ : Core.BitVec 1 => false) [] = 0
       simpa using (Core.errU_false_nil (n := 1))
   exact And.intro hFamily (And.intro hEps hWitness)
+
+/--
+  Та же проверка, но через новый интерфейс `ofCommonPDT`: стартуем с общего
+  PDT, извлечённого из shrinkage, и убеждаемся, что построенный сценарий
+  совпадает с ожидаемыми параметрами.
+-/
+lemma scenarioFromCommonPDT_smoke :
+    let C := Core.shrinkage_to_commonPDT trivialShrinkage
+    let sc :=
+      LowerBounds.BoundedAtlasScenario.ofCommonPDT
+        (n := 1)
+        (F := [f₀])
+        (C := C)
+        0
+        (by
+          intro f hf
+          have hf' : f = f₀ := by simpa using hf
+          subst hf'
+          simp [C, trivialShrinkage])
+        (by
+          simpa [C, trivialShrinkage])
+        (by
+          simpa [C, trivialShrinkage] using
+            (show (0 : Core.Q) ≤ (1 : Core.Q) / 2 by norm_num))
+    sc.family = [f₀] ∧ sc.atlas.epsilon = 0 ∧ sc.k = 0 ∧
+      ∃ S : List (Subcube 1),
+        S = [] ∧
+        Core.listSubset S sc.atlas.dict ∧
+        Core.errU f₀ S = 0 :=
+by
+  classical
+  intro C sc
+  refine And.intro ?hfam (And.intro ?heps (And.intro ?hk ?hwit))
+  · simp [sc]
+  · simp [sc, C, trivialShrinkage]
+  · simp [sc]
+  · refine ⟨[], rfl, ?_, ?_⟩
+    · simp [sc, Core.listSubset_nil]
+    ·
+      change Core.errU (fun _ : Core.BitVec 1 => false) [] = 0
+      simpa using (Core.errU_false_nil (n := 1))
+
+/--
+  Новая лемма `scenarioFromCommonPDT_k_le_pow` даёт ожидаемую границу на `k`
+  для тривиального примера: значение `k = 0` не превосходит `2^0`.
+-/
+lemma scenarioFromCommonPDT_k_le_pow_smoke :
+    let C := Core.shrinkage_to_commonPDT trivialShrinkage
+    (LowerBounds.scenarioFromCommonPDT
+        (n := 1) (F := [f₀]) (C := C)
+        (hε0 := by
+          simpa [C, trivialShrinkage])
+        (hε1 := by
+          simpa [C, trivialShrinkage] using
+            (show (0 : Core.Q) ≤ (1 : Core.Q) / 2 by norm_num))).1
+      ≤ Nat.pow 2 C.depthBound :=
+by
+  classical
+  intro C
+  simpa [C, trivialShrinkage]
+    using
+      LowerBounds.scenarioFromCommonPDT_k_le_pow
+        (n := 1) (F := [f₀]) (C := C)
+        (hε0 := by
+          simpa [C, trivialShrinkage])
+        (hε1 := by
+          simpa [C, trivialShrinkage] using
+            (show (0 : Core.Q) ≤ (1 : Core.Q) / 2 by norm_num))
+
+/--
+  Проверка новой конструкции `scenarioFromCommonPDT`: получаем сценарий из
+  тривиального общего PDT и убеждаемся, что семейство и ошибка совпадают с
+  ожидаемыми значениями.  Возвращённый параметр `k` (в данном примере равный 1)
+  допустим: пустой список листьев удовлетворяет требуемым ограничениям.
+-/
+lemma scenarioFromCommonPDT_sigma_smoke :
+    let C := Core.shrinkage_to_commonPDT trivialShrinkage
+    let result :=
+      LowerBounds.scenarioFromCommonPDT
+        (n := 1) (F := [f₀]) (C := C)
+        (hε0 := by
+          simpa [C, trivialShrinkage])
+        (hε1 := by
+          simpa [C, trivialShrinkage] using
+            (show (0 : Core.Q) ≤ (1 : Core.Q) / 2 by norm_num))
+    result.2.family = [f₀] ∧ result.2.atlas.epsilon = 0 ∧
+      ∃ S : List (Subcube 1),
+        S = [] ∧
+        S.length ≤ result.1 ∧
+        Core.listSubset S result.2.atlas.dict ∧
+        Core.errU f₀ S = 0 :=
+by
+  classical
+  intro C result
+  obtain ⟨k, sc⟩ := result
+  refine And.intro ?hfam (And.intro ?heps ?hwit)
+  · simp [result, C, trivialShrinkage]
+  · simp [result, C, trivialShrinkage]
+  · refine ⟨[], rfl, ?hlen, ?hsubset, ?herr⟩
+    ·
+      have hk : 0 ≤ k := Nat.zero_le _
+      simpa [List.length_nil] using hk
+    · simp [result, C, trivialShrinkage, Core.listSubset_nil]
+    · change Core.errU (fun _ : Core.BitVec 1 => false) [] = 0
+      simpa using (Core.errU_false_nil (n := 1))
 
 end
 

--- a/pnp3/Tests/Parity_Counterexample.lean
+++ b/pnp3/Tests/Parity_Counterexample.lean
@@ -1,18 +1,348 @@
-import Mathlib.Init
+import Mathlib.Algebra.Order.Field.Basic
+import Core.SAL_Core
+import ThirdPartyFacts.LeafBudget
 
 /-!
 # Тест: семейство паритетов как контрпример
 
-Негативный тест, который должен подтвердить, что без условия shrinkage общий атлас не существует. Планируется показать, что семейство `{p, ¬p}` не удовлетворяет предпосылкам SAL.
+Здесь мы доказываем, что семейство из двух функций `{parity, ¬ parity}`
+на одном бите **не** удовлетворяет заключению шага A без привлечения
+shrinkage-леммы.  Частичное решающее дерево глубины `0` обладает лишь
+одним листом (подкубом), и такой словарь не способен одновременно
+аппроксимировать паритет и его отрицание с ошибкой < `1/2`.
 
-Пока фиксируем структуру файла и оставляем аксиому, которую впоследствии заменим доказательством.
+Далее разворачиваем это рассуждение в Lean.  Вместо фиктивной аксиомы
+появляется конкретная теорема, запрещающая существование общего PDT
+глубины `0` с малой ошибкой для паритета.
 -/
 
 namespace Pnp3
 namespace Tests
 
-/-- TODO: формализовать контрпример паритета. -/
-axiom parity_counterexample : Prop
+open Core
+
+noncomputable section
+
+/-!
+## Базовые определения
+
+Работаем с `BitVec 1 = Fin 1 → Bool`.  Возможны лишь два вектора:
+`x₀`, всегда равный `false`, и `x₁`, всегда равный `true`.  Для
+удобства обозначим единственный индекс `Fin 1` как `idx`.
+-/
+
+@[simp] def idx : Fin 1 := ⟨0, by decide⟩
+
+/-- Константный нулевой вектор. -/
+def x₀ : BitVec 1 := fun _ => false
+
+/-- Константный единичный вектор. -/
+def x₁ : BitVec 1 := fun _ => true
+
+/-- Паритет на одном бите — просто чтение бита. -/
+def parity₁ (x : BitVec 1) : Bool := x idx
+
+/-- Отрицание паритета. -/
+def parity₁ᶜ (x : BitVec 1) : Bool := ! parity₁ x
+
+@[simp] lemma parity₁_x₀ : parity₁ x₀ = false := by simp [parity₁, x₀, idx]
+@[simp] lemma parity₁_x₁ : parity₁ x₁ = true := by simp [parity₁, x₁, idx]
+@[simp] lemma parity₁ᶜ_x₀ : parity₁ᶜ x₀ = true := by simp [parity₁ᶜ]
+@[simp] lemma parity₁ᶜ_x₁ : parity₁ᶜ x₁ = false := by simp [parity₁ᶜ]
+
+/-- Наше семейство функций: паритет и его отрицание. -/
+def parityFamily : Family 1 := [parity₁, parity₁ᶜ]
+
+@[simp] lemma parity_mem_family : parity₁ ∈ parityFamily := by simp [parityFamily]
+@[simp] lemma parityᶜ_mem_family : parity₁ᶜ ∈ parityFamily := by simp [parityFamily]
+
+/-!
+## Комбинаторика на `BitVec 1`
+
+Финитное множество всех бит-векторов длины `1` состоит из `x₀` и `x₁`.
+Это удобно зафиксировать, чтобы затем явно вычислять мощности фильтров.
+-/
+
+@[simp] lemma univ_bitvec1 :
+    (Finset.univ : Finset (BitVec 1)) = {x₀, x₁} := by
+  classical
+  apply Finset.ext
+  intro x
+  constructor
+  · intro _
+    -- Любой элемент универсума равен либо `x₀`, либо `x₁`.
+    have hx : x = x₀ ∨ x = x₁ := by
+      cases h : x idx with
+      | false =>
+          left
+          funext i
+          have hi : i = idx := Subsingleton.elim _ _
+          simpa [x₀, hi, h]
+      | true =>
+          right
+          funext i
+          have hi : i = idx := Subsingleton.elim _ _
+          simpa [x₁, hi, h]
+    cases hx with
+    | inl h => simpa [h]
+    | inr h => simpa [h]
+  · intro hx; simpa [hx]
+
+/-!
+## Ошибка аппроксимации
+
+Вычислим ошибку `errU` для пустого словаря и для словаря из одного
+подкуба.  Эти значения понадобятся при анализе возможных селекторов в
+`CommonPDT`.
+-/
+
+lemma err_parity_nil :
+    errU parity₁ ([] : List (Subcube 1)) = (1 : Q) / 2 := by
+  classical
+  unfold errU
+  have :
+      ((Finset.univ : Finset (BitVec 1)).filter
+        fun x => parity₁ x ≠ coveredB ([] : List (Subcube 1)) x).card = 1 := by
+    simp [univ_bitvec1, coveredB_nil]
+  simp [this, univ_bitvec1]
+
+lemma err_parityᶜ_nil :
+    errU parity₁ᶜ ([] : List (Subcube 1)) = (1 : Q) / 2 := by
+  classical
+  unfold errU
+  have :
+      ((Finset.univ : Finset (BitVec 1)).filter
+        fun x => parity₁ᶜ x ≠ coveredB ([] : List (Subcube 1)) x).card = 1 := by
+    simp [univ_bitvec1, coveredB_nil]
+  simp [this, univ_bitvec1]
+
+/-!
+Следующая лемма перебирает все возможные подкубы `β : Subcube 1`.
+Поскольку индекс всего один, достаточно посмотреть на `β idx`.
+-/
+
+lemma err_singleton_cases (β : Subcube 1) :
+    (errU parity₁ [β], errU parity₁ᶜ [β]) =
+      match β idx with
+      | none      => ((1 : Q) / 2, (1 : Q) / 2)
+      | some false => (1, 0)
+      | some true  => (0, 1) := by
+  classical
+  cases hβ : β idx with
+  | none =>
+      have hcov : ∀ x, coveredB [β] x = true := by
+        intro x
+        have : ∀ i : Fin 1, ∀ b : Bool, β i = some b → x i = b := by
+          intro i b hi
+          have hi' : i = idx := Subsingleton.elim _ _
+          subst hi'
+          simpa [hβ] using hi
+        have hmem := (memB_eq_true_iff (β := β) (x := x)).2 this
+        simpa [coveredB, hmem]
+      have hfilter₁ :
+          ((Finset.univ : Finset (BitVec 1)).filter
+              fun x => parity₁ x ≠ coveredB [β] x).card = 1 := by
+        simp [univ_bitvec1, hcov]
+      have hfilter₂ :
+          ((Finset.univ : Finset (BitVec 1)).filter
+              fun x => parity₁ᶜ x ≠ coveredB [β] x).card = 1 := by
+        simp [univ_bitvec1, hcov]
+      simp [errU, hfilter₁, hfilter₂, hβ, univ_bitvec1]
+  | some b =>
+      have hcov : ∀ x, coveredB [β] x = (x idx = b) := by
+        intro x
+        have : (memB β x = true) ↔ x idx = b := by
+          constructor
+          · intro h
+            have hx := (memB_eq_true_iff (β := β) (x := x)).1 h idx b
+            simpa [hβ]
+          · intro hx
+            have hxprop : ∀ i : Fin 1, ∀ c : Bool, β i = some c → x i = c := by
+              intro i c hi
+              have hi' : i = idx := Subsingleton.elim _ _
+              subst hi'
+              have hc : c = b := by simpa [hβ] using hi
+              simpa [hc, hx]
+            exact (memB_eq_true_iff (β := β) (x := x)).2 hxprop
+        by_cases hx : x idx = b
+        · have := (this.mpr hx)
+          simp [coveredB, this, hx]
+        · have hx' : memB β x ≠ true := by
+            intro h
+            exact hx ((this.mp h))
+          cases hmem : memB β x <;> simp [coveredB, hmem, hx, hx']
+      cases b
+      · have hfilter₁ :
+            ((Finset.univ : Finset (BitVec 1)).filter
+                fun x => parity₁ x ≠ coveredB [β] x).card = 2 := by
+            simp [univ_bitvec1, hcov, idx]
+        have hfilter₂ :
+            ((Finset.univ : Finset (BitVec 1)).filter
+                fun x => parity₁ᶜ x ≠ coveredB [β] x).card = 0 := by
+            simp [univ_bitvec1, hcov, idx]
+        simp [errU, hfilter₁, hfilter₂, hβ, univ_bitvec1]
+      · have hfilter₁ :
+            ((Finset.univ : Finset (BitVec 1)).filter
+                fun x => parity₁ x ≠ coveredB [β] x).card = 0 := by
+            simp [univ_bitvec1, hcov, idx]
+        have hfilter₂ :
+            ((Finset.univ : Finset (BitVec 1)).filter
+                fun x => parity₁ᶜ x ≠ coveredB [β] x).card = 2 := by
+            simp [univ_bitvec1, hcov, idx]
+        simp [errU, hfilter₁, hfilter₂, hβ, univ_bitvec1]
+
+/-!
+## Нормальная форма селекторов
+
+Если список `xs` содержится в `[β]`, то его очищенная версия (`dedup`)
+равна либо `[]`, либо `[β]`.  Это позволит рассматривать только две
+конфигурации листьев.
+-/
+
+lemma dedup_subset_singleton [DecidableEq (Subcube 1)]
+    {xs : List (Subcube 1)} {β : Subcube 1}
+    (h : listSubset xs [β]) :
+    xs.dedup = [] ∨ xs.dedup = [β] := by
+  classical
+  have hsubset := listSubset_dedup (xs := xs) (ys := [β]) h
+  have hx : ∀ γ ∈ xs.dedup, γ = β := by
+    intro γ hγ
+    have : γ ∈ [β] := listSubset.mem hsubset hγ
+    simpa using this
+  have hlen_le : xs.dedup.length ≤ 1 := by
+    simpa using
+      (ThirdPartyFacts.Aux.dedup_length_le_of_subset
+        (xs := xs) (ys := [β]) h)
+  cases hxlen : xs.dedup.length with
+  | zero =>
+      left
+      apply List.length_eq_zero.mp
+      simpa [hxlen]
+  | succ n =>
+      have hle : Nat.succ n ≤ Nat.succ 0 := by
+        simpa [hxlen] using hlen_le
+      have hn0 : n = 0 := by
+        have : n ≤ 0 := Nat.succ_le_succ_iff.mp hle
+        exact Nat.le_antisymm this (Nat.zero_le _)
+      have hxone : xs.dedup.length = 1 := by simpa [hxlen, hn0]
+      rcases (List.length_eq_one.mp hxone) with ⟨γ, hγ⟩
+      right
+      have : γ = β := by
+        have hmem : γ ∈ xs.dedup := by simpa [hγ]
+        exact hx _ hmem
+      simpa [hγ, this]
+
+/-!
+## Главный результат
+
+Покажем, что не существует общего PDT глубины `0` с ошибкой `< 1/2`
+для семейства `{parity, ¬ parity}`.
+-/
+
+theorem parity_counterexample :
+    ¬ ∃ (C : CommonPDT 1 parityFamily),
+        C.depthBound = 0 ∧ C.epsilon < (1 : Q) / 2 := by
+  classical
+  intro h
+  rcases h with ⟨C, hdepth, hεlt⟩
+  -- Глубина дерева ≤ 0 ⇒ само дерево — лист.
+  have hdepth' : PDT.depth C.tree = 0 := by
+    have := C.depth_le
+    have hzero : 0 ≤ PDT.depth C.tree := Nat.zero_le _
+    have hle : PDT.depth C.tree ≤ 0 := by simpa [hdepth]
+      using this
+    exact Nat.le_antisymm hle hzero
+  cases htree : C.tree with
+  | leaf β =>
+      -- Словарь состоит ровно из одного подкуба β.
+      have hdict : C.toAtlas.dict = [β] := by
+        simp [CommonPDT.toAtlas, Atlas.ofPDT, htree]
+      -- Свойства селекторов паритета и его отрицания.
+      have hsubset_parity : listSubset (C.selectors parity₁) [β] := by
+        intro γ hγ
+        have := C.selectors_sub (F := parityFamily)
+          (f := parity₁) (β := γ) parity_mem_family
+          (Core.mem_of_contains hγ)
+        simpa [htree] using this
+      have hsubset_parityᶜ : listSubset (C.selectors parity₁ᶜ) [β] := by
+        intro γ hγ
+        have := C.selectors_sub (F := parityFamily)
+          (f := parity₁ᶜ) (β := γ) parityᶜ_mem_family
+          (Core.mem_of_contains hγ)
+        simpa [htree] using this
+      have hdedup_parity := dedup_subset_singleton
+        (xs := C.selectors parity₁) (β := β) hsubset_parity
+      have hdedup_parityᶜ := dedup_subset_singleton
+        (xs := C.selectors parity₁ᶜ) (β := β) hsubset_parityᶜ
+      have herr_parity := C.err_le (F := parityFamily)
+        (f := parity₁) parity_mem_family
+      have herr_parityᶜ := C.err_le (F := parityFamily)
+        (f := parity₁ᶜ) parityᶜ_mem_family
+      -- Перебираем варианты очищенных списков.
+      cases hdedup_parity with
+      | inl hnil =>
+          have : (1 : Q) / 2 ≤ C.epsilon := by
+            simpa [hnil, hdict, err_parity_nil,
+              CommonPDT.toAtlas, Atlas.ofPDT, htree]
+              using herr_parity
+          exact (not_lt_of_ge this) hεlt
+      | inr hsingle =>
+          cases hdedup_parityᶜ with
+          | inl hnilᶜ =>
+              have : (1 : Q) / 2 ≤ C.epsilon := by
+                simpa [hnilᶜ, hdict, err_parityᶜ_nil,
+                  CommonPDT.toAtlas, Atlas.ofPDT, htree]
+                  using herr_parityᶜ
+              exact (not_lt_of_ge this) hεlt
+          | inr hsingleᶜ =>
+              have herr_pair := err_singleton_cases β
+              have herr_eq_parity :
+                  errU parity₁ (C.selectors parity₁) = errU parity₁ [β] := by
+                simpa [hsingle] using
+                  (Core.errU_dedup (f := parity₁)
+                    (R := C.selectors parity₁)).symm
+              have herr_eq_parityᶜ :
+                  errU parity₁ᶜ (C.selectors parity₁ᶜ)
+                    = errU parity₁ᶜ [β] := by
+                simpa [hsingleᶜ] using
+                  (Core.errU_dedup (f := parity₁ᶜ)
+                    (R := C.selectors parity₁ᶜ)).symm
+              cases hβ : β idx with
+              | none =>
+                  have hle : errU parity₁ [β] ≤ C.epsilon := by
+                    simpa [herr_eq_parity] using herr_parity
+                  have hfst := congrArg Prod.fst herr_pair
+                  have hge : (1 : Q) / 2 ≤ C.epsilon := by
+                    simpa [hβ] using (hfst ▸ hle)
+                  exact (not_lt_of_ge hge) hεlt
+              | some b =>
+                  cases b
+                  · -- β фиксирует 0 ⇒ ошибка паритета = 1.
+                    have hle : errU parity₁ [β] ≤ C.epsilon := by
+                      simpa [herr_eq_parity] using herr_parity
+                    have hfst := congrArg Prod.fst herr_pair
+                    have hge : (1 : Q) ≤ C.epsilon := by
+                      simpa [hβ] using (hfst ▸ hle)
+                    have hlt := lt_of_le_of_lt hge hεlt
+                    have : ¬ (1 : Q) < (1 : Q) / 2 := by norm_num
+                    exact this hlt
+                  · -- β фиксирует 1 ⇒ ошибка отрицания паритета = 1.
+                    have hle : errU parity₁ᶜ [β] ≤ C.epsilon := by
+                      simpa [herr_eq_parityᶜ] using herr_parityᶜ
+                    have hsnd := congrArg Prod.snd herr_pair
+                    have hge : (1 : Q) ≤ C.epsilon := by
+                      simpa [hβ] using (hsnd ▸ hle)
+                    have hlt := lt_of_le_of_lt hge hεlt
+                    have : ¬ (1 : Q) < (1 : Q) / 2 := by norm_num
+                    exact this hlt
+  | node i t₀ t₁ =>
+      -- Узел имеет положительную глубину — противоречие с `depth = 0`.
+      have : False := by
+        have := congrArg PDT.depth htree
+        simpa [PDT.depth, hdepth'] using this
+      exact this.elim
+
+end
 
 end Tests
 end Pnp3

--- a/pnp3/Tests/SAL_Smoke_AC0.lean
+++ b/pnp3/Tests/SAL_Smoke_AC0.lean
@@ -2,8 +2,10 @@ import Core.BooleanBasics
 import Core.PDT
 import Core.Atlas
 import Core.SAL_Core
+import ThirdPartyFacts.LeafBudget
 
 open Core
+open ThirdPartyFacts
 
 namespace Pnp3
 namespace Tests
@@ -104,8 +106,9 @@ lemma zeroSubcube_excludes_one :
   , depth_le := by simpa [depth_trivialTree]
   , Rsel     := fun _ => []
   , Rsel_sub := by
-      intro f hf
-      simp [listSubset]
+      intro f β hf hβ
+      -- Пустой список листьев: противоречие с предположением о принадлежности.
+      simpa using hβ
   , err_le   := by
       intro f hf
       have hf' : f = f₀ := by simpa using hf
@@ -123,6 +126,45 @@ lemma sal_smoke_ac0 :
     WorksFor (Atlas.fromShrinkage shrinkage₀) [f₀] := by
   classical
   simpa using SAL_from_Shrinkage shrinkage₀
+
+/-- Эквивалентная формулировка через промежуточный объект `CommonPDT`. -/
+lemma sal_smoke_ac0_via_commonPDT :
+    WorksFor ((Core.shrinkage_to_commonPDT shrinkage₀).toAtlas) [f₀] := by
+  classical
+  simpa using
+    (Core.commonPDT_to_atlas (C := Core.shrinkage_to_commonPDT shrinkage₀))
+
+/-- Проверяем, что новая лемма о бюджете листьев для `CommonPDT` даёт ту же
+оценку в тривиальном примере. -/
+lemma commonPDT_leaf_budget_smoke :
+    ∃ k : Nat,
+      k ≤ (PDT.leaves shrinkage₀.tree).length ∧
+      ((Core.shrinkage_to_commonPDT shrinkage₀).selectors f₀).dedup.length ≤ k := by
+  classical
+  have h :=
+    leaf_budget_from_commonPDT
+      (n := 1)
+      (F := [f₀])
+      (C := Core.shrinkage_to_commonPDT shrinkage₀)
+  rcases h with ⟨k, hk, hbound⟩
+  refine ⟨k, hk, ?_⟩
+  have hf : f₀ ∈ ([f₀] : List (BitVec 1 → Bool)) := by simp
+  simpa using hbound (f := f₀) hf
+
+/-- Ошибка после `dedup` не превосходит исходного значения `ε`. -/
+lemma commonPDT_err_dedup_smoke :
+    Core.errU f₀
+        (((Core.shrinkage_to_commonPDT shrinkage₀).selectors f₀).dedup)
+      ≤ (Core.shrinkage_to_commonPDT shrinkage₀).epsilon := by
+  classical
+  have hf : f₀ ∈ ([f₀] : List (BitVec 1 → Bool)) := by simp
+  simpa using
+    (err_le_of_dedup_commonPDT
+      (n := 1)
+      (F := [f₀])
+      (C := Core.shrinkage_to_commonPDT shrinkage₀)
+      (f := f₀)
+      hf)
 
 end Tests
 end Pnp3

--- a/pnp3/ThirdPartyFacts/LeafBudget.lean
+++ b/pnp3/ThirdPartyFacts/LeafBudget.lean
@@ -66,10 +66,35 @@ lemma dedup_length_le_of_subset [DecidableEq α]
 
 end Aux
 
+/-
+  На уровне `CommonPDT` удобно формулировать границу листьев без привязки к
+  конкретному shrinkage-сертификату.  Мы сразу переходим к этой более общей
+  версии: для любого общего PDT длина очищенных списков селекторов не превосходит
+  числа листьев дерева.
+-/
+theorem leaf_budget_from_commonPDT {n : Nat}
+    [DecidableEq (Core.Subcube n)] {F : Core.Family n}
+    (C : Core.CommonPDT n F) :
+    ∃ k : Nat,
+      k ≤ (Core.PDT.leaves C.tree).length ∧
+      ∀ {f : Core.BitVec n → Bool},
+        f ∈ F → ((C.selectors f).dedup).length ≤ k := by
+  classical
+  refine ⟨(Core.PDT.leaves C.tree).length, ?_⟩
+  refine And.intro ?_ ?_
+  · exact le_rfl
+  · intro f hf
+    have hsubset : Core.listSubset (C.selectors f) (Core.PDT.leaves C.tree) := by
+      refine Core.listSubset_of_mem ?_
+      intro β hβ
+      exact C.selectors_sub (F := F) (f := f) (β := β) hf hβ
+    have hbound := Aux.dedup_length_le_of_subset (xs := C.selectors f)
+      (ys := Core.PDT.leaves C.tree) hsubset
+    simpa using hbound
+
 /--
-  Для любого shrinkage сертификата можно выбрать единую границу `k`, равную
-  количеству листьев PDT, так что очищенные (без дубликатов) списки листьев не
-  длиннее `k`.
+  Обратно к shrinkage сертификату: подставляем извлечённый `CommonPDT` и
+  получаем точь-в-точь прежнюю формулировку для `S.Rsel`.
 -/
 theorem leaf_budget_from_shrinkage {n : Nat}
     [DecidableEq (Subcube n)] (S : Core.Shrinkage n) :
@@ -78,35 +103,60 @@ theorem leaf_budget_from_shrinkage {n : Nat}
       ∀ {f : Core.BitVec n → Bool},
         f ∈ S.F → ((S.Rsel f).dedup).length ≤ k := by
   classical
-  refine ⟨(Core.PDT.leaves S.tree).length, ?_⟩
-  refine And.intro ?_ ?_
-  · exact le_rfl
-  · intro f hf
-    have hsubset := S.Rsel_sub f hf
-    have hbound := Aux.dedup_length_le_of_subset (xs := S.Rsel f)
-      (ys := Core.PDT.leaves S.tree) hsubset
-    simpa using hbound
+  simpa [Core.Shrinkage.commonPDT_selectors (S := S)] using
+    (leaf_budget_from_commonPDT (n := n)
+      (F := S.F) (C := S.commonPDT))
 
 /--
-  Очищение списка листьев не ухудшает ошибку аппроксимации.  Удобная форма для
-  дальнейших сценариев: можно заменить `S.Rsel f` на `S.Rsel f`.dedup, сохранив
-  ту же погрешность.
+  Очищение списка листьев не ухудшает ошибку аппроксимации.  Сначала доказываем
+  это утверждение для `CommonPDT`.
 -/
+lemma err_le_of_dedup_commonPDT {n : Nat}
+    [DecidableEq (Core.Subcube n)] {F : Core.Family n}
+    (C : Core.CommonPDT n F) {f : Core.BitVec n → Bool} (hf : f ∈ F) :
+  Core.errU f ((C.selectors f).dedup) ≤ C.epsilon := by
+  classical
+  -- Сравниваем ошибки напрямую через цепочку равенств/неравенств.
+  have h := C.err_le (F := F) (f := f) hf
+  calc
+    Core.errU f ((C.selectors f).dedup)
+        = Core.errU f (C.selectors f) :=
+            Core.errU_dedup (f := f) (R := C.selectors f)
+    _ ≤ C.epsilon := h
+
+/-- Версия предыдущего утверждения, специализированная под shrinkage. -/
 lemma err_le_of_dedup {n : Nat} [DecidableEq (Subcube n)]
     (S : Core.Shrinkage n) {f : Core.BitVec n → Bool} (hf : f ∈ S.F) :
   Core.errU f ((S.Rsel f).dedup) ≤ S.ε := by
-  classical
-  -- Сравниваем ошибки напрямую через цепочку равенств/неравенств.
-  have h := S.err_le f hf
-  calc
-    Core.errU f ((S.Rsel f).dedup)
-        = Core.errU f (S.Rsel f) := Core.errU_dedup (f := f) (R := S.Rsel f)
-    _ ≤ S.ε := h
+  simpa [Core.Shrinkage.commonPDT_selectors (S := S),
+      Core.Shrinkage.commonPDT_epsilon (S := S)]
+    using (err_le_of_dedup_commonPDT
+      (C := S.commonPDT) (F := S.F) (f := f) hf)
 
 /--
   Корреляция с оценкой на число листьев: полученную границу можно сразу
   переписать через глубину PDT, применив стандартную оценку `|leaves| ≤ 2^t`.
 -/
+lemma leaf_budget_le_pow_depth_commonPDT {n : Nat}
+    [DecidableEq (Core.Subcube n)] {F : Core.Family n}
+    (C : Core.CommonPDT n F) :
+    ∀ {f : Core.BitVec n → Bool},
+      f ∈ F →
+        ((C.selectors f).dedup).length ≤ Nat.pow 2 C.depthBound := by
+  classical
+  intro f hf
+  obtain ⟨k, hk⟩ := leaf_budget_from_commonPDT (n := n)
+    (F := F) (C := C)
+  have hlen' := hk.2 hf
+  have hdepth :
+      (Core.PDT.leaves C.tree).length ≤ Nat.pow 2 (Core.PDT.depth C.tree) := by
+    exact Core.leaves_count_bound (t := C.tree)
+  have hdepthBound : Nat.pow 2 (Core.PDT.depth C.tree)
+      ≤ Nat.pow 2 C.depthBound :=
+    Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) C.depth_le
+  exact hlen'.trans (hk.1.trans (hdepth.trans hdepthBound))
+
+/-- Специализация оценки на случай shrinkage. -/
 lemma leaf_budget_le_pow_depth {n : Nat} [DecidableEq (Subcube n)]
     (S : Core.Shrinkage n) :
     ∀ {f : Core.BitVec n → Bool},
@@ -114,13 +164,11 @@ lemma leaf_budget_le_pow_depth {n : Nat} [DecidableEq (Subcube n)]
         ((S.Rsel f).dedup).length ≤ Nat.pow 2 S.t := by
   classical
   intro f hf
-  obtain ⟨k, hk⟩ := leaf_budget_from_shrinkage (n := n) S
-  have hlen' := hk.2 hf
-  have hdepth :
-      (Core.PDT.leaves S.tree).length ≤ Nat.pow 2 S.t := by
-    exact (Core.leaves_count_bound (t := S.tree)).trans
-      (Nat.pow_le_pow_right (by decide : (0 : Nat) < 2) S.depth_le)
-  exact hlen'.trans (hk.1.trans hdepth)
+  have :=
+    leaf_budget_le_pow_depth_commonPDT
+      (n := n) (F := S.F) (C := S.commonPDT) (f := f) hf
+  simpa [Core.Shrinkage.commonPDT_selectors (S := S),
+      Core.Shrinkage.commonPDT_depthBound (S := S)] using this
 
 end ThirdPartyFacts
 end Pnp3


### PR DESCRIPTION
## Summary
- add quantitative k/dictionary bounds for the shrinkage-to-scenario construction by reusing the common-PDT helpers
- specialize those bounds to the AC⁰ and local-circuit scenarios provided by the external shrinkage witnesses

## Testing
- lake build

------
https://chatgpt.com/codex/tasks/task_e_68e521dbe4c8832bb89de43784590958