### PR TITLE
Canonical closure-route policy, documentation updates, and route-policy checks

### DIFF
--- a/CHECKLIST_UNCONDITIONAL_P_NE_NP.md
+++ b/CHECKLIST_UNCONDITIONAL_P_NE_NP.md
@@ -1,13 +1,15 @@
 # Checklist: Unconditional Constructive `P ≠ NP`
 
-Updated: 2026-04-03
+Updated: 2026-04-04
 
 This is the canonical checklist for what still blocks an unconditional
 in-repo theorem `P ≠ NP`.
 
-For the current interim release posture, see `RELEASE_RC.md`.
-For the current DAG route plan, see
+For current release posture, see `RELEASE_RC.md`.
+For current DAG route plan, see
 `pnp3/Docs/Unconditional_NP_not_subset_PpolyDAG_Plan.md`.
+For hard route policy lock, see
+`pnp3/Docs/CLOSURE_ROUTE_POLICY.md`.
 
 ## Current final API (actual code)
 
@@ -23,72 +25,57 @@ P_ne_NP_final
   (hNPDag : NP_not_subset_PpolyDAG)
 ```
 
-Additional honest DAG-facing surfaces already present:
-
-- asymptotic fixed-slice collapse wrappers;
-- stable-restriction / source-closure / blocker `_TM` wrappers;
-- support-half accepted-family fallback wrappers.
-
 ## What is already closed
 
 1. Active `pnp3/` tree is axiom-clean (`axiom = 0`, `sorry/admit = 0`).
-2. `./scripts/check.sh` passes on the current tree.
+2. `./scripts/check.sh` passes on current tree.
 3. Inclusion is internalized via
    `proved_P_subset_PpolyDAG_internal : P_subset_PpolyDAG`.
-4. The DAG endpoint surface is no longer blocked on plumbing.
+4. DAG endpoint wiring is closed (wrappers/source-closure plumbing in place).
+5. Historical fixed-slice support-half branch is explicitly archived as no-go
+   route modules:
+   - `FailedRoute_FixedSliceSupportHalfCore.lean`
+   - `FailedRoute_FixedSliceSupportHalfImpossible.lean`.
 
 ## Remaining unconditional blockers
 
 ### Blocker A. Internal DAG separation theorem
 
-The repository still lacks an internal theorem
+Still missing internal theorem:
 
 ```text
 ComplexityInterfaces.NP_not_subset_PpolyDAG
 ```
 
-This is the real logical blocker behind the current external argument
-`hNPDag`.
+without an external DAG-separation assumption.
 
 ### Blocker B. Public final API cleanup
 
-Even after Blocker A is solved, the public theorem is not yet fully
-assumption-free while it still exposes
+Even after Blocker A, public theorem is not assumption-free while it still
+exposes:
 
 ```text
 hMag : MagnificationAssumptions
 ```
 
-The current implementation does not consume `hMag`, but the public theorem
-still syntactically takes it.
+Therefore full unconditionality requires both:
 
-Therefore full unconditionality requires:
+1. internal DAG separation,
+2. zero-argument public final theorem.
 
-1. internal DAG separation, and
-2. a zero-argument public final theorem.
+## Single active practical route (policy)
 
-## Practical closure routes
+Use only asymptotic/eventual theorem route:
 
-### Fastest path to remove `hNPDag`
+1. prove eventual weak-route source theorem (`acceptedFamily` or `promiseYes`),
+2. prove/instantiate required length-local bridge,
+3. derive class-level contradiction payload,
+4. instantiate existing wrappers to get internal
+   `ComplexityInterfaces.NP_not_subset_PpolyDAG`,
+5. remove external `hNPDag`,
+6. remove residual `hMag`.
 
-1. Pick a fixed slice
-   `p* := hMag.antiChecker.asymptotic.pAt n hn`.
-2. Prove one fixed-slice DAG source theorem, preferably
-   `gapPartialMCSP_supportHalfObligation p*`,
-   or equivalently `dagRouteBSourceBlocker p*`,
-   or otherwise `dag_stableRestriction_producer p*`.
-3. Feed that theorem into the already compiled asymptotic fixed-slice wrappers.
-
-### Fastest path to a zero-argument final theorem
-
-1. Choose a concrete fixed slice `p*`.
-2. Provide a concrete `GapPartialMCSP_TMWitness p*`.
-3. Prove a fixed-slice blocker on `p*`.
-4. Route that data through the existing `_TM` final wrappers.
-
-Alternative:
-
-- internalize the magnification-assumption package instead of bypassing it.
+Do **not** treat literal fixed-slice blocker hunt as active closure route.
 
 ## Proof-quality safety checks
 
@@ -102,17 +89,16 @@ Before declaring any blocker closed, confirm:
    `pnp3/Tests/BridgeLocalityRegression.lean`,
    `pnp3/Tests/WeakRouteSurfaceTests.lean`.
 3. Final endpoints in `pnp3/Magnification/FinalResultCore.lean`
-   (and compatibility import path `FinalResult.lean`) still compile.
+   (and compatibility path `FinalResult.lean`) still compile.
 4. No document claims unconditional `P ≠ NP` prematurely.
 
 ## Definition of done
 
 All of the following must hold at once:
 
-1. The repository proves `ComplexityInterfaces.NP_not_subset_PpolyDAG`
-   internally.
-2. The public final theorem no longer requires external `hNPDag`.
-3. The public final theorem no longer exposes compatibility-only `hMag`.
-4. A zero-argument theorem `P_ne_NP` is derivable in the active tree.
+1. Repository proves `ComplexityInterfaces.NP_not_subset_PpolyDAG` internally.
+2. Public final theorem no longer requires external `hNPDag`.
+3. Public final theorem no longer exposes compatibility-only `hMag`.
+4. Zero-argument theorem `P_ne_NP` is derivable in active tree.
 5. `README.md`, `STATUS.md`, `TODO.md`, and `AXIOMS_FINAL_LIST.md` are updated
-   to state unconditional status explicitly and consistently.
+   consistently to unconditional wording.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Project Status (current)
 
-Updated: 2026-04-03
+Updated: 2026-04-04
 
 Authoritative checklist:
 `CHECKLIST_UNCONDITIONAL_P_NE_NP.md`.
@@ -8,6 +8,8 @@ Current release posture:
 `RELEASE_RC.md`.
 Current DAG-route plan:
 `pnp3/Docs/Unconditional_NP_not_subset_PpolyDAG_Plan.md`.
+Route policy lock:
+`pnp3/Docs/CLOSURE_ROUTE_POLICY.md`.
 
 ## Verified State
 
@@ -39,14 +41,24 @@ Current DAG-route plan:
   `..._of_asymptotic_sourceClosure`,
   `..._of_asymptotic_blocker`,
   together with companion `P_ne_NP_final_of_*` wrappers.
-- Canonical witness-density hardwire coverage is closed, including
-  `canonicalEasyFamilyRealizesAllPatternsUpTo_of_hardwireCircuitBound`.
-- Canonical all-slices builders now exist from extraction/support budgets into
+- Canonical all-slices builders exist from extraction/support budgets into
   witness-easy-density / witness-uniform-lower / witness-transfer-quarter
   debts.
-- Support-half fallback closure is compiled through accepted-family surfaces:
+- Support-half accepted-family fallback closure is compiled through
   `noSmallDAG_of_supportHalfBoundFamily` and
   `NP_not_subset_PpolyDAG_surface_of_supportHalfBoundFamily`.
+
+### Fixed-slice no-go status (closed historical branch)
+
+The repository already formalizes that the historical fixed-slice support-half
+route is closed as a no-go branch under fixed-slice `PpolyDAG` membership:
+
+- `no_fixedSlice_stableRestriction_of_inPpolyDAG`
+- `no_fixedSlice_blocker_of_inPpolyDAG`
+- `not_gapPartialMCSP_supportHalfObligation_of_inPpolyDAG`
+
+Interpretation: literal fixed-slice blocker proving is **not** the active path
+for unconditional closure.
 
 ## What Is Still Open
 
@@ -70,70 +82,28 @@ P_ne_NP_final
   (hNPDag : NP_not_subset_PpolyDAG)
 ```
 
-The important reality split is:
+Reality split:
 
 1. `hNPDag` is the real remaining DAG-separation blocker.
-2. `hMag` remains in the signature only as compatibility context; the current
-   implementation does not consume it.
+2. `hMag` remains in the signature only as compatibility context.
 
-So the repo is not yet unconditional either in the DAG theorem layer or in the
-default public final API.
+## Single active closure route (current policy)
 
-## Best Current Closure Order
+Only one route is considered active for internal DAG separation:
 
-### 1. Fastest path to remove `hNPDag` from the `hMag`-based final route
-
-Use one fixed slice
-`p* := hMag.antiChecker.asymptotic.pAt n hn`
-and prove a fixed-slice source theorem, preferably:
-
-- `gapPartialMCSP_supportHalfObligation p*`,
-- or equivalently `dagRouteBSourceBlocker p*`,
-- or otherwise `dag_stableRestriction_producer p*`.
-
-This is now the shortest honest route because the asymptotic collapse wrappers
-are already compiled.
-
-### 2. Path to full unconditionality
-
-Removing `hNPDag` from the current compatibility theorem is not the same as
-producing a zero-argument theorem.
-
-For full unconditionality, one of the following must still happen:
-
-- bypass `hMag` with a concrete fixed slice `p*`, a concrete
-  `GapPartialMCSP_TMWitness p*`, and a fixed-slice blocker fed into the `_TM`
-  wrappers; or
-- internalize the magnification-assumption package itself.
-
-## Research Tracks
-
-### Track A: fixed-slice integration route
-
-This is the practical near-term route for current public API cleanup.
-It uses the already existing asymptotic fixed-slice collapse wrappers and needs
-only one fixed-slice DAG theorem.
-
-### Track B: canonical all-slices witness route
-
-The codebase already contains:
-
-- `canonical_smallDAG_witnessEasyDensity_source_on_slices`,
-- `canonical_smallDAG_witnessUniformLower_source_on_slices`,
-- `canonical_smallDAG_witnessTransferQuarter_source_on_slices`,
-- and compilers from support/extraction budgets into those debts.
-
-This remains a legitimate theorem program for a standalone internal
-`NP_not_subset_PpolyDAG`, but it is not the shortest current path to cleaning
-up the existing final API.
-
-### Track C: restricted-model fallback
-
-Support-half and related restricted-model closures are now useful because they
-already terminate at class-level non-inclusion surfaces. They are no longer
-mere diagnostics.
+1. prove one **asymptotic/eventual** source theorem on a non-vacuous surface
+   (eventual quantification + length-local bridge assumptions),
+2. discharge one weak-route class-level theorem payload
+   (`...acceptedFamily...` or `...promiseYes...`),
+3. feed that payload through existing endpoint wrappers to internalize
+   `ComplexityInterfaces.NP_not_subset_PpolyDAG`,
+4. then remove external `hNPDag` from the public final theorem,
+5. then remove residual `hMag` to reach zero-argument `P_ne_NP`.
 
 ## Repository-Wide Honesty Policy
 
-Any file claiming unconditional `P ≠ NP` before the DAG theorem and the final
-public API are both internalized is inaccurate.
+Any file claiming unconditional `P ≠ NP` before both of the following are
+internalized is inaccurate:
+
+1. internal DAG separation theorem;
+2. zero-argument public final API.

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO / Roadmap (current)
 
-Updated: 2026-04-03
+Updated: 2026-04-04
 
 Canonical checklist:
 `CHECKLIST_UNCONDITIONAL_P_NE_NP.md`.
@@ -8,6 +8,8 @@ Current release wording guardrail:
 `RELEASE_RC.md`.
 Current DAG plan:
 `pnp3/Docs/Unconditional_NP_not_subset_PpolyDAG_Plan.md`.
+Route policy lock:
+`pnp3/Docs/CLOSURE_ROUTE_POLICY.md`.
 
 ## Snapshot
 
@@ -15,11 +17,24 @@ Current DAG plan:
 - Active `sorry/admit` in `pnp3/`: `0`.
 - `./scripts/check.sh` passes.
 - Inclusion is already internalized.
-- The remaining work is theorem-level, not endpoint plumbing.
+- Remaining debt is theorem-level source mathematics.
+
+## Hard policy update: fixed-slice branch is not an active target
+
+The fixed-slice support-half blocker branch is now treated as a closed
+historical no-go direction for unconditional closure planning.
+
+This is already reflected by dedicated failed-route modules:
+
+- `LowerBounds/FailedRoute_FixedSliceSupportHalfCore.lean`
+- `LowerBounds/FailedRoute_FixedSliceSupportHalfImpossible.lean`
+
+So roadmap execution must not prioritize proving unconditional separation from a
+literal single fixed slice.
 
 ## The Two Remaining Closure Targets
 
-### Target 1. Replace fixed-slice blocker hunt with a sound asymptotic source theorem
+### Target 1. Internalize `NP_not_subset_PpolyDAG` via asymptotic/eventual route
 
 Current public default theorem still requires:
 
@@ -27,72 +42,65 @@ Current public default theorem still requires:
 hNPDag : ComplexityInterfaces.NP_not_subset_PpolyDAG
 ```
 
-The old fixed-slice route is no longer treated as the main theorem target.
-Current priority is to migrate source-side statements to non-vacuous
-asymptotic surfaces and close one family-level theorem that can feed the
-existing wrappers.
+Active theorem route is exactly:
 
-Immediate shape of this target:
-
-1. move one core source statement from `GapSliceFamily` to
-   eventual-indexed form (`GapSliceFamilyEventually`);
-2. switch from all-length bridge assumptions to length-local bridges
-   (`AsymptoticDAGSliceBridgeAt`);
-3. prove one non-vacuous family-level source theorem on that migrated surface;
-4. reconnect the theorem payload to already compiled endpoint wrappers.
+1. prove one eventual source theorem on a non-vacuous surface;
+2. use length-local bridge assumptions (not all-length global bridge claims);
+3. close one weak-route class-level payload (`acceptedFamily` or
+   `promiseYes` family);
+4. reconnect to existing wrappers without adding new endpoint plumbing.
 
 ### Target 2. Remove remaining public `hMag`
 
-Even after `hNPDag` is internalized, the public theorem is not yet zero-arg.
-The current default wrapper still takes `hMag` for compatibility.
+Even after Target 1 is done, theorem is not yet zero-arg while it still takes
+`hMag` for compatibility.
 
-To reach a genuinely unconditional top-level theorem, we still need either:
+To reach a genuinely unconditional top-level theorem, still need either:
 
-1. a concrete fixed-slice `GapPartialMCSP_TMWitness p*` plus a **sound**
-   fixed-slice source theorem, routed through `_TM` wrappers; or
-2. an internal proof of the current magnification-assumption package.
+1. full API cleanup/internalization that removes compatibility `hMag`; or
+2. a fully internal route proving the same payload without exposing
+   magnification assumptions in the public theorem surface.
 
 ## Execution Order
 
-### Task 1. Keep docs and audit wording honest
+### Task 1. Keep docs and audit wording strict
 
-Status: done for the current snapshot.
+Status: active discipline.
 
 Rule:
 
-- do not say the repository proves unconditional `P ≠ NP`;
-- distinguish clearly between
-  `remove hNPDag from the current route`
-  and
-  `produce a zero-argument final theorem`.
+- do not claim unconditional `P ≠ NP` yet;
+- do not present fixed-slice historical branch as current closure plan;
+- keep a single canonical active route across docs.
 
-### Task 2. Migrate one source surface to eventual/length-local form
+### Task 2. Prove one eventual weak-route source theorem (main blocker)
 
 Status: active blocker.
 
-Preferred near-term theorem targets:
+Immediate theorem targets:
 
-1. one migrated source statement on `GapSliceFamilyEventually`;
-2. one length-local bridge theorem via `AsymptoticDAGSliceBridgeAt`;
-3. one non-vacuous family-level contradiction payload consumable by existing
-   wrappers.
+1. one eventual accepted-family or promise-YES theorem with explicit
+   `n ≥ n0(β)` shape;
+2. one length-local bridge theorem sufficient to push global `PpolyDAG` witness
+   down to the targeted slices;
+3. one class-level contradiction payload consumable by existing wrappers.
 
 Acceptance condition:
 
-- at least one existing asymptotic wrapper is callable from the migrated
-  family-level theorem surface, without adding new endpoint plumbing.
+- at least one existing asymptotic wrapper is callable from the new eventual
+  source theorem, without new endpoint names.
 
 ### Task 3. Internalize `NP_not_subset_PpolyDAG`
 
 Status: pending on Task 2.
 
-Possible routes:
+Delivery condition:
 
-1. canonical all-slices witness-transfer route (primary);
-2. concrete `_TM` route with a sound fixed-slice source theorem (secondary);
-3. internalization of the magnification package after DAG-side internalization.
+- produce internal theorem
+  `ComplexityInterfaces.NP_not_subset_PpolyDAG`
+  with no external DAG-separation assumption.
 
-### Task 4. Replace the current compatibility final theorem
+### Task 4. Replace compatibility final theorem surface
 
 Status: pending on Task 3.
 
@@ -106,50 +114,20 @@ P_ne_NP_final
 
 Required end state:
 
-- a zero-argument public theorem, or at minimum
-- a theorem with no external DAG separation input.
+- no external `hNPDag` and then no residual `hMag` in public endpoint.
 
-### Task 5. Preserve the all-slices research track without mistaking it for the immediate blocker
-
-Status: active as parallel theorem program, not as the shortest integration
-task.
-
-Existing infrastructure already covers:
-
-- witness easy density,
-- witness uniform lower,
-- witness transfer quarter,
-- compilers from extraction/support budgets,
-- support-half family fallback builders.
-
-The remaining debt there is source mathematics, not glue.
-
-### Task 6. Final consistency pass after theorem closure
+### Task 5. Final consistency pass
 
 Status: pending.
 
-Do after the theorem work, not before:
+After theorem closure:
 
-1. switch `README.md`, `STATUS.md`, `TODO.md`, `CHECKLIST_*`, and publication
-   docs to unconditional wording only after the public theorem is actually
-   unconditional;
-2. rerun:
-
-```bash
-./scripts/check.sh
-for f in pnp3/Tests/AxiomsAudit.lean \
-         pnp3/Tests/BarrierAudit.lean \
-         pnp3/Tests/BarrierBypassAudit.lean \
-         pnp3/Tests/BridgeLocalityRegression.lean \
-         pnp3/Tests/WeakRouteSurfaceTests.lean; do
-  lake env lean "$f"
-done
-```
+1. update `README.md`, `STATUS.md`, `TODO.md`, `CHECKLIST_*`, release docs;
+2. rerun full `./scripts/check.sh` and audit tests.
 
 ## Non-Goals Right Now
 
-- Do not add new endpoint wrappers just to create apparent progress.
-- Do not relabel the canonical all-slices route as “done” while it still lacks
-  the source theorem.
-- Do not claim that removing `hNPDag` automatically yields full
-  unconditionality while `hMag` still appears in the public theorem surface.
+- Do not add wrappers just to show apparent progress.
+- Do not reopen fixed-slice support-half as a primary theorem target.
+- Do not claim that removing only `hNPDag` yields full unconditionality while
+  `hMag` remains in public theorem.

--- a/pnp3/Docs/CLOSURE_ROUTE_POLICY.md
+++ b/pnp3/Docs/CLOSURE_ROUTE_POLICY.md
@@ -1,0 +1,39 @@
+# Closure Route Policy (canonical)
+
+Updated: 2026-04-04.
+
+This file is a hard policy reference for DAG-side closure planning.
+It exists to prevent ambiguous routing language from re-entering status docs.
+
+## One active route
+
+Only one active route is allowed in canonical planning docs:
+
+1. asymptotic/eventual source theorem,
+2. length-local bridge assumptions,
+3. weak-route class-level payload,
+4. internal `ComplexityInterfaces.NP_not_subset_PpolyDAG`,
+5. then API cleanup (`hNPDag`, then `hMag`).
+
+## Closed/no-go route
+
+Literal fixed-slice blocker hunt is a closed historical no-go route for
+unconditional closure planning.
+
+Relevant no-go modules:
+
+- `pnp3/LowerBounds/FailedRoute_FixedSliceSupportHalfCore.lean`
+- `pnp3/LowerBounds/FailedRoute_FixedSliceSupportHalfImpossible.lean`
+
+## Documentation guardrails
+
+Canonical docs (`STATUS.md`, `TODO.md`,
+`CHECKLIST_UNCONDITIONAL_P_NE_NP.md`,
+`pnp3/Docs/Unconditional_NP_not_subset_PpolyDAG_Plan.md`, and this file)
+must satisfy all of the following:
+
+1. explicitly mention fixed-slice no-go status,
+2. explicitly mention asymptotic/eventual + length-local active route,
+3. avoid deprecated phrasing that presents fixed-slice as the fastest route.
+
+This policy is enforced in `scripts/check.sh`.

--- a/pnp3/Docs/Unconditional_NP_not_subset_PpolyDAG_Plan.md
+++ b/pnp3/Docs/Unconditional_NP_not_subset_PpolyDAG_Plan.md
@@ -1,56 +1,42 @@
 # Concrete plan to reach unconditional `NP ⊄ PpolyDAG`
 
-Last updated: 2026-04-03.
+Last updated: 2026-04-04.
 
-This file tracks the **current** DAG-side closure plan after the latest
-hardwire-coverage, support-half fallback, and asymptotic fixed-slice wrapper
-work.
-
-It is intentionally narrower than older roadmap notes. The main goal here is
-to state what is already done, what is still open, and what the shortest honest
-next theorem is.
+This file is the canonical DAG-side theorem plan for the active branch.
+Hard policy reference:
+`pnp3/Docs/CLOSURE_ROUTE_POLICY.md`.
 
 ## 1. Current verified state
 
-The repository now already has:
+Already true in repository:
 
-1. `./scripts/check.sh` passing on the active tree.
+1. `./scripts/check.sh` passes.
 2. No active project-local `axiom` and no active `sorry/admit` in `pnp3/`.
-3. Route-B blocker packaging:
-   `dagRouteBSourceBlocker`,
-   `DAGRouteBSourceClosure`,
-   direct `_TM` finals from stable restriction / source closure / blocker.
-4. Asymptotic fixed-slice wrappers:
-   `NP_not_subset_PpolyDAG_final_of_asymptotic_fixedSliceCollapse`,
-   `..._of_asymptotic_dag_stableRestriction`,
-   `..._of_asymptotic_sourceClosure`,
-   `..._of_asymptotic_blocker`,
-   plus companion `P_ne_NP_final_of_*`.
-5. Canonical witness-density hardwire coverage:
-   `canonicalEasyFamilyRealizesAllPatternsUpTo_of_hardwireCircuitBound`.
-6. Canonical all-slices compiler glue:
-   `canonical_smallDAG_witnessEasyDensity_source_on_slices_of_supportBudget`,
-   `...witnessUniformLower...`,
-   `...witnessTransferQuarter...`,
-   and their support-half-family variants.
-7. Support-half fallback closure to class-level DAG non-inclusion:
-   `noSmallDAG_of_supportHalfBoundFamily` and
-   `NP_not_subset_PpolyDAG_surface_of_supportHalfBoundFamily`.
+3. Endpoint plumbing is in place:
+   - Route-B packaging: `dagRouteBSourceBlocker`, `DAGRouteBSourceClosure`.
+   - Final wrappers: asymptotic and `_TM` surfaces in magnification finals.
+4. Weak-route class-level surfaces are implemented:
+   - `NP_not_subset_PpolyDAG_of_acceptedFamilyWeakRoute`,
+   - `NP_not_subset_PpolyDAG_of_promiseYesWeakRoute`.
+5. Eventual magnification-style aggregation lemmas are implemented:
+   - `magnificationStyleNoSmallDAG_of_eventually_acceptedFamily`,
+   - `magnificationStyleNoSmallDAG_of_eventually_promiseYesSubcube`.
 
 Conclusion:
 
-> The repository is no longer blocked on DAG endpoint plumbing.
-> The remaining debt is theorem-level.
+> endpoint wiring is not the blocker; source theorem debt is the blocker.
 
 ## 2. What is still not closed
 
-There is still no internal theorem
+Still missing internal theorem:
 
 ```text
 ComplexityInterfaces.NP_not_subset_PpolyDAG
 ```
 
-and therefore the public default final theorem is still:
+without external DAG-separation input.
+
+Current public final theorem still has compatibility shape:
 
 ```text
 P_ne_NP_final
@@ -58,169 +44,82 @@ P_ne_NP_final
   (hNPDag : NP_not_subset_PpolyDAG)
 ```
 
-Important split:
+So there are two closure layers:
 
-1. `hNPDag` is the real DAG-separation blocker.
-2. `hMag` remains in the public theorem only as compatibility context and is
-   not consumed by its current implementation.
+1. internalize DAG separation (`hNPDag` removal),
+2. remove residual compatibility `hMag`.
 
-So there are really two closure goals:
+## 3. Hard policy: fixed-slice branch is a closed historical no-go route
 
-1. remove external `hNPDag`;
-2. then remove the residual public `hMag`.
+The literal fixed-slice support-half branch is no longer an active target.
+This is documented in code-level no-go modules:
 
-## 3. Current blocker reassessment (fixed-slice route)
+- `LowerBounds/FailedRoute_FixedSliceSupportHalfCore.lean`
+- `LowerBounds/FailedRoute_FixedSliceSupportHalfImpossible.lean`
 
-The previous "fastest route" (prove one fixed-slice blocker and collapse) is
-no longer considered reliable as a primary theorem target.
+Interpretation for planning:
 
-Reason in one line:
+- keep fixed-slice wrappers only as endpoint compatibility plumbing,
+- do not spend theorem budget on reviving single-slice blocker hunt.
 
-> the fixed-slice support-half blocker quantifies over **all** strict DAG
-> witnesses while support is syntactic, so tautological rewiring/hardwiring
-> phenomena can invalidate the target for a fixed language.
+## 4. Single active theorem route
 
-### Step A. Pick one slice from the existing magnification package
+Only active route for internal DAG separation:
 
-Use
+1. Choose one asymptotic family surface (`GapSliceFamily` route already wired).
+2. Prove one **eventual** source theorem (for all large enough `n`) in one of
+   these forms:
+   - accepted-family route, or
+   - promise-YES route.
+3. Keep bridges **length-local**; avoid all-length global equalities as closure
+   assumptions.
+4. Use weak-route class-level theorem surface to derive
+   `ComplexityInterfaces.NP_not_subset_PpolyDAG` internally.
+5. Feed result into existing final wrappers (no new endpoint names).
+
+## 5. Exact immediate theorem target (next merge objective)
+
+Deliver one theorem with concrete shape:
 
 ```text
-p* := hMag.antiChecker.asymptotic.pAt n hn
+∀ β, 0 < β → β < β0 → ∃ n0, ∀ n ≥ n0, SourceAt(n, β, ε)
 ```
 
-### Step B. Do **not** prioritize fixed-slice support-half blockers as a core milestone
+where `SourceAt` is either:
 
-Deprecated as a preferred route:
+1. `SmallDAGImpliesAcceptedFamilyAt ...`, or
+2. `SmallDAGImpliesPromiseYesSubcubeAt ...`.
 
-1. `gapPartialMCSP_supportHalfObligation p*`
-2. `dagRouteBSourceBlocker p*`
-3. `dag_stableRestriction_producer p*`
+Then instantiate the existing eventual closure theorem and weak-route class-level
+closure theorem to obtain a branch-local internal DAG separation theorem.
 
-These remain useful as *interfaces* and conditional reductions, but should not
-be treated as the main source theorem debt to discharge unconditionally.
+## 6. Integration order after theorem target
 
-### Step C. Keep wrappers, migrate source mathematics to asymptotic/family-level debt
-
-The existing wrappers are still valuable plumbing:
-
-1. `NP_not_subset_PpolyDAG_final_of_asymptotic_blocker`
-2. `P_ne_NP_final_of_asymptotic_blocker`
-
-and corresponding stable-restriction / source-closure variants.
-
-But the source-side theorem program should now target eventual-family and
-length-local bridge statements (see Section 5), not fixed-slice universal
-support-half obligations.
-
-## 4. Fastest route to full zero-argument unconditionality
-
-Removing `hNPDag` from the current compatibility theorem is not yet the same as
-producing a zero-argument theorem.
-
-The shortest credible route to a true unconditional final theorem is:
-
-1. choose a concrete fixed slice `p*`;
-2. provide a concrete `GapPartialMCSP_TMWitness p*`;
-3. prove a **sound** source theorem on `p*` (not relying on universal
-   fixed-slice support-half obligations);
-4. use the existing `_TM` finals:
-   `NP_not_subset_PpolyDAG_final_of_blocker_TM`,
-   `P_ne_NP_final_of_blocker_TM`.
-
-This route bypasses `hMag` completely.
-
-Alternative:
-
-- internalize `MagnificationAssumptions` instead of bypassing them.
-
-## 5. Where the canonical all-slices route now stands
-
-The repository also already contains the infrastructure for the stronger
-canonical all-slices program:
-
-- `canonical_smallDAG_witnessEasyDensity_source_on_slices`
-- `canonical_smallDAG_witnessUniformLower_source_on_slices`
-- `canonical_smallDAG_witnessTransferQuarter_source_on_slices`
-- compilers from extraction/support budgets into those debts
-
-This remains the legitimate theorem program for a standalone internal
-`NP_not_subset_PpolyDAG`, after replacing vacuous carriers/bridges with
-eventual/length-local versions.
-
-Current migration requirements:
-
-1. replace `GapSliceFamily`-quantified surfaces with eventual-indexed ones
-   (`n ≥ N0`);
-2. replace all-length bridge assumptions with length-local slice agreement;
-3. keep fixed-slice wrappers as endpoint plumbing only.
-
-## 6. Recommended execution order
-
-### Immediate theorem target
-
-Migrate one core all-slices theorem surface from `GapSliceFamily` to
-eventual-indexed families and prove the first non-vacuous bridge lemma on that
-surface.
-
-### Immediate integration target
-
-Reconnect the migrated surface to existing endpoint wrappers (without changing
-the wrappers themselves).
-
-### Then
-
-Replace the current compatibility theorem with a theorem that no longer takes
-external `hNPDag`.
-
-### Then
-
-Finish the remaining public API cleanup and remove the residual compatibility
-`hMag` argument by either:
-
-1. concrete `_TM` route, or
-2. internalization of `MagnificationAssumptions`.
+1. Introduce internal theorem producing
+   `ComplexityInterfaces.NP_not_subset_PpolyDAG`.
+2. Switch public final API to stop requiring external `hNPDag`.
+3. Then clean residual `hMag` from public theorem surface.
 
 ## 7. Non-goals right now
 
-Do not spend the next theorem sprint on:
+Do not spend next theorem sprint on:
 
-1. adding new wrappers;
-2. rephrasing the same blocker with more endpoint names;
-3. claiming that all-slices infrastructure already closes the final theorem;
-4. claiming that removing `hNPDag` alone yields full unconditionality;
-5. using archived roadmap notes as the current branch lock.
+1. adding new wrappers,
+2. renaming existing wrappers,
+3. reopening fixed-slice blocker hunt,
+4. claiming full unconditionality before both `hNPDag` and `hMag` are removed
+   from public dependency chain.
 
-## 8. Acceptance criteria for “DAG side is closed”
+## 8. Definition of done
 
-For the DAG side to be honestly called closed in this repository, all of the
-following must hold:
+DAG side honestly closed when all hold:
 
-1. `ComplexityInterfaces.NP_not_subset_PpolyDAG` is proved internally.
-2. The public final theorem no longer takes external `hNPDag`.
-3. The repository remains clean under `./scripts/check.sh`.
-4. `README.md`, `STATUS.md`, `TODO.md`, and the release/checklist docs are all
-   updated consistently.
+1. `ComplexityInterfaces.NP_not_subset_PpolyDAG` proved internally.
+2. Public final theorem no longer takes external `hNPDag`.
+3. Repository remains clean under `./scripts/check.sh`.
+4. `README.md`, `STATUS.md`, `TODO.md`, checklist docs are consistent.
 
-For the repository to be honestly called **fully unconditional**, add:
+Fully unconditional branch when add:
 
-5. the public theorem no longer exposes compatibility-only `hMag`;
-6. a zero-argument final theorem `P_ne_NP` is derivable in the active tree.
-
-## 9. Main technical difficulty right now (why unconditionality is still hard)
-
-The dominant difficulty is no longer endpoint wiring. It is **source-side
-mathematics**:
-
-1. Fixed-slice universal support-half blockers are not a dependable primary
-   target under syntactic-support quantification.
-2. The non-vacuous all-slices route requires migrating theorem surfaces to
-   eventual-indexed families (`n ≥ N0`) and length-local bridge assumptions.
-3. After migration, one still needs a new family-level theorem that rules out
-   polynomial DAG solvers asymptotically (or yields an equivalent contradiction
-   payload), and this theorem is not currently present in the repository.
-
-In short:
-
-> plumbing is mostly done; the missing piece is a mathematically valid and
-> formalized asymptotic source theorem strong enough to instantiate internal
-> `NP_not_subset_PpolyDAG`.
+5. Public theorem no longer exposes compatibility-only `hMag`.
+6. Zero-argument final theorem `P_ne_NP` is derivable in active tree.

--- a/pnp3/Docs/Unconditionality_FAQ_ru.md
+++ b/pnp3/Docs/Unconditionality_FAQ_ru.md
@@ -1,0 +1,117 @@
+# Как довести до конца безусловное доказательство? Что реально не хватает сейчас?
+
+Обновлено: 2026-04-04.
+
+Политика маршрута (canonical lock):
+`pnp3/Docs/CLOSURE_ROUTE_POLICY.md`.
+
+## Короткий и честный ответ
+
+**Полностью безусловно — пока нет, не всё есть.**
+
+Но важная развилка такая:
+
+1. **Условно `ComplexityInterfaces.NP_not_subset_PpolyDAG` уже можно получать**
+   (через готовые wrappers), если вы подаёте недостающий source payload.
+2. **Безусловно `ComplexityInterfaces.NP_not_subset_PpolyDAG` пока нельзя**, потому что
+   в дереве всё ещё нет внутреннего theorem-level источника этого payload без внешних
+   допущений.
+
+И уже после этого остаётся второй шаг до truly zero-arg финала: убрать `hMag` из
+публичного API.
+
+---
+
+## Что уже есть «из коробки»
+
+### 1) Интерфейсное определение цели
+
+`ComplexityInterfaces.NP_not_subset_PpolyDAG` уже определён как пропозиция на уровне
+интерфейса (`∃ L, NP L ∧ ¬ PpolyDAG L`).
+
+### 2) Готовые конечные маршруты к этой цели (но с входными предпосылками)
+
+Ветка уже содержит рабочие endpoint-теоремы, например:
+
+- `NP_not_subset_PpolyDAG_final_of_asymptotic_blocker` (асимптотический маршрут),
+- `NP_not_subset_PpolyDAG_final_of_blocker_TM` (конкретный `_TM` маршрут).
+
+То есть «проводка» от source-предпосылки к финальной DAG-сепарации уже собрана.
+
+### 3) Почему текущий default всё ещё не безусловный
+
+`P_ne_NP_final` пока принимает два аргумента:
+
+- `hNPDag : NP_not_subset_PpolyDAG` (реальный оставшийся логический блокер),
+- `hMag : MagnificationAssumptions` (compatibility-контекст в сигнатуре).
+
+---
+
+## Что именно отсутствует для безусловного `NP_not_subset_PpolyDAG`
+
+Отсутствует не endpoint, а **внутренний источник** одного из входов в эти endpoint-теоремы.
+В практических терминах сейчас не хватает theorem-level результата, который внутри репозитория
+(без внешнего `hNPDag`) построит, например, один из следующих payload:
+
+- `dagRouteBSourceBlocker p*`, или
+- эквивалентную source-closure/stable-restriction нагрузку,
+
+на sound (невакуумной) поверхности.
+
+Именно это в статусных документах обозначено как главный незакрытый DAG-side theorem debt.
+
+---
+
+## Можно ли «хотя бы доказать `ComplexityInterfaces.NP_not_subset_PpolyDAG`» уже сейчас?
+
+### Да — **условно**
+
+Если у вас уже есть:
+
+- конкретный `W : GapPartialMCSP_TMWitness p`, и
+- `hBlocker : dagRouteBSourceBlocker p`,
+
+то `NP_not_subset_PpolyDAG_final_of_blocker_TM W hBlocker` уже даёт
+`ComplexityInterfaces.NP_not_subset_PpolyDAG`.
+
+### Нет — **безусловно, прямо сейчас**
+
+Потому что в активном дереве нет внутренней теоремы, которая сама (без внешнего импорта
+недостающей математики) производит необходимый `hBlocker`/эквивалентный payload.
+
+---
+
+
+## Комментарий к аудиторскому выводу (текущая позиция ветки)
+
+Да, общий вектор аудитора корректный: literal fixed-slice маршрут не является
+рабочим путём к безусловному закрытию и должен считаться no-go веткой.
+
+Важное уточнение по активной ветке: этот no-go уже частично зафиксирован на
+уровне специальных модулей исторического маршрута (`FailedRoute_*`), поэтому
+новая документация теперь трактует fixed-slice только как legacy plumbing, а
+единственный живой closure-route — asymptotic/eventual + length-local.
+
+---
+
+## Минимальный план закрытия (практически)
+
+1. Закрыть один невакуумный source theorem на eventual/length-local поверхности
+   (это текущий приоритет roadmap).
+2. Из него получить один из существующих blocker/source-closure payload-ов.
+3. Прогнать payload через уже готовый финальный wrapper и получить внутренний
+   `ComplexityInterfaces.NP_not_subset_PpolyDAG`.
+4. Затем убрать `hNPDag` из default финала.
+5. Отдельно убрать residual `hMag` (через concrete `_TM` bypass либо internalization
+   magnification-пакета), чтобы получить zero-arg `P_ne_NP`.
+
+---
+
+## Definition of done (чтобы честно говорить «безусловно»)
+
+Одновременно должны выполняться все пункты:
+
+1. `ComplexityInterfaces.NP_not_subset_PpolyDAG` доказан внутри дерева без внешнего DAG-входа.
+2. Публичный финал не требует внешнего `hNPDag`.
+3. Публичный финал не требует `hMag`.
+4. В активной ветке выводится zero-arg теорема `P_ne_NP`.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -244,6 +244,47 @@ else
   echo "Magnification assumptions policy OK (package-based finals enforced)."
 fi
 
+# Documentation route-policy guardrails:
+# keep canonical docs aligned on one active closure route and prevent silent
+# reintroduction of deprecated fixed-slice "fastest route" wording.
+route_docs=(
+  "STATUS.md"
+  "TODO.md"
+  "CHECKLIST_UNCONDITIONAL_P_NE_NP.md"
+  "pnp3/Docs/Unconditional_NP_not_subset_PpolyDAG_Plan.md"
+  "pnp3/Docs/CLOSURE_ROUTE_POLICY.md"
+)
+
+for f in "${route_docs[@]}"; do
+  if [[ ! -f "${f}" ]]; then
+    echo "Missing required route-policy document: ${f}"
+    exit 1
+  fi
+done
+
+# Hard requirement: canonical docs must explicitly mention the fixed-slice
+# no-go status and the active asymptotic/eventual route.
+if ! rg -n "fixed-slice.*no-go|no-go.*fixed-slice" "${route_docs[@]}" >/tmp/pnp3_route_nogo_hits.log; then
+  echo "Route-policy violation: canonical docs do not explicitly state fixed-slice no-go status."
+  exit 1
+fi
+
+if ! rg -n "asymptotic/eventual|eventual.*length-local|length-local.*eventual" "${route_docs[@]}" >/tmp/pnp3_route_active_hits.log; then
+  echo "Route-policy violation: canonical docs do not explicitly state the active asymptotic/eventual route."
+  exit 1
+fi
+
+# Forbidden legacy wording: these phrases historically pointed to the deprecated
+# fixed-slice closure prioritization and should not reappear in canonical docs.
+if rg -n 'Fastest path to remove `hNPDag`|Pick a fixed slice|prove one fixed-slice DAG source theorem' \
+    "${route_docs[@]}" >/tmp/pnp3_route_legacy_phrase_hits.log; then
+  echo "Detected deprecated fixed-slice closure wording in canonical docs:"
+  cat /tmp/pnp3_route_legacy_phrase_hits.log
+  exit 1
+fi
+
+echo "Route policy docs OK (fixed-slice no-go + asymptotic/eventual path enforced)."
+
 echo "[check] Step 4/6: explicit theorem-axiom surface dump"
 axiom_surface_log="/tmp/pnp3_axiom_surface.log"
 if ! rg -n -U "pnp3/Tests/AxiomsAudit\\.lean:[^\\n]*depends on axioms:\\s*\\[[^\\]]*\\]" \


### PR DESCRIPTION
### Motivation

- Formalize and lock the canonical DAG-side closure route to asymptotic/eventual + length-local planning and explicitly mark the literal fixed-slice support-half blocker as a closed historical no-go route.  
- Make status, checklist, and roadmap documents consistent with that policy and prevent accidental reintroduction of deprecated fixed-slice wording.  
- Ensure repository-level checks enforce the policy so documentation and release posture remain aligned.  

### Description

- Updated canonical status and roadmap files (`CHECKLIST_UNCONDITIONAL_P_NE_NP.md`, `STATUS.md`, `TODO.md`, `pnp3/Docs/Unconditional_NP_not_subset_PpolyDAG_Plan.md`) to reflect the asymptotic/eventual + length-local active route and to archive the fixed-slice support-half branch as a historical no-go.  
- Added a new hard policy file `pnp3/Docs/CLOSURE_ROUTE_POLICY.md` that prescribes one active route and lists the fixed-slice failed-route modules.  
- Added Russian FAQ `pnp3/Docs/Unconditionality_FAQ_ru.md` summarizing the current state and the minimal path to internalize `ComplexityInterfaces.NP_not_subset_PpolyDAG`.  
- Extended `scripts/check.sh` with route-policy guardrails that require presence of the new policy doc, require explicit fixed-slice no-go and asymptotic/eventual wording in canonical docs, and forbid legacy fixed-slice closure phrases.  
- Minor wording and formatting cleanups across the updated docs to keep release/checklist language consistent.  

### Testing

- Ran the repository sanity and policy check via `./scripts/check.sh`, and the script completed successfully under the updated policy.  
- Verified audit/regression test targets referenced in the checklist (`pnp3/Tests/AxiomsAudit.lean`, `pnp3/Tests/BarrierAudit.lean`, `pnp3/Tests/BarrierBypassAudit.lean`, `pnp3/Tests/BridgeLocalityRegression.lean`, `pnp3/Tests/WeakRouteSurfaceTests.lean`) remain the canonical list and were not violated by these doc and check changes.  
- The new route-policy checks in `scripts/check.sh` were exercised and passed in the integration run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0e4c5b92c832b95327d3a39d63510)