### PR TITLE
Prefix parser: length-convention theorem and canonical encoder for tree-MCSP prefix

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -101,6 +101,68 @@ def decodeGammaAux? {m : Nat} (y : PrefixBitVec m) (offset fuel zeros : Nat) :
 def decodeGamma? {m : Nat} (y : PrefixBitVec m) (offset : Nat) : Option (Nat × Nat) :=
   decodeGammaAux? y offset (m + 1) 0
 
+/-- Big-endian bit encoder for a fixed-width unsigned natural field. -/
+def natBitBE (value width offset : Nat) : Bool :=
+  (value / 2 ^ (width - 1 - offset)) % 2 = 1
+
+/-- Bit-level Elias-gamma encoder for the convention's `n + 1` code. -/
+def gammaBit (n offset : Nat) : Bool :=
+  let zeros := bitLength (n + 1) - 1
+  if offset < zeros then
+    false
+  else if offset = zeros then
+    true
+  else
+    natBitBE (n + 1 - 2 ^ zeros) zeros (offset - zeros - 1)
+
+/--
+Computable canonical encoder for raw tree-MCSP prefix fields.
+
+The output length is definitionally `treeMCSPPrefixM codec n`.  The final
+witness-prefix block has fixed width `codec.witnessBits n`: its first `i` bits
+come from `p`, and every inactive suffix bit is encoded as zero.  The `_hi`
+argument records the same active-prefix bound required by the parser; the
+definition itself is direct bit arithmetic, not a hidden parser inverse or
+choice principle.
+-/
+def encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (i : Nat)
+    (_hi : i ≤ codec.witnessBits n)
+    (p : PrefixBitVec i) : PrefixBitVec (treeMCSPPrefixM codec n) :=
+  fun j =>
+    let pos := j.1
+    if _htag : pos < tagLen then
+      natBitBE treePrefixTag tagLen pos
+    else
+      let gammaStart := tagLen
+      let xStart := gammaStart + gammaLen n
+      let iStart := xStart + Pnp3.Models.Partial.tableLen n
+      let pStart := iStart + idxWidth codec.witnessBits n
+      if hgamma : pos < xStart then
+        gammaBit n (pos - gammaStart)
+      else if hx : pos < iStart then
+        x ⟨pos - xStart, Nat.sub_lt_left_of_lt_add (Nat.le_of_not_lt hgamma) hx⟩
+      else if hiField : pos < pStart then
+        natBitBE i (idxWidth codec.witnessBits n) (pos - iStart)
+      else if hp : pos < pStart + i then
+        p ⟨pos - pStart, Nat.sub_lt_left_of_lt_add (Nat.le_of_not_lt hiField) hp⟩
+      else
+        false
+
+/-- Canonical encoder for an already parsed input satisfying `PrefixInput`'s bound. -/
+def encodeTreeMCSPPrefixInput
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    {m : Nat}
+    (input : PrefixInput
+      (treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec)) m) :
+    PrefixBitVec (treeMCSPPrefixM codec input.n) :=
+  encodeTreeMCSPPrefixFields codec input.n input.x input.i input.prefixLength_le input.p
+
 /-- Predicate recording the canonical zero-padding convention for parsed inputs. -/
 def CanonicalTreeMCSPPrefixInput
     {threshold : Nat → Nat}
@@ -173,6 +235,92 @@ def treeMCSPConcretePrefixParser
   tag := treePrefixTag
   M := treeMCSPPrefixM codec
   parse := parseTreeMCSPPrefixInput threshold codec
+
+/--
+Successful concrete parsing enforces the P1P-02 single-length convention.
+
+The parser performs the exact ambient-length check immediately after decoding
+`n`, before any dependent field slices are reified as a `PrefixInput`.  This
+theorem exposes that check in the shape required by the runtime parser
+interface: every accepted ambient string has length exactly
+`treeMCSPPrefixM codec input.n`.
+-/
+theorem parseTreeMCSPPrefixInput_length_convention
+    (threshold : Nat → Nat)
+    (codec : TreeCircuitWitnessCodec threshold)
+    {m : Nat}
+    (y : PrefixBitVec m)
+    (input : PrefixInput
+      (treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec)) m)
+    (h : parseTreeMCSPPrefixInput threshold codec y = some input) :
+    m = treeMCSPPrefixM codec input.n := by
+  unfold parseTreeMCSPPrefixInput at h
+  cases htagRead : readNatBE y 0 tagLen with
+  | none => simp [htagRead] at h
+  | some tag =>
+      simp [htagRead] at h
+      by_cases htag : tag = treePrefixTag
+      · simp [htag] at h
+        cases hdecoded : decodeGamma? y tagLen with
+        | none => simp [hdecoded] at h
+        | some decoded =>
+            simp [hdecoded] at h
+            by_cases hlen : m = treeMCSPPrefixM codec decoded.1
+            · simp [hlen] at h
+              let xOffset := tagLen + decoded.2
+              cases hx : sliceBits? y xOffset (Pnp3.Models.Partial.tableLen decoded.1) with
+              | none => simp [xOffset, hx] at h
+              | some x =>
+                  simp [xOffset, hx] at h
+                  let iOffset := xOffset + Pnp3.Models.Partial.tableLen decoded.1
+                  cases hiRead : readNatBE y iOffset (idxWidth codec.witnessBits decoded.1) with
+                  | none => simp_all [xOffset, iOffset]
+                  | some i =>
+                      simp_all [xOffset, iOffset]
+                      by_cases hi : i ≤ codec.witnessBits decoded.1
+                      · simp [hi] at h
+                        let pOffset := iOffset + idxWidth codec.witnessBits decoded.1
+                        cases hp : sliceBits? y pOffset i with
+                        | none => simp_all [xOffset, iOffset, pOffset]
+                        | some p =>
+                            simp_all [xOffset, iOffset, pOffset]
+                            let padOffset := pOffset + i
+                            let padWidth := codec.witnessBits decoded.1 - i
+                            cases hpad : sliceBits? y padOffset padWidth with
+                            | none => simp_all [xOffset, iOffset, pOffset, padOffset, padWidth]
+                            | some pad =>
+                                simp_all [xOffset, iOffset, pOffset, padOffset, padWidth]
+                                cases hzeroRead : allZeroSlice? y padOffset padWidth with
+                                | none => simp_all [xOffset, iOffset, pOffset, padOffset, padWidth]
+                                | some padZero =>
+                                    simp_all [xOffset, iOffset, pOffset, padOffset, padWidth]
+                                    by_cases hzero : padZero = true
+                                    · simp [hzero] at h
+                                      cases h
+                                      simp
+                                    · simp [hzero] at h
+                      · simp [hi] at h
+            · simp [hlen] at h
+      · simp [htag] at h
+
+/--
+Runtime-budget hook for the concrete parser's length-convention field.
+
+This deliberately fills only the arithmetic/parser soundness field.  It does
+not inhabit `parser_polynomial_time_in_M`, whose proof remains a separate
+runtime obligation.
+-/
+theorem treeMCSPConcretePrefixParser_length_convention_matches_M
+    (threshold : Nat → Nat)
+    (codec : TreeCircuitWitnessCodec threshold) :
+    ∀ {m : Nat}, ∀ y : PrefixBitVec m,
+      ∀ input : PrefixInput
+        (treeMCSPSearchProblem threshold
+          (TreeMCSPSearchWitnessEncoding.ofCodec codec)) m,
+      parsePrefixInput (treeMCSPConcretePrefixParser threshold codec) y = some input →
+        m = (treeMCSPConcretePrefixParser threshold codec).M input.n := by
+  intro m y input h
+  exact parseTreeMCSPPrefixInput_length_convention threshold codec y input h
 
 /-- A wrong version tag is rejected before any dependent field slicing occurs. -/
 theorem parseTreeMCSPPrefixInput_bad_tag

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -44,9 +44,13 @@ def check_C_DAG : CircuitFamilyClass :=
 #check Pnp4.Frontier.ContractExpansion.gammaLen
 #check Pnp4.Frontier.ContractExpansion.idxWidth
 #check Pnp4.Frontier.ContractExpansion.treeMCSPPrefixM
+#check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields
+#check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixInput
 #check Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput
 #check Pnp4.Frontier.ContractExpansion.treeMCSPConcretePrefixParser
 #print axioms Pnp4.Frontier.ContractExpansion.tableLen_le_treeMCSPPrefixM
+#print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
+#print axioms Pnp4.Frontier.ContractExpansion.treeMCSPConcretePrefixParser_length_convention_matches_M
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -196,6 +196,10 @@ end Pnp4
 #check Pnp4.Frontier.ContractExpansion.RuntimeAwarePrefixParser
 #check Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixRuntimeBudget
 #print axioms Pnp4.Frontier.ContractExpansion.tableLen_le_treeMCSPPrefixM
+#check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields
+#check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixInput
+#print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
+#print axioms Pnp4.Frontier.ContractExpansion.treeMCSPConcretePrefixParser_length_convention_matches_M
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected
 #check Pnp4.Frontier.ContractExpansion.treeMCSPConcretePrefixParser


### PR DESCRIPTION
### Motivation

- Implement the P1P-02 prefix serialization convention in Lean by exposing the single-length-per-target ambient-length fact and a computable encoder for the concrete tree-MCSP prefix layout to enable later canonical parse/encode round-trip and runtime-budget wiring.

### Description

- Added a proven length-convention theorem `parseTreeMCSPPrefixInput_length_convention` showing that any successful `parseTreeMCSPPrefixInput` recovers a target `n` with ambient length `m = treeMCSPPrefixM codec input.n` and a small wrapper theorem `treeMCSPConcretePrefixParser_length_convention_matches_M` that populates the runtime parser length hook shape.  
- Implemented bit-level encoders `natBitBE` and `gammaBit` and a computable canonical encoder `encodeTreeMCSPPrefixFields` together with `encodeTreeMCSPPrefixInput` that produces a `PrefixBitVec` of definitionally correct length `treeMCSPPrefixM codec n` and zero-pads the inactive witness suffix.  
- Kept all definitions computable and avoided forbidden constructs such as `Classical.choose`, `noncomputable`, `native_decide`, `axiom`, `sorry`, or `admit`.  
- Integrated the theorems and encoders into `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` and wired the runtime-hook theorem into the existing `PrefixParser` package.

### Testing

- Built the modified module via `lake build Pnp4.Frontier.ContractExpansion.PrefixParserConvention` which completed successfully.  
- Performed a full project build with `lake build PnP3 Pnp4` which completed successfully after the changes.  
- Ran the repository-level CI checker `./scripts/check.sh` which completed successfully; linter warnings were reported but there were no build failures and no occurrences of forbidden tokens (`Classical.choose`, `noncomputable`, `native_decide`, `axiom`, `sorry`, `admit`, `opaque`) in the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09c98485bc832bbf358fd49da2fff9)