### PR TITLE
Add asymptotic DAG bridge, promise-YES source split, final weak-route wrappers, and smoke tests

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -107,6 +107,7 @@ lean_lib PnP3 where
     Glob.one `Tests.BarrierBypassAudit,
     Glob.one `Tests.AxiomsAudit,
     Glob.one `Tests.BridgeLocalityRegression,
+    Glob.one `Tests.WeakRouteSurfaceTests,
     Glob.one `Tests.SmokeTests,
     Glob.one `Tests.UnitTests
   ]

--- a/pnp3/Docs/AsymptoticDAGBarrier_Status.md
+++ b/pnp3/Docs/AsymptoticDAGBarrier_Status.md
@@ -1,7 +1,206 @@
-# Asymptotic DAG Barrier Status (2026-03-26)
+# Asymptotic DAG Barrier Status (2026-03-28)
 
 This note documents the **current** theorem-level DAG barrier API after the
 latest refactor.
+
+## Plan execution matrix (what is still not implemented)
+
+Below is the short status map against the current weak-mainline plan.
+
+- ✅ **Done (infrastructure / endpoint surface):**
+  - weak terminal consumer fixed at `AcceptedFamilyCertificateAt`;
+  - mainline source target surface fixed at `PromiseYesSubcube*`;
+  - backup producer `PRGImageAcceptanceAt` wired to accepted-family closure;
+  - strong fallback restriction stack is compiled through weak consumer;
+  - thin final wrappers exposed in `Magnification/FinalResult.lean` for
+    accepted-family, promise-YES, PRG-image backup, fallback extraction+numeric,
+    and eventual magnification-style no-small-DAG closure.
+
+- 🟡 **Partially done (parallel theorem tracks):**
+  - restricted-model ladder has first footholds (`supportHalfBound*`,
+    `valueSupported` variants), but not yet a broad ladder with multiple model
+    classes and source-theorem extraction results.
+
+- ❌ **Not done (the real blocker):**
+  - no internal theorem proving either
+    `SmallDAGWitnessOnSlice -> PromiseYesSubcubeCertificateAt`
+    **or**
+    `SmallDAGWitnessOnSlice -> PRGImageAcceptanceAt`
+    on the full target model;
+  - therefore no internal unconditional proof of
+    `ComplexityInterfaces.NP_not_subset_PpolyDAG`;
+  - final `P_ne_NP_final*` wrappers still require an external DAG-separation
+    hypothesis `hNPDag`.
+
+- ❌ **Not done (publication/completion criteria):**
+  - asymptotic final layer still not fed by an internalized `NP_not_subset_PpolyDAG`;
+  - docs/release claims cannot yet state unconditional `P ≠ NP`.
+
+## Concrete next work plan (execution-ready)
+
+This section is the immediate patch plan for the next theorem sprints.
+Each item has:
+- concrete deliverable,
+- target files,
+- minimal acceptance check.
+
+### A. Main blocker theorem split: semantic forcing vs quantitative slack
+
+**Goal:** progress on
+`SmallDAGWitnessOnSlice -> PromiseYesSubcubeCertificateAt`.
+
+1. **Semantic half (one-sided forcing):**
+   - deliverable: a theorem that constructs a YES center `yYes` and a value-set
+     `S` with one-sided acceptance forcing on valid promise inputs;
+   - target files:
+     - `pnp3/LowerBounds/DAGStableRestrictionProducer.lean`
+     - (if needed) `pnp3/LowerBounds/AsymptoticDAGBarrier.lean`;
+   - acceptance check:
+     - theorem lands in the shape of `PromiseYesAcceptanceInvariantAt` or a
+       direct constructor path to `PromiseYesSubcubeCertificateAt` (without yet
+       requiring final slack strength).
+
+2. **Quantitative half (same-set slack):**
+   - deliverable: bound/slack theorem for the **same** `S` produced above;
+   - target files:
+     - `pnp3/LowerBounds/DAGStableRestrictionProducer.lean`
+     - `pnp3/LowerBounds/AcceptedFamilyBarrier.lean` (only if additional
+       counting adapter is required);
+   - acceptance check:
+     - theorem composes directly with semantic half and yields
+       `PromiseYesSubcubeCertificateAt` without introducing new endpoint layers.
+
+Current implementation note:
+- decomposition API is now explicit in code via
+  `PromiseYesSourceDecompositionAt`,
+  `promiseYesSubcubeCertificateAt_of_sourceDecomposition`,
+  provider-level split interfaces
+  `promiseYesAcceptanceInvariantAtProviderOnSlices` /
+  `promiseYesSlackOnInvariantProviderOnSlices`,
+  and compiled closure
+  `noSmallDAG_of_promiseYesSemanticAndSlackProvidersOnSlices`;
+- pairwise package providers now also reduce explicitly into that split API via
+  `promiseYesAcceptanceInvariantAtProviderOnSlices_of_promiseValueLocalityPackageProvider`
+  and
+  `promiseYesSlackOnInvariantProviderOnSlices_of_promiseValueLocalityPackageProvider`,
+  with closure theorem
+  `noSmallDAG_of_promiseValueLocalityPackageProviderOnSlices_viaSemanticAndSlack`;
+- what remains open is proving those providers from strict DAG semantics.
+
+### B. Backup producer track: PRG-image route
+
+**Goal:** progress on
+`SmallDAGWitnessOnSlice -> PRGImageAcceptanceAt`.
+
+1. **Structured image extraction theorem:**
+   - deliverable: witness-indexed theorem that extracts an accepted structured
+     image family from small-DAG semantics;
+   - target file:
+     - `pnp3/LowerBounds/DAGStableRestrictionProducer.lean`;
+   - acceptance check:
+     - theorem feeds existing bridge
+       `acceptedFamilyCertificateAt_of_prgImageAcceptanceAt` and then
+       `no_small_dag_solver_of_acceptedFamilyCertificateAt` without new API.
+
+### C. Restriction fallback as diagnostic (not main endpoint)
+
+**Goal:** use fallback to mine invariants for the weak route.
+
+1. **Value-supported extraction pass:**
+   - deliverable: theorem(s) showing when restriction data implies
+     value-supported conditions needed by promise-value / promise-YES route;
+   - target file:
+     - `pnp3/LowerBounds/DAGStableRestrictionProducer.lean`;
+   - acceptance check:
+     - compiles via existing reductions
+       `promiseValueLocalityPackageAt_of_*` and then
+       `promiseYesSubcubeCertificateAt_of_*`.
+
+### D. FinalResult boundary discipline
+
+**Goal:** keep `FinalResult` as surface-only file.
+
+1. **Boundary rule for new additions:**
+   - only add wrappers to:
+     - `¬ SmallDAGSolver ...` and/or
+     - `MagnificationStyleNoSmallDAG ...`,
+     - and eventually `NP_not_subset_PpolyDAG` / `P_ne_NP` once the real bridge
+       exists;
+   - do **not** add source-level internal reductions here.
+   - target file:
+     - `pnp3/Magnification/FinalResult.lean`;
+   - acceptance check:
+     - source-side technical reductions remain in lower-bounds producer/barrier
+       modules.
+
+### E. Bridge to internalized DAG separation (critical integration milestone)
+
+**Goal:** remove external `hNPDag` eventually.
+
+1. **Asymptotic bridge theorem skeleton:**
+   - deliverable: theorem statement (and first supporting lemmas) that maps a
+     global `ComplexityInterfaces.PpolyDAG` witness to the asymptotic
+     `SmallDAGSolver`/`SizeBound` surface consumed by current magnification-style
+     no-small-DAG theorems;
+   - target files:
+     - `pnp3/Magnification/FinalResult.lean` (surface theorem statement),
+     - `pnp3/LowerBounds/AsymptoticDAGBarrier.lean` (quantifier plumbing),
+     - optional bridge helper near `pnp3/LowerBounds/DAGStableRestrictionProducer.lean`;
+   - acceptance check:
+     - one explicit theorem-level dependency edge appears:
+       `PpolyDAG witness -> asymptotic SmallDAGSolver family`.
+
+Progress update (implemented):
+
+- Added witness-level bridge in `pnp3/LowerBounds/AsymptoticDAGBarrier.lean`:
+  - `ppolyDAGSizeBoundOnSlices`
+  - `smallDAGSolver_of_inPpolyDAGFamilyOnSlices`
+- Added membership-level adapter/bridge:
+  - `inPpolyDAGFamilyOnSlices_of_PpolyDAG`
+  - `smallDAGSolver_of_PpolyDAGOnSlices`
+- Added eventual-surface bridge layer:
+  - `EventuallyInPpolyDAGWitnessFamily`
+  - `EventuallyPpolyDAGWitnessFamily`
+  - `EventuallySmallDAGSolverSurface`
+  - `eventuallySmallDAGSolverSurface_of_eventuallyInPpolyDAGWitnessFamily`
+  - `eventuallySmallDAGSolverSurface_of_eventuallyPpolyDAGWitnessFamily`
+- Added single-global witness packaging bridge:
+  - `AsymptoticDAGLanguageBridge`
+  - `ppolyDAGOnSlices_of_globalWitness`
+  - `eventuallySmallDAGSolverSurface_of_globalPpolyDAGWitness`
+- Added bridge-local contradiction schema:
+  - `not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies`
+- Added concrete weak-route instantiations:
+  - `not_globalPpolyDAG_of_acceptedFamilyWeakRoute`
+  - `not_globalPpolyDAG_of_promiseYesWeakRoute`
+  - `NP_not_subset_PpolyDAG_of_acceptedFamilyWeakRoute`
+  - `NP_not_subset_PpolyDAG_of_promiseYesWeakRoute`
+- Added thin final-surface route reuse without new bridge plumbing:
+  - `not_globalPpolyDAG_surface_of_prgImageAcceptanceWeakRoute`
+  - `NP_not_subset_PpolyDAG_surface_of_prgImageAcceptanceWeakRoute`
+  - `not_globalPpolyDAG_surface_of_restrictionFallbackWeakRoute`
+  - `NP_not_subset_PpolyDAG_surface_of_restrictionFallbackWeakRoute`
+- Scope note:
+  - this closes the **quantifier plumbing** edge from per-slice `PpolyDAG`
+    assumptions to per-slice/eventual `SmallDAGSolver` existence, including a
+    single-global witness packaging layer;
+  - this now also includes an explicit global witness contradiction schema
+    under uniform no-small-solver assumptions for canonical witness families;
+  - this now reaches explicit class-level separation statements
+    `NP_not_subset_PpolyDAG_of_<weak-route-theorem>`;
+  - the remaining task is to internalize final `P_ne_NP` wrappers and
+    progressively remove external `hNPDag` assumptions.
+  - full theorem-level DAG separation internalization is still open.
+
+## Immediate patch queue (next 3 patches)
+
+1. **Patch Q1:** semantic half for promise-YES source theorem (no slack yet).
+2. **Patch Q2:** quantitative same-`S` slack upgrade and composition to
+   `PromiseYesSubcubeCertificateAt`.
+3. **Patch Q3:** wire
+   `NP_not_subset_PpolyDAG_of_<weak-route-theorem>`
+   into final `P_ne_NP` endpoint wrappers and retire the remaining external
+   DAG-separation parameters.
 
 ## Canonical module
 
@@ -250,8 +449,9 @@ Current policy after the accepted-family refactor:
   structured producer targets feeding the generic accepted-family consumer;
 - treat `SmallDAGWitnessSemanticConeCertificateAt` as a secondary diagnostic /
   restricted-model theorem target rather than the default unconditional engine;
-- postpone thin final DAG-wrapper work until there is a clearer source theorem
-  feeding the weak route.
+- thin final DAG-wrapper work is already in place; prioritize source-theorem
+  mathematics over additional wrapper layering unless a new bridge is required
+  by a concrete proof.
 
 Sanity policy:
 

--- a/pnp3/LowerBounds/AsymptoticDAGBarrier.lean
+++ b/pnp3/LowerBounds/AsymptoticDAGBarrier.lean
@@ -270,6 +270,343 @@ def SmallDAGSolver
     SizeBound n β ε (DagCircuit.size C) ∧
       CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β))
 
+/--
+Canonical size-bound surface extracted from a slice-indexed strict `PpolyDAG`
+witness family.
+
+For each slice `(n,β)`, the bound is read from that slice witness at the
+encoded input length `GapSliceFamily.encodedLen F n β`; the `ε` parameter is
+ignored intentionally (non-uniform witnesses do not depend on approximation
+accuracy in this interface).
+-/
+def ppolyDAGSizeBoundOnSlices
+    (F : GapSliceFamily)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    Nat → Rat → Rat → Nat → Prop :=
+  fun n β _ε s => s ≤ (hInDag n β).polyBound (GapSliceFamily.encodedLen F n β)
+
+/--
+Bridge lemma (witness-indexed form):
+from strict DAG witnesses on each slice language to explicit small-solver
+existence on every `(n,β,ε)`.
+
+This is the intended theorem-skeleton target for Q3-style bridge work: once a
+global route is able to provide `InPpolyDAG` witnesses for each slice language,
+the asymptotic barrier surface receives concrete `SmallDAGSolver` witnesses
+mechanically.
+-/
+theorem smallDAGSolver_of_inPpolyDAGFamilyOnSlices
+    (F : GapSliceFamily)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    ∀ n : Nat, ∀ β ε : Rat,
+      SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε := by
+  intro n β ε
+  let w : ComplexityInterfaces.InPpolyDAG
+      (gapPartialMCSP_Language (F.paramsOf n β)) := hInDag n β
+  refine ⟨w.family (GapSliceFamily.encodedLen F n β), ?_, ?_⟩
+  · simpa [ppolyDAGSizeBoundOnSlices] using
+      w.family_size_le (GapSliceFamily.encodedLen F n β)
+  · constructor
+    · intro x hxYes
+      have hxLang :
+          gapPartialMCSP_Language (F.paramsOf n β)
+              (GapSliceFamily.encodedLen F n β) x = true := by
+        simpa [gapSliceOfParams] using hxYes
+      exact (w.correct (GapSliceFamily.encodedLen F n β) x).trans hxLang
+    · intro x hxNo
+      have hxLang :
+          gapPartialMCSP_Language (F.paramsOf n β)
+              (GapSliceFamily.encodedLen F n β) x = false := by
+        simpa [gapSliceOfParams] using hxNo
+      exact (w.correct (GapSliceFamily.encodedLen F n β) x).trans hxLang
+
+/--
+Choice-level adapter from proposition-level per-slice DAG membership
+(`PpolyDAG`) to strict witnesses (`InPpolyDAG`).
+
+This is intentionally noncomputable: `PpolyDAG` is an existential proposition,
+and the bridge extracts a concrete witness family for theorem composition.
+-/
+noncomputable def inPpolyDAGFamilyOnSlices_of_PpolyDAG
+    (F : GapSliceFamily)
+    (hDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.PpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    ∀ n : Nat, ∀ β : Rat,
+      ComplexityInterfaces.InPpolyDAG
+        (gapPartialMCSP_Language (F.paramsOf n β)) := by
+  classical
+  intro n β
+  exact Classical.choose (hDag n β)
+
+/--
+Bridge lemma (membership-level form):
+if each slice language is in `PpolyDAG`, then the asymptotic barrier receives
+explicit small-solver witnesses on every `(n,β,ε)` via the canonical extracted
+size bound `ppolyDAGSizeBoundOnSlices`.
+-/
+theorem smallDAGSolver_of_PpolyDAGOnSlices
+    (F : GapSliceFamily)
+    (hDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.PpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    let hInDag := inPpolyDAGFamilyOnSlices_of_PpolyDAG F hDag
+    ∀ n : Nat, ∀ β ε : Rat,
+      SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε := by
+  intro hInDag
+  exact smallDAGSolver_of_inPpolyDAGFamilyOnSlices F hInDag
+
+/--
+Eventual per-`β` strict witness-family hypothesis.
+
+Interpretation:
+for each sufficiently small positive `β`, there is a cutoff `n0(β)` such that
+every slice language `(n,β)` with `n ≥ n0(β)` already has a strict
+`InPpolyDAG` witness.
+-/
+abbrev EventuallyInPpolyDAGWitnessFamily
+    (F : GapSliceFamily)
+    (β0 : Rat) : Type :=
+  ∀ β : Rat, 0 < β → β < β0 →
+    Σ n0 : Nat, ∀ n ≥ n0,
+      ComplexityInterfaces.InPpolyDAG
+        (gapPartialMCSP_Language (F.paramsOf n β))
+
+/--
+Eventual per-`β` proposition-level witness-family hypothesis (`PpolyDAG` form).
+-/
+def EventuallyPpolyDAGWitnessFamily
+    (F : GapSliceFamily)
+    (β0 : Rat) : Prop :=
+  ∀ β : Rat, 0 < β → β < β0 →
+    ∃ n0 : Nat, ∀ n ≥ n0,
+      ComplexityInterfaces.PpolyDAG
+        (gapPartialMCSP_Language (F.paramsOf n β))
+
+/--
+Canonical "eventually small-solver surface" used by the bridge milestone.
+
+This keeps exactly the asymptotic quantifier shape needed downstream, but on
+the **existence** side (`SmallDAGSolver`) rather than contradiction side
+(`¬ SmallDAGSolver`): a fixed `(ε,β0)` window and eventual-in-`n` solver
+existence for each sufficiently small `β`.
+-/
+def EventuallySmallDAGSolverSurface (F : GapSliceFamily) : Prop :=
+  ∃ SizeBound : Nat → Rat → Rat → Nat → Prop,
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0 : Rat, 0 < β0 ∧
+        ∀ β : Rat, 0 < β → β < β0 →
+          ∃ n0 : Nat, ∀ n ≥ n0, SmallDAGSolver F SizeBound n β ε
+
+/--
+Bridge theorem (strict-witness family form):
+`EventuallyInPpolyDAGWitnessFamily` implies the eventual `SmallDAGSolver`
+surface.
+
+Implementation note:
+`SizeBound := True` is intentional in this bridge layer.  The goal here is
+quantifier plumbing from witness families to solver existence; quantitative
+size refinements can be layered later without changing the asymptotic shape.
+-/
+theorem eventuallySmallDAGSolverSurface_of_eventuallyInPpolyDAGWitnessFamily
+    (F : GapSliceFamily)
+    (ε β0 : Rat)
+    (hε : 0 < ε)
+    (hβ0 : 0 < β0)
+    (hWitness : EventuallyInPpolyDAGWitnessFamily F β0) :
+    EventuallySmallDAGSolverSurface F := by
+  refine ⟨fun _n _β _ε _s => True, ε, hε, β0, hβ0, ?_⟩
+  intro β hβpos hβlt
+  rcases hWitness β hβpos hβlt with ⟨n0, hn0⟩
+  refine ⟨n0, ?_⟩
+  intro n hn
+  let w : ComplexityInterfaces.InPpolyDAG
+      (gapPartialMCSP_Language (F.paramsOf n β)) := hn0 n hn
+  refine ⟨w.family (GapSliceFamily.encodedLen F n β), trivial, ?_⟩
+  constructor
+  · intro x hxYes
+    have hxLang :
+        gapPartialMCSP_Language (F.paramsOf n β)
+            (GapSliceFamily.encodedLen F n β) x = true := by
+      simpa [gapSliceOfParams] using hxYes
+    exact (w.correct (GapSliceFamily.encodedLen F n β) x).trans hxLang
+  · intro x hxNo
+    have hxLang :
+        gapPartialMCSP_Language (F.paramsOf n β)
+            (GapSliceFamily.encodedLen F n β) x = false := by
+      simpa [gapSliceOfParams] using hxNo
+    exact (w.correct (GapSliceFamily.encodedLen F n β) x).trans hxLang
+
+/--
+Bridge theorem (proposition-level family form):
+`EventuallyPpolyDAGWitnessFamily` implies the eventual `SmallDAGSolver`
+surface by extracting strict witnesses pointwise via `Classical.choose`.
+-/
+theorem eventuallySmallDAGSolverSurface_of_eventuallyPpolyDAGWitnessFamily
+    (F : GapSliceFamily)
+    (ε β0 : Rat)
+    (hε : 0 < ε)
+    (hβ0 : 0 < β0)
+    (hWitness : EventuallyPpolyDAGWitnessFamily F β0) :
+    EventuallySmallDAGSolverSurface F := by
+  classical
+  refine eventuallySmallDAGSolverSurface_of_eventuallyInPpolyDAGWitnessFamily
+    (F := F) (ε := ε) (β0 := β0) hε hβ0 ?_
+  intro β hβpos hβlt
+  let hExists :
+      ∃ n0 : Nat, ∀ n ≥ n0,
+        ComplexityInterfaces.PpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)) :=
+    hWitness β hβpos hβlt
+  let n0 : Nat := Classical.choose hExists
+  let hn0 :
+      ∀ n ≥ n0, ComplexityInterfaces.PpolyDAG
+        (gapPartialMCSP_Language (F.paramsOf n β)) :=
+    Classical.choose_spec hExists
+  refine ⟨n0, ?_⟩
+  intro n hn
+  exact Classical.choose (hn0 n hn)
+
+/--
+Bridge package connecting one global asymptotic language `L` to all concrete
+slice languages of a fixed family `F`.
+
+This is the missing "single-global witness packaging" interface: if a theorem
+is proved for one global `L`, this structure records the extensional equality
+needed to transport that witness to each `(n,β)` slice language.
+-/
+structure AsymptoticDAGLanguageBridge (F : GapSliceFamily) : Type where
+  L : Language
+  sliceEq :
+    ∀ n : Nat, ∀ β : Rat, ∀ N : Nat, ∀ x : Bitstring N,
+      L N x = gapPartialMCSP_Language (F.paramsOf n β) N x
+
+/--
+Single-global-witness transport:
+from `PpolyDAG` on one global language `bridge.L` to `PpolyDAG` on every slice
+language of `F`.
+
+No asymptotic cutoff is needed here: transport is pointwise and exact for all
+`(n,β)` by `bridge.sliceEq`.
+-/
+theorem ppolyDAGOnSlices_of_globalWitness
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hDagGlobal : ComplexityInterfaces.PpolyDAG bridge.L) :
+    ∀ n : Nat, ∀ β : Rat,
+      ComplexityInterfaces.PpolyDAG
+        (gapPartialMCSP_Language (F.paramsOf n β)) := by
+  rcases hDagGlobal with ⟨w, -⟩
+  intro n β
+  refine ⟨{ polyBound := w.polyBound
+            polyBound_poly := w.polyBound_poly
+            family := w.family
+            family_size_le := w.family_size_le
+            correct := ?_ }, trivial⟩
+  intro N x
+  have hEvalGlobal : DagCircuit.eval (w.family N) x = bridge.L N x := w.correct N x
+  have hSlice :
+      bridge.L N x =
+        gapPartialMCSP_Language (F.paramsOf n β) N x := by
+    exact bridge.sliceEq n β N x
+  exact hEvalGlobal.trans hSlice
+
+/--
+Global-to-eventual bridge in one theorem:
+`PpolyDAG bridge.L` gives the eventual `SmallDAGSolver` surface.
+
+This theorem is intentionally phrased with explicit `(ε,β0)` parameters so it
+matches the quantifier front used by magnification-style endpoint wrappers.
+Since the transported slice witnesses hold for all `n`, the eventual cutoff can
+be chosen as `n0 = 0`.
+-/
+theorem eventuallySmallDAGSolverSurface_of_globalPpolyDAGWitness
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (ε β0 : Rat)
+    (hε : 0 < ε)
+    (hβ0 : 0 < β0)
+    (hDagGlobal : ComplexityInterfaces.PpolyDAG bridge.L) :
+    EventuallySmallDAGSolverSurface F := by
+  have hSlices :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.PpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)) :=
+    ppolyDAGOnSlices_of_globalWitness F bridge hDagGlobal
+  refine eventuallySmallDAGSolverSurface_of_eventuallyPpolyDAGWitnessFamily
+    (F := F) (ε := ε) (β0 := β0) hε hβ0 ?_
+  intro β hβpos hβlt
+  refine ⟨0, ?_⟩
+  intro n _hn
+  exact hSlices n β
+
+/--
+Global contradiction schema for the new bridge layer.
+
+Assume we have a *uniform no-small-solver barrier* for every canonical
+size-bound family produced by strict slice witnesses. Then any global
+`PpolyDAG` witness on `bridge.L` is impossible.
+
+This theorem is intentionally bridge-centric and still independent of the final
+`NP_not_subset_PpolyDAG` endpoint. It isolates the core contradiction step:
+
+`global DAG witness` + `magnification-style no-small-solver` -> `False`.
+-/
+theorem not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hNoSmall :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, ∀ n ≥ n0,
+                ¬ SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  intro hDagGlobal
+  have hSlices :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.PpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)) :=
+    ppolyDAGOnSlices_of_globalWitness F bridge hDagGlobal
+  let hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)) :=
+    inPpolyDAGFamilyOnSlices_of_PpolyDAG F hSlices
+  have hBarrier :
+      ∃ ε : Rat, 0 < ε ∧
+        ∃ β0 : Rat, 0 < β0 ∧
+          ∀ β : Rat, 0 < β → β < β0 →
+            ∃ n0 : Nat, ∀ n ≥ n0,
+              ¬ SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε :=
+    hNoSmall hInDag
+  rcases hBarrier with ⟨ε, hε, β0, hβ0, hEventuallyNo⟩
+  -- Choose a concrete β strictly inside the magnification window.
+  let β : Rat := β0 / 2
+  have hβpos : 0 < β := by
+    dsimp [β]
+    nlinarith [hβ0]
+  have hβlt : β < β0 := by
+    dsimp [β]
+    nlinarith [hβ0]
+  rcases hEventuallyNo β hβpos hβlt with ⟨n0, hnNo⟩
+  have hSolverAtN0 :
+      SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n0 β ε :=
+    smallDAGSolver_of_inPpolyDAGFamilyOnSlices F hInDag n0 β ε
+  exact (hnNo n0 (le_rfl)) hSolverAtN0
+
 /-- Single-slice composition: Layer A + Layer B imply no correct DAG solver. -/
 theorem no_dag_solver_of_two_layer
     (F : GapSliceFamily)
@@ -449,6 +786,127 @@ theorem no_dag_solver_of_promise_yes_subcube
     ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε := by
   intro n β ε
   exact no_dag_solver_of_promise_yes_subcube_at F SizeBound n β ε (hYes n β ε)
+
+/--
+Helper: convert a pointwise no-small-solver statement into the explicit
+magnification quantifier shape used by
+`not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies`.
+
+This keeps the canonical contradiction theorem generic while allowing concrete
+weak-route source theorems to plug in without restating quantifier plumbing.
+-/
+theorem noSmallQuantifierShape_of_pointwiseNoSmall
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hNo : ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε) :
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0 : Rat, 0 < β0 ∧
+        ∀ β : Rat, 0 < β → β < β0 →
+          ∃ n0 : Nat, ∀ n ≥ n0, ¬ SmallDAGSolver F SizeBound n β ε := by
+  refine ⟨1, by norm_num, 1, by norm_num, ?_⟩
+  intro β _hβpos _hβlt
+  refine ⟨0, ?_⟩
+  intro n _hn
+  exact hNo n β 1
+
+/--
+Concrete bridge-local contradiction instantiated with the weak accepted-family
+source theorem.
+
+If the accepted-family weak route is available for every canonical witness
+size-bound family, then the bridged global language is not in `PpolyDAG`.
+-/
+theorem not_globalPpolyDAG_of_acceptedFamilyWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hAcceptedWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        SmallDAGImpliesAcceptedFamilyStatement
+          F (ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  refine
+    not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies
+      (F := F) (bridge := bridge) ?_
+  intro hInDag
+  have hNoPointwise :
+      ∀ n : Nat, ∀ β ε : Rat,
+        ¬ SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε :=
+    no_dag_solver_of_acceptedFamily
+      F (ppolyDAGSizeBoundOnSlices F hInDag) (hAcceptedWeak hInDag)
+  exact
+    noSmallQuantifierShape_of_pointwiseNoSmall
+      F (ppolyDAGSizeBoundOnSlices F hInDag) hNoPointwise
+
+/--
+Concrete bridge-local contradiction instantiated with the nearer-term one-sided
+promise-YES source theorem.
+-/
+theorem not_globalPpolyDAG_of_promiseYesWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        SmallDAGImpliesPromiseYesSubcubeStatement
+          F (ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  refine
+    not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies
+      (F := F) (bridge := bridge) ?_
+  intro hInDag
+  have hNoPointwise :
+      ∀ n : Nat, ∀ β ε : Rat,
+        ¬ SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε :=
+    no_dag_solver_of_promise_yes_subcube
+      F (ppolyDAGSizeBoundOnSlices F hInDag) (hYesWeak hInDag)
+  exact
+    noSmallQuantifierShape_of_pointwiseNoSmall
+      F (ppolyDAGSizeBoundOnSlices F hInDag) hNoPointwise
+
+/--
+Class-level closure from the weak accepted-family source theorem to
+`NP_not_subset_PpolyDAG`, parameterized by an explicit NP witness for
+`bridge.L`.
+-/
+theorem NP_not_subset_PpolyDAG_of_acceptedFamilyWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hAcceptedWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        SmallDAGImpliesAcceptedFamilyStatement
+          F (ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine ⟨bridge.L, hNP, ?_⟩
+  exact not_globalPpolyDAG_of_acceptedFamilyWeakRoute F bridge hAcceptedWeak
+
+/--
+Class-level closure from the one-sided promise-YES weak source theorem to
+`NP_not_subset_PpolyDAG`, parameterized by an explicit NP witness for
+`bridge.L`.
+-/
+theorem NP_not_subset_PpolyDAG_of_promiseYesWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        SmallDAGImpliesPromiseYesSubcubeStatement
+          F (ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine ⟨bridge.L, hNP, ?_⟩
+  exact not_globalPpolyDAG_of_promiseYesWeakRoute F bridge hYesWeak
 
 /--
 Primary endpoint schema (magnification-style quantifiers):

--- a/pnp3/LowerBounds/DAGStableRestrictionProducer.lean
+++ b/pnp3/LowerBounds/DAGStableRestrictionProducer.lean
@@ -1577,6 +1577,44 @@ def promiseYesSubcubeCertificateAt_of_acceptanceInvariant
   hAccept := inv.hAccept
 
 /--
+Split form of the current mainline source objective at one witness:
+
+1. semantic one-sided YES-centered forcing (`inv`);
+2. quantitative slack on the **same** semantic coordinate set (`hSlackOnInvS`).
+
+This packages the Q1/Q2 theorem-sprint decomposition explicitly in the API so
+source-side proofs can target each half independently and still compose
+mechanically to `PromiseYesSubcubeCertificateAt`.
+-/
+structure PromiseYesSourceDecompositionAt
+    {p : GapPartialMCSPParams}
+    {SizeBound : Rat → Nat → Prop}
+    {ε : Rat}
+    (W : SmallDAGWitnessOnSlice p SizeBound ε) where
+  /-- Semantic one-sided forcing component (Q1 target). -/
+  inv : PromiseYesAcceptanceInvariantAt W
+  /-- Quantitative slack on the same semantic coordinates (Q2 target). -/
+  hSlackOnInvS :
+    Models.circuitCountBound p.n (p.sNO - 1) <
+      2 ^ (Models.Partial.tableLen p.n - inv.S.card)
+
+/--
+Mechanical compilation from the split Q1/Q2 source package to the operational
+promise-YES weak-route certificate used by counting closure.
+-/
+def promiseYesSubcubeCertificateAt_of_sourceDecomposition
+    {p : GapPartialMCSPParams}
+    {SizeBound : Rat → Nat → Prop}
+    {ε : Rat}
+    {W : SmallDAGWitnessOnSlice p SizeBound ε}
+    (src : PromiseYesSourceDecompositionAt W) :
+    PromiseYesSubcubeCertificateAt W :=
+  promiseYesSubcubeCertificateAt_of_acceptanceInvariant
+    (W := W)
+    src.inv
+    src.hSlackOnInvS
+
+/--
 Forget the slack field of a promise-aware YES-centered weak-route certificate,
 leaving just the semantic invariant.
 -/
@@ -1592,6 +1630,47 @@ def promiseYesAcceptanceInvariantAt_of_promiseYesSubcubeCertificateAt
   hValidYes := cert.hValidYes
   S := cert.S
   hAccept := cert.hAccept
+
+/--
+Slice-family provider for semantic one-sided YES-centered forcing certificates
+(Q1-level provider target).
+-/
+abbrev promiseYesAcceptanceInvariantAtProviderOnSlices
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop) : Type :=
+  ∀ n : Nat, ∀ β ε : Rat,
+    ∀ W : SmallDAGWitnessOnSlice (F.paramsOf n β) (fun ε' s => SizeBound n β ε' s) ε,
+      PromiseYesAcceptanceInvariantAt W
+
+/--
+Slice-family provider for quantitative slack on the same semantic coordinate set
+produced by a semantic provider (Q2-level provider target).
+-/
+abbrev promiseYesSlackOnInvariantProviderOnSlices
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hInv : promiseYesAcceptanceInvariantAtProviderOnSlices F SizeBound) : Prop :=
+  ∀ n : Nat, ∀ β ε : Rat,
+    ∀ W : SmallDAGWitnessOnSlice (F.paramsOf n β) (fun ε' s => SizeBound n β ε' s) ε,
+      Models.circuitCountBound (F.paramsOf n β).n ((F.paramsOf n β).sNO - 1) <
+        2 ^ (Models.Partial.tableLen (F.paramsOf n β).n - (hInv n β ε W).S.card)
+
+/--
+Compile separate semantic and quantitative source providers into the existing
+provider surface `promiseYesSubcubeCertificateAtProviderOnSlices`.
+-/
+def promiseYesSubcubeCertificateAtProviderOnSlices_of_semanticAndSlackProvider
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hInv : promiseYesAcceptanceInvariantAtProviderOnSlices F SizeBound)
+    (hSlack : promiseYesSlackOnInvariantProviderOnSlices F SizeBound hInv) :
+    ∀ n : Nat, ∀ β ε : Rat,
+      ∀ W : SmallDAGWitnessOnSlice (F.paramsOf n β) (fun ε' s => SizeBound n β ε' s) ε,
+        PromiseYesSubcubeCertificateAt W := by
+  intro n β ε W
+  exact promiseYesSubcubeCertificateAt_of_sourceDecomposition
+    { inv := hInv n β ε W
+      hSlackOnInvS := hSlack n β ε W }
 
 /--
 The existing pairwise promise/value locality package already yields the more
@@ -1679,6 +1758,24 @@ def promiseYesSubcubeCertificateAt_of_decisionCertificate
     hSlack
 
 /--
+Package the decision-certificate route directly in the split Q1/Q2 form:
+semantic forcing plus slack on the same `S`.
+-/
+def promiseYesSourceDecompositionAt_of_decisionCertificate
+    {p : GapPartialMCSPParams}
+    {SizeBound : Rat → Nat → Prop}
+    {ε : Rat}
+    {W : SmallDAGWitnessOnSlice p SizeBound ε}
+    (cert : PromiseYesDecisionCertificateAt W)
+    (hSlack :
+      Models.circuitCountBound p.n (p.sNO - 1) <
+        2 ^ (Models.Partial.tableLen p.n - cert.S.card)) :
+    PromiseYesSourceDecompositionAt W where
+  inv := promiseYesAcceptanceInvariantAt_of_decisionCertificate cert
+  hSlackOnInvS := by
+    simpa [promiseYesAcceptanceInvariantAt_of_decisionCertificate] using hSlack
+
+/--
 The existing pairwise promise/value locality package already yields the
 acceptance-only semantic invariant via the more operational YES-decision
 certificate.
@@ -1711,6 +1808,21 @@ noncomputable def promiseYesSubcubeCertificateAt_of_promiseValueLocalityPackageA
   let inv : PromiseYesAcceptanceInvariantAt W :=
     promiseYesAcceptanceInvariantAt_of_promiseValueLocalityPackageAt cert
   exact promiseYesSubcubeCertificateAt_of_acceptanceInvariant inv cert.hSlack
+
+/--
+Package the pairwise promise/value route directly in the split Q1/Q2 form.
+-/
+noncomputable def promiseYesSourceDecompositionAt_of_promiseValueLocalityPackageAt
+    {p : GapPartialMCSPParams}
+    {SizeBound : Rat → Nat → Prop}
+    {ε : Rat}
+    {W : SmallDAGWitnessOnSlice p SizeBound ε}
+    (cert : PromiseValueLocalityPackageAt W) :
+    PromiseYesSourceDecompositionAt W := by
+  refine
+    { inv := promiseYesAcceptanceInvariantAt_of_promiseValueLocalityPackageAt cert
+      hSlackOnInvS := ?_ }
+  simpa [promiseYesAcceptanceInvariantAt_of_promiseValueLocalityPackageAt] using cert.hSlack
 
 /--
 Value-supported encoded-coordinate restriction packages already imply the
@@ -1809,6 +1921,49 @@ abbrev promiseYesSubcubeCertificateAtProviderOnSlices
       PromiseYesSubcubeCertificateAt W
 
 /--
+Provider reduction: pairwise promise/value packages already supply the semantic
+Q1 half (`PromiseYesAcceptanceInvariantAt`) on every slice.
+-/
+noncomputable def promiseYesAcceptanceInvariantAtProviderOnSlices_of_promiseValueLocalityPackageProvider
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hPkg : promiseValueLocalityPackageAtProviderOnSlices F SizeBound) :
+    promiseYesAcceptanceInvariantAtProviderOnSlices F SizeBound := by
+  intro n β ε W
+  exact promiseYesAcceptanceInvariantAt_of_promiseValueLocalityPackageAt (hPkg n β ε W)
+
+/--
+Provider reduction: pairwise promise/value packages also supply the Q2 half,
+namely counting slack on the same semantic set chosen by the Q1 provider above.
+-/
+theorem promiseYesSlackOnInvariantProviderOnSlices_of_promiseValueLocalityPackageProvider
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hPkg : promiseValueLocalityPackageAtProviderOnSlices F SizeBound) :
+    promiseYesSlackOnInvariantProviderOnSlices
+      F SizeBound
+      (promiseYesAcceptanceInvariantAtProviderOnSlices_of_promiseValueLocalityPackageProvider
+        F SizeBound hPkg) := by
+  intro n β ε W
+  simpa [promiseYesAcceptanceInvariantAtProviderOnSlices_of_promiseValueLocalityPackageProvider,
+    promiseYesAcceptanceInvariantAt_of_promiseValueLocalityPackageAt] using (hPkg n β ε W).hSlack
+
+/--
+Provider reduction from pairwise promise/value packages to the split Q1/Q2 API.
+-/
+noncomputable def promiseYesSubcubeCertificateAtProviderOnSlices_of_promiseValueLocalityPackageProvider_viaSemanticAndSlack
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hPkg : promiseValueLocalityPackageAtProviderOnSlices F SizeBound) :
+    promiseYesSubcubeCertificateAtProviderOnSlices F SizeBound :=
+  promiseYesSubcubeCertificateAtProviderOnSlices_of_semanticAndSlackProvider
+    F SizeBound
+    (promiseYesAcceptanceInvariantAtProviderOnSlices_of_promiseValueLocalityPackageProvider
+      F SizeBound hPkg)
+    (promiseYesSlackOnInvariantProviderOnSlices_of_promiseValueLocalityPackageProvider
+      F SizeBound hPkg)
+
+/--
 Provider-level reduction from the existing pairwise promise/value package route
 to the weaker promise-aware YES-centered route.
 -/
@@ -1838,6 +1993,25 @@ theorem noSmallDAG_of_promiseYesSubcubeCertificateAtProviderOnSlices
   exact no_small_dag_solver_of_promiseYesSubcubeCertificateAt W (hCert n β ε W)
 
 /--
+Compiled closure from the explicit Q1/Q2 split provider interface:
+
+1. semantic one-sided forcing provider (`hInv`);
+2. quantitative slack-on-the-same-`S` provider (`hSlack`).
+
+This theorem is the direct provider-level counterpart of the decomposition
+package `PromiseYesSourceDecompositionAt`.
+-/
+theorem noSmallDAG_of_promiseYesSemanticAndSlackProvidersOnSlices
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hInv : promiseYesAcceptanceInvariantAtProviderOnSlices F SizeBound)
+    (hSlack : promiseYesSlackOnInvariantProviderOnSlices F SizeBound hInv) :
+    ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε := by
+  exact noSmallDAG_of_promiseYesSubcubeCertificateAtProviderOnSlices F SizeBound
+    (promiseYesSubcubeCertificateAtProviderOnSlices_of_semanticAndSlackProvider
+      F SizeBound hInv hSlack)
+
+/--
 Direct closure from the existing pairwise promise/value package route through
 the nearer-term promise-aware YES-centered source theorem target.
 -/
@@ -1848,6 +2022,21 @@ theorem noSmallDAG_of_promiseValueLocalityPackageProviderOnSlices
     ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε := by
   exact noSmallDAG_of_promiseYesSubcubeCertificateAtProviderOnSlices F SizeBound
     (promiseYesSubcubeCertificateAtProviderOnSlices_of_promiseValueLocalityPackageProvider
+      F SizeBound hPkg)
+
+/--
+Same closure as `noSmallDAG_of_promiseValueLocalityPackageProviderOnSlices`, but
+factored explicitly through the split Q1/Q2 provider interface.
+-/
+theorem noSmallDAG_of_promiseValueLocalityPackageProviderOnSlices_viaSemanticAndSlack
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hPkg : promiseValueLocalityPackageAtProviderOnSlices F SizeBound) :
+    ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε := by
+  exact noSmallDAG_of_promiseYesSemanticAndSlackProvidersOnSlices F SizeBound
+    (promiseYesAcceptanceInvariantAtProviderOnSlices_of_promiseValueLocalityPackageProvider
+      F SizeBound hPkg)
+    (promiseYesSlackOnInvariantProviderOnSlices_of_promiseValueLocalityPackageProvider
       F SizeBound hPkg)
 
 /--

--- a/pnp3/Magnification/FinalResult.lean
+++ b/pnp3/Magnification/FinalResult.lean
@@ -4,6 +4,7 @@ import Magnification.Facts_Magnification_Partial
 import Magnification.LocalityProvider_Partial
 import Magnification.PipelineStatements_Partial
 import LowerBounds.DAGStableRestrictionProducer
+import LowerBounds.AsymptoticDAGBarrier
 import Models.Model_PartialMCSP
 import Complexity.Interfaces
 import Complexity.PsubsetPpolyDAG_Internal
@@ -315,6 +316,351 @@ theorem P_ne_NP_final_dag_only
       hPDag
 
 /-!
+Thin DAG weak-route wrappers (active mainline surface):
+
+- source theorem target:
+  `SmallDAGImpliesPromiseYesSubcubeAt` / `SmallDAGImpliesPromiseYesSubcubeStatement`
+- weak terminal consumer:
+  `SmallDAGImpliesAcceptedFamilyAt` / `SmallDAGImpliesAcceptedFamilyStatement`
+- asymptotic no-small-DAG endpoint:
+  `MagnificationStyleNoSmallDAG (SmallDAGSolver F SizeBound)`.
+
+These wrappers intentionally keep the final file oriented to the weak accepted-family
+route without forcing the stronger restriction-provider contracts as the only
+frontier.
+-/
+
+/--
+Final-surface wrapper: global no-small-DAG closure from the weak accepted-family
+statement.
+
+This is the theorem-level bridge used by the new weak mainline:
+`AcceptedFamilyCertificateAt` is treated as terminal consumer, and the closure
+to per-slice impossibility of small DAG solvers is entirely mechanical.
+-/
+theorem noSmallDAG_surface_of_acceptedFamilyStatement
+  (F : LowerBounds.GapSliceFamily)
+  (SizeBound : Nat → Rat → Rat → Nat → Prop)
+  (hAccepted : LowerBounds.SmallDAGImpliesAcceptedFamilyStatement F SizeBound) :
+  ∀ n : Nat, ∀ β ε : Rat, ¬ LowerBounds.SmallDAGSolver F SizeBound n β ε := by
+  exact LowerBounds.no_dag_solver_of_acceptedFamily F SizeBound hAccepted
+
+/--
+Final-surface wrapper: global no-small-DAG closure from the one-sided YES-centered
+source statement.
+
+This keeps the nearest-term source target explicit in `FinalResult`:
+`SmallDAGImpliesPromiseYesSubcubeStatement` is reduced immediately to the same
+no-solver endpoint.
+-/
+theorem noSmallDAG_surface_of_promiseYesSubcubeStatement
+  (F : LowerBounds.GapSliceFamily)
+  (SizeBound : Nat → Rat → Rat → Nat → Prop)
+  (hYes : LowerBounds.SmallDAGImpliesPromiseYesSubcubeStatement F SizeBound) :
+  ∀ n : Nat, ∀ β ε : Rat, ¬ LowerBounds.SmallDAGSolver F SizeBound n β ε := by
+  exact LowerBounds.no_dag_solver_of_promise_yes_subcube F SizeBound hYes
+
+/--
+Final-surface wrapper for the parallel structured-image backup route:
+
+`PRGImageAcceptanceAt provider -> no small DAG solver`.
+
+This keeps the backup producer compiled at the same endpoint level as the
+promise-YES and accepted-family mainline wrappers.
+-/
+theorem noSmallDAG_surface_of_prgImageAcceptanceProviderOnSlices
+  (F : LowerBounds.GapSliceFamily)
+  (SizeBound : Nat → Rat → Rat → Nat → Prop)
+  (hPrg : LowerBounds.prgImageAcceptanceAtProviderOnSlices F SizeBound) :
+  ∀ n : Nat, ∀ β ε : Rat, ¬ LowerBounds.SmallDAGSolver F SizeBound n β ε := by
+  exact LowerBounds.noSmallDAG_of_prgImageAcceptanceAtProviderOnSlices F SizeBound hPrg
+
+/--
+Final-surface wrapper for the strong restriction/shrinkage fallback stack.
+
+This theorem intentionally routes the stronger extraction+numerics contract into
+the same weak accepted-family terminal closure, so the fallback remains
+compatible with the weak mainline rather than reintroducing a separate endpoint.
+-/
+theorem noSmallDAG_surface_of_restrictionFallbackOnSlices
+  (F : LowerBounds.GapSliceFamily)
+  (SizeBound : Nat → Rat → Rat → Nat → Prop)
+  (hExtract : LowerBounds.smallDAGWitnessRestrictionExtractionProviderOnSlices F SizeBound)
+  (hNumeric :
+    LowerBounds.smallDAGWitnessRestrictionNumericDataProviderOnSlices F SizeBound hExtract) :
+  ∀ n : Nat, ∀ β ε : Rat, ¬ LowerBounds.SmallDAGSolver F SizeBound n β ε := by
+  exact
+    LowerBounds.noSmallDAG_of_restrictionExtractionAndNumericProviderOnSlices_via_acceptedFamily
+      F SizeBound hExtract hNumeric
+
+/--
+Asymptotic weak-route wrapper from eventual accepted-family production.
+-/
+theorem magnificationStyleNoSmallDAG_surface_of_eventuallyAcceptedFamily
+    (F : LowerBounds.GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (ε β0 : Rat)
+    (hε : 0 < ε)
+    (hβ0 : 0 < β0)
+    (hEventuallyAccepted :
+      ∀ β : Rat, 0 < β → β < β0 →
+        ∃ nAcc : Nat, ∀ n ≥ nAcc, LowerBounds.SmallDAGImpliesAcceptedFamilyAt F SizeBound n β ε) :
+    LowerBounds.MagnificationStyleNoSmallDAG (LowerBounds.SmallDAGSolver F SizeBound) := by
+  exact LowerBounds.magnificationStyleNoSmallDAG_of_eventually_acceptedFamily
+    F SizeBound ε β0 hε hβ0 hEventuallyAccepted
+
+/--
+Asymptotic weak-route wrapper from eventual one-sided YES-subcube production.
+-/
+theorem magnificationStyleNoSmallDAG_surface_of_eventuallyPromiseYesSubcube
+    (F : LowerBounds.GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (ε β0 : Rat)
+    (hε : 0 < ε)
+    (hβ0 : 0 < β0)
+    (hEventuallyYes :
+      ∀ β : Rat, 0 < β → β < β0 →
+        ∃ nYes : Nat, ∀ n ≥ nYes, LowerBounds.SmallDAGImpliesPromiseYesSubcubeAt F SizeBound n β ε) :
+    LowerBounds.MagnificationStyleNoSmallDAG (LowerBounds.SmallDAGSolver F SizeBound) := by
+  exact LowerBounds.magnificationStyleNoSmallDAG_of_eventually_promiseYesSubcube
+    F SizeBound ε β0 hε hβ0 hEventuallyYes
+
+/--
+Thin bridge wrapper (variant-1 style): a single global `PpolyDAG` witness on an
+asymptotic language `bridge.L` implies the eventual small-solver surface for
+the chosen slice family `F`.
+
+This wrapper intentionally stops at `EventuallySmallDAGSolverSurface`; it does
+not yet claim DAG separation by itself.  Its purpose is to expose the new
+global-to-slice quantifier plumbing at the `FinalResult` boundary.
+-/
+theorem eventuallySmallDAGSolverSurface_surface_of_globalPpolyDAGWitness
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (ε β0 : Rat)
+    (hε : 0 < ε)
+    (hβ0 : 0 < β0)
+    (hDagGlobal : ComplexityInterfaces.PpolyDAG bridge.L) :
+    LowerBounds.EventuallySmallDAGSolverSurface F := by
+  exact LowerBounds.eventuallySmallDAGSolverSurface_of_globalPpolyDAGWitness
+    F bridge ε β0 hε hβ0 hDagGlobal
+
+/--
+Thin contradiction wrapper at the global-witness bridge boundary:
+if magnification-style no-small-solver is available uniformly for every
+canonical witness-derived size-bound family, then the bridged global language
+cannot belong to `PpolyDAG`.
+
+This theorem keeps the result bridge-local (`¬ PpolyDAG bridge.L`) and avoids
+claiming full class separation prematurely.
+-/
+theorem not_globalPpolyDAG_surface_of_noSmallCanonicalWitnessFamilies
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (hNoSmall :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, ∀ n ≥ n0,
+                ¬ LowerBounds.SmallDAGSolver
+                    F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag) n β ε) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  exact
+    LowerBounds.not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies
+      F bridge hNoSmall
+
+/--
+Thin bridge-local contradiction wrapper instantiated with the weak
+accepted-family source theorem.
+-/
+theorem not_globalPpolyDAG_surface_of_acceptedFamilyWeakRoute
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (hAcceptedWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        LowerBounds.SmallDAGImpliesAcceptedFamilyStatement
+          F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  exact
+    LowerBounds.not_globalPpolyDAG_of_acceptedFamilyWeakRoute
+      F bridge hAcceptedWeak
+
+/--
+Thin bridge-local contradiction wrapper instantiated with the nearer-term
+promise-YES weak source theorem.
+-/
+theorem not_globalPpolyDAG_surface_of_promiseYesWeakRoute
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (hYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        LowerBounds.SmallDAGImpliesPromiseYesSubcubeStatement
+          F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  exact
+    LowerBounds.not_globalPpolyDAG_of_promiseYesWeakRoute
+      F bridge hYesWeak
+
+/--
+Bridge-local contradiction wrapper instantiated with the structured-image weak
+route:
+
+`PRGImageAcceptanceAt provider -> accepted-family weak statement ->
+not_globalPpolyDAG`.
+
+This uses only already-compiled bridges and the canonical contradiction schema;
+no extra asymptotic plumbing is introduced.
+-/
+theorem not_globalPpolyDAG_surface_of_prgImageAcceptanceWeakRoute
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (hPrgWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        LowerBounds.prgImageAcceptanceAtProviderOnSlices
+          F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  refine
+    LowerBounds.not_globalPpolyDAG_of_acceptedFamilyWeakRoute
+      F bridge ?_
+  intro hInDag
+  exact
+    LowerBounds.smallDAGAcceptedFamilyStatement_of_prgImageAcceptanceProvider
+      F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag) (hPrgWeak hInDag)
+
+/--
+Bridge-local contradiction wrapper instantiated with a stronger fallback route:
+
+`restrictionExtraction + numeric side-data -> accepted-family weak statement ->
+not_globalPpolyDAG`.
+
+The key design point is that this also reuses the same accepted-family bridge
+schema, so strengthening the source route does not require any new asymptotic
+bridge layer.
+-/
+theorem not_globalPpolyDAG_surface_of_restrictionFallbackWeakRoute
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (hFallbackWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ hExtract :
+          LowerBounds.smallDAGWitnessRestrictionExtractionProviderOnSlices
+            F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag),
+          LowerBounds.smallDAGWitnessRestrictionNumericDataProviderOnSlices
+            F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag) hExtract) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  refine
+    LowerBounds.not_globalPpolyDAG_of_acceptedFamilyWeakRoute
+      F bridge ?_
+  intro hInDag
+  rcases hFallbackWeak hInDag with ⟨hExtract, hNumeric⟩
+  exact
+    LowerBounds.smallDAGAcceptedFamilyStatement_of_restrictionExtractionAndNumericProvider
+      F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag) hExtract hNumeric
+
+/--
+Class-level wrapper: accepted-family weak route + explicit NP witness on
+`bridge.L` gives `NP_not_subset_PpolyDAG`.
+-/
+theorem NP_not_subset_PpolyDAG_surface_of_acceptedFamilyWeakRoute
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hAcceptedWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        LowerBounds.SmallDAGImpliesAcceptedFamilyStatement
+          F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  exact
+    LowerBounds.NP_not_subset_PpolyDAG_of_acceptedFamilyWeakRoute
+      F bridge hNP hAcceptedWeak
+
+/--
+Class-level wrapper: promise-YES weak route + explicit NP witness on
+`bridge.L` gives `NP_not_subset_PpolyDAG`.
+-/
+theorem NP_not_subset_PpolyDAG_surface_of_promiseYesWeakRoute
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        LowerBounds.SmallDAGImpliesPromiseYesSubcubeStatement
+          F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  exact
+    LowerBounds.NP_not_subset_PpolyDAG_of_promiseYesWeakRoute
+      F bridge hNP hYesWeak
+
+/--
+Class-level wrapper for the structured-image weak route.
+
+This is the class-separation closure corresponding to
+`not_globalPpolyDAG_surface_of_prgImageAcceptanceWeakRoute`.
+-/
+theorem NP_not_subset_PpolyDAG_surface_of_prgImageAcceptanceWeakRoute
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hPrgWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        LowerBounds.prgImageAcceptanceAtProviderOnSlices
+          F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine ⟨bridge.L, hNP, ?_⟩
+  exact
+    not_globalPpolyDAG_surface_of_prgImageAcceptanceWeakRoute
+      F bridge hPrgWeak
+
+/--
+Class-level wrapper for the stronger fallback route
+`restrictionExtraction + numeric side-data`.
+-/
+theorem NP_not_subset_PpolyDAG_surface_of_restrictionFallbackWeakRoute
+    (F : LowerBounds.GapSliceFamily)
+    (bridge : LowerBounds.AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hFallbackWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ hExtract :
+          LowerBounds.smallDAGWitnessRestrictionExtractionProviderOnSlices
+            F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag),
+          LowerBounds.smallDAGWitnessRestrictionNumericDataProviderOnSlices
+            F (LowerBounds.ppolyDAGSizeBoundOnSlices F hInDag) hExtract) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine ⟨bridge.L, hNP, ?_⟩
+  exact
+    not_globalPpolyDAG_surface_of_restrictionFallbackWeakRoute
+      F bridge hFallbackWeak
+
+/-!
 Current DAG endpoint ledger for this file:
 
 - `P_ne_NP_final` remains conditional on explicit DAG separation
@@ -331,10 +677,10 @@ Current DAG endpoint ledger for this file:
   `SmallDAGImpliesPromiseYesSubcubeStatement`, and
   `YesSubcubeCertificateAt` is wired as a stronger structured producer into
   that route.
-- This file still does not expose asymptotic final wrappers consuming that weak
-  route directly; the remaining open step is the actual DAG-side source theorem
-  producing the accepted-family endpoint (or a structured producer reducing to
-  it).
+- This file now exposes thin asymptotic weak-route wrappers (`magnificationStyle*`)
+  consuming eventual accepted-family / promise-YES-subcube statements directly.
+  The remaining open step is the actual DAG-side source theorem producing those
+  eventual statements from strict small-DAG semantics.
 -/
 
 /--

--- a/pnp3/Tests/SmokeTests.lean
+++ b/pnp3/Tests/SmokeTests.lean
@@ -6,6 +6,7 @@ import ThirdPartyFacts.Facts_Switching
 import LowerBounds.AntiChecker_Partial
 import Magnification.Facts_Magnification_Partial
 import Complexity.Interfaces
+import Tests.WeakRouteSurfaceTests
 
 /-!
 # Smoke Tests for pnp3

--- a/pnp3/Tests/WeakRouteSurfaceTests.lean
+++ b/pnp3/Tests/WeakRouteSurfaceTests.lean
@@ -1,0 +1,499 @@
+import Magnification.FinalResult
+
+/-!
+# Weak-route final surface smoke tests
+
+This module is intentionally lightweight: it does not attempt to construct
+nontrivial witnesses, but it **does** force Lean to elaborate the exact theorem
+types that define the current weak-route final interface.
+
+Rationale:
+- when endpoint names or signatures drift during refactors, these declarations
+  fail immediately;
+- this gives a small, explicit regression surface for the current roadmap:
+  accepted-family endpoint, promise-YES endpoint, PRG-image backup, and
+  restriction fallback wrappers in `Magnification.FinalResult`.
+-/
+
+namespace Pnp3.Tests
+
+open Pnp3
+open Pnp3.LowerBounds
+open Pnp3.Magnification
+
+/-!
+## Type-level interface checks
+
+Each `def` below pins one exported theorem to its current type.
+If any theorem is renamed or its argument order/type changes, this file stops
+compiling and signals an interface regression.
+-/
+
+/-- Surface accepted-family wrapper is available with the expected type. -/
+def check_noSmallDAG_surface_of_acceptedFamilyStatement :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop),
+      SmallDAGImpliesAcceptedFamilyStatement F SizeBound →
+        ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε :=
+  noSmallDAG_surface_of_acceptedFamilyStatement
+
+/-- Surface promise-YES statement wrapper is available with the expected type. -/
+def check_noSmallDAG_surface_of_promiseYesSubcubeStatement :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop),
+      SmallDAGImpliesPromiseYesSubcubeStatement F SizeBound →
+        ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε :=
+  noSmallDAG_surface_of_promiseYesSubcubeStatement
+
+/-- Surface PRG-image backup wrapper is available with the expected type. -/
+def check_noSmallDAG_surface_of_prgImageAcceptanceProviderOnSlices :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop),
+      prgImageAcceptanceAtProviderOnSlices F SizeBound →
+        ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε :=
+  noSmallDAG_surface_of_prgImageAcceptanceProviderOnSlices
+
+/-- Surface restriction-fallback wrapper is available with the expected type. -/
+def check_noSmallDAG_surface_of_restrictionFallbackOnSlices :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop)
+      (hExtract : smallDAGWitnessRestrictionExtractionProviderOnSlices F SizeBound),
+      smallDAGWitnessRestrictionNumericDataProviderOnSlices F SizeBound hExtract →
+        ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε :=
+  noSmallDAG_surface_of_restrictionFallbackOnSlices
+
+/--
+Technical source-level reduction from pairwise promise/value packages to the
+mainline promise-YES statement remains in the lower-bounds producer layer
+(not in `Magnification.FinalResult`).
+-/
+def check_smallDAGPromiseYesSubcubeStatement_of_packageProvider :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop),
+      promiseValueLocalityPackageAtProviderOnSlices F SizeBound →
+        SmallDAGImpliesPromiseYesSubcubeStatement F SizeBound :=
+  smallDAGPromiseYesSubcubeStatement_of_packageProvider
+
+/--
+Q1/Q2 split-provider compilation to promise-YES certificate provider is
+available with the expected type.
+-/
+def check_promiseYesSubcubeCertificateAtProviderOnSlices_of_semanticAndSlackProvider :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop)
+      (hInv : promiseYesAcceptanceInvariantAtProviderOnSlices F SizeBound),
+      promiseYesSlackOnInvariantProviderOnSlices F SizeBound hInv →
+        (∀ n : Nat, ∀ β ε : Rat,
+          ∀ W : SmallDAGWitnessOnSlice (F.paramsOf n β) (fun ε' s => SizeBound n β ε' s) ε,
+            PromiseYesSubcubeCertificateAt W) :=
+  promiseYesSubcubeCertificateAtProviderOnSlices_of_semanticAndSlackProvider
+
+/-- Q1/Q2 split-provider no-small-DAG closure is available with the expected type. -/
+def check_noSmallDAG_of_promiseYesSemanticAndSlackProvidersOnSlices :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop)
+      (hInv : promiseYesAcceptanceInvariantAtProviderOnSlices F SizeBound),
+      promiseYesSlackOnInvariantProviderOnSlices F SizeBound hInv →
+        ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε :=
+  noSmallDAG_of_promiseYesSemanticAndSlackProvidersOnSlices
+
+/--
+Package-provider -> Q1 semantic-provider reduction is available with the
+expected type.
+-/
+noncomputable def check_promiseYesAcceptanceInvariantAtProviderOnSlices_of_promiseValueLocalityPackageProvider :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop),
+      promiseValueLocalityPackageAtProviderOnSlices F SizeBound →
+        promiseYesAcceptanceInvariantAtProviderOnSlices F SizeBound :=
+  promiseYesAcceptanceInvariantAtProviderOnSlices_of_promiseValueLocalityPackageProvider
+
+/--
+Package-provider -> Q2 slack-provider reduction is available with the expected
+dependent-provider type.
+-/
+noncomputable def check_promiseYesSlackOnInvariantProviderOnSlices_of_promiseValueLocalityPackageProvider :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop)
+      (hPkg : promiseValueLocalityPackageAtProviderOnSlices F SizeBound),
+      promiseYesSlackOnInvariantProviderOnSlices
+        F SizeBound
+        (promiseYesAcceptanceInvariantAtProviderOnSlices_of_promiseValueLocalityPackageProvider
+          F SizeBound hPkg) :=
+  promiseYesSlackOnInvariantProviderOnSlices_of_promiseValueLocalityPackageProvider
+
+/--
+Package-provider closure through split Q1/Q2 interface is available with the
+expected type.
+-/
+noncomputable def check_noSmallDAG_of_promiseValueLocalityPackageProviderOnSlices_viaSemanticAndSlack :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop),
+      promiseValueLocalityPackageAtProviderOnSlices F SizeBound →
+        ∀ n : Nat, ∀ β ε : Rat, ¬ SmallDAGSolver F SizeBound n β ε :=
+  noSmallDAG_of_promiseValueLocalityPackageProviderOnSlices_viaSemanticAndSlack
+
+/-- Asymptotic eventual accepted-family surface wrapper is available. -/
+def check_magnificationStyleNoSmallDAG_surface_of_eventuallyAcceptedFamily :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop)
+      (ε β0 : Rat),
+      0 < ε →
+      0 < β0 →
+      (∀ β : Rat, 0 < β → β < β0 →
+        ∃ nAcc : Nat, ∀ n ≥ nAcc, SmallDAGImpliesAcceptedFamilyAt F SizeBound n β ε) →
+      MagnificationStyleNoSmallDAG (SmallDAGSolver F SizeBound) :=
+  magnificationStyleNoSmallDAG_surface_of_eventuallyAcceptedFamily
+
+/-- Asymptotic eventual promise-YES surface wrapper is available. -/
+def check_magnificationStyleNoSmallDAG_surface_of_eventuallyPromiseYesSubcube :
+    ∀ (F : GapSliceFamily)
+      (SizeBound : Nat → Rat → Rat → Nat → Prop)
+      (ε β0 : Rat),
+      0 < ε →
+      0 < β0 →
+      (∀ β : Rat, 0 < β → β < β0 →
+        ∃ nYes : Nat, ∀ n ≥ nYes, SmallDAGImpliesPromiseYesSubcubeAt F SizeBound n β ε) →
+      MagnificationStyleNoSmallDAG (SmallDAGSolver F SizeBound) :=
+  magnificationStyleNoSmallDAG_surface_of_eventuallyPromiseYesSubcube
+
+/--
+Q3 bridge skeleton (witness-level): slice-indexed strict `InPpolyDAG` witnesses
+compile into explicit `SmallDAGSolver` witnesses for all `(n,β,ε)`.
+-/
+def check_smallDAGSolver_of_inPpolyDAGFamilyOnSlices :
+    ∀ (F : GapSliceFamily)
+      (hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (Models.gapPartialMCSP_Language (F.paramsOf n β))),
+      ∀ n : Nat, ∀ β ε : Rat,
+        SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε :=
+  smallDAGSolver_of_inPpolyDAGFamilyOnSlices
+
+/--
+Q3 bridge skeleton (membership-level): per-slice `PpolyDAG` assumptions are
+lifted to strict witnesses and then to `SmallDAGSolver`.
+-/
+def check_smallDAGSolver_of_PpolyDAGOnSlices :
+    ∀ (F : GapSliceFamily)
+      (hDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.PpolyDAG
+            (Models.gapPartialMCSP_Language (F.paramsOf n β))),
+      let hInDag := inPpolyDAGFamilyOnSlices_of_PpolyDAG F hDag
+      ∀ n : Nat, ∀ β ε : Rat,
+        SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε :=
+  smallDAGSolver_of_PpolyDAGOnSlices
+
+/--
+Eventual strict-witness family bridge exposes the canonical eventual
+`SmallDAGSolver` surface.
+-/
+def check_eventuallySmallDAGSolverSurface_of_eventuallyInPpolyDAGWitnessFamily :
+    ∀ (F : GapSliceFamily)
+      (ε β0 : Rat),
+      0 < ε →
+      0 < β0 →
+      EventuallyInPpolyDAGWitnessFamily F β0 →
+      EventuallySmallDAGSolverSurface F :=
+  eventuallySmallDAGSolverSurface_of_eventuallyInPpolyDAGWitnessFamily
+
+/--
+Eventual proposition-level witness family bridge also lands at the same
+eventual `SmallDAGSolver` surface.
+-/
+def check_eventuallySmallDAGSolverSurface_of_eventuallyPpolyDAGWitnessFamily :
+    ∀ (F : GapSliceFamily)
+      (ε β0 : Rat),
+      0 < ε →
+      0 < β0 →
+      EventuallyPpolyDAGWitnessFamily F β0 →
+      EventuallySmallDAGSolverSurface F :=
+  eventuallySmallDAGSolverSurface_of_eventuallyPpolyDAGWitnessFamily
+
+/--
+Global-language bridge package and transport theorem are available with expected
+types (single-global witness -> slice-wise `PpolyDAG`).
+-/
+def check_ppolyDAGOnSlices_of_globalWitness :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F),
+      ComplexityInterfaces.PpolyDAG bridge.L →
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.PpolyDAG
+            (Models.gapPartialMCSP_Language (F.paramsOf n β)) :=
+  ppolyDAGOnSlices_of_globalWitness
+
+/--
+Global `PpolyDAG` witness bridge to eventual `SmallDAGSolver` surface is
+available with expected type.
+-/
+def check_eventuallySmallDAGSolverSurface_of_globalPpolyDAGWitness :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (ε β0 : Rat),
+      0 < ε →
+      0 < β0 →
+      ComplexityInterfaces.PpolyDAG bridge.L →
+      EventuallySmallDAGSolverSurface F :=
+  eventuallySmallDAGSolverSurface_of_globalPpolyDAGWitness
+
+/--
+FinalResult exports the thin wrapper for the new global-witness bridge.
+-/
+def check_eventuallySmallDAGSolverSurface_surface_of_globalPpolyDAGWitness :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (ε β0 : Rat),
+      0 < ε →
+      0 < β0 →
+      ComplexityInterfaces.PpolyDAG bridge.L →
+      EventuallySmallDAGSolverSurface F :=
+  eventuallySmallDAGSolverSurface_surface_of_globalPpolyDAGWitness
+
+/--
+Global contradiction schema in lower-bounds bridge layer is available.
+-/
+def check_not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hNoSmall :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          ∃ ε : Rat, 0 < ε ∧
+            ∃ β0 : Rat, 0 < β0 ∧
+              ∀ β : Rat, 0 < β → β < β0 →
+                ∃ n0 : Nat, ∀ n ≥ n0,
+                  ¬ SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε),
+      ¬ ComplexityInterfaces.PpolyDAG bridge.L :=
+  not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies
+
+/--
+FinalResult exports the same contradiction schema as a thin boundary wrapper.
+-/
+def check_not_globalPpolyDAG_surface_of_noSmallCanonicalWitnessFamilies :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hNoSmall :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          ∃ ε : Rat, 0 < ε ∧
+            ∃ β0 : Rat, 0 < β0 ∧
+              ∀ β : Rat, 0 < β → β < β0 →
+                ∃ n0 : Nat, ∀ n ≥ n0,
+                  ¬ SmallDAGSolver F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε),
+      ¬ ComplexityInterfaces.PpolyDAG bridge.L :=
+  not_globalPpolyDAG_surface_of_noSmallCanonicalWitnessFamilies
+
+/--
+Concrete accepted-family weak-route contradiction theorem is available.
+-/
+def check_not_globalPpolyDAG_of_acceptedFamilyWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hAcceptedWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          SmallDAGImpliesAcceptedFamilyStatement
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ¬ ComplexityInterfaces.PpolyDAG bridge.L :=
+  not_globalPpolyDAG_of_acceptedFamilyWeakRoute
+
+/--
+Concrete promise-YES weak-route contradiction theorem is available.
+-/
+def check_not_globalPpolyDAG_of_promiseYesWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hYesWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          SmallDAGImpliesPromiseYesSubcubeStatement
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ¬ ComplexityInterfaces.PpolyDAG bridge.L :=
+  not_globalPpolyDAG_of_promiseYesWeakRoute
+
+/--
+Accepted-family weak route + NP witness closure to class-level separation is
+available.
+-/
+def check_NP_not_subset_PpolyDAG_of_acceptedFamilyWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hNP : ComplexityInterfaces.NP bridge.L)
+      (_hAcceptedWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          SmallDAGImpliesAcceptedFamilyStatement
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_acceptedFamilyWeakRoute
+
+/--
+Promise-YES weak route + NP witness closure to class-level separation is
+available.
+-/
+def check_NP_not_subset_PpolyDAG_of_promiseYesWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hNP : ComplexityInterfaces.NP bridge.L)
+      (_hYesWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          SmallDAGImpliesPromiseYesSubcubeStatement
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_promiseYesWeakRoute
+
+/--
+FinalResult exports the accepted-family weak-route contradiction wrapper.
+-/
+def check_not_globalPpolyDAG_surface_of_acceptedFamilyWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hAcceptedWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          SmallDAGImpliesAcceptedFamilyStatement
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ¬ ComplexityInterfaces.PpolyDAG bridge.L :=
+  not_globalPpolyDAG_surface_of_acceptedFamilyWeakRoute
+
+/--
+FinalResult exports the promise-YES weak-route contradiction wrapper.
+-/
+def check_not_globalPpolyDAG_surface_of_promiseYesWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hYesWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          SmallDAGImpliesPromiseYesSubcubeStatement
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ¬ ComplexityInterfaces.PpolyDAG bridge.L :=
+  not_globalPpolyDAG_surface_of_promiseYesWeakRoute
+
+/--
+FinalResult exports accepted-family weak-route class-level separation wrapper.
+-/
+def check_NP_not_subset_PpolyDAG_surface_of_acceptedFamilyWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hNP : ComplexityInterfaces.NP bridge.L)
+      (_hAcceptedWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          SmallDAGImpliesAcceptedFamilyStatement
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_surface_of_acceptedFamilyWeakRoute
+
+/--
+FinalResult exports promise-YES weak-route class-level separation wrapper.
+-/
+def check_NP_not_subset_PpolyDAG_surface_of_promiseYesWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hNP : ComplexityInterfaces.NP bridge.L)
+      (_hYesWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          SmallDAGImpliesPromiseYesSubcubeStatement
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_surface_of_promiseYesWeakRoute
+
+/--
+FinalResult exports PRG-image weak-route contradiction wrapper.
+-/
+def check_not_globalPpolyDAG_surface_of_prgImageAcceptanceWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hPrgWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          prgImageAcceptanceAtProviderOnSlices
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ¬ ComplexityInterfaces.PpolyDAG bridge.L :=
+  not_globalPpolyDAG_surface_of_prgImageAcceptanceWeakRoute
+
+/--
+FinalResult exports stronger-fallback weak-route contradiction wrapper.
+-/
+def check_not_globalPpolyDAG_surface_of_restrictionFallbackWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hFallbackWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          ∃ hExtract :
+            smallDAGWitnessRestrictionExtractionProviderOnSlices
+              F (ppolyDAGSizeBoundOnSlices F hInDag),
+            smallDAGWitnessRestrictionNumericDataProviderOnSlices
+              F (ppolyDAGSizeBoundOnSlices F hInDag) hExtract),
+      ¬ ComplexityInterfaces.PpolyDAG bridge.L :=
+  not_globalPpolyDAG_surface_of_restrictionFallbackWeakRoute
+
+/--
+FinalResult exports PRG-image weak-route class-level separation wrapper.
+-/
+def check_NP_not_subset_PpolyDAG_surface_of_prgImageAcceptanceWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hNP : ComplexityInterfaces.NP bridge.L)
+      (_hPrgWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          prgImageAcceptanceAtProviderOnSlices
+            F (ppolyDAGSizeBoundOnSlices F hInDag)),
+      ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_surface_of_prgImageAcceptanceWeakRoute
+
+/--
+FinalResult exports stronger-fallback weak-route class-level separation wrapper.
+-/
+def check_NP_not_subset_PpolyDAG_surface_of_restrictionFallbackWeakRoute :
+    ∀ (F : GapSliceFamily)
+      (bridge : AsymptoticDAGLanguageBridge F)
+      (_hNP : ComplexityInterfaces.NP bridge.L)
+      (_hFallbackWeak :
+        ∀ hInDag :
+          ∀ n : Nat, ∀ β : Rat,
+            ComplexityInterfaces.InPpolyDAG
+              (Models.gapPartialMCSP_Language (F.paramsOf n β)),
+          ∃ hExtract :
+            smallDAGWitnessRestrictionExtractionProviderOnSlices
+              F (ppolyDAGSizeBoundOnSlices F hInDag),
+            smallDAGWitnessRestrictionNumericDataProviderOnSlices
+              F (ppolyDAGSizeBoundOnSlices F hInDag) hExtract),
+      ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_surface_of_restrictionFallbackWeakRoute
+
+end Pnp3.Tests


### PR DESCRIPTION
### Motivation
- Expose a thin asymptotic bridge from global `PpolyDAG` witnesses to the per-slice `SmallDAGSolver` surface so quantifier plumbing is available for later bridge work. 
- Factor the main near-term DAG source target into a semantic one-sided forcing part and a quantitative slack part so the Q1/Q2 theorem sprint decomposition is explicit and composable. 
- Keep `FinalResult` as a thin surface-only file by wiring brief wrappers from the new lower-bound bridge layer into the magnification final surface. 

### Description
- Added a new asymptotic bridge layer in `pnp3/LowerBounds/AsymptoticDAGBarrier.lean` including `ppolyDAGSizeBoundOnSlices`, `smallDAGSolver_of_*` bridges, eventual-witness surfaces (`EventuallyInPpolyDAGWitnessFamily`, `EventuallySmallDAGSolverSurface`), the `AsymptoticDAGLanguageBridge` packaging structure, and global-to-slice contradiction/closure theorems (`not_globalPpolyDAG_of_*`, `NP_not_subset_PpolyDAG_of_*`).
- Split the promise-YES source interface in `pnp3/LowerBounds/DAGStableRestrictionProducer.lean` by introducing `PromiseYesSourceDecompositionAt`, provider-level Q1/Q2 types (`promiseYesAcceptanceInvariantAtProviderOnSlices`, `promiseYesSlackOnInvariantProviderOnSlices`) and compilation/closure helpers (`promiseYesSubcubeCertificateAt_of_sourceDecomposition`, `noSmallDAG_of_promiseYesSemanticAndSlackProvidersOnSlices`, plus reductions from the existing pairwise package into the split API).
- Exposed thin final-surface wrappers in `pnp3/Magnification/FinalResult.lean` that consume the new lower-bounds bridge layer (accepted-family, promise-YES, PRG-image backup, restriction fallback, eventual/global-witness wrappers and corresponding contradiction/NP-closure wrappers). Also imported the new barrier module where needed.
- Added the weak-route surface smoke test module `pnp3/Tests/WeakRouteSurfaceTests.lean` and enabled it in the build (`lakefile.lean`) and imported it into `Tests.SmokeTests` to provide a lightweight regression surface that pins exported theorem types.

### Testing
- Ran the project's compilation/typecheck smoke tests including the `Tests.TestDriver` surface which now includes `Tests.WeakRouteSurfaceTests`, and verified the codebase type-checks; the automated smoke tests succeeded. 
- Confirmed that the new `WeakRouteSurfaceTests.lean` elaborates the exported `FinalResult`/lower-bounds wrappers and the new bridge APIs by compilation; the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c70b4e8094832b818f2992b08fc794)