### PR TITLE
D3: Strengthen anti-collapse implication guard for log-width payloads

### DIFF
--- a/pnp3/Magnification/AuditRoutes/DistinguisherMatrixProvenance/V_gpt55/AntiCollapse.lean
+++ b/pnp3/Magnification/AuditRoutes/DistinguisherMatrixProvenance/V_gpt55/AntiCollapse.lean
@@ -78,6 +78,38 @@ theorem no_sparse_matrix_separates_overlapping_singletons
   rintro ⟨D, _hSparse, hsep⟩
   exact no_self_fingerprintSeparation D x r hsep
 
+
+/--
+Support-cardinality/all-essential payload facts cannot be used as a black-box
+implication producing a sparse fingerprint separator, even for a single fixed
+finite audit relation.  The conclusion below is deliberately the *negation of
+an automatic derivation principle*: if such a principle tried to turn the exact
+log-width support-cardinality theorem into a positive-radius sparse separator
+for the overlapping singleton relation, it would contradict
+`no_sparse_matrix_separates_overlapping_singletons`.
+
+This theorem is the most compact Target-C form of the D3 anti-collapse lesson:
+the payload facts are real and kernel-checked, but the matrix/relation witness is
+not derivable from them alone.
+-/
+theorem no_supportProfile_implication_to_overlapping_separation
+    (F : PayloadFamily)
+    (hF : AllEssentialPayload F)
+    (n m k r : Nat)
+    (x : Bitstring n) :
+    ¬ (((FormulaCircuit.support (adversaryFamily_v_arbpayload F n)).card =
+          widthFn n) →
+        ∃ D : BoolMatrix m n,
+          SparseDistinguisherMatrix m n k D ∧
+            FingerprintSeparation D ({x} : Finset (Bitstring n)) ({x}) (r + 1)) := by
+  intro hderive
+  have hSupport :
+      (FormulaCircuit.support (adversaryFamily_v_arbpayload F n)).card =
+        widthFn n :=
+    adversaryFamily_v_arbpayload_support_card F hF n
+  exact no_sparse_matrix_separates_overlapping_singletons
+    (m := m) (n := n) (k := k) x r (hderive hSupport)
+
 /--
 D3 anti-collapse theorem.
 


### PR DESCRIPTION
### Motivation

- Show that the syntactic support-cardinality / all-essential payload facts do not by themselves imply a semantic `FingerprintSeparation` witness, so the matrix/relation is additional data (anti-collapse lesson for the distinguisher-matrix audit route). 
- Capture a Target-C style statement that blocks the unsafe implication pattern `support-profile ⇒ exists sparse separating matrix` while preserving the intended quantifier discipline (do not prove a blanket `∀ payload, ¬ ∃ D` claim). 

### Description

- Added `no_supportProfile_implication_to_overlapping_separation` to `pnp3/Magnification/AuditRoutes/DistinguisherMatrixProvenance/V_gpt55/AntiCollapse.lean`, formalizing that an exact log-width support-cardinality fact for an all-essential payload cannot be used as a black-box to derive a positive-radius sparse fingerprint separator for the overlapping singleton relation. 
- Reused local primitives (`FingerprintSeparation`, `no_sparse_matrix_separates_overlapping_singletons`, and `adversaryFamily_v_arbpayload_support_card`) to keep the statement finite, concrete, and kernel-checked, and left the existing `allEssentialLogWidthPayload_no_fingerprintSeparation` theorem intact. 
- Proof strategy: derive the payload support-cardinality fact from `adversaryFamily_v_arbpayload_support_card`, feed it into the hypothetical automatic-derivation, and contradict the overlapping-singleton anti-collapse kernel. 
- No forbidden constructs were introduced (no `axiom`/`sorry`/`admit`/`Classical.choose` etc.), and the change is scoped to the D3 AntiCollapse module only. 

### Testing

- Ran `lake build PnP3 Pnp4` and the new module type-checked as part of the full build, which completed successfully. 
- Ran the repository validation script `./scripts/check.sh`; an initial transient coordinator HTTP reset occurred during an intermediate run but the check was re-run and the full script passed all steps. 
- Ran a proof-hole scan `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no `sorry`/`admit` occurrences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0547707694832b8363ace66dc7a777)