### PR TITLE
Introduce single-file frontier reduction (CoreFrontierObligation) and report

### DIFF
--- a/outputs/frontier_reduction_report.md
+++ b/outputs/frontier_reduction_report.md
@@ -1,0 +1,70 @@
+# Frontier reduction report
+
+## 1) Chosen path
+
+Chosen path: **Goal A** (honest fallback route with primary DAG-separation focus).
+
+Reason:
+- on this branch there is no already-compiled concrete fixed slice `p*` plus concrete
+  `GapPartialMCSP_TMWitness p*` object available as a ready witness package;
+- therefore a direct zero-arg closure to unconditional `P_ne_NP` through existing `_TM`
+  wrappers cannot be completed from current concrete objects alone.
+
+## 2) Exact selected frontier theorem
+
+`Pnp3.Frontier.CoreFrontierObligation` in
+`pnp3/Frontier/UnconditionalPneNpFrontier.lean`:
+
+```lean
+∃ hMag : MagnificationAssumptions,
+  ∃ n : Nat,
+    ∃ hn : hMag.antiChecker.asymptotic.N0 ≤ n,
+      gapPartialMCSP_supportHalfObligation
+        (hMag.antiChecker.asymptotic.pAt n hn)
+```
+
+This is the only contentful frontier proposition in the new file.
+
+## 3) Why this is the shortest honest route
+
+- Priority order requested by task was support-half -> blocker -> stable-restriction.
+- `dagRouteBSourceBlocker` is definitionally `gapPartialMCSP_supportHalfObligation`,
+  so support-half is the minimal source obligation.
+- Existing asymptotic final wrappers already reduce this blocker to
+  `NP_not_subset_PpolyDAG` without adding new theorem machinery.
+
+## 4) Existing wrappers/theorems used
+
+- `LowerBounds.dagRouteBSourceBlocker` (alias of support-half obligation).
+- `Magnification.NP_not_subset_PpolyDAG_final_of_asymptotic_blocker`.
+- Internal route chain already compiled in repository:
+  blocker -> source closure -> stable restriction -> fixed-slice collapse ->
+  asymptotic DAG separation.
+
+## 5) What must now be solved in one file
+
+Work only with:
+- `pnp3/Frontier/UnconditionalPneNpFrontier.lean`
+
+Single mathematical target:
+- prove `CoreFrontierObligation`.
+
+After that, theorems
+`frontier_reduces_to_real_NP_not_subset_PpolyDAG`
+and
+`frontier_reduces_to_real_P_ne_NP`
+produce the class-separation object and end-to-end `P_ne_NP` interface
+immediately.
+
+## 6) What is still missing for full zero-arg unconditional theorem
+
+Still missing concrete object(s) for the **direct** `_TM` zero-arg closure route:
+- concrete `p* : GapPartialMCSPParams`;
+- concrete `W : Models.GapPartialMCSP_TMWitness p*`.
+
+(And of course a proved source blocker on that same fixed slice if choosing the `_TM` route.)
+
+## 7) Commands run
+
+- `./scripts/check.sh`
+- `lake env lean pnp3/Frontier/UnconditionalPneNpFrontier.lean`

--- a/pnp3/Frontier/UnconditionalPneNpFrontier.lean
+++ b/pnp3/Frontier/UnconditionalPneNpFrontier.lean
@@ -1,0 +1,88 @@
+import Magnification.FinalResultCore
+
+namespace Pnp3
+namespace Frontier
+
+open Models
+open LowerBounds
+open Magnification
+open ComplexityInterfaces
+
+/-!
+# Single-file frontier reduction (honest fallback)
+
+This file intentionally concentrates the remaining DAG-side theorem debt into
+one named proposition `CoreFrontierObligation`.
+
+Current blocker reduced here:
+- we do **not** have a compiled concrete fixed slice `p* : GapPartialMCSPParams`
+  together with a concrete `GapPartialMCSP_TMWitness p*` in this branch, so the
+  direct zero-argument `_TM` route to unconditional `P ≠ NP` cannot be closed
+  from existing objects alone;
+- therefore we expose the shortest honest fallback frontier: one support-half
+  source obligation on one asymptotic slice (packed together with the needed
+  asymptotic assumptions package).
+
+If `CoreFrontierObligation` is proved, this file derives
+`ComplexityInterfaces.NP_not_subset_PpolyDAG` immediately via existing wrappers.
+It also derives `ComplexityInterfaces.P_ne_NP` by the already-compiled DAG-only
+final wrapper.
+The **last external object** still missing for the direct zero-argument theorem
+is a concrete fixed-slice witness package
+`W : Models.GapPartialMCSP_TMWitness p*` (with concrete `p*`) suitable for the
+existing `_TM` wrappers.
+-/
+
+/--
+Canonical single remaining frontier obligation.
+
+Contentful payload (support-half priority): provide one asymptotic magnification
+package and one concrete asymptotic slice where the Route-B source blocker
+holds.  Everything downstream is packaging/glue.
+-/
+def CoreFrontierObligation : Prop :=
+  ∃ hMag : MagnificationAssumptions,
+    ∃ n : Nat,
+      ∃ hn : hMag.antiChecker.asymptotic.N0 ≤ n,
+        gapPartialMCSP_supportHalfObligation
+          (hMag.antiChecker.asymptotic.pAt n hn)
+
+/-- Adapter: turn support-half obligation into the named Route-B blocker. -/
+private theorem blocker_of_supportHalf
+    {hMag : MagnificationAssumptions}
+    {n : Nat}
+    {hn : hMag.antiChecker.asymptotic.N0 ≤ n}
+    (hSupportHalf :
+      gapPartialMCSP_supportHalfObligation
+        (hMag.antiChecker.asymptotic.pAt n hn)) :
+    dagRouteBSourceBlocker (hMag.antiChecker.asymptotic.pAt n hn) := by
+  exact hSupportHalf
+
+/--
+Single-file reduction: proving `CoreFrontierObligation` is enough to derive the
+repository's DAG-side class separation target.
+-/
+theorem frontier_reduces_to_real_NP_not_subset_PpolyDAG :
+    CoreFrontierObligation → ComplexityInterfaces.NP_not_subset_PpolyDAG := by
+  intro hCore
+  rcases hCore with ⟨hMag, n, hn, hSupportHalf⟩
+  exact
+    NP_not_subset_PpolyDAG_final_of_asymptotic_blocker
+      (hMag := hMag)
+      (n := n)
+      (hn := hn)
+      (hBlocker := blocker_of_supportHalf (hMag := hMag) (n := n) (hn := hn) hSupportHalf)
+
+/--
+Companion end-to-end reduction: the same single frontier obligation already
+implies the repository-level `P ≠ NP` interface through the DAG-only final
+wrapper.
+-/
+theorem frontier_reduces_to_real_P_ne_NP :
+    CoreFrontierObligation → ComplexityInterfaces.P_ne_NP := by
+  intro hCore
+  exact P_ne_NP_final_dag_only
+    (frontier_reduces_to_real_NP_not_subset_PpolyDAG hCore)
+
+end Frontier
+end Pnp3


### PR DESCRIPTION
### Motivation

- Concentrate the remaining DAG-side theorem debt into a single named frontier obligation because a concrete fixed-slice `_TM` witness is not available on this branch. 
- Expose the minimal honest fallback source obligation (support-half on an asymptotic slice) so existing asymptotic wrappers can complete the reduction to the repository-level separation targets. 

### Description

- Add `pnp3/Frontier/UnconditionalPneNpFrontier.lean` which defines `CoreFrontierObligation` as an existential magnification package plus an asymptotic slice satisfying `gapPartialMCSP_supportHalfObligation`. 
- Provide a private adapter `blocker_of_supportHalf` and two top-level reductions `frontier_reduces_to_real_NP_not_subset_PpolyDAG` and `frontier_reduces_to_real_P_ne_NP` that reuse `NP_not_subset_PpolyDAG_final_of_asymptotic_blocker` and `P_ne_NP_final_dag_only`. 
- Add `outputs/frontier_reduction_report.md` documenting the chosen path, the exact frontier theorem, dependencies, remaining gaps, and the commands run. 

### Testing

- Ran `./scripts/check.sh` which completed successfully. 
- Ran `lake env lean pnp3/Frontier/UnconditionalPneNpFrontier.lean` which type-checked the new file successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dacff5df6c832baea8afad101c091a)