### PR TITLE
Add D0.1 predicate spec and second-review for AlmostNaturalProvenance_BC

### DIFF
--- a/seed_packs/fp3b7_almost_natural_provenance/reports/D0_1_bc_hybrid_spec_gpt55.md
+++ b/seed_packs/fp3b7_almost_natural_provenance/reports/D0_1_bc_hybrid_spec_gpt55.md
@@ -1,0 +1,373 @@
+# fp3b7-D0.1 B/C hybrid predicate specification — gpt55
+
+Slot: `fp3b7-D0.1`
+Handle: `gpt55`
+Progress classification: Infrastructure / markdown-only predicate audit.  This report does not reduce `SearchMCSPWeakLowerBound` or `VerifiedNPDAGLowerBoundSource`, does not create or promote a `ProvenanceFilter`, and does not claim a `P != NP` endpoint.
+
+## 1. Executive verdict
+
+**INCONCLUSIVE_needs_more_design**
+
+This report specifies exactly one candidate predicate family:
+
+```text
+AlmostNaturalProvenance_BC
+= Sparse Structured-Payload Promise with Payload-Independent Provenance Certificate.
+```
+
+The predicate is intentionally narrow.  It can make the three requested paper-level safety lemmas credible:
+
+1. **Non-largeness:** credible, because the accepted semantic targets form a doubly-exponentially tiny subset of all `n`-bit-input Boolean functions and are also sparse inside each logarithmic hardwiring slice.
+2. **Non-circularity:** credible, because promise membership is defined by explicit low-parameter algebraic / combinatorial payload families and representation-invariant lift data, not by circuit lower bounds or absence of small witnesses.
+3. **Hardwiring rejection:** credible against the NOGO-000006 arbitrary all-essential log-width truth-table payloads, because an arbitrary payload is accepted only if it already lies in the public structured payload class; otherwise the full payload truth table must be inserted into the certificate and exceeds the certificate-cost and payload-independence rules.
+
+However, the same restrictions that make the predicate safe also make its **usefulness toward `PpolyDAG` unclear and probably weak**.  At this D0.1 level it should not open a full fp3b7 Round 1.  The missing piece is finite and explicit: a non-circular theorem showing that this sparse promise class contains an `NP` language family whose exclusion from `PpolyDAG` follows from the predicate rather than from a hidden hardness assumption.
+
+## 2. Formal-ish predicate sketch
+
+### 2.1 Ambient universe
+
+For each ambient input length `n`, let
+
+```text
+BoolFun(n) := ({0,1}^n -> {0,1})
+UniverseSize(n) := |BoolFun(n)| = 2^(2^n).
+```
+
+A witness `w_n` semantically denotes a Boolean function
+
+```text
+⟦w_n⟧ : {0,1}^n -> {0,1}.
+```
+
+The predicate is semantic in `⟦w_n⟧`, not in the displayed formula, circuit, DAG, gate order, or syntactic normal form used to present `w_n`.
+
+### 2.2 Public structured payload class
+
+Fix once and for all a public family of structured payload classes
+
+```text
+PayloadClass(ell) ⊆ ({0,1}^ell -> {0,1})
+```
+
+with the following parameters.
+
+- `ell = ell(n) ≤ ceil(log2(n + 1))` for the hardwiring-relevant slice.
+- `|PayloadClass(ell)| ≤ 2^(a * ell^b)` for fixed constants `a,b` with `ell^b = o(2^ell)`.
+- Membership in `PayloadClass(ell)` is defined by an explicit low-parameter non-hardness condition, for example: “there exists a public index `i` of length at most `a * ell^b` such that `p = EvalPayload_ell(i)`”, where `EvalPayload` is a fixed algebraic/combinatorial evaluator.
+- The definition must not mention any of: “not computable by small circuits”, “not in `PpolyDAG`”, “has no small witness”, “requires large formula size”, or an equivalent lower-bound phrase.
+
+Examples of allowed payload evaluators at this level are low-degree polynomial threshold templates, bounded-rank algebraic forms, small-orbit group-invariant templates, or fixed-recursion combinatorial templates.  These are examples only; the predicate family below is the single object, and the report does not branch into multiple candidate predicates.
+
+### 2.3 Sparse target ensemble `T_n`
+
+A target in `T_n` is a semantic lift of a structured payload into the ambient `n` variables.  A lift datum is
+
+```text
+LiftDatum_n := (ell, pi, rho, tau)
+```
+
+where:
+
+- `ell ≤ ceil(log2(n + 1))`;
+- `pi : [ell] -> [n]` is an injective coordinate map selecting the payload window;
+- `rho` is a public representation-invariant wrapper schema chosen from a fixed family of size `2^(polylog n)`;
+- `tau` is a public promise tag, also from a fixed family of size `2^(polylog n)`, describing semantic side conditions such as symmetry, orbit restriction, or input-domain promise.
+
+For `p ∈ PayloadClass(ell)`, define
+
+```text
+Lift_n(LiftDatum_n, p) : {0,1}^n -> {0,1}
+```
+
+by evaluating `p` on the selected coordinates and combining it with the wrapper schema `rho` on the promised domain specified by `tau`.  The target ensemble is
+
+```text
+T_n := { Lift_n(d, p) | d ∈ LiftDatum_n, p ∈ PayloadClass(ell(d)) }.
+```
+
+The density target is
+
+```text
+|T_n| ≤ 2^(polylog n),
+```
+
+or at worst `2^(n^o(1))`, never `2^(Ω(2^n))`.  More importantly for NOGO-000006, inside any fixed logarithmic payload window and wrapper skeleton, the number of accepted payload truth tables is at most `2^(a * ell^b)`, while the number of arbitrary payloads is `2^(2^ell)`.
+
+### 2.4 Witness `w`
+
+A witness is a presented object `w_n` together with its semantic denotation `⟦w_n⟧`.  The presentation may be a formula, circuit, DAG, table, or other representation, but the predicate may inspect the presentation only through the semantic equality relation below and the external certificate.
+
+### 2.5 Certificate `Cert_n`
+
+A certificate is a tuple
+
+```text
+Cert_n := (d, i, q, proof_payload, proof_lift, proof_promise, cost_receipt)
+```
+
+where:
+
+- `d ∈ LiftDatum_n`;
+- `i` is an index of length at most `a * ell(d)^b`;
+- `q := EvalPayload_ell(d)(i)` is the structured payload denoted by `i`;
+- `proof_payload` certifies `q ∈ PayloadClass(ell(d))` using only the public evaluator and index `i`;
+- `proof_lift` certifies semantic equality `⟦w_n⟧ = Lift_n(d, q)` on the promised domain;
+- `proof_promise` certifies the promise tag `tau` in `d` using the public promise definition;
+- `cost_receipt` records the size of `d`, `i`, and the proof objects under the cost measure below.
+
+The certificate is allowed to identify a structured payload by a short public index.  It is not allowed to carry an arbitrary `2^ell`-bit truth table for the payload unless that length is charged explicitly.
+
+### 2.6 Representation-invariance relation
+
+Define a relation
+
+```text
+RepEq_n(w, w') : Prop := ∀ x ∈ PromiseDomain(tau), ⟦w⟧(x) = ⟦w'⟧(x),
+```
+
+with the convention that if `tau` is the total-domain tag then this is ordinary extensional equality on `{0,1}^n`.
+
+The accepted predicate must satisfy:
+
+```text
+RepEq_n(w, w')
+∧ AlmostNaturalProvenance_BC(w, Cert_n)
+→ AlmostNaturalProvenance_BC(w', Cert_n)
+```
+
+provided the same `Cert_n` proves the same semantic lift on the same promise domain.  Thus tautological rewrites, gate reordering, associativity rewrites, bottom-up normalisation, and alternative formula presentations do not change acceptance.
+
+### 2.7 Payload-independence condition
+
+Payload-independence is the critical B/C hybrid condition.  For a fixed lift skeleton `d` and length `ell`, write an arbitrary log-width hardwired payload as
+
+```text
+h : {0,1}^ell -> {0,1}.
+```
+
+A certificate `Cert_n` is payload-independent relative to `d` if every non-public bit in `Cert_n` is recoverable from:
+
+```text
+(n, d, i, public evaluator descriptions, public promise descriptions)
+```
+
+and not from oracle access to the full truth table of `h`, except through the short structured index `i` when `h = EvalPayload_ell(i)`.
+
+Equivalently, for arbitrary payload families `h`, a certificate may depend on `h` only by proving that `h` is one of the public structured payloads and by naming its short index.  If `h` is not in `PayloadClass(ell)`, the only way to force equality with `Lift_n(d,h)` is to include payload-specific truth-table information, and that information is charged as `2^ell` bits.
+
+### 2.8 Cost measure
+
+Let
+
+```text
+Cost(Cert_n) := |d| + |i| + |proof_payload| + |proof_lift| + |proof_promise| + |cost_receipt| + PayloadBits(Cert_n).
+```
+
+Here `PayloadBits(Cert_n)` is the number of arbitrary payload truth-table bits used by the certificate outside the public structured index mechanism.  The acceptance threshold is
+
+```text
+Cost(Cert_n) ≤ C(n) := K * (log(n + 2))^r
+```
+
+for fixed constants `K,r` chosen before seeing the payload family.  For the NOGO-000006 regime `ell = ceil(log2(n + 1))`, an arbitrary payload truth table has length `2^ell = Θ(n)`, so explicitly charging it violates the polylogarithmic certificate budget.
+
+### 2.9 Accepted predicate
+
+The single candidate predicate is:
+
+```text
+AlmostNaturalProvenance_BC(w_n, Cert_n) holds iff:
+
+1. Cert_n parses as (d, i, q, proof_payload, proof_lift, proof_promise, cost_receipt);
+2. q = EvalPayload_ell(d)(i);
+3. proof_payload verifies q ∈ PayloadClass(ell(d));
+4. proof_promise verifies that tau(d) defines the active promise domain;
+5. proof_lift verifies ⟦w_n⟧ = Lift_n(d,q) on that promise domain;
+6. Cert_n is representation-invariant under RepEq_n;
+7. Cert_n is payload-independent relative to d;
+8. Cost(Cert_n) ≤ K * (log(n + 2))^r.
+```
+
+The usefulness claim, if any, is explicitly restricted to the promise ensemble `T_n`.  The predicate does not classify all Boolean functions, does not claim largeness in `BoolFun(n)`, and does not assert a lower bound for arbitrary functions outside `T_n`.
+
+## 3. Non-largeness lemma, paper-level
+
+**Lemma 1 — Non-largeness of `AlmostNaturalProvenance_BC`.**  For every sufficiently large `n`, the number of Boolean functions accepted by `AlmostNaturalProvenance_BC` is at most `2^(polylog n)` or, under the weaker parameter allowance, at most `2^(n^o(1))`.  In particular, its density in the full Boolean-function universe is
+
+```text
+|Accepted_n| / |BoolFun(n)|
+≤ 2^(polylog n) / 2^(2^n)
+= 2^(-2^n + polylog n),
+```
+
+so it is not large in the Razborov--Rudich sense.
+
+**Mechanism.**  Acceptance implies membership in `T_n`.  The number of lift data is at most `2^(polylog n)`, and for each logarithmic payload length the number of public structured payloads is at most `2^(a * ell^b) = 2^(polylog n)`.  Therefore the total number of semantic functions that can be accepted is bounded by the number of lift data times the number of public payload indices.  This is tiny compared with `2^(2^n)`.
+
+This proof does not use the forbidden mechanism “hard functions are rare.”  It uses only explicit sparsity of the promise ensemble and the certificate-index budget.
+
+## 4. Non-circularity lemma, paper-level
+
+**Lemma 2 — Non-circularity of promise and certificate membership.**  Membership in the `AlmostNaturalProvenance_BC` promise/certificate class does not encode the desired circuit lower bound, because the definitions of `PayloadClass`, `LiftDatum`, `PromiseDomain`, `RepEq`, `Cost`, and `PayloadBits` are syntactic-semantic resource definitions that avoid lower-bound language.
+
+**Required definitional discipline.**  The predicate is permitted to say:
+
+- `p = EvalPayload_ell(i)` for a public evaluator and short index;
+- `⟦w_n⟧ = Lift_n(d,p)` on a stated promise domain;
+- `Cost(Cert_n) ≤ K(log n)^r`;
+- the certificate does not use arbitrary payload truth-table bits except through an explicitly charged field.
+
+The predicate is forbidden to say or paraphrase:
+
+- `⟦w_n⟧` is not computable by small circuits;
+- `⟦w_n⟧` is not in `PpolyDAG`;
+- no small witness exists;
+- every small circuit fails on some input;
+- the payload is hard, pseudorandom against circuits, or lower-bound-certified unless that statement is replaced by an independently defined public evaluator / promise condition.
+
+**Proof idea.**  A future formalization can parse and verify the certificate without invoking `PpolyDAG`, `NP_not_subset_PpolyDAG`, circuit lower-bound predicates, or nonexistence of circuits.  All membership checks are positive checks: public index evaluation, semantic lift equality on the promise domain, representation-invariant equality, and accounting of certificate bits.
+
+This lemma is credible only under the strict reading above.  If a future version defines `PayloadClass` by saying that its members are “functions outside small DAGs,” “truth tables without small witnesses,” or equivalent hardness phrases, then this lemma fails and the verdict must become **RED-light_family_B**.
+
+## 5. Hardwiring rejection lemma, paper-level
+
+**Lemma 3 — Rejection of arbitrary all-essential log-width truth-table payloads.**  Let `ell(n) = ceil(log2(n + 1))`, and let
+
+```text
+h_n : {0,1}^ell(n) -> {0,1}
+```
+
+be an arbitrary all-essential payload of the NOGO-000006 kind, hardwired into an ambient `n`-variable formula by a fixed injection and wrapper skeleton.  Then `Lift_n(d,h_n)` can satisfy `AlmostNaturalProvenance_BC` only in one of the following two cases:
+
+1. `h_n ∈ PayloadClass(ell(n))` and has a short public index `i`; or
+2. the certificate explicitly carries enough payload-specific truth-table information to identify `h_n`, in which case `PayloadBits(Cert_n) ≥ 2^ell(n) = Θ(n)` and `Cost(Cert_n) > K(log n)^r` for sufficiently large `n`.
+
+Thus arbitrary all-essential log-width truth-table payloads cannot satisfy the predicate unless their payload-specific truth-table information is explicitly charged.
+
+**Where the arbitrary payload fails.**
+
+- **Promise membership:** a generic all-essential payload is not in the public structured class `PayloadClass(ell)`.  Since `PayloadClass(ell)` has size `2^(a * ell^b)` and the full payload universe has size `2^(2^ell)`, almost all payloads fail membership.
+- **Payload-independence:** a certificate tailored to the arbitrary truth table of `h_n` violates payload-independence unless the dependence is exposed through `PayloadBits(Cert_n)`.
+- **Certificate cost:** once exposed, the arbitrary truth table costs `2^ell = Θ(n)` bits in the NOGO-000006 log-width regime, exceeding the polylogarithmic cost threshold.
+- **Representation-invariance:** tautological rewrites of the same hardwired function do not help.  Acceptance depends on semantic membership in `T_n` plus a payload-independent certificate, not on displayed gate shapes.
+- **Distribution/promise mismatch:** the predicate's usefulness domain is `T_n`; an arbitrary payload hardwiring lies outside that promise unless it is one of the public structured payloads.
+
+This directly targets the NOGO-000006 obstruction: support size `ell = O(log n)` by itself no longer suffices for acceptance.
+
+## 6. Support-cardinality / syntax / normalisation cross-check
+
+### NOGO-000007 support-cardinality-only: **addressed**
+
+Reason: `AlmostNaturalProvenance_BC` is not a function of support cardinality.  Two witnesses with the same support profile can differ on whether the selected payload is in `PayloadClass(ell)`, whether a payload-independent certificate exists, and whether `PayloadBits` exceeds the cost threshold.  A canonical hardwiring twin with the same support size is rejected unless its payload belongs to the sparse structured class or pays for the arbitrary truth table.
+
+### NOGO-000008 tautological rewrite: **addressed**
+
+Reason: acceptance is representation-invariant under semantic equality on the promise domain.  Adding a redundant gate such as `(x_0 OR NOT x_0)` changes displayed syntax but does not change `⟦w_n⟧`, `T_n` membership, the public payload index, or the certificate cost.  A rewrite therefore cannot turn a non-structured arbitrary payload into a structured payload.
+
+### NOGO-000009 normalise-then-filter: **addressed**
+
+Reason: the predicate does not use a context-uniform bottom-up structural normaliser followed by a syntactic mixed-gate filter.  It uses semantic lift equality and certificate accounting.  Normalisation may be used as an implementation aid for a presentation, but it is not the mathematical acceptance criterion and cannot be the reason a witness gains or loses the required OR/NOT/displayed-shape feature.
+
+Residual risk: all three answers become **not addressed** if a future implementation replaces semantic lift equality and payload accounting with displayed syntax, support-cardinality thresholds, or normalise-then-syntax filtering.
+
+## 7. Razborov--Rudich analysis
+
+### Constructivity
+
+The predicate can be constructive relative to the public evaluator and certificate verifier.  Given `(w_n, Cert_n)`, checking the certificate may be efficient or at least explicitly costed.  This is useful for a formal provenance filter but creates natural-proofs risk if combined with largeness and broad usefulness.
+
+### Largeness
+
+Largeness is deliberately false.  The accepted family is bounded by the number of sparse promise targets and short certificates, at most `2^(polylog n)` or `2^(n^o(1))`, inside a universe of size `2^(2^n)`.  The predicate is therefore **almost-natural but non-large**, not a classical large natural property.
+
+### Usefulness
+
+Usefulness is the weak leg.  The only non-circular usefulness statement currently available is promise-local:
+
+```text
+If a target family lies in T_n and has an accepted payload-independent provenance certificate,
+then the route may reason about that target inside the T_n / promise ensemble.
+```
+
+That does not yet imply a worst-case lower bound against `PpolyDAG` and does not produce an `NP` language outside `PpolyDAG`.
+
+### Classification
+
+The predicate is:
+
+```text
+almost-natural but non-large;
+not natural-proof-shaped in the full Boolean-function universe;
+constructive relative to certificates;
+unclear / likely too weak for repository-level usefulness.
+```
+
+It avoids the Razborov--Rudich triad by failing largeness.  It does not provide a natural-proofs bypass witness for a final lower-bound proof, and it does not address relativization or algebrization beyond the fact that those barrier interfaces remain unclaimed.
+
+## 8. Usefulness toward `PpolyDAG`
+
+The repository goal would require a bridge of the following strength:
+
+```text
+ResearchGapWitness.dagSeparation : NP_not_subset_PpolyDAG
+```
+
+For `AlmostNaturalProvenance_BC` to matter, usefulness would need to say something like:
+
+```text
+There exists an NP language L and infinitely many / all relevant lengths n
+such that the length-n truth-table slice of L belongs to T_n with accepted
+payload-independent provenance, and every PpolyDAG family fails to compute L.
+```
+
+The present predicate does not supply this.  It only defines a sparse promise class and rejects arbitrary payload hardwiring.  Because `T_n` is intentionally low-description and sparse, the route faces a serious usefulness hazard:
+
+- If `PayloadClass` is explicit and easily evaluable, accepted targets may themselves have small circuits or small DAGs, making them poor lower-bound candidates.
+- If `PayloadClass` is made hard enough to contain an `NP` language outside `PpolyDAG`, the hardness may have been smuggled into the promise definition, violating non-circularity.
+- If usefulness is stated only distributionally or only inside `T_n`, it remains a side track and does not imply `NP_not_subset_PpolyDAG`.
+
+Answer:
+
+```text
+only_distributional_side_track
+```
+
+A plausible path to `PpolyDAG` has not been shown.  The predicate may be useful as an audit object for rejecting known hardwiring attacks, but it is not yet a mainline lower-bound source.
+
+## 9. Structural double-bind search
+
+The candidate exposes a sharp double-bind.
+
+### Bind A — cheap enough to verify vs. too easy to compute
+
+If the public payload index and lift certificate are cheap enough to verify and produce, then the accepted target may be cheap enough to compute.  In that regime the predicate is safe from hardwiring but useless for separating `NP` from `PpolyDAG`.
+
+### Bind B — restrictive enough to reject hardwiring vs. too sparse for usefulness
+
+The sparse promise class rejects arbitrary log-width truth-table payloads by admitting only `2^(a * ell^b)` payloads out of `2^(2^ell)`.  But the same sparsity means the predicate says nothing about almost every Boolean function and has no automatic route to a worst-case `NP` lower bound.
+
+### Bind C — hard enough to be useful vs. circular
+
+If `PayloadClass` is strengthened until it contains a meaningful `NP`-hard or `PpolyDAG`-separating target, the strengthened promise risks saying, in disguised form, that the target has no small circuits or no small DAG witnesses.  That would collapse the non-circularity lemma and force **RED-light_family_B**.
+
+### Bind D — semantic enough to avoid syntax attacks vs. natural-proof pressure
+
+The semantic, representation-invariant design avoids NOGO-000008 and NOGO-000009.  If it were expanded from sparse `T_n` to a broad efficiently decidable semantic property of many truth tables, it would regain largeness and become natural-proof-shaped.  Keeping it non-large avoids Razborov--Rudich but weakens usefulness.
+
+Net result: the predicate survives the local NoGo/barrier chain as a specification, but the double-bind blocks any responsible claim of mainline progress.
+
+## 10. Recommended next action
+
+```text
+run_second_D0_1_review
+```
+
+The next review should not open full fp3b7 Round 1.  It should challenge exactly one missing bridge:
+
+```text
+Can this sparse structured-payload promise class contain a non-circular NP target
+whose accepted provenance can imply a PpolyDAG lower bound?
+```
+
+If the answer requires defining `PayloadClass` by lower-bound language, then the family should be marked **RED-light_family_B**.  If the answer remains only distributional or promise-local, fp3b7 should be treated as a side track rather than mainline progress toward `P != NP`.

--- a/seed_packs/fp3b7_almost_natural_provenance/reports/D0_1_second_review_gpt55.md
+++ b/seed_packs/fp3b7_almost_natural_provenance/reports/D0_1_second_review_gpt55.md
@@ -1,0 +1,408 @@
+# fp3b7-D0.1 second review — AlmostNaturalProvenance_BC
+
+Slot: `fp3b7-D0.1-second-review`
+Handle: `gpt55`
+Progress classification: Infrastructure / markdown-only independent review.  This report does not reduce `SearchMCSPWeakLowerBound` or `VerifiedNPDAGLowerBoundSource`, does not promote a `ProvenanceFilter`, and does not claim any endpoint.
+
+## 1. Executive verdict
+
+```text
+RED_light_family_B
+```
+
+The D0.1 predicate is a useful audit specification, but it is **not worth opening into full fp3b7 Round 1** as a route toward the repository target.
+
+My review is adversarial but not dismissive:
+
+- **Non-largeness:** passed, conditional on the D0.1 size caps for payloads, lift data, wrappers, and promise tags being kept fixed and explicit.
+- **Non-circularity:** passed for the written predicate, because it deliberately defines membership by positive structured-index and lift checks rather than by circuit lower-bound language.
+- **Hardwiring rejection:** passed with an implementation caveat: it works only if the payload-independence and cost accounting charge every payload-dependent bit in the lift datum, wrapper, promise tag, and proof objects.
+- **Usefulness toward `PpolyDAG`: failed / likely too weak.**  The same design choices that make the predicate safe make accepted targets low-description and promise-local.  No credible non-circular mechanism is given by which this sparse structured-payload class could contain an `NP` target and imply `NP_not_subset_PpolyDAG`.
+
+The central answer is therefore:
+
+```text
+Core question: Can this sparse structured-payload promise class contain a
+non-circular NP target whose accepted provenance can imply a PpolyDAG lower bound?
+
+Review answer: not credibly, without either making the target easy or hiding the
+lower bound in PayloadClass / promise membership.
+```
+
+## 2. Summary of `AlmostNaturalProvenance_BC`
+
+D0.1 specifies one predicate family:
+
+```text
+AlmostNaturalProvenance_BC
+= Sparse Structured-Payload Promise with Payload-Independent Provenance Certificate.
+```
+
+In my own words, the objects are as follows.
+
+### Target ensemble `T_n`
+
+For ambient input length `n`, the full semantic universe is
+
+```text
+BoolFun(n) = ({0,1}^n -> {0,1}),
+|BoolFun(n)| = 2^(2^n).
+```
+
+The predicate does not range over all of `BoolFun(n)`.  It accepts only functions lying in a sparse target ensemble
+
+```text
+T_n = { Lift_n(d, p) | d in LiftDatum_n, p in PayloadClass(ell(d)) }.
+```
+
+The intended size is at most `2^(polylog n)` or at worst `2^(n^o(1))`.
+
+### Payload class
+
+For `ell <= ceil(log2(n + 1))`, `PayloadClass(ell)` is a public, low-parameter, structured set of Boolean payloads
+
+```text
+PayloadClass(ell) ⊆ ({0,1}^ell -> {0,1})
+```
+
+with cardinality at most `2^(a * ell^b)`, where this is tiny compared with the full payload universe `2^(2^ell)`.  Membership is by a short public index `i` and evaluator `EvalPayload_ell(i)`, not by saying the payload is hard.
+
+### Lift datum
+
+A lift datum is
+
+```text
+d = (ell, pi, rho, tau)
+```
+
+where `pi` selects an `ell`-coordinate window inside `[n]`, `rho` is a public wrapper schema, and `tau` is a public promise tag.  The crucial safety requirement is that `rho` and `tau` come from fixed small public families and cannot smuggle the arbitrary payload truth table.
+
+### Certificate
+
+A certificate is
+
+```text
+Cert_n = (d, i, q, proof_payload, proof_lift, proof_promise, cost_receipt)
+```
+
+where `q = EvalPayload_ell(i)`, the payload proof checks `q ∈ PayloadClass(ell)`, the lift proof checks semantic equality between the witness and `Lift_n(d,q)` on the promised domain, and the cost receipt records all certificate resources.
+
+### Payload-independence
+
+A certificate is payload-independent when its non-public bits are recoverable from public data and the short structured index, not from arbitrary oracle access to the payload truth table.  If the payload is not in `PayloadClass(ell)`, any certificate that identifies it must explicitly carry payload-specific truth-table information.
+
+### Cost measure
+
+The D0.1 cost measure is
+
+```text
+Cost(Cert_n)
+  = |d| + |i| + |proof_payload| + |proof_lift|
+    + |proof_promise| + |cost_receipt| + PayloadBits(Cert_n),
+```
+
+with threshold
+
+```text
+Cost(Cert_n) <= K * (log(n + 2))^r.
+```
+
+Since a log-width arbitrary payload has truth table length `2^ell = Θ(n)`, explicitly carrying it exceeds the polylogarithmic cost threshold.
+
+### Accepted predicate
+
+`AlmostNaturalProvenance_BC(w_n, Cert_n)` accepts exactly when the certificate parses, names a structured payload, proves promise/lift membership semantically, is invariant under representation changes, is payload-independent, and fits the polylogarithmic cost budget.  Usefulness is restricted to `T_n`; the predicate does not claim to classify all Boolean functions.
+
+## 3. Non-largeness review
+
+Verdict:
+
+```text
+passed
+```
+
+The D0.1 non-largeness argument works at the paper level, subject to preserving the stated parameter caps.
+
+### Accepted set size bound
+
+Acceptance implies membership in `T_n`.  Therefore
+
+```text
+|Accepted_n| <= |LiftDatum_n| * max_ell |PayloadClass(ell)|,
+```
+
+up to possible collisions in `Lift_n`, which can only reduce the count.
+
+For `ell <= O(log n)`, the coordinate map count is not dangerous:
+
+```text
+# injections [ell] -> [n] <= n^ell <= 2^(O((log n)^2)).
+```
+
+If wrappers and promise tags are each capped by `2^(polylog n)` and payload indices by `2^(polylog n)`, then `|Accepted_n| <= 2^(polylog n)`.
+
+### Dependence on `PayloadClass` size
+
+The argument depends essentially on
+
+```text
+|PayloadClass(ell)| <= 2^(a * ell^b) << 2^(2^ell).
+```
+
+If future work lets `PayloadClass(ell)` approach the full truth-table universe or allows a universal interpreter whose index length is `Θ(2^ell)`, the non-largeness proof collapses for the hardwiring slice.  D0.1 does not do that.
+
+### Wrappers / lift data large-class risk
+
+The dangerous channel is not `pi`; it is `rho` and `tau`.  If a wrapper schema or promise tag can carry arbitrary advice of length `Θ(n)` or select an arbitrary subset of `{0,1}^n`, then the lift side can reintroduce largeness.  D0.1 prevents this by requiring fixed public wrapper/promise families of size `2^(polylog n)`.  This constraint must be treated as part of the predicate, not as an optional implementation detail.
+
+### Measurement universe
+
+Largeness is correctly measured in the full Boolean-function universe `BoolFun(n)`, not merely inside the promise class.  Inside `T_n` the predicate may be large or even total; that is irrelevant to Razborov--Rudich largeness over all truth tables.  The escape is genuine non-largeness, not a relabeling of the sample space.
+
+## 4. Non-circularity review
+
+Verdict:
+
+```text
+passed
+```
+
+The written predicate avoids the obvious circular phrases.  It defines promise/certificate membership by:
+
+- public structured payload indices;
+- semantic lift equality;
+- promise-domain membership;
+- representation invariance;
+- payload-independence;
+- explicit certificate cost accounting.
+
+It does **not** define membership by saying:
+
+- not computable by small circuits;
+- not in `PpolyDAG`;
+- has no small witness;
+- every small circuit fails;
+- pseudorandom against small circuits;
+- requires large formula/DAG;
+- hard for a circuit class.
+
+The review pass is narrow.  It says only that the D0.1 predicate definition is not circular.  It does not say that the predicate can later become useful without circularity.  That later step is exactly where I expect failure: any attempt to make `PayloadClass` contain a meaningful `NP` target outside `PpolyDAG` appears likely to introduce one of the forbidden lower-bound phrases, directly or under a pseudorandomness/hardness synonym.
+
+## 5. Hardwiring rejection review
+
+Verdict:
+
+```text
+passed
+```
+
+The hardwiring rejection works against the NOGO-000006 family if the D0.1 accounting rules are enforced literally.
+
+### Is `PayloadClass` small enough?
+
+Yes.  For `ell = O(log n)`, the full payload universe has size
+
+```text
+2^(2^ell) = 2^(Θ(n)),
+```
+
+while the accepted public payload class has size at most
+
+```text
+2^(a * ell^b) = 2^(polylog n).
+```
+
+Thus a generic all-essential truth-table payload is not in `PayloadClass(ell)`.
+
+### Is payload-independence well-defined enough?
+
+For a markdown-level review, yes, but it is the least formal part of the design.  The intended condition is not merely “the certificate is short”; it is “the certificate's non-public bits are not functions of the arbitrary payload truth table except through a public short index.”  A future formalization would need a precise dependency / oracle-use model.
+
+For the decision here, the condition is strong enough to reject the known NOGO-000006 attack because an arbitrary payload has no public short index.
+
+### Could an adversary encode payload through lift datum / wrapper / promise tag?
+
+Only if D0.1's caps are weakened.  This is the main implementation caveat.
+
+- If `rho` can be an arbitrary wrapper with `Θ(n)` advice bits, the payload can move into `rho`.
+- If `tau` can specify an arbitrary promise subset with payload-dependent membership, the payload can move into `tau`.
+- If `proof_lift` can contain arbitrary per-input exceptions without charging them, the payload can move into the proof.
+
+D0.1 rejects these channels by bounding `d`, requiring public wrapper/promise families, and including `PayloadBits(Cert_n)` in `Cost(Cert_n)`.  Therefore the hardwiring review passes only with the explicit condition:
+
+```text
+Every payload-dependent bit in d, rho, tau, proof_lift, proof_promise,
+and cost_receipt must either come from the public short index i or be charged
+as PayloadBits(Cert_n).
+```
+
+### Does representation-invariance reintroduce adaptivity?
+
+No.  Representation-invariance removes displayed-syntax dependence; it does not by itself create a new certificate.  An adversary may change the formula presentation, but the semantic target still needs either a structured payload index or an explicitly charged arbitrary payload.  Tautological rewriting does not manufacture a public index.
+
+## 6. NOGO cross-check
+
+### NOGO-000006 — arbitrary all-essential log-width payload
+
+```text
+addressed
+```
+
+The arbitrary payload no longer passes just because it has logarithmic support.  It must either lie in the sparse public payload class or pay `Θ(n)` payload bits, violating the polylog certificate threshold.
+
+### NOGO-000007 — support-cardinality-only meta-barrier
+
+```text
+addressed
+```
+
+The predicate is not determined by support cardinality.  Two witnesses with the same support can differ by structured-payload membership, payload-independent certificate existence, and charged payload bits.
+
+### NOGO-000008 — tautological rewrite attack
+
+```text
+addressed
+```
+
+The predicate is semantic/representation-invariant rather than displayed-gate-count-sensitive.  Adding a tautological seed changes syntax but not membership in `T_n` or the certificate's payload dependence.
+
+### NOGO-000009 — normalise-then-filter self-defeat
+
+```text
+addressed
+```
+
+The predicate is not a structural normaliser followed by a syntactic mixed-gate filter.  Normalisation is not the acceptance criterion.  The V2-A normalisation self-defeat pattern therefore does not directly apply.
+
+### Residual NOGO caveat
+
+All four answers are conditional on not weakening the D0.1 accounting.  In particular, allowing `rho`, `tau`, or proof objects to carry uncharged arbitrary truth-table advice would reopen NOGO-000006 immediately.
+
+## 7. Razborov--Rudich / Natural Proofs review
+
+### Constructivity
+
+The predicate is constructive relative to the certificate verifier.  Given `w_n` and `Cert_n`, the checker can in principle verify public-index payload membership, lift equality on the promised domain, representation invariance obligations, and cost accounting.  If lift equality is made fully semantic over `{0,1}^n`, the check may be expensive; if it is made efficiently checkable by structure, then accepted targets become even more low-description.
+
+### Largeness
+
+The predicate is non-large enough to escape the classical Razborov--Rudich triad.  Its accepted set is tiny in `BoolFun(n)`, assuming the D0.1 caps are respected.  This is the strongest part of the design.
+
+### Usefulness
+
+Usefulness is the fatal weakness.  The predicate is useful only inside `T_n`, and `T_n` is designed to be sparse and low-description.  That is exactly what blocks largeness, but it also deprives the predicate of a visible route to `NP_not_subset_PpolyDAG`.
+
+### Tradeoff
+
+The tradeoff is:
+
+```text
+Make T_n small and payload-independent  -> RR/largeness and hardwiring are controlled,
+                                           but accepted targets look too structured/easy.
+
+Make T_n rich enough to contain a hard NP target -> usefulness improves,
+                                                    but either largeness returns or the
+                                                    promise starts encoding hardness.
+```
+
+So the predicate is constructive enough to check and non-large enough to avoid RR, but not useful enough to matter for the repository target.
+
+## 8. Usefulness toward `PpolyDAG`
+
+Verdict:
+
+```text
+likely_too_weak
+```
+
+`AlmostNaturalProvenance_BC` does not plausibly help produce
+
+```text
+ResearchGapWitness.dagSeparation : NP_not_subset_PpolyDAG
+```
+
+without hiding a lower bound inside `PayloadClass` or promise membership.
+
+### Why accepted targets may have small circuits/DAGs
+
+The accepted target has a short description:
+
+```text
+(d, i) with |d| + |i| = polylog(n),
+```
+
+plus public evaluators and public wrappers.  If `EvalPayload`, `Lift_n`, `rho`, and `tau` are efficiently evaluable, then each accepted function is not merely low-density as a set of truth tables; it is also operationally easy to compute from its short index.  That strongly suggests accepted targets have small nonuniform circuits/DAGs obtained by hardwiring `(d,i)` and implementing the public evaluator/wrapper.
+
+This is not a formal upper bound yet, but it is the adversarial default: a polylog-indexed public evaluator normally gives a small nonuniform algorithm for every accepted target.  Such targets cannot be the source of `NP_not_subset_PpolyDAG` unless some evaluator or promise check is itself hard in a way not captured by the certificate.
+
+### Why making the target hard risks circularity
+
+To get an `NP` language outside `PpolyDAG`, future work would need a lemma of the form:
+
+```text
+There exists an NP language L such that for infinitely many/all n,
+L_n ∈ T_n with accepted payload-independent provenance, and no PpolyDAG
+family computes L.
+```
+
+But D0.1 supplies no independent source for the final clause.  If the future proof tries to obtain it by defining `PayloadClass` as a class of pseudorandom, circuit-hard, DAG-hard, lower-bound-certified, or no-small-witness payloads, then non-circularity fails.  If it keeps `PayloadClass` as a public low-parameter evaluator, then the accepted functions look nonuniformly easy.
+
+### Why this is not merely “unclear”
+
+At D0, uncertainty was reasonable because the predicate had not been specified.  After D0.1, the specification is concrete enough to expose the double-bind.  Safety is achieved precisely by restricting to a sparse, short-indexed, payload-independent class.  That restriction is not an accidental missing bridge; it is the core design.  It makes the route a good hardwiring-audit toy and a poor `PpolyDAG` lower-bound source.
+
+Therefore the usefulness verdict is `likely_too_weak`, not `plausible_path_exists` and not merely `only_distributional_side_track`.
+
+## 9. Structural double-bind review
+
+The strongest double-bind is:
+
+```text
+Either the certificate is genuinely cheap and payload-independent,
+or the target may be useful for lower bounds, but not both.
+```
+
+More explicitly:
+
+1. **Cheap certificate implies low-description target.**  If `(d,i)` and the proofs are polylogarithmic and public evaluators are usable, then the accepted function is specified by a tiny nonuniform advice string.  The adversarial expectation is that such a function has small `PpolyDAG` implementations.
+
+2. **Restrictive certificate rejects hardwiring but also rejects arbitrary useful targets.**  The predicate successfully rejects generic all-essential log-width payloads, but it does so by admitting only a tiny structured subset.  A generic hard `NP` slice has no reason to land in that subset.
+
+3. **Semantic + constructive + broadly useful would reawaken natural proofs.**  If the predicate were broadened from sparse `T_n` to a broad efficiently checkable semantic property useful against `PpolyDAG`, it would move back toward the Razborov--Rudich triad.
+
+4. **Non-large means no automatic worst-case leverage.**  Non-largeness is the RR escape hatch, but it also means the predicate says nothing about almost every Boolean function.  A worst-case `NP` lower bound needs a separate target-location theorem, and no non-circular candidate for that theorem is visible.
+
+5. **Payload-independence blocks the very evidence a hard target would seem to need.**  A meaningful hard target would typically need target-specific information.  The predicate either refuses that information as payload-dependent or charges it, exceeding the budget.  If the information is compressed into a public short index, the target again looks easy/nonuniformly computable.
+
+This is a structural failure, not a request for more parameter tuning.
+
+## 10. Final recommendation
+
+```text
+B. RED_light_fp3b7
+```
+
+I recommend **not** opening full fp3b7 Round 1 for `AlmostNaturalProvenance_BC`.
+
+Reason by gate:
+
+- Non-largeness: passed.
+- Non-circularity: passed for the written predicate.
+- Hardwiring rejection: passed with strict accounting.
+- Usefulness path to `PpolyDAG`: failed / likely too weak.
+
+A full Round 1 would spend effort formalizing a predicate that is safe mainly because it is too narrow.  That is not mainline progress toward `VerifiedNPDAGLowerBoundSource`, `SearchMCSPWeakLowerBound`, or `ResearchGapWitness.dagSeparation`.
+
+### NoGo or archive?
+
+Do **not** file a formal NoGoLog entry yet.  This review is markdown-level and does not provide a Lean formalized meta-barrier analogous to NOGO-000007 or NOGO-000009.  The correct action is to archive fp3b7 Family B as a red-lighted design path unless an operator explicitly wants a later formal NoGo slot.
+
+If a future NoGo is desired, the candidate statement should target the double-bind:
+
+```text
+For short-index public payload/lift evaluators, accepted targets admit small
+nonuniform DAGs; if the evaluator/promise is strengthened to avoid that, the
+strengthening either becomes nonconstructive/unusable or encodes the lower bound.
+```
+
+That is a possible future audit theorem, but it is not needed to reject full Round 1 now.


### PR DESCRIPTION
### Motivation

- Provide a concrete D0.1 candidate predicate family `AlmostNaturalProvenance_BC` that formalizes a sparse structured-payload promise with payload-independent provenance certificates.
- Record an adversarial independent second review of the D0.1 specification assessing Razborov--Rudich, NoGo, and hardwiring concerns and deciding the family is not suitable to open full fp3b7 Round 1.
- Capture the design constraints and implementation caveats required to preserve non-largeness, non-circularity, and hardwiring rejection in future formalizations.

### Description

- Add `seed_packs/fp3b7_almost_natural_provenance/reports/D0_1_bc_hybrid_spec_gpt55.md` containing a detailed formal-ish specification of the `AlmostNaturalProvenance_BC` predicate, including ambient universe, payload class, lift data, certificate format, payload-independence, cost measure, and three paper-level lemmas (non-largeness, non-circularity, hardwiring rejection).
- Add `seed_packs/fp3b7_almost_natural_provenance/reports/D0_1_second_review_gpt55.md` containing an adversarial second review that issues verdict `RED_light_family_B`, documents why non-largeness and non-circularity pass under strict caps, explains the double-bind limiting usefulness toward `PpolyDAG`, and recommends not opening full Round 1.
- State required implementation constraints (bounded wrapper/promise families, strict `PayloadBits` accounting, representation-invariance) and recommend a focused follow-up `run_second_D0_1_review` rather than escalation.

### Testing

- No automated tests were run for these changes because they are Markdown-only specification and review documents.
- Validation consisted only of adding the two report files to the repository tree; no code execution or CI-affecting changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a062d435050832b8328b6de2902291f)