### PR TITLE
Add eventual one-sided promise-YES bridge lemmas and Russian handoff note

### DIFF
--- a/outputs/unconditional-proof-handoff-ru.md
+++ b/outputs/unconditional-proof-handoff-ru.md
@@ -12,6 +12,10 @@
 - builder `smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt`,
 - bridge closure `not_globalPpolyDAG_of_eventuallyPromiseYesWeakRoute`,
 - class-level closure `NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute`.
+- пакетная теорема под envelope-гипотезы:
+  `eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelope`,
+  и финальный компоновщик
+  `NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRoute`.
 
 Следовательно, остаётся только source-side family-specific математика.
 

--- a/outputs/unconditional-proof-handoff-ru.md
+++ b/outputs/unconditional-proof-handoff-ru.md
@@ -1,0 +1,153 @@
+# Handoff для математиков: финальный remaining debt для безусловного закрытия route
+
+**Дата:** 2026-04-08
+**Статус:** bridge/magnification инфраструктура уже закрыта; остался только family-specific source-step для конкретного `F`.
+
+---
+
+## 1) Что уже закрыто в коде (не требует новых идей)
+
+### 1.1 Уже реализован generic builder
+
+В коде есть теорема:
+
+- `smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt`
+
+Она переводит изоляционный source-сертификат вида
+
+- YES-центр `yYes`,
+- координатный набор `S`,
+- slack inequality,
+- `AgreeOnValues -> z ∈ Yes`,
+
+в целевой predicate:
+
+- `SmallDAGImpliesPromiseYesSubcubeAt ...`.
+
+То есть source-side больше не обязан отдельно доказывать `eval C z = true` напрямую;
+это добирается из корректности solver на YES.
+
+### 1.2 Уже закрыт eventual weak-route bridge
+
+Также в коде есть:
+
+- `not_globalPpolyDAG_of_eventuallyPromiseYesWeakRoute`,
+- `NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute`.
+
+Значит, после получения нужного eventual source payload pipeline до
+`NP_not_subset_PpolyDAG` уже механический.
+
+---
+
+## 2) Что именно осталось доказать математически
+
+Осталась ровно одна family-specific цель:
+
+## `canonical_smallDAG_certificateIsolation_on_slices F`
+
+Смысл: для канонического slice при малых `β` и больших `n`, любой корректный
+малый DAG даёт one-sided isolating certificate `ρ` на табличных координатах с
+контролируемым budget и нужным slack.
+
+Эквивалентно нужно обеспечить (для каждого `hInDag`):
+
+```text
+∃ β0 > 0,
+  ∀ β, 0 < β → β < β0 →
+    ∃ n0, ∀ n ≥ n0,
+      SmallDAGImpliesPromiseYesSubcubeAt
+        F (ppolyDAGSizeBoundOnSlices F hInDag) n β 1
+```
+
+(для canonical bound параметр `ε` можно фиксировать как `1`).
+
+---
+
+## 3) Минимальный proof-contract (что математически нужно вернуть)
+
+Нужно вернуть theorem-пакет со следующими блоками.
+
+### A. Конкретизация семейства `F`
+
+Явно задать/указать формулы:
+
+- `F.paramsOf n β`,
+- `GapSliceFamily.encodedLen F n β`,
+- `GapSliceFamily.tableLen F n β`,
+- `F.Mof n (F.Tof n β)`,
+- описание множеств `Yes` и `No` на slice.
+
+### B. Конструкция изоляции `ρ`
+
+Для любого корректного `C` под canonical bound построить:
+
+- `D ⊆ Fin (tableLen)` и частичное присваивание `ρ` на `D`,
+
+такое что:
+
+1. `(Yes ∪ No) ∩ [ρ] ≠ ∅`;
+2. `(Yes ∪ No) ∩ [ρ] ⊆ Yes`;
+3. `|D| ≤ κ(n,β)` (или более сильный budget напрямую).
+
+### C. Координатная семантика (`AgreeOnValues`)
+
+Нужна точная usable-лемма:
+
+`y ∈ [ρ] ∧ ValidEncoding p z ∧ AgreeOnValues (p := p) D y z -> z ∈ [ρ]`.
+
+Без неё не закрывается acceptance-шаг builder-леммы.
+
+### D. Slack-оценка
+
+Нужно доказать:
+
+`F.Mof n (F.Tof n β) < 2^(tableLen - κ(n,β))`.
+
+Тогда через `|D| ≤ κ(n,β)` автоматически получается требуемый `hSlack`:
+
+`F.Mof n (F.Tof n β) < 2^(tableLen - |D|)`.
+
+### E. Size-cutoff (если source-лемма сначала в другом режиме)
+
+Если исходная лемма доказывается в режиме `size ≤ 2^(β·m)`, нужно добавить:
+
+- что такое `m` (`n`/`encodedLen`/`tableLen`),
+- лемму перехода от `ppolyDAGSizeBoundOnSlices` к этому режиму,
+- явный `n0_size(β)`.
+
+---
+
+## 4) Что не нужно доказывать снова
+
+1. Не нужно заново доказывать bridge-level contradiction wrappers.
+2. Не нужно заново доказывать class-level closure до `NP_not_subset_PpolyDAG`.
+3. Не нужно строить новые API-endpoint'ы: текущие достаточно мощные.
+
+---
+
+## 5) Формат ответа от математиков (приёмка)
+
+Ответ считается достаточным, если в нём есть:
+
+1. Полный statement по кванторам (`β`, `n`, bounds, eventual пороги),
+2. Конструкция `ρ` + доказательства non-vacuity/purity,
+3. Координатная лемма про `AgreeOnValues`,
+4. Натуральный budget `κ(n,β)` + slack inequality,
+5. (при необходимости) size-cutoff мост,
+6. Явное указание, какие леммы обеспечивают перенос в builder
+   `smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt`.
+
+---
+
+## 6) Короткий итог для пересылки
+
+Всё, кроме family-specific source-step, уже закрыто в Lean.
+
+Чтобы полностью завершить route, математикам нужно дать только один пакет:
+
+- построение one-sided isolating certificate `ρ` на канонических slices,
+- координатную связку через `AgreeOnValues`,
+- и slack через натуральный envelope `κ(n,β)`.
+
+После этого endpoint `NP_not_subset_PpolyDAG` собирается существующими
+теоремами без дополнительных архитектурных изменений.

--- a/outputs/unconditional-proof-handoff-ru.md
+++ b/outputs/unconditional-proof-handoff-ru.md
@@ -1,153 +1,156 @@
-# Handoff для математиков: финальный remaining debt для безусловного закрытия route
+# Remaining debt: строгий theorem package для family-specific closure
 
 **Дата:** 2026-04-08
-**Статус:** bridge/magnification инфраструктура уже закрыта; остался только family-specific source-step для конкретного `F`.
+**Статус:** общий редукционный шаг закрыт; осталась только инстанциация для конкретного `F`.
 
 ---
 
-## 1) Что уже закрыто в коде (не требует новых идей)
+## 1) Что уже закрыто строго
 
-### 1.1 Уже реализован generic builder
+В коде уже есть инфраструктура, достаточная для финального перехода:
 
-В коде есть теорема:
+- builder `smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt`,
+- bridge closure `not_globalPpolyDAG_of_eventuallyPromiseYesWeakRoute`,
+- class-level closure `NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute`.
 
-- `smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt`
-
-Она переводит изоляционный source-сертификат вида
-
-- YES-центр `yYes`,
-- координатный набор `S`,
-- slack inequality,
-- `AgreeOnValues -> z ∈ Yes`,
-
-в целевой predicate:
-
-- `SmallDAGImpliesPromiseYesSubcubeAt ...`.
-
-То есть source-side больше не обязан отдельно доказывать `eval C z = true` напрямую;
-это добирается из корректности solver на YES.
-
-### 1.2 Уже закрыт eventual weak-route bridge
-
-Также в коде есть:
-
-- `not_globalPpolyDAG_of_eventuallyPromiseYesWeakRoute`,
-- `NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute`.
-
-Значит, после получения нужного eventual source payload pipeline до
-`NP_not_subset_PpolyDAG` уже механический.
+Следовательно, остаётся только source-side family-specific математика.
 
 ---
 
-## 2) Что именно осталось доказать математически
+## 2) Обозначения
 
-Осталась ровно одна family-specific цель:
+Для фиксированных `F, hInDag, n, β`:
 
-## `canonical_smallDAG_certificateIsolation_on_slices F`
+- `p := F.paramsOf n β`,
+- `T := GapSliceFamily.tableLen F n β`,
+- `Y := (gapSliceOfParams p).Yes`,
+- `N := (gapSliceOfParams p).No`,
+- `P := Y ∪ N`,
+- `M := F.Mof n (F.Tof n β)`.
 
-Смысл: для канонического slice при малых `β` и больших `n`, любой корректный
-малый DAG даёт one-sided isolating certificate `ρ` на табличных координатах с
-контролируемым budget и нужным slack.
-
-Эквивалентно нужно обеспечить (для каждого `hInDag`):
-
-```text
-∃ β0 > 0,
-  ∀ β, 0 < β → β < β0 →
-    ∃ n0, ∀ n ≥ n0,
-      SmallDAGImpliesPromiseYesSubcubeAt
-        F (ppolyDAGSizeBoundOnSlices F hInDag) n β 1
-```
-
-(для canonical bound параметр `ε` можно фиксировать как `1`).
+Size-bound: `ppolyDAGSizeBoundOnSlices F hInDag`.
 
 ---
 
-## 3) Минимальный proof-contract (что математически нужно вернуть)
+## 3) Теорема 1 (strict sufficient theorem)
 
-Нужно вернуть theorem-пакет со следующими блоками.
+### Предпосылки
 
-### A. Конкретизация семейства `F`
+#### (V) YES-валидность
 
-Явно задать/указать формулы:
+`∀ y, y ∈ Y → ValidEncoding p y`.
 
-- `F.paramsOf n β`,
-- `GapSliceFamily.encodedLen F n β`,
-- `GapSliceFamily.tableLen F n β`,
-- `F.Mof n (F.Tof n β)`,
-- описание множеств `Yes` и `No` на slice.
+#### (Iso) Eventual certificate isolation
 
-### B. Конструкция изоляции `ρ`
+Существуют `β0 > 0`, функция `κ : Nat × Rat → Nat`, функция `n_iso(β)` такие, что
+для любого `β` с `0 < β < β0`, любого `n ≥ n_iso(β)`, любого корректного `C` под canonical bound,
+существуют `D ⊆ Fin(T)` и частичное присваивание `ρ` на `D` со свойствами:
 
-Для любого корректного `C` под canonical bound построить:
+1. `P ∩ [ρ] ≠ ∅`,
+2. `P ∩ [ρ] ⊆ Y`,
+3. `|D| ≤ κ(n,β)`,
+4. `M < 2^(T - κ(n,β))`,
+5. `y ∈ [ρ] ∧ ValidEncoding p z ∧ AgreeOnValues (p := p) D y z -> z ∈ [ρ]`.
 
-- `D ⊆ Fin (tableLen)` и частичное присваивание `ρ` на `D`,
+### Вывод
 
-такое что:
+`∃ β0 > 0, ∀ β, 0 < β → β < β0 → ∃ n0, ∀ n ≥ n0,`
 
-1. `(Yes ∪ No) ∩ [ρ] ≠ ∅`;
-2. `(Yes ∪ No) ∩ [ρ] ⊆ Yes`;
-3. `|D| ≤ κ(n,β)` (или более сильный budget напрямую).
+`SmallDAGImpliesPromiseYesSubcubeAt F (ppolyDAGSizeBoundOnSlices F hInDag) n β 1`.
 
-### C. Координатная семантика (`AgreeOnValues`)
+### Доказательство (идея)
 
-Нужна точная usable-лемма:
+Для фиксированных `β,n,C`:
 
-`y ∈ [ρ] ∧ ValidEncoding p z ∧ AgreeOnValues (p := p) D y z -> z ∈ [ρ]`.
+- из (1) выбираем `yYes ∈ P ∩ [ρ]`,
+- из (2) получаем `yYes ∈ Y`, из (V) — `ValidEncoding p yYes`,
+- берём `S := D`,
+- из (4) и `|D| ≤ κ` получаем `M < 2^(T - |D|)` (монотонность `2^m`),
+- для любого `z`, согласующегося с `yYes` на `S`, по (5) получаем `z ∈ [ρ]`,
+  затем `z ∈ P ∩ [ρ] ⊆ Y`,
+- по корректности `C` на YES имеем `eval C z = true`.
 
-Без неё не закрывается acceptance-шаг builder-леммы.
+Это ровно поля `SmallDAGImpliesPromiseYesSubcubeAt ... n β 1`.
 
-### D. Slack-оценка
-
-Нужно доказать:
-
-`F.Mof n (F.Tof n β) < 2^(tableLen - κ(n,β))`.
-
-Тогда через `|D| ≤ κ(n,β)` автоматически получается требуемый `hSlack`:
-
-`F.Mof n (F.Tof n β) < 2^(tableLen - |D|)`.
-
-### E. Size-cutoff (если source-лемма сначала в другом режиме)
-
-Если исходная лемма доказывается в режиме `size ≤ 2^(β·m)`, нужно добавить:
-
-- что такое `m` (`n`/`encodedLen`/`tableLen`),
-- лемму перехода от `ppolyDAGSizeBoundOnSlices` к этому режиму,
-- явный `n0_size(β)`.
+∎
 
 ---
 
-## 4) Что не нужно доказывать снова
+## 4) Теорема 2 (прямая форма, ближе к builder)
 
-1. Не нужно заново доказывать bridge-level contradiction wrappers.
-2. Не нужно заново доказывать class-level closure до `NP_not_subset_PpolyDAG`.
-3. Не нужно строить новые API-endpoint'ы: текущие достаточно мощные.
+Достаточно иметь eventual данные без явного цилиндра `[ρ]`:
 
----
+для каждого допустимого `β,n` и корректного `C` существуют
+`yYes ∈ Y`, `D ⊆ Fin(T)` такие, что
 
-## 5) Формат ответа от математиков (приёмка)
+1. `ValidEncoding p yYes`,
+2. `|D| ≤ κ(n,β)`,
+3. `M < 2^(T - κ(n,β))`,
+4. `((z ∈ Y ∨ z ∈ N) ∧ ValidEncoding p z ∧ AgreeOnValues (p := p) D yYes z) -> z ∈ Y`.
 
-Ответ считается достаточным, если в нём есть:
-
-1. Полный statement по кванторам (`β`, `n`, bounds, eventual пороги),
-2. Конструкция `ρ` + доказательства non-vacuity/purity,
-3. Координатная лемма про `AgreeOnValues`,
-4. Натуральный budget `κ(n,β)` + slack inequality,
-5. (при необходимости) size-cutoff мост,
-6. Явное указание, какие леммы обеспечивают перенос в builder
-   `smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt`.
+Тогда тот же eventual payload с `ε := 1` следует напрямую из
+`smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt` + численного шага `κ -> |D|`.
 
 ---
 
-## 6) Короткий итог для пересылки
+## 5) Теорема 3 (witness-coordinate presentation ⇒ Теорема 2)
 
-Всё, кроме family-specific source-step, уже закрыто в Lean.
+Если family-specific структура даёт:
 
-Чтобы полностью завершить route, математикам нужно дать только один пакет:
+- малый блок координат `J`,
+- принимающий шаблон `a*` на `J`,
+- YES-центр `y* ∈ Y` с `y*|_J = a*`,
+- `ValidEncoding p y*`,
+- `|J| ≤ κ(n,β)`,
+- `M < 2^(T - κ(n,β))`,
+- forcing: любой promise-valid `z` с `z|_J = a*` лежит в `Y`,
 
-- построение one-sided isolating certificate `ρ` на канонических slices,
-- координатную связку через `AgreeOnValues`,
-- и slack через натуральный envelope `κ(n,β)`.
+и `AgreeOnValues (p := p) J y* z` эквивалентно совпадению на `J`,
+то берём `D := J`, `yYes := y*` и получаем предпосылки Теоремы 2.
 
-После этого endpoint `NP_not_subset_PpolyDAG` собирается существующими
-теоремами без дополнительных архитектурных изменений.
+---
+
+## 6) Теорема 4 (size-cutoff bridge)
+
+Если source-лемма доказана сначала в альтернативном size-режиме
+`size(C) ≤ B_alt(n,β)`, а canonical bound даёт этот режим после `n_size(β)`,
+то всё переносится на canonical route с порогом
+
+`max(n0(β), n_size(β))`.
+
+---
+
+## 7) Финальный вывод до endpoint
+
+Если для вашего `F` выполнена гипотеза Теоремы 1 (или 2/3 + 4), равномерно по
+`hInDag`, то вместе с `hNP : NP bridge.L` автоматически получаем
+
+`NP_not_subset_PpolyDAG`
+
+через уже реализованный
+`NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute`.
+
+---
+
+## 8) Что осталось purely family-specific
+
+Нужно прислать/доказать только:
+
+1. явные определения `paramsOf / tableLen / encodedLen / Mof∘Tof` и смысл `Y,N`;
+2. точную семантику `AgreeOnValues` в терминах table-координат;
+3. family-specific construction (`ρ` или witness-coordinate форма);
+4. slack inequality через `κ(n,β)`;
+5. при необходимости размерный cutoff bridge.
+
+Больше никакой новой bridge-математики не нужно.
+
+---
+
+## 9) Короткий operational итог
+
+Оставшийся долг эквивалентен одной из двух форм:
+
+- **цилиндровая форма:** eventual one-sided isolating `ρ` + slack-envelope `κ`; или
+- **координатная форма:** eventual `(yYes, D)` с forcing-импликацией на YES.
+
+Обе формы напрямую закрывают source-предикат через уже реализованные леммы.

--- a/pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
+++ b/pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
@@ -805,6 +805,128 @@ theorem NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute
     F bridge hEventuallyYesWeak
 
 /--
+Canonical eventual promise-YES payload from an isolation+envelope source package.
+
+This theorem packages the generic reduction used in the handoff:
+if on each sufficiently large slice every small correct solver admits
+- a YES center and coordinate set `D` forcing YES on all agreeing promise-valid
+  points,
+- a cardinality bound `D.card ≤ κ n β`,
+- and a numeric envelope `M < 2^(tableLen - κ n β)`,
+then we obtain the eventual `SmallDAGImpliesPromiseYesSubcubeAt` payload on
+canonical bounds (with fixed `ε = 1`).
+-/
+theorem eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelope
+    (F : GapSliceFamily)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hYesValid :
+      ∀ n : Nat, ∀ β : Rat,
+        ∀ y : Bitstring (GapSliceFamily.encodedLen F n β),
+          y ∈ (gapSliceOfParams (F.paramsOf n β)).Yes →
+            ValidEncoding (F.paramsOf n β) y)
+    (hIso :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ nIso β →
+        ∀ C : DagCircuit (GapSliceFamily.encodedLen F n β),
+          ppolyDAGSizeBoundOnSlices F hInDag n β 1 (DagCircuit.size C) →
+          CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+            ∃ yYes : Bitstring (GapSliceFamily.encodedLen F n β),
+              yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+              ∃ D : Finset (Fin (GapSliceFamily.tableLen F n β)),
+                D.card ≤ κ n β ∧
+                ∀ z : Bitstring (GapSliceFamily.encodedLen F n β),
+                  (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                    z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                  ValidEncoding (F.paramsOf n β) z →
+                  AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                    z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes)
+    (hSlackEnvelope :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ nIso β →
+          F.Mof n (F.Tof n β) <
+            2 ^ (GapSliceFamily.tableLen F n β - κ n β)) :
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0' : Rat, 0 < β0' ∧
+        ∀ β : Rat, 0 < β → β < β0' →
+          ∃ n0 : Nat, ∀ n ≥ n0,
+            SmallDAGImpliesPromiseYesSubcubeAt
+              F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε := by
+  refine ⟨(1 : Rat), by norm_num, β0, hβ0, ?_⟩
+  intro β hβPos hβLt
+  refine ⟨nIso β, ?_⟩
+  intro n hn
+  refine smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt
+    F (ppolyDAGSizeBoundOnSlices F hInDag) n β 1 (hYesValid n β) ?_
+  intro C hSize hCorrect
+  rcases hIso n β hβPos hβLt hn C hSize hCorrect with ⟨yYes, hyYes, D, hDCard, hAllYes⟩
+  refine ⟨yYes, hyYes, D, ?_, hAllYes⟩
+  have hSub :
+      GapSliceFamily.tableLen F n β - κ n β ≤
+        GapSliceFamily.tableLen F n β - D.card :=
+    Nat.sub_le_sub_left hDCard (GapSliceFamily.tableLen F n β)
+  have hPowNat :
+      (2 ^ (GapSliceFamily.tableLen F n β - κ n β) : Nat) ≤
+        (2 ^ (GapSliceFamily.tableLen F n β - D.card) : Nat) :=
+    Nat.pow_le_pow_right (by decide : 0 < 2) hSub
+  exact lt_of_lt_of_le (hSlackEnvelope n β hβPos hβLt hn) hPowNat
+
+/--
+Class-level closure from an eventual isolation-envelope family package.
+
+This theorem is the direct code-level endpoint for the handoff contract:
+once the family provides the eventual isolation+envelope data uniformly for
+every canonical witness family, `NP_not_subset_PpolyDAG` follows mechanically.
+-/
+theorem NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hIsoFamily :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ β0 : Rat, 0 < β0 ∧
+          ∃ κ : Nat → Rat → Nat,
+            ∃ nIso : Rat → Nat,
+              (∀ n : Nat, ∀ β : Rat,
+                ∀ y : Bitstring (GapSliceFamily.encodedLen F n β),
+                  y ∈ (gapSliceOfParams (F.paramsOf n β)).Yes →
+                    ValidEncoding (F.paramsOf n β) y) ∧
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ nIso β →
+                ∀ C : DagCircuit (GapSliceFamily.encodedLen F n β),
+                  ppolyDAGSizeBoundOnSlices F hInDag n β 1 (DagCircuit.size C) →
+                  CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+                    ∃ yYes : Bitstring (GapSliceFamily.encodedLen F n β),
+                      yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+                      ∃ D : Finset (Fin (GapSliceFamily.tableLen F n β)),
+                        D.card ≤ κ n β ∧
+                        ∀ z : Bitstring (GapSliceFamily.encodedLen F n β),
+                          (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                          ValidEncoding (F.paramsOf n β) z →
+                          AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) ∧
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ nIso β →
+                  F.Mof n (F.Tof n β) <
+                    2 ^ (GapSliceFamily.tableLen F n β - κ n β))) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute F bridge hNP ?_
+  intro hInDag
+  rcases hIsoFamily hInDag with ⟨β0, hβ0, κ, nIso, hYesValid, hIso, hSlackEnvelope⟩
+  exact eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelope
+    F hInDag β0 hβ0 κ nIso hYesValid hIso hSlackEnvelope
+
+/--
 Primary endpoint schema (magnification-style quantifiers):
 
 `∃ ε>0, ∃ β₀>0, ∀ β∈(0,β₀), ∃ n₀, ∀ n≥n₀, ¬ SmallDAGSolver(n,β,ε)`.

--- a/pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
+++ b/pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
@@ -485,6 +485,45 @@ theorem no_dag_solver_of_promise_value_locality_at
       hCorrectPromise
 
 /--
+Builder lemma: derive `SmallDAGImpliesPromiseYesSubcubeAt` from an isolation-style
+source property that already yields:
+- a YES center `yYes`,
+- a coordinate set `S` with the required slack inequality,
+- and the fact that every promise-valid input agreeing on `S` lies in YES.
+
+This removes the need for source proofs to produce `DagCircuit.eval C z = true`
+directly; correctness on YES then finishes that field automatically.
+-/
+theorem smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (n : Nat) (β ε : Rat)
+    (hYesValid :
+      ∀ y : Bitstring (GapSliceFamily.encodedLen F n β),
+        y ∈ (gapSliceOfParams (F.paramsOf n β)).Yes →
+          ValidEncoding (F.paramsOf n β) y)
+    (hIso :
+      ∀ C : DagCircuit (GapSliceFamily.encodedLen F n β),
+        SizeBound n β ε (DagCircuit.size C) →
+        CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+          ∃ yYes : Bitstring (GapSliceFamily.encodedLen F n β),
+            yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+            ∃ S : Finset (Fin (GapSliceFamily.tableLen F n β)),
+              F.Mof n (F.Tof n β) < 2 ^ (GapSliceFamily.tableLen F n β - S.card) ∧
+              ∀ z : Bitstring (GapSliceFamily.encodedLen F n β),
+                (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                  z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                ValidEncoding (F.paramsOf n β) z →
+                AgreeOnValues (p := F.paramsOf n β) S yYes z →
+                  z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) :
+    SmallDAGImpliesPromiseYesSubcubeAt F SizeBound n β ε := by
+  intro C hSize hCorrect
+  rcases hIso C hSize hCorrect with ⟨yYes, hyYes, S, hSlack, hAllYes⟩
+  refine ⟨yYes, hyYes, hYesValid yYes hyYes, S, hSlack, ?_⟩
+  intro z hzPromise hzValid hAgree
+  exact hCorrect.1 z (hAllYes z hzPromise hzValid hAgree)
+
+/--
 Single-slice closure using the one-sided YES-centered promise/value endpoint.
 -/
 theorem no_dag_solver_of_promise_yes_subcube_at
@@ -666,6 +705,42 @@ theorem not_globalPpolyDAG_of_promiseYesWeakRoute
       F (ppolyDAGSizeBoundOnSlices F hInDag) hNoPointwise
 
 /--
+Bridge-local contradiction instantiated with an eventual one-sided promise-YES
+payload on canonical slices.
+
+Compared with `not_globalPpolyDAG_of_promiseYesWeakRoute`, this theorem accepts
+the eventual (`∃ ε, ∃ β0, ...`) source shape directly, without first requiring
+the stronger pointwise statement `SmallDAGImpliesPromiseYesSubcubeStatement`.
+-/
+theorem not_globalPpolyDAG_of_eventuallyPromiseYesWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hEventuallyYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, ∀ n ≥ n0,
+                SmallDAGImpliesPromiseYesSubcubeAt
+                  F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  refine
+    not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies
+      (F := F) (bridge := bridge) ?_
+  intro hInDag
+  rcases hEventuallyYesWeak hInDag with ⟨ε, hε, β0, hβ0, hEventuallyYes⟩
+  refine ⟨ε, hε, β0, hβ0, ?_⟩
+  intro β hβPos hβLt
+  rcases hEventuallyYes β hβPos hβLt with ⟨n0, hn0⟩
+  refine ⟨n0, ?_⟩
+  intro n hn
+  exact no_dag_solver_of_promise_yes_subcube_at
+    F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε (hn0 n hn)
+
+/--
 Class-level closure from the weak accepted-family source theorem to
 `NP_not_subset_PpolyDAG`, parameterized by an explicit NP witness for
 `bridge.L`.
@@ -704,6 +779,30 @@ theorem NP_not_subset_PpolyDAG_of_promiseYesWeakRoute
     ComplexityInterfaces.NP_not_subset_PpolyDAG := by
   refine ⟨bridge.L, hNP, ?_⟩
   exact not_globalPpolyDAG_of_promiseYesWeakRoute F bridge hYesWeak
+
+/--
+Class-level closure from an eventual one-sided promise-YES payload on canonical
+slices to `NP_not_subset_PpolyDAG`.
+-/
+theorem NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hEventuallyYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, ∀ n ≥ n0,
+                SmallDAGImpliesPromiseYesSubcubeAt
+                  F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine ⟨bridge.L, hNP, ?_⟩
+  exact not_globalPpolyDAG_of_eventuallyPromiseYesWeakRoute
+    F bridge hEventuallyYesWeak
 
 /--
 Primary endpoint schema (magnification-style quantifiers):
@@ -775,6 +874,57 @@ theorem magnificationStyleNoSmallDAG_of_eventually_acceptedFamily
   refine ⟨nAcc, ?_⟩
   intro n hn
   exact no_dag_solver_of_acceptedFamily_at F SizeBound n β ε (hnAcc n hn)
+
+/--
+Canonical "eventual weak-route payload" extracted from a pointwise
+`SmallDAGImpliesPromiseYesSubcubeStatement`.
+
+This helper packages the quantifier shape required by the magnification bridge:
+we choose fixed positive constants `ε = 1/4` and `β0 = 1/2`, and use the
+pointwise statement directly with cutoff `n0 = 0` on every valid `β < β0`.
+
+The theorem is intentionally generic in `SizeBound`; in the P/poly route it is
+instantiated with `SizeBound := ppolyDAGSizeBoundOnSlices F hInDag`.
+-/
+theorem eventual_promiseYesSubcube_of_smallDAG
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hYes : SmallDAGImpliesPromiseYesSubcubeStatement F SizeBound) :
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0 : Rat, 0 < β0 ∧
+        ∀ (β : Rat), 0 < β → β < β0 →
+          ∃ n0 : Nat, ∀ n ≥ n0,
+            SmallDAGImpliesPromiseYesSubcubeAt F SizeBound n β ε := by
+  refine ⟨(1 / 4 : Rat), by positivity, (1 / 2 : Rat), by positivity, ?_⟩
+  intro β hβPos hβLt
+  refine ⟨0, ?_⟩
+  intro n hn
+  simpa using hYes n β (1 / 4 : Rat)
+
+/--
+Canonical-slice specialization of `eventual_promiseYesSubcube_of_smallDAG`.
+
+This matches the Gate-G1 / bridge-facing shape where the size bound is obtained
+from a concrete global witness family via `ppolyDAGSizeBoundOnSlices`.
+The proof is purely a specialization step.
+-/
+theorem eventual_promiseYesSubcube_of_smallDAG_onCanonicalSlices
+    (F : GapSliceFamily)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (hYes :
+      SmallDAGImpliesPromiseYesSubcubeStatement
+        F (ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0 : Rat, 0 < β0 ∧
+        ∀ (β : Rat), 0 < β → β < β0 →
+          ∃ n0 : Nat, ∀ n ≥ n0,
+            SmallDAGImpliesPromiseYesSubcubeAt
+              F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε := by
+  exact eventual_promiseYesSubcube_of_smallDAG
+    F (ppolyDAGSizeBoundOnSlices F hInDag) hYes
 
 /--
 Eventual magnification-style closure using the nearer-term one-sided


### PR DESCRIPTION
### Motivation
- Introduce bridge-local lemmas to close the remaining family-specific source-step by accepting eventual one-sided promise-YES payloads on canonical slices. 
- Package pointwise `SmallDAGImpliesPromiseYesSubcubeStatement` into the magnification-style eventual quantifier shape used by the rest of the pipeline. 
- Provide a compact Russian handoff document describing the remaining family-specific obligations for mathematicians.

### Description
- Add `smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt` which derives `SmallDAGImpliesPromiseYesSubcubeAt` from an isolation-style source property that already supplies a YES center, coordinate set `S` with slack, and an `AgreeOnValues` transfer lemma. 
- Add eventual/bridge wrappers `not_globalPpolyDAG_of_eventuallyPromiseYesWeakRoute` and `NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute` to accept the eventual (`∃ ε, ∃ β0, ∀ β < β0, ∃ n0, ∀ n≥n0, ...`) payload shape. 
- Add quantifier-shaping helpers `eventual_promiseYesSubcube_of_smallDAG` and `eventual_promiseYesSubcube_of_smallDAG_onCanonicalSlices` and corresponding magnification-style closure theorems so existing magnification machinery can consume the eventual payload. 
- Add a new Russian handoff file `outputs/unconditional-proof-handoff-ru.md` describing what is already closed and the precise family-specific proof package required. 

### Testing
- Built the Lean project with `lake build` and typechecked the modified `AsymptoticDAGBarrierTheorems.lean` file, and the new declarations typecheck successfully. 
- Ran the project's suite of Lean checks (`lake build` / `lean --make` equivalently) and no new compile errors or test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d373d297e8832b9b43b27cecf78ba5)