### PR TITLE
Add D5 structured failure report for fp3b6 (missing seed-pack materials)

### DIFF
--- a/seed_packs/fp3b6_distinguisher_matrix_provenance/failures/D5_gpt55.md
+++ b/seed_packs/fp3b6_distinguisher_matrix_provenance/failures/D5_gpt55.md
@@ -1,0 +1,45 @@
+# 1. What was attempted
+
+I attempted to start slot D5 (`literature-to-parameter table, markdown only`) for `seed_packs/fp3b6_distinguisher_matrix_provenance/` by checking the repository for the required seed-pack prompt, README, research constitution, and NOGO log inputs.
+
+Commands used locally:
+
+- `pwd`
+- `rg --files -g 'AGENTS.md' -g 'WORKER_PROMPT.md' -g 'README.md' -g 'RESEARCH_CONSTITUTION.md' -g 'nogolog.jsonl'`
+- `find .. -name AGENTS.md -print`
+- `find seed_packs -path '*WORKER_PROMPT.md' -print`
+- `find . -maxdepth 2 -type d | sort`
+- `find . -maxdepth 4 -iname '*fp3b6*' -o -iname '*nogolog*' -o -iname 'RESEARCH_CONSTITUTION.md' | sort`
+- `find outputs -maxdepth 2 -type f | sort`
+
+# 2. Where it broke
+
+The required local inputs for D5 are absent from this checkout:
+
+- `seed_packs/fp3b6_distinguisher_matrix_provenance/README.md` is absent because the `seed_packs/` directory itself was not present before this failure report was created.
+- `seed_packs/fp3b6_distinguisher_matrix_provenance/WORKER_PROMPT.md` is absent for the same reason.
+- `seed_packs/fp3b5_outcome_b_design_audit/audits/outcome_b_strategic_audit.md` is absent.
+- `seed_packs/first_move_search_2026/reports/gpt55/Q4_distinguisher-matrix-magnification.md` is absent.
+- `outputs/nogolog.jsonl` is absent, so entries `NOGO-000006`, `NOGO-000007`, `NOGO-000008`, and `NOGO-000009` cannot be read from the required local source.
+- `RESEARCH_CONSTITUTION.md` is absent.
+
+Because the user prompt requires reading and following `WORKER_PROMPT.md` completely, and because the allowed scope permits only a D5 report or D5 failure report under the fp3b6 seed pack, I did not fabricate the missing seed-pack context or proceed with a literature-to-parameter report that could not be grounded in the required local materials.
+
+# 3. Local vs global obstruction
+
+This is a local repository/materials obstruction, not a global mathematical or literature obstruction.
+
+The requested D5 work may still be feasible once the missing seed-pack directory and required audit/NOGO/context files are restored. I did not determine that the fp3b6 route is mathematically impossible; I only determined that this checkout lacks the mandatory inputs needed to complete D5 under the stated rules.
+
+# 4. What an integrator must know
+
+An integrator should provide or restore the following files before rerunning D5:
+
+- `seed_packs/fp3b6_distinguisher_matrix_provenance/README.md`
+- `seed_packs/fp3b6_distinguisher_matrix_provenance/WORKER_PROMPT.md`
+- `seed_packs/fp3b5_outcome_b_design_audit/audits/outcome_b_strategic_audit.md`
+- `seed_packs/first_move_search_2026/reports/gpt55/Q4_distinguisher-matrix-magnification.md`
+- `outputs/nogolog.jsonl` containing entries `NOGO-000006`, `NOGO-000007`, `NOGO-000008`, and `NOGO-000009`
+- `RESEARCH_CONSTITUTION.md`
+
+No Lean code was written. No trust-root, lakefile, NOGO log, attempts log, known guards, candidates directory, `SourceTheorem`, `gap_from`, endpoint, `P≠NP`, `ResearchGapWitness`, or `ProvenanceFilter_v1` changes were made.


### PR DESCRIPTION
### Motivation
- The D5 slot (literature-to-parameter table) for `fp3b6_distinguisher_matrix_provenance` could not be completed because the required seed-pack inputs and local NOGO/constitutional files were absent, so a structured failure report documenting the obstruction was needed.

### Description
- Add a markdown-only structured failure report at `seed_packs/fp3b6_distinguisher_matrix_provenance/failures/D5_gpt55.md` that records the discovery steps, lists the missing files (`seed_packs/.../README.md`, `WORKER_PROMPT.md`, prior audit/Q4 reports, `outputs/nogolog.jsonl`, `RESEARCH_CONSTITUTION.md`), and confirms no Lean or restricted artifacts were created or modified.

### Testing
- Ran `./scripts/check.sh`; the full Lean build and many checks completed, but the script exited during Step 5 when `lake env lean pnp4/Pnp4/Tests/AxiomsAudit.lean` failed to resolve the `Pnp4` module prefix in this environment, so the repo-level check did not fully complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ba368d28832b9a0e4d1bda7d715b)