### PR TITLE
Partial round-trip lemmas for tree-MCSP prefix parser/encoder (P1P-02L3)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -180,6 +180,93 @@ def encodeTreeMCSPPrefixFields
             else
               false
 
+
+/--
+Partial P1P-02L3 round-trip progress: the full parser/encoder theorem remains
+open, but the byte tag and the direct dependent slices below are already tied to
+`encodeTreeMCSPPrefixFields`.  The remaining hard pieces are the generic
+big-endian and Elias-gamma decode lemmas needed for the `i` and `n` fields.
+-/
+theorem readNatBE_encodeTreeMCSPPrefixFields_tag
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    readNatBE (encodeTreeMCSPPrefixFields codec fields) 0 tagLen = some treePrefixTag := by
+  have h0 : 0 < treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    omega
+  have h1 : 1 < treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    omega
+  have h2 : 2 < treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    omega
+  have h3 : 3 < treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    omega
+  have h4 : 4 < treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    omega
+  have h5 : 5 < treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    omega
+  have h6 : 6 < treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    omega
+  have h7 : 7 < treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    omega
+  norm_num [readNatBE, readBit?, encodeTreeMCSPPrefixFields, h0, h1, h2, h3, h4, h5, h6, h7,
+    treePrefixTag, tagLen, natBitBE]
+
+/-- The raw-field encoder exposes the truth-table payload at the canonical offset. -/
+theorem sliceBits_encodeTreeMCSPPrefixFields_x
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n) (Pnp3.Models.Partial.tableLen fields.n) = some fields.x := by
+  unfold sliceBits?
+  have h : tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n ≤
+      treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    omega
+  simp [h]
+  ext j
+  simp [encodeTreeMCSPPrefixFields]
+  have hnotTag : ¬ (tagLen + gammaLen fields.n + j.1 < tagLen) := by
+    omega
+  simp [hnotTag]
+
+/-- The raw-field encoder exposes the active witness prefix at the canonical offset. -/
+theorem sliceBits_encodeTreeMCSPPrefixFields_p
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+        idxWidth codec.witnessBits fields.n)
+      fields.i = some fields.p := by
+  unfold sliceBits?
+  have h : tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i ≤ treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM tagLen
+    exact Nat.add_le_add_left fields.prefixLength_le _
+  simp [h]
+  ext j
+  simp [encodeTreeMCSPPrefixFields]
+  have hnotTag : ¬ (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + j.1 < tagLen) := by
+    omega
+  have hnotGamma : ¬ (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + j.1 < tagLen + gammaLen fields.n) := by
+    omega
+  have hnotX : ¬ (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + j.1 <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n) := by
+    omega
+  simp [hnotTag, hnotGamma, hnotX]
+
 /-- The raw-field encoder's length is the canonical `M(n)` by its result type. -/
 theorem encodeTreeMCSPPrefixFields_length_convention
     {threshold : Nat → Nat}
@@ -187,6 +274,31 @@ theorem encodeTreeMCSPPrefixFields_length_convention
     (fields : CanonicalRawTreeMCSPPrefixFields codec) :
     (treeMCSPPrefixM codec fields.n) = treeMCSPPrefixM codec fields.n := by
   rfl
+
+
+/--
+Canonical parsed input associated to raw canonical tree-MCSP prefix fields.
+
+This is the object the concrete parser is expected to return after decoding
+`encodeTreeMCSPPrefixFields`: the version tag and payload fields are copied
+verbatim, and the inactive witness suffix is represented as the canonical
+all-zero padding block of length `codec.witnessBits fields.n - fields.i`.
+-/
+def CanonicalRawTreeMCSPPrefixFields.toPrefixInput
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    PrefixInput
+      (treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec))
+      (treeMCSPPrefixM codec fields.n) where
+  tag := treePrefixTag
+  n := fields.n
+  x := fields.x
+  i := fields.i
+  prefixLength_le := fields.prefixLength_le
+  p := fields.p
+  padBits := codec.witnessBits fields.n - fields.i
+  pad := fun _ => false
 
 /-- Predicate recording the canonical zero-padding convention for parsed inputs. -/
 def CanonicalTreeMCSPPrefixInput

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2471,6 +2471,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 
 #check Pnp4.Frontier.ContractExpansion.CanonicalRawTreeMCSPPrefixFields
 #check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields
+#check Pnp4.Frontier.ContractExpansion.CanonicalRawTreeMCSPPrefixFields.toPrefixInput
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encodeTreeMCSPPrefixFields_tag
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encodeTreeMCSPPrefixFields_x
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encodeTreeMCSPPrefixFields_p
 #print axioms Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -198,6 +198,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.tableLen_le_treeMCSPPrefixM
 #check Pnp4.Frontier.ContractExpansion.CanonicalRawTreeMCSPPrefixFields
 #check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields
+#check Pnp4.Frontier.ContractExpansion.CanonicalRawTreeMCSPPrefixFields.toPrefixInput
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encodeTreeMCSPPrefixFields_tag
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encodeTreeMCSPPrefixFields_x
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encodeTreeMCSPPrefixFields_p
 #print axioms Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention


### PR DESCRIPTION
### Motivation
- Provide the first usable progress toward the P1P-02 canonical parse/encode round-trip for canonical raw tree-MCSP prefix fields by exposing a canonical parsed constructor and proving the straightforward dependent-slice facts that the encoder writes into the canonical offsets. 
- Make the parser/encoder contract explicit so the remaining decode lemmas (big-endian `readNatBE` and Elias-gamma `decodeGamma?`) can be isolated and proved without changing the existing serialization convention.

### Description
- Add `CanonicalRawTreeMCSPPrefixFields.toPrefixInput` producing the canonical `PrefixInput` with `tag = treePrefixTag`, copied payloads, `padBits = codec.witnessBits fields.n - fields.i`, and all-zero `pad` so encoded fields have a canonical parsed representative. 
- Prove three partial round-trip support lemmas: `readNatBE_encodeTreeMCSPPrefixFields_tag` for the 8-bit tag, `sliceBits_encodeTreeMCSPPrefixFields_x` for the truth-table slice, and `sliceBits_encodeTreeMCSPPrefixFields_p` for the active witness-prefix slice. 
- Add a doc-comment explaining the full `parse (encode fields) = some canonical` theorem remains open and identify the remaining blockers (generic `readNatBE`/`natBitBE` and `decodeGamma?`/`gammaBit` lemmas). 
- Register the new `toPrefixInput` constructor and the partial lemma surfaces in the pnp4 surface tests and the axioms-audit surface so they are visible to downstream audits. 

### Testing
- Ran `lake build PnP3 Pnp4` and the targeted modules built successfully. 
- Ran the repository check-suite `./scripts/check.sh` and all checks passed (full CI-style checks and governance lints succeeded). 
- Ran the search for holes `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no `sorry`/`admit` occurrences in pnp3/pnp4.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e4d9e4fc832bb5ad26e869eca658)