### PR TITLE
Introduce non‑vacuous eventual‑carrier bridge, canonical‑length transport, and audit of table‑force dead‑end

### DIFF
--- a/outputs/unconditional-proof-handoff-ru.md
+++ b/outputs/unconditional-proof-handoff-ru.md
@@ -1,0 +1,345 @@
+# Handoff (после доработки non-vacuous eventual route): что уже реализовано, что ещё можно сделать generic, и где реальные блокеры
+
+**Дата:** 2026-04-09
+
+## Текущий статус (фиксированная карта маршрутов)
+
+Ниже — актуальный state machine по route-слоям после рефакторинга.
+
+### ✅ Active / рекомендованный путь
+
+1. **Canonical-length bridge surface**:
+   `AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths`.
+2. **Continuation surface**:
+   accepted-family route (`SmallDAGImpliesAcceptedFamilyStatement`).
+3. **Точка импорта для активного продолжения**:
+   `LowerBounds/RouteNextStep_AcceptedFamily.lean` c alias
+   `NP_not_subset_PpolyDAG_viaAcceptedFamilyRoute`.
+
+### ⚠️ Deprecated convenience (оставлено для совместимости)
+
+- `NP_not_subset_PpolyDAG_of_tableForceSlackEventually_of_sliceConst`
+  — оставлен как исторический convenience endpoint, но не должен
+  использоваться в новых инстанциациях.
+
+### ❌ Closed / failed routes (аудитно закрыты)
+
+1. `tableForce + slack` (для intended MCSP semantics) — закрыт теоремой
+   `false_of_tableForceFamilyEventually_and_slack`.
+2. `tableForce + sliceConst` — закрыт теоремой
+   `false_of_tableForceFamilyEventually_and_sliceConst`.
+3. Эти диагнозы изолированы в
+   `LowerBounds/FailedRoute_EventualTableForceSlackObstruction.lean` и
+   реэкспортируются через `LowerBounds/FailedRoutes.lean`.
+
+## Что внедрено в код прямо сейчас
+
+Ниже — фактически реализованный theorem package, который поднимает route с
+вакуозного `GapSliceFamily` на живой носитель `GapSliceFamilyEventually`.
+
+### 0) Зафиксирована «последняя общая теорема» (final generic reduction)
+
+Добавлены новые теоремы:
+
+- `isoStrongFamilyEventually_of_tableForceFamilyEventually`
+- `NP_not_subset_PpolyDAG_of_tableForceSlackEventually_of_sliceConst`
+
+Смысл:
+
+1. Из table-force + slack строится `IsoStrongFamilyEventually` (для любого `hInDag`).
+2. Через уже существующий адаптер `isoFamily_withPromise_of_isoStrongFamilyEventually`
+   получаем wrapper-форму.
+3. Через endpoint
+   `NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually_of_sliceConst`
+   выводится
+   `ComplexityInterfaces.NP_not_subset_PpolyDAG`.
+
+То есть это именно тот «последний общий редукционный шаг», после которого
+остаётся только подстановка конкретных семейных артефактов.
+
+### 0.1) Проведён аудит convenience-route через `sliceConst`
+
+В коде добавлены строгие диагностические теоремы:
+
+- `no_membership_on_later_canonical_slice_of_sliceConst`
+- `false_of_tableForceFamilyEventually_and_sliceConst`
+- `NP_not_subset_PpolyDAG_of_tableForceSlackEventually_atCanonicalLengths`
+
+Смысл аудита:
+
+1. Если зафиксировать глобальный язык через `canonicalGlobalLanguageEventually`
+   и потребовать all-length равенство (`sliceConstFamilyEventually`), то на
+   canonical длинах поздних slices (`n > F.N0`) язык принудительно падает в `No`.
+2. Поэтому нетривиальный `tableForceFamilyEventually` несовместим с `sliceConst`.
+3. Корректный финальный route для нетривиального семейства — через
+   `AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths` и endpoint
+   `NP_not_subset_PpolyDAG_of_tableForceSlackEventually_atCanonicalLengths`.
+
+### 0.2) Доказана counting-обструкция для `tableForce + slack`
+
+Добавлена теорема:
+
+- `false_of_tableForceFamilyEventually_and_slack`
+
+Она формализует более сильный диагноз: при стандартной MCSP-counting семантике
+(`eventual_coherence_at` + shannon-style witness
+`exists_hard_function_with_value_constraints_of_countingSlack`) контракт
+`tableForceFamilyEventually F β0 κ nIso` несовместим с обычной slack-оценкой.
+
+Практическое следствие:
+
+1. route через `tableForce/patternForce + slack` для intended MCSP нельзя
+   инстанцировать нетривиальным семейством;
+2. `patternForceFamilyEventually` тоже отпадает, так как уже есть
+   `tableForceFamilyEventually_of_patternForceFamilyEventually`;
+3. живым кандидатом остаётся более слабая accepted-family поверхность
+   (без требования, что целый блок completion-таблиц обязан лежать в YES).
+
+### 0.3) Тупиковый путь вынесен в отдельный модуль failed-routes
+
+Добавлен модуль:
+
+- `LowerBounds/FailedRoute_EventualTableForceSlackObstruction.lean`
+
+В нём собраны:
+
+- `failedRoute_tableForce_slack`,
+- `failedRoute_tableForce_sliceConst`.
+
+Это позволяет держать активный маршрут и тупиковые диагнозы раздельно:
+исторический/аудитный путь уходит в `FailedRoutes`, а дальнейшая работа
+переключается на accepted-family surface.
+
+Для активного continuation-route добавлен отдельный модуль:
+
+- `LowerBounds/RouteNextStep_AcceptedFamily.lean`,
+- endpoint alias: `NP_not_subset_PpolyDAG_viaAcceptedFamilyRoute`.
+
+### 1) Введены eventual-объекты
+
+В `AsymptoticDAGBarrierTheorems.lean` добавлены:
+
+- `ppolyDAGSizeBoundOnSlicesEventually`
+- `SmallDAGSolverEventually`
+- `SmallDAGImpliesPromiseYesSubcubeAtEventually`
+
+Это прямые eventual-аналоги старых объектов для legacy-carrier.
+
+### 2) Добавлен локально-валидный builder на eventual-carrier
+
+Добавлена теорема:
+
+- `smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt_localValid_eventually`
+
+Она работает в правильной локальной форме:
+в source-гипотезе требуется `ValidEncoding` только для конкретного `yYes`,
+а не глобально для всех `y ∈ Yes`.
+
+### 3) Добавлена coherence-лемма с явным использованием `n ≥ F.N0`
+
+Добавлена лемма:
+
+- `eventual_coherence_at`
+
+которая даёт нужные переписывания:
+
+- `(F.paramsOf n β).n = n`,
+- `F.Tof n β = (F.paramsOf n β).sNO - 1`,
+- `F.Mof n (F.Tof n β) = circuitCountBound ...`,
+
+при условии `F.N0 ≤ n`.
+
+### 4) Добавлен главный envelope->eventual payload theorem на живом носителе
+
+Добавлена теорема:
+
+- `eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelopeEventually`
+
+с правильным порогом
+
+- `n ≥ max F.N0 (nIso β)`
+
+и с локальной валидностью центра `yYes`.
+
+### 5) Добавлен global-transport bridge на живом носителе (две версии)
+
+Добавлены:
+
+- `AsymptoticDAGLanguageBridgeEventually`
+- `ppolyDAGOnSlicesEventually_of_globalWitness`
+- `AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths`
+- `ppolyDAGOnSlicesEventually_of_globalWitness_atCanonicalLengths`
+
+Ключевой момент: теперь есть и **безопасная canonical-length поверхность**.
+В canonical-length версии перенос делается так:
+
+- на длине `GapSliceFamilyEventually.encodedLen F n β` используется исходное семейство;
+- вне canonical-length используется `constFalseDag`;
+- корректность off-canonical ветки доказывается через определение
+  `gapPartialMCSP_Language` (там по определению `false` вне canonical длины).
+
+Это снимает риск «нечаянного global-collapse» из-за слишком сильного all-length
+равенства.
+
+### 6) Добавлены closure-теоремы до endpoint на живом носителе
+
+Добавлены:
+
+- `smallDAGSolverEventually_of_inPpolyDAGFamilyOnSlices`
+- `no_dag_solver_of_promise_yes_subcube_at_eventually`
+- `not_globalPpolyDAG_of_eventuallyPromiseYesWeakRouteEventually`
+- `NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRouteEventually`
+- `NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually`
+- `not_globalPpolyDAG_of_eventuallyPromiseYesWeakRouteEventually_atCanonicalLengths`
+- `NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRouteEventually_atCanonicalLengths`
+- `NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually_atCanonicalLengths`
+
+То есть endpoint-цепочка теперь доступна и на canonical-length bridge surface
+(не только на legacy all-length surface).
+
+
+### 7) Добавлена лемма покрытия `Yes ∪ No` на canonical длине
+
+Добавлена лемма:
+
+- `mem_yes_or_no_gapSliceOfParams`
+
+Она фиксирует, что для любого
+`x : Bitstring (partialInputLen p)` выполняется
+
+- `x ∈ (gapSliceOfParams p).Yes ∨ x ∈ (gapSliceOfParams p).No`.
+
+Практический смысл: в family-specific forcing-леммах дизъюнкт
+`(z ∈ Yes ∨ z ∈ No)` обычно можно считать техническим (автоматически истинным
+на canonical длине), а содержательная часть — это `ValidEncoding` + agreement.
+
+Итог: non-vacuous generic bridge-математика закрыта **в обеих поверхностях**
+(all-length и canonical-length), причём canonical-length является предпочтительной
+для избежания искусственных коллапсов.
+
+---
+
+## Что осталось после этого (действительно family-specific + один интерфейсный выбор)
+
+От предметной части всё ещё нужны ровно 4 артефакта:
+
+1. `def Fₑ : GapSliceFamilyEventually := ...`
+2. `def κ : Nat → Rat → Nat := ...`
+3. source-theorem в iso/forcing форме (локально-валидный `yYes` + `D` + forcing)
+4. slack-лемма
+
+```lean
+Fₑ.Mof n (Fₑ.Tof n β) <
+  2 ^ (GapSliceFamilyEventually.tableLen Fₑ n β - κ n β)
+```
+
+на нужном eventual-пороге `n ≥ max Fₑ.N0 (nIso β)`.
+
+И дополнительно нужно выбрать, в какой global-surface вы подаёте NP-гипотезу:
+
+- либо legacy all-length bridge (`AsymptoticDAGLanguageBridgeEventually`);
+- либо (предпочтительно) canonical-length bridge
+  (`AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths`).
+
+---
+
+## Что больше НЕ является блокером (проверено повторно)
+
+- Переход на non-vacuous carrier (`GapSliceFamilyEventually`) — реализован.
+- Локальная валидность центра вместо глобального `hYesValid` — реализована.
+- Global-to-slices bridge и class-level closure до `NP_not_subset_PpolyDAG`
+  на eventual-carrier — реализованы, включая canonical-length вариант.
+
+То есть дальше остаётся только конкретная математика для выбранного `Fₑ`,
+без новых инфраструктурных дыр.
+
+
+## Нормальная форма семейного долга (после последнего сужения)
+
+В коде добавлен контракт:
+
+- `IsoStrongFamilyEventually`
+- `isoFamily_withPromise_of_isoStrongFamilyEventually`
+
+Это фиксирует следующий workflow:
+
+1. Предметная сторона может доказывать **сильную** forcing-форму без явного
+   предположения `(z ∈ Yes ∨ z ∈ No)`.
+2. Для совместимости с текущими wrapper-ами используется адаптер, который
+   восстанавливает требуемую форму с promise-дизъюнктом (технически).
+
+Иными словами, ответственность предметной стороны теперь ещё уже:
+нужно дать именно strong-family пакет (`Fₑ`, `κ`, forcing, slack), а bridge-слой
+сам дотягивает его до ожидаемого wrapper-интерфейса.
+
+
+## Ответ на вопрос «можно ли ещё продвинуться к безусловности?» (честный статус)
+
+Коротко: **да, немного можно (и мы продвинулись), но полностью безусловно закрыть
+ещё нельзя**.
+
+Что удалось дожать на generic-уровне:
+
+1. Добавлена canonical-length bridge surface и transport, чтобы убрать
+   неестественную all-length жёсткость.
+2. Добавлены endpoint-теоремы в canonical-length форме, чтобы финальный вывод
+   `NP_not_subset_PpolyDAG` можно было получать без all-length предположения.
+
+Что остаётся принципиальным блокером (уже не infrastructure, а content):
+
+1. Не хватает конкретного `Fₑ`.
+2. Не хватает конкретного `κ`.
+3. Не хватает forcing/isolation инстанса для этого `Fₑ`.
+4. Не хватает slack-инстанса для этого `Fₑ` и `κ`.
+5. Не хватает содержательной NP-точки входа (`hNP`) для выбранного global `L`.
+
+То есть дальше блокеры не «невозможные вообще», а **неразрешимые без новой
+предметной математики** (её нельзя синтезировать из текущего кода автоматически).
+
+## Перепроверка статуса: можно ли уже безусловно закрыть `NP_not_subset_PpolyDAG`?
+
+Короткий ответ: **ещё нет**.
+
+Почему строго:
+
+1. В репозитории по-прежнему отсутствует конкретный объект
+   `def Fₑ : GapSliceFamilyEventually := ...`.
+2. Нет конкретной функции budget
+   `def κ : Nat → Rat → Nat := ...`
+   для выбранного `Fₑ`.
+3. Нет предметной family-леммы (в strong-форме или table-level форме),
+   которая инстанцирует `IsoStrongFamilyEventually` для этого `Fₑ`.
+4. Нет предметной slack-леммы для того же `Fₑ` и `κ`.
+5. Для class-endpoint дополнительно нужен конкретный `bridge` и `hNP : NP bridge.L`
+   (generic route уже умеет их использовать, но не синтезирует из воздуха).
+
+Следовательно, из текущего контекста уже нельзя честно вывести
+`NP_not_subset_PpolyDAG` без новых family-specific данных.
+
+Хорошая новость: generic-инфраструктура уже достаточно полная, и при появлении
+этих данных остаётся в основном предметная инстанциация без архитектурного
+рефакторинга.
+
+
+## Дополнительное сжатие входных данных (реализовано в коде)
+
+Чтобы математики не тащили лишние формы, в код добавлены следующие
+контракты/утилиты:
+
+- `tableForceFamilyEventually`
+- `patternForceFamilyEventually`
+- `tableForceFamilyEventually_of_patternForceFamilyEventually`
+- `canonicalGlobalLanguageEventually`
+- `sliceConstFamilyEventually`
+- `bridgeEventually_of_sliceConst`
+- `NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually_of_sliceConst`
+
+Практический смысл:
+
+1. Можно присылать table-level forcing пакет (или ещё более сильный pattern-level),
+   не доказывая bitstring-level пакет вручную.
+2. Для глобальной части можно прислать не `(bridge, hNP)`, а более лёгкую пару
+   `(hSliceConst, hNP0)` относительно `canonicalGlobalLanguageEventually`;
+   bridge строится автоматически функцией `bridgeEventually_of_sliceConst`.
+3. Это ещё сильнее сужает ответственность предметной стороны до конкретного
+   `Fₑ`, `κ`, forcing и slack.

--- a/pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
+++ b/pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
@@ -485,6 +485,79 @@ theorem no_dag_solver_of_promise_value_locality_at
       hCorrectPromise
 
 /--
+Builder lemma: derive `SmallDAGImpliesPromiseYesSubcubeAt` from an isolation-style
+source property that already yields:
+- a YES center `yYes`,
+- a coordinate set `S` with the required slack inequality,
+- and the fact that every promise-valid input agreeing on `S` lies in YES.
+
+This removes the need for source proofs to produce `DagCircuit.eval C z = true`
+directly; correctness on YES then finishes that field automatically.
+-/
+theorem smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (n : Nat) (β ε : Rat)
+    (hYesValid :
+      ∀ y : Bitstring (GapSliceFamily.encodedLen F n β),
+        y ∈ (gapSliceOfParams (F.paramsOf n β)).Yes →
+          ValidEncoding (F.paramsOf n β) y)
+    (hIso :
+      ∀ C : DagCircuit (GapSliceFamily.encodedLen F n β),
+        SizeBound n β ε (DagCircuit.size C) →
+        CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+          ∃ yYes : Bitstring (GapSliceFamily.encodedLen F n β),
+            yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+            ∃ S : Finset (Fin (GapSliceFamily.tableLen F n β)),
+              F.Mof n (F.Tof n β) < 2 ^ (GapSliceFamily.tableLen F n β - S.card) ∧
+              ∀ z : Bitstring (GapSliceFamily.encodedLen F n β),
+                (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                  z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                ValidEncoding (F.paramsOf n β) z →
+                AgreeOnValues (p := F.paramsOf n β) S yYes z →
+                  z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) :
+    SmallDAGImpliesPromiseYesSubcubeAt F SizeBound n β ε := by
+  intro C hSize hCorrect
+  rcases hIso C hSize hCorrect with ⟨yYes, hyYes, S, hSlack, hAllYes⟩
+  refine ⟨yYes, hyYes, hYesValid yYes hyYes, S, hSlack, ?_⟩
+  intro z hzPromise hzValid hAgree
+  exact hCorrect.1 z (hAllYes z hzPromise hzValid hAgree)
+
+/--
+Refined builder lemma with **local** validity of the chosen YES center.
+
+Compared with `smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt`, this
+variant does not assume the global side condition
+`∀ y ∈ Yes, ValidEncoding y`.  Instead, the source package returns
+`ValidEncoding` for the specific witness center `yYes` it constructs.
+-/
+theorem smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt_localValid
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (n : Nat) (β ε : Rat)
+    (hIso :
+      ∀ C : DagCircuit (GapSliceFamily.encodedLen F n β),
+        SizeBound n β ε (DagCircuit.size C) →
+        CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+          ∃ yYes : Bitstring (GapSliceFamily.encodedLen F n β),
+            yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+            ValidEncoding (F.paramsOf n β) yYes ∧
+            ∃ S : Finset (Fin (GapSliceFamily.tableLen F n β)),
+              F.Mof n (F.Tof n β) < 2 ^ (GapSliceFamily.tableLen F n β - S.card) ∧
+              ∀ z : Bitstring (GapSliceFamily.encodedLen F n β),
+                (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                  z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                ValidEncoding (F.paramsOf n β) z →
+                AgreeOnValues (p := F.paramsOf n β) S yYes z →
+                  z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) :
+    SmallDAGImpliesPromiseYesSubcubeAt F SizeBound n β ε := by
+  intro C hSize hCorrect
+  rcases hIso C hSize hCorrect with ⟨yYes, hyYes, hyValidYes, S, hSlack, hAllYes⟩
+  refine ⟨yYes, hyYes, hyValidYes, S, hSlack, ?_⟩
+  intro z hzPromise hzValid hAgree
+  exact hCorrect.1 z (hAllYes z hzPromise hzValid hAgree)
+
+/--
 Single-slice closure using the one-sided YES-centered promise/value endpoint.
 -/
 theorem no_dag_solver_of_promise_yes_subcube_at
@@ -666,6 +739,42 @@ theorem not_globalPpolyDAG_of_promiseYesWeakRoute
       F (ppolyDAGSizeBoundOnSlices F hInDag) hNoPointwise
 
 /--
+Bridge-local contradiction instantiated with an eventual one-sided promise-YES
+payload on canonical slices.
+
+Compared with `not_globalPpolyDAG_of_promiseYesWeakRoute`, this theorem accepts
+the eventual (`∃ ε, ∃ β0, ...`) source shape directly, without first requiring
+the stronger pointwise statement `SmallDAGImpliesPromiseYesSubcubeStatement`.
+-/
+theorem not_globalPpolyDAG_of_eventuallyPromiseYesWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hEventuallyYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, ∀ n ≥ n0,
+                SmallDAGImpliesPromiseYesSubcubeAt
+                  F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  refine
+    not_globalPpolyDAG_of_noSmallForCanonicalWitnessFamilies
+      (F := F) (bridge := bridge) ?_
+  intro hInDag
+  rcases hEventuallyYesWeak hInDag with ⟨ε, hε, β0, hβ0, hEventuallyYes⟩
+  refine ⟨ε, hε, β0, hβ0, ?_⟩
+  intro β hβPos hβLt
+  rcases hEventuallyYes β hβPos hβLt with ⟨n0, hn0⟩
+  refine ⟨n0, ?_⟩
+  intro n hn
+  exact no_dag_solver_of_promise_yes_subcube_at
+    F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε (hn0 n hn)
+
+/--
 Class-level closure from the weak accepted-family source theorem to
 `NP_not_subset_PpolyDAG`, parameterized by an explicit NP witness for
 `bridge.L`.
@@ -704,6 +813,1304 @@ theorem NP_not_subset_PpolyDAG_of_promiseYesWeakRoute
     ComplexityInterfaces.NP_not_subset_PpolyDAG := by
   refine ⟨bridge.L, hNP, ?_⟩
   exact not_globalPpolyDAG_of_promiseYesWeakRoute F bridge hYesWeak
+
+/--
+Class-level closure from an eventual one-sided promise-YES payload on canonical
+slices to `NP_not_subset_PpolyDAG`.
+-/
+theorem NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hEventuallyYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, ∀ n ≥ n0,
+                SmallDAGImpliesPromiseYesSubcubeAt
+                  F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine ⟨bridge.L, hNP, ?_⟩
+  exact not_globalPpolyDAG_of_eventuallyPromiseYesWeakRoute
+    F bridge hEventuallyYesWeak
+
+/--
+Canonical eventual promise-YES payload from an isolation+envelope source package.
+
+This theorem packages the generic reduction used in the handoff:
+if on each sufficiently large slice every small correct solver admits
+- a YES center and coordinate set `D` forcing YES on all agreeing promise-valid
+  points,
+- a cardinality bound `D.card ≤ κ n β`,
+- and a numeric envelope `M < 2^(tableLen - κ n β)`,
+then we obtain the eventual `SmallDAGImpliesPromiseYesSubcubeAt` payload on
+canonical bounds (with fixed `ε = 1`).
+-/
+theorem eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelope
+    (F : GapSliceFamily)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hIso :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ nIso β →
+        ∀ C : DagCircuit (GapSliceFamily.encodedLen F n β),
+          ppolyDAGSizeBoundOnSlices F hInDag n β 1 (DagCircuit.size C) →
+          CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+            ∃ yYes : Bitstring (GapSliceFamily.encodedLen F n β),
+              yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+              ValidEncoding (F.paramsOf n β) yYes ∧
+              ∃ D : Finset (Fin (GapSliceFamily.tableLen F n β)),
+                D.card ≤ κ n β ∧
+                ∀ z : Bitstring (GapSliceFamily.encodedLen F n β),
+                  (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                    z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                  ValidEncoding (F.paramsOf n β) z →
+                  AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                    z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes)
+    (hSlackEnvelope :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ nIso β →
+          F.Mof n (F.Tof n β) <
+            2 ^ (GapSliceFamily.tableLen F n β - κ n β)) :
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0' : Rat, 0 < β0' ∧
+        ∀ β : Rat, 0 < β → β < β0' →
+          ∃ n0 : Nat, ∀ n ≥ n0,
+            SmallDAGImpliesPromiseYesSubcubeAt
+              F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε := by
+  refine ⟨(1 : Rat), by norm_num, β0, hβ0, ?_⟩
+  intro β hβPos hβLt
+  refine ⟨nIso β, ?_⟩
+  intro n hn
+  refine smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt_localValid
+    F (ppolyDAGSizeBoundOnSlices F hInDag) n β 1 ?_
+  intro C hSize hCorrect
+  rcases hIso n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hyValidYes, D, hDCard, hAllYes⟩
+  refine ⟨yYes, hyYes, hyValidYes, D, ?_, hAllYes⟩
+  have hSub :
+      GapSliceFamily.tableLen F n β - κ n β ≤
+        GapSliceFamily.tableLen F n β - D.card :=
+    Nat.sub_le_sub_left hDCard (GapSliceFamily.tableLen F n β)
+  have hPowNat :
+      (2 ^ (GapSliceFamily.tableLen F n β - κ n β) : Nat) ≤
+        (2 ^ (GapSliceFamily.tableLen F n β - D.card) : Nat) :=
+    Nat.pow_le_pow_right (by decide : 0 < 2) hSub
+  exact lt_of_lt_of_le (hSlackEnvelope n β hβPos hβLt hn) hPowNat
+
+/--
+Class-level closure from an eventual isolation-envelope family package.
+
+This theorem is the direct code-level endpoint for the handoff contract:
+once the family provides the eventual isolation+envelope data uniformly for
+every canonical witness family, `NP_not_subset_PpolyDAG` follows mechanically.
+-/
+theorem NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hIsoFamily :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ β0 : Rat, 0 < β0 ∧
+          ∃ κ : Nat → Rat → Nat,
+            ∃ nIso : Rat → Nat,
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ nIso β →
+                ∀ C : DagCircuit (GapSliceFamily.encodedLen F n β),
+                  ppolyDAGSizeBoundOnSlices F hInDag n β 1 (DagCircuit.size C) →
+                  CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+                    ∃ yYes : Bitstring (GapSliceFamily.encodedLen F n β),
+                      yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+                      ValidEncoding (F.paramsOf n β) yYes ∧
+                      ∃ D : Finset (Fin (GapSliceFamily.tableLen F n β)),
+                        D.card ≤ κ n β ∧
+                        ∀ z : Bitstring (GapSliceFamily.encodedLen F n β),
+                          (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                          ValidEncoding (F.paramsOf n β) z →
+                          AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) ∧
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ nIso β →
+                  F.Mof n (F.Tof n β) <
+                    2 ^ (GapSliceFamily.tableLen F n β - κ n β))) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRoute F bridge hNP ?_
+  intro hInDag
+  rcases hIsoFamily hInDag with ⟨β0, hβ0, κ, nIso, hIso, hSlackEnvelope⟩
+  exact eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelope
+    F hInDag β0 hβ0 κ nIso hIso hSlackEnvelope
+
+/-!
+## Non-vacuous eventual-carrier route (`GapSliceFamilyEventually`)
+
+The legacy wrappers above are parametrized by `GapSliceFamily` (kept for
+compatibility).  The declarations below lift the same route to the non-vacuous
+carrier `GapSliceFamilyEventually`.
+-/
+
+/-- Canonical DAG-size bound on eventual slices. -/
+def ppolyDAGSizeBoundOnSlicesEventually
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    Nat → Rat → Rat → Nat → Prop :=
+  fun n β _ε s =>
+    s ≤ (hInDag n β).polyBound (GapSliceFamilyEventually.encodedLen F n β)
+
+/-- Eventual-slice analogue of `SmallDAGSolver`. -/
+def SmallDAGSolverEventually
+    (F : GapSliceFamilyEventually)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (n : Nat) (β ε : Rat) : Prop :=
+  ∃ C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β),
+    SizeBound n β ε (DagCircuit.size C) ∧
+      CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β))
+
+/--
+Eventual-slice analogue of the one-sided YES-centered source predicate.
+-/
+def SmallDAGImpliesPromiseYesSubcubeAtEventually
+    (F : GapSliceFamilyEventually)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (n : Nat) (β ε : Rat) : Prop :=
+  let p := F.paramsOf n β
+  ∀ C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β),
+    SizeBound n β ε (DagCircuit.size C) →
+    CorrectOnPromiseSlice C (gapSliceOfParams p) →
+      ∃ yYes : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+        yYes ∈ (gapSliceOfParams p).Yes ∧
+        ValidEncoding p yYes ∧
+        ∃ S : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+          F.Mof n (F.Tof n β) <
+            2 ^ (GapSliceFamilyEventually.tableLen F n β - S.card) ∧
+          ∀ z : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+            (z ∈ (gapSliceOfParams p).Yes ∨ z ∈ (gapSliceOfParams p).No) →
+            ValidEncoding p z →
+            AgreeOnValues (p := p) S yYes z →
+            DagCircuit.eval C z = true
+
+/--
+Eventual-carrier local-validity builder.
+-/
+theorem smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt_localValid_eventually
+    (F : GapSliceFamilyEventually)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (n : Nat) (β ε : Rat)
+    (hIso :
+      ∀ C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β),
+        SizeBound n β ε (DagCircuit.size C) →
+        CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+          ∃ yYes : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+            yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+            ValidEncoding (F.paramsOf n β) yYes ∧
+            ∃ S : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+              F.Mof n (F.Tof n β) <
+                2 ^ (GapSliceFamilyEventually.tableLen F n β - S.card) ∧
+              ∀ z : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                  z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                ValidEncoding (F.paramsOf n β) z →
+                AgreeOnValues (p := F.paramsOf n β) S yYes z →
+                  z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) :
+    SmallDAGImpliesPromiseYesSubcubeAtEventually F SizeBound n β ε := by
+  intro C hSize hCorrect
+  rcases hIso C hSize hCorrect with ⟨yYes, hyYes, hyValid, S, hSlack, hForce⟩
+  refine ⟨yYes, hyYes, hyValid, S, hSlack, ?_⟩
+  intro z hzPromise hzValid hAgree
+  exact hCorrect.1 z (hForce z hzPromise hzValid hAgree)
+
+/-- Coherence rewrite used in eventual closure steps (`n ≥ F.N0`). -/
+theorem eventual_coherence_at
+    (F : GapSliceFamilyEventually)
+    (n : Nat) (β : Rat)
+    (hn0 : F.N0 ≤ n) :
+    (F.paramsOf n β).n = n ∧
+      F.Tof n β = (F.paramsOf n β).sNO - 1 ∧
+      F.Mof n (F.Tof n β) =
+        Models.circuitCountBound (F.paramsOf n β).n ((F.paramsOf n β).sNO - 1) := by
+  constructor
+  · exact F.hIndex n hn0 β
+  constructor
+  · exact F.hT n hn0 β
+  · calc
+      F.Mof n (F.Tof n β)
+          = Models.circuitCountBound n (F.Tof n β) := by
+              simpa using F.hM n hn0 (F.Tof n β)
+      _ = Models.circuitCountBound (F.paramsOf n β).n ((F.paramsOf n β).sNO - 1) := by
+            simp [F.hIndex n hn0 β, F.hT n hn0 β]
+
+/--
+At the canonical encoded length, every input belongs to `Yes ∪ No`.
+
+This packages the Bool totality of `gapPartialMCSP_Language` into slice
+membership form and is useful for simplifying source payloads.
+-/
+lemma mem_yes_or_no_gapSliceOfParams
+    (p : GapPartialMCSPParams)
+    (x : Bitstring (partialInputLen p)) :
+    x ∈ (gapSliceOfParams p).Yes ∨ x ∈ (gapSliceOfParams p).No := by
+  cases hLang : gapPartialMCSP_Language p (partialInputLen p) x <;>
+    simp [gapSliceOfParams, hLang]
+
+/--
+Strong family-specific isolation package (without explicit `Yes ∨ No` premise in
+the forcing clause).
+
+This is the narrowed source contract after introducing
+`mem_yes_or_no_gapSliceOfParams`.
+-/
+def IsoStrongFamilyEventually
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) : Prop :=
+  ∃ β0 : Rat, 0 < β0 ∧
+    ∃ κ : Nat → Rat → Nat,
+      ∃ nIso : Rat → Nat,
+        (∀ n : Nat, ∀ β : Rat,
+          0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+          ∀ C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β),
+            ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) →
+            CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+              ∃ yYes : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+                ValidEncoding (F.paramsOf n β) yYes ∧
+                ∃ D : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+                  D.card ≤ κ n β ∧
+                  ∀ z : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                    ValidEncoding (F.paramsOf n β) z →
+                    AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                      z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) ∧
+        (∀ n : Nat, ∀ β : Rat,
+          0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+            F.Mof n (F.Tof n β) <
+              2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β))
+
+/--
+Adapter from the stronger source contract (`IsoStrongFamilyEventually`) to the
+wrapper-ready contract with an explicit `Yes ∨ No` premise.
+
+The only extra step is inserting
+`mem_yes_or_no_gapSliceOfParams (p := F.paramsOf n β) z`.
+-/
+theorem isoFamily_withPromise_of_isoStrongFamilyEventually
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (hStrong : IsoStrongFamilyEventually F hInDag) :
+    ∃ β0 : Rat, 0 < β0 ∧
+      ∃ κ : Nat → Rat → Nat,
+        ∃ nIso : Rat → Nat,
+          (∀ n : Nat, ∀ β : Rat,
+            0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+            ∀ C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β),
+              ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) →
+              CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+                ∃ yYes : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                  yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+                  ValidEncoding (F.paramsOf n β) yYes ∧
+                  ∃ D : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+                    D.card ≤ κ n β ∧
+                    ∀ z : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                      (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                        z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                      ValidEncoding (F.paramsOf n β) z →
+                      AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                        z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) ∧
+          (∀ n : Nat, ∀ β : Rat,
+            0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+              F.Mof n (F.Tof n β) <
+                2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β)) := by
+  rcases hStrong with ⟨β0, hβ0, κ, nIso, hIsoStrong, hSlack⟩
+  refine ⟨β0, hβ0, κ, nIso, ?_, hSlack⟩
+  intro n β hβPos hβLt hn C hSize hCorrect
+  rcases hIsoStrong n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hyValid, D, hDCard, hForce⟩
+  refine ⟨yYes, hyYes, hyValid, D, hDCard, ?_⟩
+  intro z hzPromise hzValid hzAgree
+  have _hzAutoFromAssumption :
+      z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+      z ∈ (gapSliceOfParams (F.paramsOf n β)).No := hzPromise
+  have _hzAutoCanonical :
+      z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+      z ∈ (gapSliceOfParams (F.paramsOf n β)).No :=
+    mem_yes_or_no_gapSliceOfParams (p := F.paramsOf n β) z
+  -- `hzPromise` is now redundant: the strong forcing hypothesis already ignores it.
+  exact hForce z hzValid hzAgree
+
+/--
+Table-level forcing package requested for family-specific handoff.
+
+This is often the cleanest source surface: the forcing condition is stated on
+`PartialTruthTable`s instead of raw bitstrings.
+-/
+def tableForceFamilyEventually
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat) : Prop :=
+  ∀ n : Nat, ∀ β : Rat,
+    0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+    let p := F.paramsOf n β
+    ∃ Ty : PartialTruthTable p.n,
+      PartialMCSP_YES p Ty ∧
+      ∃ D : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+        D.card ≤ κ n β ∧
+        ∀ T : PartialTruthTable p.n,
+          (∀ i ∈ D,
+            Partial.valPart (encodePartial T) i =
+            Partial.valPart (encodePartial Ty) i) →
+          PartialMCSP_YES p T
+
+/--
+Pattern-oriented family package (`D + a*`) that is stronger than the table-force
+form and is often natural for witness-coordinate constructions.
+-/
+def patternForceFamilyEventually
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat) : Prop :=
+  ∀ n : Nat, ∀ β : Rat,
+    0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+    let p := F.paramsOf n β
+    ∃ D : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+      D.card ≤ κ n β ∧
+      ∃ aStar : Fin (GapSliceFamilyEventually.tableLen F n β) → Bool,
+        ∃ Ty : PartialTruthTable p.n,
+          PartialMCSP_YES p Ty ∧
+          (∀ i ∈ D,
+            Partial.valPart (encodePartial Ty) i = aStar i) ∧
+          ∀ T : PartialTruthTable p.n,
+            (∀ i ∈ D,
+              Partial.valPart (encodePartial T) i = aStar i) →
+            PartialMCSP_YES p T
+
+/--
+`patternForceFamilyEventually` immediately implies
+`tableForceFamilyEventually` by choosing the same `Ty` and eliminating `a*`.
+-/
+theorem tableForceFamilyEventually_of_patternForceFamilyEventually
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hPattern : patternForceFamilyEventually F β0 κ nIso) :
+    tableForceFamilyEventually F β0 κ nIso := by
+  intro n β hβPos hβLt hn
+  rcases hPattern n β hβPos hβLt hn with ⟨D, hDCard, aStar, Ty, hTyYes, hTyPat, hForce⟩
+  refine ⟨Ty, hTyYes, D, hDCard, ?_⟩
+  intro T hEqTy
+  apply hForce T
+  intro i hi
+  calc
+    Partial.valPart (encodePartial T) i = Partial.valPart (encodePartial Ty) i := hEqTy i hi
+    _ = aStar i := hTyPat i hi
+
+/--
+Build the strong eventual isolation package from a table-level forcing package
+plus a slack envelope.
+
+This theorem is the last generic reduction step: it discharges the entire
+family-to-wrapper adaptation and leaves only concrete family instantiation
+(`F`, `κ`, forcing, slack, slice-constancy, NP-entry`) to the source side.
+
+`hDecodeEncode` is kept explicit to mirror the handoff contract; in the current
+development it is normally instantiated by `Models.decodePartial_encodePartial`.
+-/
+theorem isoStrongFamilyEventually_of_tableForceFamilyEventually
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hTable : tableForceFamilyEventually F β0 κ nIso)
+    (hSlack :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+          F.Mof n (F.Tof n β) <
+            2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β))
+    (hDecodeEncode :
+      ∀ {n : Nat} (T : PartialTruthTable n), decodePartial (encodePartial T) = T) :
+    ∀ hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)),
+      IsoStrongFamilyEventually F hInDag := by
+  intro hInDag
+  refine ⟨β0, hβ0, κ, nIso, ?_, hSlack⟩
+  intro n β hβPos hβLt hn _C _hSize _hCorrect
+  -- `_C`, `_hSize`, `_hCorrect` are part of the wrapper shape but are not needed
+  -- by pure table-level forcing.
+  let p := F.paramsOf n β
+  rcases hTable n β hβPos hβLt hn with ⟨Ty, hTyYes, D, hDCard, hTableForce⟩
+  let yYes : Bitstring (GapSliceFamilyEventually.encodedLen F n β) := encodePartial Ty
+  have hyYesYes : yYes ∈ (gapSliceOfParams p).Yes := by
+    have hLangTrue :
+        gapPartialMCSP_Language p (partialInputLen p) yYes = true := by
+      -- Use the canonical-length language characterization and the explicit
+      -- decode-after-encode assumption from the theorem contract.
+      exact (gapPartialMCSP_language_true_iff_yes p yYes).2 (by
+        simpa [yYes, hDecodeEncode Ty] using hTyYes)
+    simpa [gapSliceOfParams, p, GapSliceFamilyEventually.encodedLen, yYes] using hLangTrue
+  have hyYesValid : ValidEncoding p yYes := by
+    simpa [p, yYes] using validEncoding_encodePartial p Ty
+  refine ⟨yYes, hyYesYes, hyYesValid, D, hDCard, ?_⟩
+  intro z hzValid hzAgree
+  have hzCanonical : z = encodePartial (decodePartial z) := hzValid
+  have hEqOnD :
+      ∀ i ∈ D,
+        Partial.valPart (encodePartial (decodePartial z)) i =
+          Partial.valPart (encodePartial Ty) i := by
+    intro i hi
+    have hAgreeZi : Partial.valPart z i = Partial.valPart yYes i := Eq.symm (hzAgree i hi)
+    have hCanonicalVal :
+        Partial.valPart (encodePartial (decodePartial z)) i =
+          Partial.valPart z i :=
+      congrArg (fun x => Partial.valPart x i) (Eq.symm hzCanonical)
+    calc
+      Partial.valPart (encodePartial (decodePartial z)) i = Partial.valPart z i := hCanonicalVal
+      _ = Partial.valPart yYes i := hAgreeZi
+      _ = Partial.valPart (encodePartial Ty) i := by simp [yYes]
+  have hYesDecoded : PartialMCSP_YES p (decodePartial z) := hTableForce (decodePartial z) hEqOnD
+  have hLangTrue :
+      gapPartialMCSP_Language p (partialInputLen p) z = true :=
+    (gapPartialMCSP_language_true_iff_yes p z).2 hYesDecoded
+  simpa [gapSliceOfParams] using hLangTrue
+
+/-- Canonical global language representative for eventual family routes. -/
+noncomputable def canonicalGlobalLanguageEventually
+    (F : GapSliceFamilyEventually) : Language :=
+  gapPartialMCSP_Language (F.paramsOf F.N0 (1 : Rat))
+
+/--
+Pairwise constancy of slice languages against one canonical representative.
+-/
+def sliceConstFamilyEventually
+    (F : GapSliceFamilyEventually) : Prop :=
+  ∀ n : Nat, ∀ β : Rat, ∀ N : Nat, ∀ x : Bitstring N,
+    canonicalGlobalLanguageEventually F N x =
+      gapPartialMCSP_Language (F.paramsOf n β) N x
+
+/--
+Eventual envelope package -> eventual one-sided promise-YES payload on canonical
+bounds (non-vacuous carrier).
+-/
+theorem eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelopeEventually
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hIso :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+        ∀ C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β),
+          ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) →
+          CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+            ∃ yYes : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+              yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+              ValidEncoding (F.paramsOf n β) yYes ∧
+              ∃ D : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+                D.card ≤ κ n β ∧
+                ∀ z : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                  (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                    z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                  ValidEncoding (F.paramsOf n β) z →
+                  AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                    z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes)
+    (hSlackEnvelope :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+          F.Mof n (F.Tof n β) <
+            2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β)) :
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0' : Rat, 0 < β0' ∧
+        ∀ β : Rat, 0 < β → β < β0' →
+          ∃ n0 : Nat, F.N0 ≤ n0 ∧
+            ∀ n ≥ n0,
+              SmallDAGImpliesPromiseYesSubcubeAtEventually
+                F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n β ε := by
+  refine ⟨(1 : Rat), by norm_num, β0, hβ0, ?_⟩
+  intro β hβPos hβLt
+  refine ⟨max F.N0 (nIso β), le_max_left _ _, ?_⟩
+  intro n hn
+  refine smallDAGImpliesPromiseYesSubcubeAt_of_yesIsolationAt_localValid_eventually
+    F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n β 1 ?_
+  intro C hSize hCorrect
+  rcases hIso n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hyValidYes, D, hDCard, hAllYes⟩
+  refine ⟨yYes, hyYes, hyValidYes, D, ?_, hAllYes⟩
+  have hSub :
+      GapSliceFamilyEventually.tableLen F n β - κ n β ≤
+        GapSliceFamilyEventually.tableLen F n β - D.card :=
+    Nat.sub_le_sub_left hDCard (GapSliceFamilyEventually.tableLen F n β)
+  have hPowNat :
+      (2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β) : Nat) ≤
+        (2 ^ (GapSliceFamilyEventually.tableLen F n β - D.card) : Nat) :=
+    Nat.pow_le_pow_right (by decide : 0 < 2) hSub
+  exact lt_of_lt_of_le (hSlackEnvelope n β hβPos hβLt hn) hPowNat
+
+/--
+Bridge package connecting one global language to all eventual slice languages.
+-/
+structure AsymptoticDAGLanguageBridgeEventually
+    (F : GapSliceFamilyEventually) : Type where
+  L : Language
+  sliceEq :
+    ∀ n : Nat, ∀ β : Rat, ∀ N : Nat, ∀ x : Bitstring N,
+      L N x = gapPartialMCSP_Language (F.paramsOf n β) N x
+
+/--
+Canonical-length-only bridge (non-collapsing variant).
+
+This is the mathematically safe eventual bridge: agreement is required only on
+the canonical encoded length of each slice.
+-/
+structure AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths
+    (F : GapSliceFamilyEventually) : Type where
+  L : Language
+  sliceEq :
+    ∀ n : Nat, ∀ β : Rat,
+      ∀ x : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+        L (GapSliceFamilyEventually.encodedLen F n β) x =
+          gapPartialMCSP_Language (F.paramsOf n β)
+            (GapSliceFamilyEventually.encodedLen F n β) x
+
+/-- One-gate constant-false DAG used off canonical lengths. -/
+private def constFalseDag (n : Nat) : ComplexityInterfaces.DagCircuit n where
+  gates := 1
+  gate := fun _ => ComplexityInterfaces.DagGate.const false
+  output := ComplexityInterfaces.DagWire.gate ⟨0, by simp⟩
+
+@[simp] private theorem constFalseDag_size {n : Nat} :
+    ComplexityInterfaces.DagCircuit.size (constFalseDag n) = 2 := by
+  simp [constFalseDag, ComplexityInterfaces.DagCircuit.size]
+
+@[simp] private theorem constFalseDag_eval {n : Nat}
+    (x : ComplexityInterfaces.Bitstring n) :
+    ComplexityInterfaces.DagCircuit.eval (constFalseDag n) x = false := by
+  simp [constFalseDag, ComplexityInterfaces.DagCircuit.eval,
+    ComplexityInterfaces.DagCircuit.eval.evalGateAt]
+
+/-- Monotone padding used for the canonical-length transport witness. -/
+private theorem dag_poly_bound_lift (n c : Nat) :
+    n ^ c + c ≤ n ^ (c + 2) + (c + 2) := by
+  by_cases hn : n = 0
+  · subst hn
+    cases c <;> simp
+  · have h1 : 1 ≤ n := Nat.succ_le_of_lt (Nat.pos_of_ne_zero hn)
+    have hpow : n ^ c ≤ n ^ (c + 2) := by
+      simpa [Nat.add_assoc] using Nat.pow_le_pow_right h1 (Nat.le_add_right c 2)
+    have hc : c ≤ c + 2 := by omega
+    exact Nat.add_le_add hpow hc
+
+/--
+Construct the eventual bridge object from pairwise slice constancy.
+-/
+noncomputable def bridgeEventually_of_sliceConst
+    (F : GapSliceFamilyEventually)
+    (hConst : sliceConstFamilyEventually F) :
+    AsymptoticDAGLanguageBridgeEventually F where
+  L := canonicalGlobalLanguageEventually F
+  sliceEq := hConst
+
+/-- Transport global `PpolyDAG` witness to all eventual slices. -/
+theorem ppolyDAGOnSlicesEventually_of_globalWitness
+    (F : GapSliceFamilyEventually)
+    (bridge : AsymptoticDAGLanguageBridgeEventually F)
+    (hDagGlobal : ComplexityInterfaces.PpolyDAG bridge.L) :
+    ∀ n : Nat, ∀ β : Rat,
+      ComplexityInterfaces.PpolyDAG
+        (gapPartialMCSP_Language (F.paramsOf n β)) := by
+  rcases hDagGlobal with ⟨w, -⟩
+  intro n β
+  refine ⟨{ polyBound := w.polyBound
+            polyBound_poly := w.polyBound_poly
+            family := w.family
+            family_size_le := w.family_size_le
+            correct := ?_ }, trivial⟩
+  intro N x
+  exact (w.correct N x).trans (bridge.sliceEq n β N x)
+
+/--
+Transport from a global witness using the canonical-length-only bridge.
+
+On the target canonical length we reuse the global witness family.
+Off that length we use `constFalseDag`; correctness is immediate because
+`gapPartialMCSP_Language` is definitionally `false` off canonical length.
+-/
+theorem ppolyDAGOnSlicesEventually_of_globalWitness_atCanonicalLengths
+    (F : GapSliceFamilyEventually)
+    (bridge : AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths F)
+    (hDagGlobal : ComplexityInterfaces.PpolyDAG bridge.L) :
+    ∀ n : Nat, ∀ β : Rat,
+      ComplexityInterfaces.PpolyDAG
+        (gapPartialMCSP_Language (F.paramsOf n β)) := by
+  rcases hDagGlobal with ⟨w, -⟩
+  intro n β
+  let N0 := GapSliceFamilyEventually.encodedLen F n β
+  rcases w.polyBound_poly with ⟨c, hc⟩
+  refine ⟨{ polyBound := fun N => N ^ (c + 2) + (c + 2)
+            polyBound_poly := ?_
+            family := fun N => if hN : N = N0 then w.family N else constFalseDag N
+            family_size_le := ?_
+            correct := ?_ }, trivial⟩
+  · refine ⟨c + 2, ?_⟩
+    intro N
+    rfl
+  · intro N
+    by_cases hN : N = N0
+    · cases hN
+      simp
+      exact Nat.le_trans (w.family_size_le N0) (Nat.le_trans (hc N0) (dag_poly_bound_lift N0 c))
+    · simp [hN]
+      have hTwo : 2 ≤ c + 2 := by omega
+      exact Nat.le_trans hTwo (Nat.le_add_left (c + 2) (N ^ (c + 2)))
+  · intro N x
+    by_cases hN : N = N0
+    · subst hN
+      have hGlobal :
+          DagCircuit.eval (w.family N0) x = bridge.L N0 x := w.correct N0 x
+      have hSlice :
+          bridge.L N0 x =
+            gapPartialMCSP_Language (F.paramsOf n β) N0 x :=
+        bridge.sliceEq n β x
+      simpa [N0] using hGlobal.trans hSlice
+    · have hOff :
+        gapPartialMCSP_Language (F.paramsOf n β) N x = false := by
+          have hLen :
+              N ≠ partialInputLen (F.paramsOf n β) := by
+            simpa [GapSliceFamilyEventually.encodedLen, N0] using hN
+          simp [gapPartialMCSP_Language, hLen]
+      simp [hN, hOff]
+
+/-- Canonical small-solver witness on eventual slices from `InPpolyDAG` witnesses. -/
+theorem smallDAGSolverEventually_of_inPpolyDAGFamilyOnSlices
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    ∀ n : Nat, ∀ β ε : Rat,
+      SmallDAGSolverEventually
+        F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n β ε := by
+  intro n β ε
+  let w : ComplexityInterfaces.InPpolyDAG
+      (gapPartialMCSP_Language (F.paramsOf n β)) := hInDag n β
+  refine ⟨w.family (GapSliceFamilyEventually.encodedLen F n β), ?_, ?_⟩
+  · simpa [ppolyDAGSizeBoundOnSlicesEventually] using
+      w.family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  · constructor
+    · intro x hxYes
+      have hxLang :
+          gapPartialMCSP_Language (F.paramsOf n β)
+              (GapSliceFamilyEventually.encodedLen F n β) x = true := by
+        simpa [gapSliceOfParams] using hxYes
+      exact (w.correct (GapSliceFamilyEventually.encodedLen F n β) x).trans hxLang
+    · intro x hxNo
+      have hxLang :
+          gapPartialMCSP_Language (F.paramsOf n β)
+              (GapSliceFamilyEventually.encodedLen F n β) x = false := by
+        simpa [gapSliceOfParams] using hxNo
+      exact (w.correct (GapSliceFamilyEventually.encodedLen F n β) x).trans hxLang
+
+/--
+Single-slice contradiction on the eventual carrier (requires `n ≥ F.N0` for
+coherence rewrites from `F.Mof/F.Tof` to the counting theorem format).
+-/
+theorem no_dag_solver_of_promise_yes_subcube_at_eventually
+    (F : GapSliceFamilyEventually)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (n : Nat) (β ε : Rat)
+    (hn0 : F.N0 ≤ n)
+    (hYes :
+      SmallDAGImpliesPromiseYesSubcubeAtEventually F SizeBound n β ε) :
+    ¬ SmallDAGSolverEventually F SizeBound n β ε := by
+  intro hExists
+  rcases hExists with ⟨C, hSize, hCorrect⟩
+  let p := F.paramsOf n β
+  rcases hYes C hSize hCorrect with ⟨yYes, hyYes, hyValidYes, S, hSlack, hAccept⟩
+  have hcoh := eventual_coherence_at F n β hn0
+  rcases hcoh with ⟨hpn, hTof, hMof⟩
+  have hSlack' :
+      Models.circuitCountBound p.n (p.sNO - 1) <
+        2 ^ (Models.Partial.tableLen p.n - S.card) := by
+    calc
+      Models.circuitCountBound p.n (p.sNO - 1)
+          = Models.circuitCountBound (F.paramsOf n β).n ((F.paramsOf n β).sNO - 1) := by
+              simp [p]
+      _ = F.Mof n (F.Tof n β) := by simpa [hMof]
+      _ < 2 ^ (GapSliceFamilyEventually.tableLen F n β - S.card) := hSlack
+      _ = 2 ^ (Models.Partial.tableLen p.n - S.card) := by
+            simp [GapSliceFamilyEventually.tableLen, p, hpn]
+  have hCorrectPromise :
+      SolvesPromise (GapPartialMCSPPromise p) (DagCircuit.eval C) := by
+    constructor
+    · intro x hx
+      exact hCorrect.1 x (by simpa [GapPartialMCSPPromise, gapSliceOfParams, p] using hx)
+    · intro x hx
+      exact hCorrect.2 x (by simpa [GapPartialMCSPPromise, gapSliceOfParams, p] using hx)
+  exact
+    LowerBounds.no_one_sided_value_local_function_solves_mcsp_of_countingSlack
+      (p := p)
+      (f := DagCircuit.eval C)
+      (x_yes := yYes)
+      (S := S)
+      (hYes := by simpa [GapPartialMCSPPromise, gapSliceOfParams, p] using hyYes)
+      (hValidYes := hyValidYes)
+      hSlack'
+      (fun z hzPromise hzValid hAgree =>
+        hAccept z
+          ((by
+            cases hzPromise with
+            | inl hzYes =>
+                exact Or.inl (by simpa [gapSliceOfParams, p] using hzYes)
+            | inr hzNo =>
+                exact Or.inr (by simpa [gapSliceOfParams, p] using hzNo)))
+          hzValid
+          hAgree)
+      hCorrectPromise
+
+/--
+Non-vacuous global contradiction schema for eventual-carrier one-sided
+promise-YES payloads.
+-/
+theorem not_globalPpolyDAG_of_eventuallyPromiseYesWeakRouteEventually
+    (F : GapSliceFamilyEventually)
+    (bridge : AsymptoticDAGLanguageBridgeEventually F)
+    (hEventuallyYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, F.N0 ≤ n0 ∧
+                ∀ n ≥ n0,
+                  SmallDAGImpliesPromiseYesSubcubeAtEventually
+                    F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n β ε) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  intro hDagGlobal
+  have hSlices :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.PpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)) :=
+    ppolyDAGOnSlicesEventually_of_globalWitness F bridge hDagGlobal
+  let hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)) :=
+    fun n β => Classical.choose (hSlices n β)
+  rcases hEventuallyYesWeak hInDag with ⟨ε, hε, β0, hβ0, hEventuallyYes⟩
+  let β : Rat := β0 / 2
+  have hβpos : 0 < β := by
+    dsimp [β]
+    nlinarith [hβ0]
+  have hβlt : β < β0 := by
+    dsimp [β]
+    nlinarith [hβ0]
+  rcases hEventuallyYes β hβpos hβlt with ⟨n0, hn0_ge, hNoAtLarge⟩
+  have hSolverAtN0 :
+      SmallDAGSolverEventually
+        F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n0 β ε :=
+    smallDAGSolverEventually_of_inPpolyDAGFamilyOnSlices F hInDag n0 β ε
+  exact
+    (no_dag_solver_of_promise_yes_subcube_at_eventually
+      F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n0 β ε hn0_ge
+      (hNoAtLarge n0 (le_rfl))) hSolverAtN0
+
+/--
+Canonical-length variant of
+`not_globalPpolyDAG_of_eventuallyPromiseYesWeakRouteEventually`.
+
+This is the non-collapsing bridge surface: global/slice agreement is only
+required on encoded lengths of the target slices.
+-/
+theorem not_globalPpolyDAG_of_eventuallyPromiseYesWeakRouteEventually_atCanonicalLengths
+    (F : GapSliceFamilyEventually)
+    (bridge : AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths F)
+    (hEventuallyYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, F.N0 ≤ n0 ∧
+                ∀ n ≥ n0,
+                  SmallDAGImpliesPromiseYesSubcubeAtEventually
+                    F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n β ε) :
+    ¬ ComplexityInterfaces.PpolyDAG bridge.L := by
+  intro hDagGlobal
+  have hSlices :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.PpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)) :=
+    ppolyDAGOnSlicesEventually_of_globalWitness_atCanonicalLengths F bridge hDagGlobal
+  let hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)) :=
+    fun n β => Classical.choose (hSlices n β)
+  rcases hEventuallyYesWeak hInDag with ⟨ε, hε, β0, hβ0, hEventuallyYes⟩
+  let β : Rat := β0 / 2
+  have hβpos : 0 < β := by
+    dsimp [β]
+    nlinarith [hβ0]
+  have hβlt : β < β0 := by
+    dsimp [β]
+    nlinarith [hβ0]
+  rcases hEventuallyYes β hβpos hβlt with ⟨n0, hn0_ge, hNoAtLarge⟩
+  have hSolverAtN0 :
+      SmallDAGSolverEventually
+        F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n0 β ε :=
+    smallDAGSolverEventually_of_inPpolyDAGFamilyOnSlices F hInDag n0 β ε
+  exact
+    (no_dag_solver_of_promise_yes_subcube_at_eventually
+      F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n0 β ε hn0_ge
+      (hNoAtLarge n0 (le_rfl))) hSolverAtN0
+
+/-- Class-level endpoint from eventual-carrier one-sided promise-YES payloads. -/
+theorem NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRouteEventually
+    (F : GapSliceFamilyEventually)
+    (bridge : AsymptoticDAGLanguageBridgeEventually F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hEventuallyYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, F.N0 ≤ n0 ∧
+                ∀ n ≥ n0,
+                  SmallDAGImpliesPromiseYesSubcubeAtEventually
+                    F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n β ε) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine ⟨bridge.L, hNP, ?_⟩
+  exact not_globalPpolyDAG_of_eventuallyPromiseYesWeakRouteEventually
+    F bridge hEventuallyYesWeak
+
+/--
+Class-level endpoint from eventual-carrier one-sided promise-YES payloads on
+the canonical-length bridge surface.
+-/
+theorem NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRouteEventually_atCanonicalLengths
+    (F : GapSliceFamilyEventually)
+    (bridge : AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hEventuallyYesWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ ε : Rat, 0 < ε ∧
+          ∃ β0 : Rat, 0 < β0 ∧
+            ∀ β : Rat, 0 < β → β < β0 →
+              ∃ n0 : Nat, F.N0 ≤ n0 ∧
+                ∀ n ≥ n0,
+                  SmallDAGImpliesPromiseYesSubcubeAtEventually
+                    F (ppolyDAGSizeBoundOnSlicesEventually F hInDag) n β ε) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine ⟨bridge.L, hNP, ?_⟩
+  exact not_globalPpolyDAG_of_eventuallyPromiseYesWeakRouteEventually_atCanonicalLengths
+    F bridge hEventuallyYesWeak
+
+/--
+Non-vacuous eventual isolation-envelope -> NP endpoint.
+-/
+theorem NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually
+    (F : GapSliceFamilyEventually)
+    (bridge : AsymptoticDAGLanguageBridgeEventually F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hIsoFamily :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ β0 : Rat, 0 < β0 ∧
+          ∃ κ : Nat → Rat → Nat,
+            ∃ nIso : Rat → Nat,
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+                ∀ C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β),
+                  ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) →
+                  CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+                    ∃ yYes : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                      yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+                      ValidEncoding (F.paramsOf n β) yYes ∧
+                      ∃ D : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+                        D.card ≤ κ n β ∧
+                        ∀ z : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                          (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                          ValidEncoding (F.paramsOf n β) z →
+                          AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) ∧
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+                  F.Mof n (F.Tof n β) <
+                    2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β))) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRouteEventually
+    F bridge hNP ?_
+  intro hInDag
+  rcases hIsoFamily hInDag with ⟨β0, hβ0, κ, nIso, hIso, hSlackEnvelope⟩
+  exact eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelopeEventually
+    F hInDag β0 hβ0 κ nIso hIso hSlackEnvelope
+
+/--
+Canonical-length bridge variant of the eventual isolation-envelope endpoint.
+
+Compared to `...WeakRouteEventually`, this endpoint requires only
+canonical-length agreement between the global language and each slice.
+-/
+theorem NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually_atCanonicalLengths
+    (F : GapSliceFamilyEventually)
+    (bridge : AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hIsoFamily :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ β0 : Rat, 0 < β0 ∧
+          ∃ κ : Nat → Rat → Nat,
+            ∃ nIso : Rat → Nat,
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+                ∀ C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β),
+                  ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) →
+                  CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+                    ∃ yYes : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                      yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+                      ValidEncoding (F.paramsOf n β) yYes ∧
+                      ∃ D : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+                        D.card ≤ κ n β ∧
+                        ∀ z : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                          (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                          ValidEncoding (F.paramsOf n β) z →
+                          AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) ∧
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+                  F.Mof n (F.Tof n β) <
+                    2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β))) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine NP_not_subset_PpolyDAG_of_eventuallyPromiseYesWeakRouteEventually_atCanonicalLengths
+    F bridge hNP ?_
+  intro hInDag
+  rcases hIsoFamily hInDag with ⟨β0, hβ0, κ, nIso, hIso, hSlackEnvelope⟩
+  exact eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelopeEventually
+    F hInDag β0 hβ0 κ nIso hIso hSlackEnvelope
+
+/--
+Convenience endpoint: use `(hSliceConst, hNP0)` instead of explicitly passing a
+bridge object.
+-/
+theorem NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually_of_sliceConst
+    (F : GapSliceFamilyEventually)
+    (hSliceConst : sliceConstFamilyEventually F)
+    (hNP0 : ComplexityInterfaces.NP (canonicalGlobalLanguageEventually F))
+    (hIsoFamily :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        ∃ β0 : Rat, 0 < β0 ∧
+          ∃ κ : Nat → Rat → Nat,
+            ∃ nIso : Rat → Nat,
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+                ∀ C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β),
+                  ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) →
+                  CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) →
+                    ∃ yYes : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                      yYes ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∧
+                      ValidEncoding (F.paramsOf n β) yYes ∧
+                      ∃ D : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)),
+                        D.card ≤ κ n β ∧
+                        ∀ z : Bitstring (GapSliceFamilyEventually.encodedLen F n β),
+                          (z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes ∨
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).No) →
+                          ValidEncoding (F.paramsOf n β) z →
+                          AgreeOnValues (p := F.paramsOf n β) D yYes z →
+                            z ∈ (gapSliceOfParams (F.paramsOf n β)).Yes) ∧
+              (∀ n : Nat, ∀ β : Rat,
+                0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+                  F.Mof n (F.Tof n β) <
+                    2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β))) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  let bridge : AsymptoticDAGLanguageBridgeEventually F :=
+    bridgeEventually_of_sliceConst F hSliceConst
+  have hNP : ComplexityInterfaces.NP bridge.L := by
+    simpa [bridge, bridgeEventually_of_sliceConst, canonicalGlobalLanguageEventually] using hNP0
+  exact NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually
+    F bridge hNP hIsoFamily
+
+/--
+Deprecated convenience endpoint.
+
+For active/non-collapsing developments prefer
+`NP_not_subset_PpolyDAG_of_tableForceSlackEventually_atCanonicalLengths`.
+-/
+theorem NP_not_subset_PpolyDAG_of_tableForceSlackEventually_of_sliceConst
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hTable : tableForceFamilyEventually F β0 κ nIso)
+    (hSlack :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+          F.Mof n (F.Tof n β) <
+            2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β))
+    (hSliceConst : sliceConstFamilyEventually F)
+    (hNP0 : ComplexityInterfaces.NP (canonicalGlobalLanguageEventually F))
+    (hDecodeEncode :
+      ∀ {n : Nat} (T : PartialTruthTable n), decodePartial (encodePartial T) = T) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually_of_sliceConst
+    F hSliceConst hNP0 ?_
+  intro hInDag
+  -- 1) Build the strong forcing package from table-force + slack.
+  have hStrong : IsoStrongFamilyEventually F hInDag :=
+    isoStrongFamilyEventually_of_tableForceFamilyEventually
+      F β0 hβ0 κ nIso hTable hSlack hDecodeEncode hInDag
+  -- 2) Adapt to the wrapper format with explicit `Yes ∨ No`.
+  exact isoFamily_withPromise_of_isoStrongFamilyEventually F hInDag hStrong
+
+/--
+If all eventual slices are forced equal to one fixed canonical global language
+(`sliceConstFamilyEventually`), then every strictly-later canonical slice is
+forced into the `No` side.
+
+This theorem formalizes the collapse risk of the convenience `sliceConst`
+surface: once `n > F.N0`, the canonical encoded lengths differ, so the fixed
+global language evaluates to `false` on that length by definition.
+-/
+theorem no_membership_on_later_canonical_slice_of_sliceConst
+    (F : GapSliceFamilyEventually)
+    (hSliceConst : sliceConstFamilyEventually F)
+    (n : Nat)
+    (β : Rat)
+    (hnGt : F.N0 < n)
+    (x : Bitstring (GapSliceFamilyEventually.encodedLen F n β)) :
+    x ∈ (gapSliceOfParams (F.paramsOf n β)).No := by
+  have hnGe : F.N0 ≤ n := Nat.le_of_lt hnGt
+  have hIndexN :
+      (F.paramsOf n β).n = n := (eventual_coherence_at F n β hnGe).1
+  have hIndex0 :
+      (F.paramsOf F.N0 (1 : Rat)).n = F.N0 := (eventual_coherence_at F F.N0 (1 : Rat) (le_rfl)).1
+  have hLenNe :
+      GapSliceFamilyEventually.encodedLen F n β ≠
+        GapSliceFamilyEventually.encodedLen F F.N0 (1 : Rat) := by
+    intro hEq
+    have hEqInputLen : Partial.inputLen n = Partial.inputLen F.N0 := by
+      simpa [GapSliceFamilyEventually.encodedLen, partialInputLen, hIndexN, hIndex0] using hEq
+    exact (Nat.ne_of_gt hnGt) (Models.partialInputLen_injective hEqInputLen)
+  have hCanonFalse :
+      canonicalGlobalLanguageEventually F (GapSliceFamilyEventually.encodedLen F n β) x = false := by
+    have hNe :
+        GapSliceFamilyEventually.encodedLen F n β ≠
+          partialInputLen (F.paramsOf F.N0 (1 : Rat)) := by
+      simpa [GapSliceFamilyEventually.encodedLen] using hLenNe
+    simp [canonicalGlobalLanguageEventually, gapPartialMCSP_Language, hNe]
+  have hSliceFalse :
+      gapPartialMCSP_Language (F.paramsOf n β)
+        (GapSliceFamilyEventually.encodedLen F n β) x = false := by
+    simpa [hSliceConst n β (GapSliceFamilyEventually.encodedLen F n β) x] using hCanonFalse
+  simpa [gapSliceOfParams] using hSliceFalse
+
+/--
+`tableForceFamilyEventually` and `sliceConstFamilyEventually` are incompatible
+on nontrivial eventual carriers (strictly after `F.N0`).
+
+This extracts the concrete contradiction used to audit the convenience
+`..._of_sliceConst` route.
+-/
+theorem false_of_tableForceFamilyEventually_and_sliceConst
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hTable : tableForceFamilyEventually F β0 κ nIso)
+    (hSliceConst : sliceConstFamilyEventually F)
+    (hDecodeEncode :
+      ∀ {n : Nat} (T : PartialTruthTable n), decodePartial (encodePartial T) = T) :
+    False := by
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    nlinarith [hβ0]
+  have hβLt : β < β0 := by
+    dsimp [β]
+    nlinarith [hβ0]
+  let n : Nat := max (F.N0 + 1) (nIso β)
+  have hnGe : n ≥ max F.N0 (nIso β) := by
+    dsimp [n]
+    exact max_le (Nat.le_trans (Nat.le_add_right F.N0 1) (Nat.le_max_left _ _))
+      (Nat.le_max_right _ _)
+  have hnGt : F.N0 < n := by
+    dsimp [n]
+    exact lt_of_lt_of_le (Nat.lt_succ_self F.N0) (Nat.le_max_left _ _)
+  rcases hTable n β hβPos hβLt hnGe with ⟨Ty, hTyYes, D, hDCard, hForce⟩
+  let p := F.paramsOf n β
+  let y : Bitstring (GapSliceFamilyEventually.encodedLen F n β) := encodePartial Ty
+  have hyYes : y ∈ (gapSliceOfParams p).Yes := by
+    have hLangTrue : gapPartialMCSP_Language p (partialInputLen p) y = true :=
+      (gapPartialMCSP_language_true_iff_yes p y).2 (by
+        simpa [y, hDecodeEncode Ty] using hTyYes)
+    simpa [gapSliceOfParams, p, GapSliceFamilyEventually.encodedLen, y] using hLangTrue
+  have hyNo : y ∈ (gapSliceOfParams p).No := by
+    simpa [p] using
+      no_membership_on_later_canonical_slice_of_sliceConst F hSliceConst n β hnGt y
+  have hTrue :
+      gapPartialMCSP_Language p (GapSliceFamilyEventually.encodedLen F n β) y = true := by
+    simpa [gapSliceOfParams] using hyYes
+  have hFalse :
+      gapPartialMCSP_Language p (GapSliceFamilyEventually.encodedLen F n β) y = false := by
+    simpa [gapSliceOfParams] using hyNo
+  have hContra : true = false := by simpa [hFalse] using hTrue
+  exact Bool.noConfusion hContra
+
+/--
+Counting obstruction for the table-force source contract.
+
+This theorem is independent of `sliceConst`: it shows that, under the intended
+MCSP counting semantics (wired through `eventual_coherence_at` and the Shannon
+counting witness for prescribed constraints), `tableForceFamilyEventually`
+cannot coexist with the standard slack inequality.
+-/
+theorem false_of_tableForceFamilyEventually_and_slack
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hTable : tableForceFamilyEventually F β0 κ nIso)
+    (hSlack :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+          F.Mof n (F.Tof n β) <
+            2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β)) :
+    False := by
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    nlinarith [hβ0]
+  have hβLt : β < β0 := by
+    dsimp [β]
+    nlinarith [hβ0]
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := by
+    exact le_rfl
+  let p := F.paramsOf n β
+  rcases hTable n β hβPos hβLt hn with ⟨Ty, hTyYes, D, hDCard, hForce⟩
+  have hcoh := eventual_coherence_at F n β (le_trans (Nat.le_max_left _ _) hn)
+  rcases hcoh with ⟨hpn, hTof, hMof⟩
+  have hSub :
+      GapSliceFamilyEventually.tableLen F n β - κ n β ≤
+        GapSliceFamilyEventually.tableLen F n β - D.card :=
+    Nat.sub_le_sub_left hDCard (GapSliceFamilyEventually.tableLen F n β)
+  have hPowNat :
+      (2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β) : Nat) ≤
+        (2 ^ (GapSliceFamilyEventually.tableLen F n β - D.card) : Nat) :=
+    Nat.pow_le_pow_right (by decide : 0 < 2) hSub
+  have hSlackCount :
+      Models.circuitCountBound p.n (p.sNO - 1) <
+        2 ^ (Partial.tableLen p.n - D.card) := by
+    calc
+      Models.circuitCountBound p.n (p.sNO - 1)
+          = F.Mof n (F.Tof n β) := by
+              symm
+              simpa [p, hpn] using hMof
+      _ < 2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β) :=
+        hSlack n β hβPos hβLt hn
+      _ ≤ 2 ^ (GapSliceFamilyEventually.tableLen F n β - D.card) := hPowNat
+      _ = 2 ^ (Partial.tableLen p.n - D.card) := by
+            simp [GapSliceFamilyEventually.tableLen, p, hpn]
+  let values : Fin (Partial.tableLen p.n) → Bool :=
+    fun i => Partial.valPart (encodePartial Ty) i
+  rcases Counting.exists_hard_function_with_value_constraints_of_countingSlack
+      p D values hSlackCount with ⟨g, hgValues, hgNo⟩
+  have hAgree :
+      ∀ i ∈ D,
+        Partial.valPart (encodePartial (Models.totalTableToPartial g)) i =
+          Partial.valPart (encodePartial Ty) i := by
+    intro i hi
+    calc
+      Partial.valPart (encodePartial (Models.totalTableToPartial g)) i = g i := by
+        simp [Models.encodeTotalAsPartial, Models.totalTableToPartial,
+          Partial.valPart, encodePartial, Partial.valIndex]
+      _ = Partial.valPart (encodePartial Ty) i := by
+        simpa [values] using hgValues i hi
+  have hYesTotal : PartialMCSP_YES p (Models.totalTableToPartial g) :=
+    hForce (Models.totalTableToPartial g) hAgree
+  exact partial_no_not_yes p (Models.totalTableToPartial g) hgNo hYesTotal
+
+/--
+Canonical-length final endpoint: table-force + slack + a canonical bridge + NP
+witness imply `NP_not_subset_PpolyDAG`.
+
+Unlike the `..._of_sliceConst` convenience route, this statement does not use
+global all-length equalities and therefore does not enforce the slice-collapse
+described above.
+-/
+theorem NP_not_subset_PpolyDAG_of_tableForceSlackEventually_atCanonicalLengths
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hTable : tableForceFamilyEventually F β0 κ nIso)
+    (hSlack :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+          F.Mof n (F.Tof n β) <
+            2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β))
+    (bridge : AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hDecodeEncode :
+      ∀ {n : Nat} (T : PartialTruthTable n), decodePartial (encodePartial T) = T) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  refine NP_not_subset_PpolyDAG_of_eventuallyIsolationEnvelopeWeakRouteEventually_atCanonicalLengths
+    F bridge hNP ?_
+  intro hInDag
+  have hStrong : IsoStrongFamilyEventually F hInDag :=
+    isoStrongFamilyEventually_of_tableForceFamilyEventually
+      F β0 hβ0 κ nIso hTable hSlack hDecodeEncode hInDag
+  exact isoFamily_withPromise_of_isoStrongFamilyEventually F hInDag hStrong
 
 /--
 Primary endpoint schema (magnification-style quantifiers):
@@ -775,6 +2182,57 @@ theorem magnificationStyleNoSmallDAG_of_eventually_acceptedFamily
   refine ⟨nAcc, ?_⟩
   intro n hn
   exact no_dag_solver_of_acceptedFamily_at F SizeBound n β ε (hnAcc n hn)
+
+/--
+Canonical "eventual weak-route payload" extracted from a pointwise
+`SmallDAGImpliesPromiseYesSubcubeStatement`.
+
+This helper packages the quantifier shape required by the magnification bridge:
+we choose fixed positive constants `ε = 1/4` and `β0 = 1/2`, and use the
+pointwise statement directly with cutoff `n0 = 0` on every valid `β < β0`.
+
+The theorem is intentionally generic in `SizeBound`; in the P/poly route it is
+instantiated with `SizeBound := ppolyDAGSizeBoundOnSlices F hInDag`.
+-/
+theorem eventual_promiseYesSubcube_of_smallDAG
+    (F : GapSliceFamily)
+    (SizeBound : Nat → Rat → Rat → Nat → Prop)
+    (hYes : SmallDAGImpliesPromiseYesSubcubeStatement F SizeBound) :
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0 : Rat, 0 < β0 ∧
+        ∀ (β : Rat), 0 < β → β < β0 →
+          ∃ n0 : Nat, ∀ n ≥ n0,
+            SmallDAGImpliesPromiseYesSubcubeAt F SizeBound n β ε := by
+  refine ⟨(1 / 4 : Rat), by positivity, (1 / 2 : Rat), by positivity, ?_⟩
+  intro β hβPos hβLt
+  refine ⟨0, ?_⟩
+  intro n hn
+  simpa using hYes n β (1 / 4 : Rat)
+
+/--
+Canonical-slice specialization of `eventual_promiseYesSubcube_of_smallDAG`.
+
+This matches the Gate-G1 / bridge-facing shape where the size bound is obtained
+from a concrete global witness family via `ppolyDAGSizeBoundOnSlices`.
+The proof is purely a specialization step.
+-/
+theorem eventual_promiseYesSubcube_of_smallDAG_onCanonicalSlices
+    (F : GapSliceFamily)
+    (hInDag :
+      ∀ n : Nat, ∀ β : Rat,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (hYes :
+      SmallDAGImpliesPromiseYesSubcubeStatement
+        F (ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0 : Rat, 0 < β0 ∧
+        ∀ (β : Rat), 0 < β → β < β0 →
+          ∃ n0 : Nat, ∀ n ≥ n0,
+            SmallDAGImpliesPromiseYesSubcubeAt
+              F (ppolyDAGSizeBoundOnSlices F hInDag) n β ε := by
+  exact eventual_promiseYesSubcube_of_smallDAG
+    F (ppolyDAGSizeBoundOnSlices F hInDag) hYes
 
 /--
 Eventual magnification-style closure using the nearer-term one-sided

--- a/pnp3/LowerBounds/FailedRoute_EventualTableForceSlackObstruction.lean
+++ b/pnp3/LowerBounds/FailedRoute_EventualTableForceSlackObstruction.lean
@@ -1,0 +1,62 @@
+import LowerBounds.AsymptoticDAGBarrierTheorems
+
+namespace Pnp3
+namespace LowerBounds
+
+/-!
+`FailedRoute_EventualTableForceSlackObstruction`
+
+This module isolates one closed/deprecated route:
+
+*source contract* `tableForceFamilyEventually + slack` (and convenience
+`sliceConst` packaging) for the intended MCSP semantics.
+
+Main outcome:
+the route is internally inconsistent for nontrivial eventual slices, so it
+should not be used as an active target for family instantiation.
+
+Operational rule:
+import this module only for audit/impossibility references; active development
+should continue from `LowerBounds.RouteNextStep_AcceptedFamily`.
+-/
+
+/--
+Convenience wrapper: the `tableForce + slack` source package is contradictory
+for the intended counting semantics.
+-/
+theorem failedRoute_tableForce_slack
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hTable : tableForceFamilyEventually F β0 κ nIso)
+    (hSlack :
+      ∀ n : Nat, ∀ β : Rat,
+        0 < β → β < β0 → n ≥ max F.N0 (nIso β) →
+          F.Mof n (F.Tof n β) <
+            2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β)) :
+    False :=
+  false_of_tableForceFamilyEventually_and_slack
+    F β0 hβ0 κ nIso hTable hSlack
+
+/--
+Convenience wrapper: `tableForce` is also incompatible with the `sliceConst`
+convenience global-language packaging.
+-/
+theorem failedRoute_tableForce_sliceConst
+    (F : GapSliceFamilyEventually)
+    (β0 : Rat)
+    (hβ0 : 0 < β0)
+    (κ : Nat → Rat → Nat)
+    (nIso : Rat → Nat)
+    (hTable : tableForceFamilyEventually F β0 κ nIso)
+    (hSliceConst : sliceConstFamilyEventually F)
+    (hDecodeEncode :
+      ∀ {n : Nat} (T : PartialTruthTable n), decodePartial (encodePartial T) = T) :
+    False :=
+  false_of_tableForceFamilyEventually_and_sliceConst
+    F β0 hβ0 κ nIso hTable hSliceConst hDecodeEncode
+
+end LowerBounds
+end Pnp3

--- a/pnp3/LowerBounds/FailedRoutes.lean
+++ b/pnp3/LowerBounds/FailedRoutes.lean
@@ -1,6 +1,7 @@
 import LowerBounds.FailedRoute_FixedSliceSupportHalfCore
 import LowerBounds.FailedRoute_FixedSliceSupportHalfImpossible
 import LowerBounds.FailedRoute_GapSliceFamilyVacuous
+import LowerBounds.FailedRoute_EventualTableForceSlackObstruction
 
 namespace Pnp3
 namespace LowerBounds
@@ -10,7 +11,9 @@ Aggregation module for closed / deprecated proof routes.
 
 Purpose:
 * give one import path for audit-only impossibility/vacuity facts,
-* keep active endpoint modules free from historical-route statements.
+* keep active endpoint modules free from historical-route statements,
+* document that these imports are for diagnostics/audit only and must not be
+  used as continuation targets for the main NP-vs-P/poly development.
 -/
 
 end LowerBounds

--- a/pnp3/LowerBounds/RouteNextStep_AcceptedFamily.lean
+++ b/pnp3/LowerBounds/RouteNextStep_AcceptedFamily.lean
@@ -1,0 +1,38 @@
+import LowerBounds.AsymptoticDAGBarrierTheorems
+
+namespace Pnp3
+namespace LowerBounds
+
+/-!
+`RouteNextStep_AcceptedFamily`
+
+Active continuation route after closing/deprecating the table-force dead-end.
+
+This module intentionally contains only forwarding statements for the accepted
+family surface, so downstream files can import one stable "next step" module
+without touching deprecated convenience paths or failed-route diagnostics.
+-/
+
+/--
+Primary active endpoint alias.
+
+Use this route when the source side can provide accepted-family witnesses for
+small DAG solvers (`SmallDAGImpliesAcceptedFamilyStatement`).
+-/
+theorem NP_not_subset_PpolyDAG_viaAcceptedFamilyRoute
+    (F : GapSliceFamily)
+    (bridge : AsymptoticDAGLanguageBridge F)
+    (hNP : ComplexityInterfaces.NP bridge.L)
+    (hAcceptedWeak :
+      ∀ hInDag :
+        ∀ n : Nat, ∀ β : Rat,
+          ComplexityInterfaces.InPpolyDAG
+            (gapPartialMCSP_Language (F.paramsOf n β)),
+        SmallDAGImpliesAcceptedFamilyStatement
+          F (ppolyDAGSizeBoundOnSlices F hInDag)) :
+    ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_acceptedFamilyWeakRoute
+    F bridge hNP hAcceptedWeak
+
+end LowerBounds
+end Pnp3


### PR DESCRIPTION
### Motivation

- Lift the generic bridge/endpoint infrastructure from the vacuous `GapSliceFamily` carrier to a non‑vacuous eventual carrier `GapSliceFamilyEventually` so the handoff can be expressed without vacuity assumptions. 
- Provide a canonical‑length bridge surface to avoid artificial all‑length collapses while keeping an all‑length option for compatibility, and isolate a previously attempted `tableForce + slack` route as provably inconsistent for the intended counting semantics. 
- Reduce the source burden on family authors by adding local‑validity builders and adapters so the family side only needs to provide a small set of artifacts (`Fₑ`, `κ`, forcing, slack) to reach `NP_not_subset_PpolyDAG` through the generic route.

### Description

- Extended `AsymptoticDAGBarrierTheorems.lean` with eventual‑carrier variants and helpers including `ppolyDAGSizeBoundOnSlicesEventually`, `SmallDAGSolverEventually`, `SmallDAGImpliesPromiseYesSubcubeAtEventually`, `eventual_coherence_at`, and `eventual_promiseYesSubcube_onCanonicalSlices_of_eventualIsolationEnvelopeEventually`, plus the `IsoStrongFamilyEventually` contract and adapter `isoFamily_withPromise_of_isoStrongFamilyEventually`.
- Added two bridge structures `AsymptoticDAGLanguageBridgeEventually` and `AsymptoticDAGLanguageBridgeEventuallyAtCanonicalLengths`, a one‑gate `constFalseDag` for off‑canonical lengths, and transport theorems `ppolyDAGOnSlicesEventually_of_globalWitness` and its canonical‑length variant, and many closure/endpoints culminating in `NP_not_subset_PpolyDAG` for various eventual/canonical configurations.
- Introduced table/pattern forcing predicates on the eventual carrier and completed the last generic reduction `isoStrongFamilyEventually_of_tableForceFamilyEventually`, plus concrete impossibility diagnoses: `false_of_tableForceFamilyEventually_and_sliceConst` and `false_of_tableForceFamilyEventually_and_slack`.
- Factored dead routes into `LowerBounds/FailedRoute_EventualTableForceSlackObstruction.lean`, added a stable continuation alias module `LowerBounds/RouteNextStep_AcceptedFamily.lean`, and updated `LowerBounds/FailedRoutes.lean` to import the new failed‑route module.
- Added a Russian handoff summary `outputs/unconditional-proof-handoff-ru.md` documenting the current route, what remains family‑specific, and guidance for next steps.

### Testing

- Performed a full Lean project typecheck via `lake build` to ensure the newly added and modified Lean files typecheck; the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d373d297e8832b9b43b27cecf78ba5)