### PR TITLE
P1P-02L2: Prefix parser length convention, encoder, and runtime hook

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -101,6 +101,85 @@ def decodeGammaAux? {m : Nat} (y : PrefixBitVec m) (offset fuel zeros : Nat) :
 def decodeGamma? {m : Nat} (y : PrefixBitVec m) (offset : Nat) : Option (Nat × Nat) :=
   decodeGammaAux? y offset (m + 1) 0
 
+/-- Big-endian bit view of a natural number at a raw index in a fixed-width field. -/
+def natBitBEAt (value width idx : Nat) : Bool :=
+  (value / 2 ^ (width - 1 - idx)) % 2 = 1
+
+/-- Big-endian bit view of a natural number restricted to a fixed width. -/
+def natBitBE (value width : Nat) (j : Fin width) : Bool :=
+  natBitBEAt value width j.1
+
+/--
+The canonical Elias-gamma bit for the natural number `n` encoded as `n + 1`.
+
+The first `bitLength (n + 1) - 1` positions are the unary zero prefix, the next
+position is the terminator, and the remaining positions are the low payload
+bits of `n + 1` in big-endian order.  This is executable and uses only the
+explicit field convention, not parser inversion or choice.
+-/
+def gammaBit (n : Nat) (j : Fin (gammaLen n)) : Bool :=
+  let zeros := bitLength (n + 1) - 1
+  if j.1 < zeros then
+    false
+  else if j.1 = zeros then
+    true
+  else
+    natBitBEAt (n + 1 - 2 ^ zeros) zeros (j.1 - (zeros + 1))
+
+/-- Read a component bit at an offset, returning `false` off the component. -/
+def componentBit {M len : Nat}
+    (offset : Nat)
+    (bits : PrefixBitVec len)
+    (j : Fin M) : Bool :=
+  if h : offset ≤ j.1 ∧ j.1 < offset + len then
+    bits ⟨j.1 - offset, by omega⟩
+  else
+    false
+
+/--
+Computable canonical encoder for raw tree-MCSP prefix fields.
+
+The output length is definitionally `treeMCSPPrefixM codec n`.  The final
+witness-prefix block has fixed size `codec.witnessBits n`: the first `i` bits
+come from `p`, and every inactive padding bit is encoded as zero.
+-/
+def encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (i : Nat)
+    (_hi : i ≤ codec.witnessBits n)
+    (p : PrefixBitVec i) :
+    PrefixBitVec (treeMCSPPrefixM codec n) :=
+  fun j =>
+    if htag : j.1 < tagLen then
+      natBitBE treePrefixTag tagLen ⟨j.1, htag⟩
+    else if hgamma : tagLen ≤ j.1 ∧ j.1 < tagLen + gammaLen n then
+      gammaBit n ⟨j.1 - tagLen, by omega⟩
+    else
+      let xOffset := tagLen + gammaLen n
+      let iOffset := xOffset + Pnp3.Models.Partial.tableLen n
+      let pOffset := iOffset + idxWidth codec.witnessBits n
+      if hx : xOffset ≤ j.1 ∧ j.1 < xOffset + Pnp3.Models.Partial.tableLen n then
+        x ⟨j.1 - xOffset, by omega⟩
+      else if hiField : iOffset ≤ j.1 ∧ j.1 < iOffset + idxWidth codec.witnessBits n then
+        natBitBE i (idxWidth codec.witnessBits n) ⟨j.1 - iOffset, by omega⟩
+      else if hp : pOffset ≤ j.1 ∧ j.1 < pOffset + i then
+        p ⟨j.1 - pOffset, by omega⟩
+      else
+        false
+
+/-- Canonical encoder for an already parsed input whose fields satisfy the raw convention. -/
+def encodeTreeMCSPPrefixInput
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    {m : Nat}
+    (input : PrefixInput
+      (treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec)) m) :
+    PrefixBitVec (treeMCSPPrefixM codec input.n) :=
+  encodeTreeMCSPPrefixFields codec input.n input.x input.i input.prefixLength_le input.p
+
 /-- Predicate recording the canonical zero-padding convention for parsed inputs. -/
 def CanonicalTreeMCSPPrefixInput
     {threshold : Nat → Nat}
@@ -165,6 +244,64 @@ def parseTreeMCSPPrefixInput
   else
     none
 
+
+/--
+Successful concrete parsing enforces the single ambient-length convention.
+
+This is the serialization-side fact required by the R1-B2a runtime interface:
+the parser accepts no trailing garbage and no alternate padding convention, so
+the ambient string length is exactly `treeMCSPPrefixM codec input.n` for the
+decoded target parameter.
+-/
+theorem parseTreeMCSPPrefixInput_length_convention
+    (threshold : Nat → Nat)
+    (codec : TreeCircuitWitnessCodec threshold)
+    {m : Nat}
+    (y : PrefixBitVec m)
+    (input : PrefixInput
+      (treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec)) m)
+    (h : parseTreeMCSPPrefixInput threshold codec y = some input) :
+    m = treeMCSPPrefixM codec input.n := by
+  unfold parseTreeMCSPPrefixInput at h
+  cases htagRead : readNatBE y 0 tagLen with
+  | none => simp [htagRead] at h
+  | some tag =>
+      by_cases htag : tag = treePrefixTag
+      · cases hgamma : decodeGamma? y tagLen with
+        | none => simp [htagRead, htag, hgamma] at h
+        | some decoded =>
+            let n := decoded.1
+            by_cases hlen : m = treeMCSPPrefixM codec n
+            · let xOffset := tagLen + decoded.2
+              cases hx : sliceBits? y xOffset (Pnp3.Models.Partial.tableLen n) with
+              | none => simp [htagRead, htag, hgamma, hlen, hx, n, xOffset] at h
+              | some x =>
+                  let iOffset := xOffset + Pnp3.Models.Partial.tableLen n
+                  cases hiRead : readNatBE y iOffset (idxWidth codec.witnessBits n) with
+                  | none => simp [htagRead, htag, hgamma, hlen, hx, hiRead, n, xOffset, iOffset] at h
+                  | some i =>
+                      by_cases hi : i ≤ codec.witnessBits n
+                      · let pOffset := iOffset + idxWidth codec.witnessBits n
+                        cases hp : sliceBits? y pOffset i with
+                        | none => simp [htagRead, htag, hgamma, hlen, hx, hiRead, hi, hp, n, xOffset, iOffset, pOffset] at h
+                        | some p =>
+                            let padOffset := pOffset + i
+                            let padWidth := codec.witnessBits n - i
+                            cases hpad : sliceBits? y padOffset padWidth with
+                            | none => simp [htagRead, htag, hgamma, hlen, hx, hiRead, hi, hp, hpad, n, xOffset, iOffset, pOffset, padOffset, padWidth] at h
+                            | some pad =>
+                                cases hzeroRead : allZeroSlice? y padOffset padWidth with
+                                | none => simp [htagRead, htag, hgamma, hlen, hx, hiRead, hi, hp, hpad, hzeroRead, n, xOffset, iOffset, pOffset, padOffset, padWidth] at h
+                                | some padZero =>
+                                    by_cases hzero : padZero = true
+                                    · simp [htagRead, htag, hgamma, hlen, hx, hiRead, hi, hp, hpad, hzeroRead, hzero, n, xOffset, iOffset, pOffset, padOffset, padWidth] at h
+                                      cases h
+                                      exact hlen
+                                    · simp [htagRead, htag, hgamma, hlen, hx, hiRead, hi, hp, hpad, hzeroRead, hzero, n, xOffset, iOffset, pOffset, padOffset, padWidth] at h
+                      · simp [htagRead, htag, hgamma, hlen, hx, hiRead, hi, n, xOffset, iOffset] at h
+            · simp [htagRead, htag, hgamma, hlen, n] at h
+      · simp [htagRead, htag] at h
+
 /-- The concrete parser packaged in the existing `PrefixParser` interface. -/
 def treeMCSPConcretePrefixParser
     (threshold : Nat → Nat)
@@ -185,6 +322,25 @@ theorem parseTreeMCSPPrefixInput_bad_tag
     (hbad : tag ≠ treePrefixTag) :
     parseTreeMCSPPrefixInput threshold codec y = none := by
   simp [parseTreeMCSPPrefixInput, htag, hbad]
+
+/--
+The concrete parser satisfies the runtime-interface length-convention field.
+
+This theorem intentionally packages only the proved length fact; it does not
+claim a parser running-time bound or instantiate `RuntimeAwarePrefixParser`,
+whose `parser_polynomial_time_in_M` field remains a separate real obligation.
+-/
+theorem treeMCSPConcretePrefixParser_length_convention_matches_M
+    (threshold : Nat → Nat)
+    (codec : TreeCircuitWitnessCodec threshold) :
+    ∀ {m : Nat}, ∀ y : PrefixBitVec m,
+      ∀ input : PrefixInput
+        (treeMCSPSearchProblem threshold
+          (TreeMCSPSearchWitnessEncoding.ofCodec codec)) m,
+        parsePrefixInput (treeMCSPConcretePrefixParser threshold codec) y = some input →
+          m = (treeMCSPConcretePrefixParser threshold codec).M input.n := by
+  intro m y input h
+  exact parseTreeMCSPPrefixInput_length_convention threshold codec y input h
 
 /-- Parser failures are nonmembers of the prefix-extension language. -/
 theorem parseTreeMCSPPrefixInput_malformed_rejected

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -45,8 +45,12 @@ def check_C_DAG : CircuitFamilyClass :=
 #check Pnp4.Frontier.ContractExpansion.idxWidth
 #check Pnp4.Frontier.ContractExpansion.treeMCSPPrefixM
 #check Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput
+#check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields
+#check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixInput
 #check Pnp4.Frontier.ContractExpansion.treeMCSPConcretePrefixParser
 #print axioms Pnp4.Frontier.ContractExpansion.tableLen_le_treeMCSPPrefixM
+#print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
+#print axioms Pnp4.Frontier.ContractExpansion.treeMCSPConcretePrefixParser_length_convention_matches_M
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -196,6 +196,10 @@ end Pnp4
 #check Pnp4.Frontier.ContractExpansion.RuntimeAwarePrefixParser
 #check Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixRuntimeBudget
 #print axioms Pnp4.Frontier.ContractExpansion.tableLen_le_treeMCSPPrefixM
+#print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
+#print axioms Pnp4.Frontier.ContractExpansion.treeMCSPConcretePrefixParser_length_convention_matches_M
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected
+#check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields
+#check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixInput
 #check Pnp4.Frontier.ContractExpansion.treeMCSPConcretePrefixParser


### PR DESCRIPTION
### Motivation
- Fix and formalize the prefix serialization convention for the tree‑MCSP target so the parser enforces a single ambient length per decoded parameter and the encoding is canonical and computable. 
- Provide a computable encoder for the raw/parsed prefix fields so future round‑trip proofs and runtime-budget obligations have an executable representation to work with. 
- Expose the proved length fact as the runtime hook required by the R1‑B2a runtime interface while leaving the parser runtime/time bounds as a separate staged obligation.

### Description
- Added executable bit helpers and encoders: `natBitBEAt`, `natBitBE`, `gammaBit`, `componentBit`, `encodeTreeMCSPPrefixFields`, and `encodeTreeMCSPPrefixInput` (all in `PrefixParserConvention.lean`).
- Proved the ambient-length convention theorem `parseTreeMCSPPrefixInput_length_convention` showing that a successful parse forces `m = treeMCSPPrefixM codec input.n`.
- Staged the runtime hook as `treeMCSPConcretePrefixParser_length_convention_matches_M` which uses the proved length theorem but does not assert any polynomial-time parser bound.
- Updated test/audit surfaces to expose the new encoder and theorem names in `AlgorithmsToLowerBoundsSurfaceTests.lean` and `AxiomsAudit.lean` so CI/axiom audits list the new definitions.

### Testing
- Ran `lake build PnP3 Pnp4` and the build completed successfully (the new module type‑checked and integrated into the PnP4 build). 
- Ran the repository checks `./scripts/check.sh` which completed successfully (all CI smoke and governance checks passed). 
- Searched for proof holes/hacks with `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no occurrences, confirming no unexpected proof holes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c98485bc832bbf358fd49da2fff9)