### PR TITLE
Clarify and enforce Partial‑MCSP as the active MCSP variant; add guardrails and doc updates

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -21,6 +21,13 @@ These compile on the current tree.
 
 No. Current `P_ne_NP_final` is conditional.
 
+## Are we currently using GapMCSP or Partial MCSP in active code?
+
+Active code (`pnp3/`) uses **Partial MCSP** (`GapPartialMCSP*` objects).
+Legacy GapMCSP material is preserved under `archive/` for provenance only.
+If a document references GapMCSP, verify whether it is archival before treating
+it as a statement about the active pipeline.
+
 ## Is the active tree axiom-free in the strictest sense?
 
 No. Active `pnp3/` has no project-local `axiom` and no `sorry/admit`, but the

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ the form:
 The active `pnp3/` branch is maintained as an auditable contract: what is
 constructively formalized now, and what assumptions are still explicit.
 
+## MCSP Variant Boundary (Audit-Critical)
+
+Active `pnp3/` development uses **Partial MCSP** (`GapPartialMCSP*` names).
+
+- Working model: `pnp3/Models/Model_PartialMCSP.lean`.
+- Active language/promise names: `gapPartialMCSP_Language`,
+  `GapPartialMCSPPromise`.
+- Legacy **GapMCSP (total-table)** material is retained only under `archive/`
+  for provenance and must not be treated as active pipeline code.
+
+When reviewing current claims, prefer `pnp3/` + top-level status docs and treat
+`archive/` as historical context only.
+
 ## Current State (No Overstatement)
 
 - `pnp3/` builds; `./scripts/check.sh` passes.

--- a/pnp3/Magnification/Facts_Magnification_Partial.lean
+++ b/pnp3/Magnification/Facts_Magnification_Partial.lean
@@ -33,7 +33,8 @@ Restriction-style locality witness used by the partial magnification bridge.
 
 It packages:
 * a polylog test set `T`,
-* a local solver `loc` for the partial GapMCSP promise,
+* a local solver `loc` for the active partial-MCSP promise
+  (`Models.GapPartialMCSPPromise p`),
 * numerical bounds matching the locality-lift shape.
 -/
 def RestrictionLocalityPartial (p : GapPartialMCSPParams) : Prop :=

--- a/pnp3/README.md
+++ b/pnp3/README.md
@@ -15,6 +15,16 @@
 
 `SAL -> Covering-Power -> anti-checker -> magnification -> DAG-final wrappers`
 
+## Граница вариантов MCSP (важно для аудита)
+
+В активном `pnp3/` используется **только Partial MCSP**:
+
+- модель: `Models/Model_PartialMCSP.lean`;
+- язык/обещание: `gapPartialMCSP_Language`, `GapPartialMCSPPromise`.
+
+Legacy-модель **GapMCSP (total truth table)** хранится в `archive/` и не
+является источником текущего активного статуса.
+
 Текущая DAG-граница формализована через
 `pnp3/LowerBounds/AsymptoticDAGBarrier.lean`:
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -72,6 +72,24 @@ if [[ -f pnp3/Complexity/Interfaces_InternalSource.lean ]]; then
   exit 1
 fi
 
+# MCSP-variant guardrails:
+# active code must stay on Partial-MCSP names; total-table GapMCSP is legacy.
+if rg -n "^[[:space:]]*import[[:space:]]+Models\\.Model_GapMCSP\\b" -g"*.lean" \
+    pnp3 >/tmp/pnp3_gapmcsp_import_hits.log; then
+  echo "Detected forbidden import of legacy total-table model Models.Model_GapMCSP in active pnp3:"
+  cat /tmp/pnp3_gapmcsp_import_hits.log
+  exit 1
+fi
+
+# Allow the token `GapMCSPParams` only in the explicit third-party interop
+# adapter where we map external naming into Partial-MCSP semantics.
+if rg -n "\\bGapMCSPParams\\b" -g"*.lean" pnp3 \
+    -g"!pnp3/ThirdPartyFacts/PartialLocalityLift.lean" >/tmp/pnp3_gapmcsp_name_hits.log; then
+  echo "Detected unexpected GapMCSPParams usage outside the dedicated Partial interop adapter:"
+  cat /tmp/pnp3_gapmcsp_name_hits.log
+  exit 1
+fi
+
 if rg -n "^[[:space:]]*import[[:space:]]+Complexity\\.Interfaces_InternalSource\\b" -g"*.lean" \
     pnp3 >/tmp/pnp3_internal_source_import_hits.log; then
   echo "Detected forbidden import of legacy internal-source interface module:"


### PR DESCRIPTION
### Motivation

- Make explicit that the active `pnp3/` pipeline uses Partial MCSP (not the legacy total-table GapMCSP) and ensure reviewers treat `archive/` as historical provenance only.
- Update in-code documentation and magnification facts to reference the active Partial-MCSP interfaces and promise names for audit clarity.
- Prevent accidental reintroduction of legacy GapMCSP imports or names into the active `pnp3/` codebase via automated guardrails.

### Description

- Updated top-level docs (`FAQ.md`, `README.md`, `pnp3/README.md`) to document the MCSP variant boundary and to point readers to the active `pnp3/Models/Model_PartialMCSP.lean` and `gapPartialMCSP_*` symbols while noting `archive/` is legacy. 
- Edited `pnp3/Magnification/Facts_Magnification_Partial.lean` to update comments and a locality definition to explicitly reference the partial-MCSP promise (`Models.GapPartialMCSPPromise`) and to clarify the active semantics. 
- Added MCSP-variant guardrail checks to `scripts/check.sh` to forbid importing `Models.Model_GapMCSP` in `pnp3/` and to disallow use of the token `GapMCSPParams` outside the dedicated interop adapter `pnp3/ThirdPartyFacts/PartialLocalityLift.lean`.

### Testing

- Ran the repository checks via `./scripts/check.sh` and the script completed without errors. 
- Verified that the updated `pnp3/` documentation and the added `check.sh` guardrails do not produce any new import/name violations under the current tree when the checks are executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccd9d842b4832bae419c196ab47fe7)