### PR TITLE
Add toy sparse fingerprint separation

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -127,6 +127,7 @@ lean_lib PnP3 where
     Glob.one `Magnification.FinalResultCore,
     Glob.one `Magnification.UnconditionalResearchGap,
     Glob.one `Magnification.AuditRoutes.DistinguisherMatrixProvenance.V_gpt55.MatrixPrimitives,
+    Glob.one `Magnification.AuditRoutes.DistinguisherMatrixProvenance.V_gpt55.ToySeparation,
     Glob.one `Magnification.FinalResult,
     -- Research Governance v0.1, PR 4a: refuted-predicate registry.
     Glob.one `RefutedPredicates.Registry,

--- a/pnp3/Magnification/AuditRoutes/DistinguisherMatrixProvenance/V_gpt55/ToySeparation.lean
+++ b/pnp3/Magnification/AuditRoutes/DistinguisherMatrixProvenance/V_gpt55/ToySeparation.lean
@@ -1,0 +1,93 @@
+import Magnification.AuditRoutes.DistinguisherMatrixProvenance.V_gpt55.MatrixPrimitives
+import Mathlib.Tactic
+
+/-!
+# Toy sparse fingerprint separation
+
+This D2 module is a deliberately tiny, fully explicit smoke theorem for the D1
+matrix primitives.  It stays on the audit-route side: the theorem below only
+shows that one hand-written sparse Boolean matrix separates one hand-written
+YES fingerprint from one hand-written NO fingerprint.  It introduces no source
+theorem, no gap object, and no P-vs-NP endpoint.
+-/
+
+namespace Pnp3
+namespace Magnification
+namespace AuditRoutes
+namespace DistinguisherMatrixProvenance
+namespace V_gpt55
+
+open ComplexityInterfaces
+
+/-- Hamming distance between two same-length bitstrings. -/
+def toyFingerprintDistance {m : Nat} (u v : Bitstring m) : Nat :=
+  (Finset.univ.filter (fun i : Fin m => u i ≠ v i)).card
+
+/--
+Local D2 separation predicate used because D1 intentionally did not yet define
+an official `FingerprintSeparation` surface.
+-/
+def ToyFingerprintSeparation {m n : Nat} (D : BoolMatrix m n)
+    (YES NO : Finset (Bitstring n)) (r : Nat) : Prop :=
+  ∀ y, y ∈ YES → ∀ z, z ∈ NO → r ≤ toyFingerprintDistance (fingerprint D y) (fingerprint D z)
+
+/--
+A `2 × 4` matrix with two singleton rows: row `0` reads input bit `0`, and row
+`1` reads input bit `1`.  Thus every row and every column has support at most
+one, well below the slot budget `k ≤ 2`.
+-/
+def toyMatrix : BoolMatrix 2 4 :=
+  fun i j =>
+    match (i : Nat), (j : Nat) with
+    | 0, 0 => true
+    | 1, 1 => true
+    | _, _ => false
+
+/-- The sole YES point: the all-false four-bit string. -/
+def toyYESPoint : Bitstring 4 :=
+  fun _ => false
+
+/-- The sole NO point: only the first coordinate is true. -/
+def toyNOPoint : Bitstring 4 :=
+  fun j => if j = (0 : Fin 4) then true else false
+
+/-- Explicit singleton YES set for the toy instance. -/
+def toyYES : Finset (Bitstring 4) :=
+  {toyYESPoint}
+
+/-- Explicit singleton NO set for the toy instance. -/
+def toyNO : Finset (Bitstring 4) :=
+  {toyNOPoint}
+
+/-- The toy matrix is sparse with budget `k = 2`. -/
+theorem toyMatrix_sparse : SparseDistinguisherMatrix 2 4 2 toyMatrix := by
+  constructor
+  · intro i
+    fin_cases i <;> decide
+  · intro j
+    fin_cases j <;> decide
+
+/-- The two explicit points have fingerprints at Hamming distance exactly one. -/
+theorem toy_fingerprint_distance_eq_one :
+    toyFingerprintDistance (fingerprint toyMatrix toyYESPoint)
+      (fingerprint toyMatrix toyNOPoint) = 1 := by
+  decide
+
+/--
+Toy sparse fingerprint separation theorem for the D2 slot.
+
+The statement is intentionally local and finite: the explicit sparse matrix
+separates the singleton YES set `{0000}` from the singleton NO set `{1000}` at
+radius `1` after applying the D1 parity fingerprint map.
+-/
+theorem toy_fingerprint_separation :
+    ToyFingerprintSeparation toyMatrix toyYES toyNO 1 := by
+  intro y hy z hz
+  simp [toyYES, toyNO] at hy hz
+  rw [hy, hz, toy_fingerprint_distance_eq_one]
+
+end V_gpt55
+end DistinguisherMatrixProvenance
+end AuditRoutes
+end Magnification
+end Pnp3


### PR DESCRIPTION
### Motivation
- Provide a minimal kernel-checked D2 smoke theorem that exercises the D1 distinguisher-matrix primitives and demonstrates that a sparse matrix can semantically separate YES/NO fingerprints. 
- Deliver a tiny explicit example (small `m,n,k`) to validate the `SparseDistinguisherMatrix`/`fingerprint` machinery before Round‑2 work (D3/D4). 

### Description
- Added `pnp3/Magnification/AuditRoutes/DistinguisherMatrixProvenance/V_gpt55/ToySeparation.lean` which defines a local predicate `ToyFingerprintSeparation`, an explicit `2×4` Boolean matrix `toyMatrix`, singleton `toyYES`/`toyNO` sets, and proves `toy_fingerprint_separation`. 
- The fingerprint uses the D1 parity-based `fingerprint` from `MatrixPrimitives.lean` and the proof is kernel-checked with no `sorry`/`admit`/`axiom`/`opaque`/`Fact`. 
- Wired the new module into the build by adding `Magnification.AuditRoutes.DistinguisherMatrixProvenance.V_gpt55.ToySeparation` to `lakefile.lean` so it is included in library builds. 

### Testing
- Ran `lake build Magnification.AuditRoutes.DistinguisherMatrixProvenance.V_gpt55.ToySeparation` and the module built successfully. 
- Ran `lake build PnP3 Pnp4` and the full project build completed successfully (no errors). 
- Ran `./scripts/check.sh` and the repository-level checks passed. 
- Verified via `rg` that there are no `sorry`/`admit` placeholders in `pnp3`/`pnp4` after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d2799bb0832b92545d72761daf57)