### PR TITLE
T1 canonical normalise: structured failure report (handle g55)

### DIFF
--- a/seed_packs/fp3b3_3_v2_a_1_minimal_normalisation/failures/T1_g55.md
+++ b/seed_packs/fp3b3_3_v2_a_1_minimal_normalisation/failures/T1_g55.md
@@ -1,0 +1,131 @@
+# 1. What was attempted
+
+I attempted to land the T1 structural normaliser as a new module
+`pnp3/Magnification/AuditRoutes/ProvenanceFilterV2/V2_A_1_g55/CanonicalNormalise.lean`.
+
+The attempted construction was fully syntax-directed:
+
+- a structural `canonicalNormalise : FormulaCircuit n → FormulaCircuit n`;
+- a local syntactic equality test on `FormulaCircuit n` subtrees, used only to
+  detect literal syntactic complements such as `C` versus `not C`;
+- local gate constructors for `not`, `and`, and `or`, applying only the fixed
+  seed-pack reductions:
+  - double negation;
+  - `C ∨ ¬C ↦ const true` and `¬C ∨ C ↦ const true`;
+  - `C ∧ ¬C ↦ const false` and `¬C ∧ C ↦ const false`;
+  - `C ∧ const true ↦ C` and `const true ∧ C ↦ C`;
+  - optionally `C ∨ const false ↦ C` and `const false ∨ C ↦ C`.
+
+The proof plan was:
+
+- prove soundness of the syntactic equality test;
+- prove local semantic preservation and size non-increase for the three local
+  constructors;
+- prove `canonicalNormalise_eval` and `canonicalNormalise_size_le` by structural
+  induction on `FormulaCircuit`;
+- prove the requested hard-minimum reduction lemmas by reducing them to local
+  constructor lemmas.
+
+# 2. Where it broke
+
+The construction reached a proof-engineering bottleneck around the interaction
+between constant negation, double negation, and the two required AND lemmas.
+
+The important observation is that the requested theorem set forces constant
+negation to be normalised.  In particular, the following two requested lemmas
+specialise to the same left-hand side:
+
+```lean
+canonicalNormalise_and_self_not_self (FormulaCircuit.const true)
+canonicalNormalise_and_true_const (FormulaCircuit.not (FormulaCircuit.const true))
+```
+
+Both concern:
+
+```lean
+canonicalNormalise
+  (FormulaCircuit.and
+    (FormulaCircuit.const true)
+    (FormulaCircuit.not (FormulaCircuit.const true)))
+```
+
+The first lemma requires this term to be `FormulaCircuit.const false`.  The
+second lemma requires it to be:
+
+```lean
+canonicalNormalise (FormulaCircuit.not (FormulaCircuit.const true))
+```
+
+Therefore the requested theorem surface forces:
+
+```lean
+canonicalNormalise (FormulaCircuit.not (FormulaCircuit.const true))
+  = FormulaCircuit.const false
+```
+
+and symmetrically:
+
+```lean
+canonicalNormalise (FormulaCircuit.not (FormulaCircuit.const false))
+  = FormulaCircuit.const true
+```
+
+After adding these constant-negation reductions, the attempted proof of the
+plain local involution
+
+```lean
+normaliseNot (normaliseNot C) = C
+```
+
+became false for arbitrary syntax such as `C = FormulaCircuit.not
+(FormulaCircuit.const true)`.  The correct invariant is not an unconditional
+local involution, but an image invariant: canonical outputs must exclude the bad
+forms `not (const b)` and `not (not C)`, and only canonical outputs should be
+used in the double-negation proof.
+
+I started replacing the false unconditional lemma with a `notStable` image
+invariant for canonical outputs.  That exposed a second proof-engineering layer:
+Lean's generated nested matches for the local `normaliseAnd`/`normaliseOr`
+constructors require a more carefully factored normal-form predicate and helper
+lemmas than fit safely in this worker pass without risking a brittle or
+under-specified proof.
+
+# 3. Local vs global obstruction
+
+Local.
+
+This is a proof-engineering failure, not evidence that the T1 route is globally
+impossible.  The attempted structural definition did not use any forbidden
+shape: no truth-table reconstruction, no semantic argmin, no semantic quotient,
+no `Classical.choose`, and no meta-level decidability of `FormulaCircuit.eval`.
+
+The mathematically relevant constraint discovered here is local and useful:
+any successful T1 normaliser satisfying the full requested hard-minimum theorem
+surface should include constant-negation reductions and should prove double
+negation through an image invariant for canonical outputs, not through an
+unconditional involution theorem for the local NOT normaliser.
+
+# 4. What an integrator must know
+
+A likely successful integration plan is:
+
+1. Define `canonicalNormalise` structurally, with local constructors ordered so
+   that constants are normalised under NOT:
+   - `not (const true) ↦ const false`;
+   - `not (const false) ↦ const true`;
+   - `not (not C) ↦ C` after recursive normalisation.
+2. Add a small syntactic normal-form predicate, for example excluding at least:
+   - `not (const _)` at the root;
+   - `not (not _)` at the root.
+3. Prove that every `canonicalNormalise C` satisfies this predicate.
+4. Prove the double-negation theorem from the image invariant, not from the
+   false statement that the local NOT normaliser is involutive on all raw
+   `FormulaCircuit` syntax.
+5. Factor `normaliseAnd` and `normaliseOr` into smaller helper functions or
+   prove their local lemmas by explicit constructor cases, avoiding broad
+   `repeat' split` proofs over deeply nested generated matches.
+
+The shortest next move is to dispatch a follow-up T1 proof-engineering pass that
+keeps the structural definition but introduces a formal canonical-output
+invariant before attempting `canonicalNormalise_double_not` and the AND/OR
+hard-minimum lemmas.


### PR DESCRIPTION
### Motivation
- Attempt a structural `canonicalNormalise : FormulaCircuit n → FormulaCircuit n` and land the T1 artifacts required by the V2-A.1 seed pack, including the specified evaluation-preservation and size bounds plus the hard-minimum reduction lemmas.

### Description
- Added a structured failure report at `seed_packs/fp3b3_3_v2_a_1_minimal_normalisation/failures/T1_g55.md` documenting a local proof-engineering obstruction discovered while implementing a fully structural normaliser (the attempted `CanonicalNormalise.lean` was created during the attempt but not landed; the only committed artifact is the failure report).

### Testing
- Attempted a targeted build of the helper library with `lake build Magnification.AuditRoutes.ProvenanceFilterV2.V2_A_1_g55.CanonicalNormalise`, which encountered proof obligations and did not complete, motivating the failure report (module was not landed).
- Ran the full repository checks with `./scripts/check.sh`, and the baseline verification suite passed after reverting the partial module (final result: `./scripts/check.sh` OK); `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` returned no placeholders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0341efd410832ba639935b589cd8d5)