### PR TITLE
Document P1P-02L3 round-trip proof obstruction

### DIFF
--- a/seed_packs/phase1_20engineer_parallel_dispatch/failures/P1P_02L3_gpt55.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/failures/P1P_02L3_gpt55.md
@@ -1,0 +1,140 @@
+# P1P-02L3 Structured Failure — canonical parse/encode round trip
+
+## 1. What was attempted
+
+I classified the task as **Infrastructure** under the repository rules: it
+improves parser/encoder API hygiene and auditability, but it does not reduce
+`SearchMCSPWeakLowerBound` or `VerifiedNPDAGLowerBoundSource` and must not be
+reported as P-vs-NP mainline progress.
+
+I read the repository constitution, the P1P-02 parser-convention design note,
+`PrefixParserConvention.lean`, and the runtime interface.  The requested
+P1P-02L2 operator-review file was not present under
+`seed_packs/phase1_20engineer_parallel_dispatch/docs/`, so there was no review
+text to consume.
+
+I then attempted to stage the full theorem in
+`pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` in the
+expected shape:
+
+```lean
+def CanonicalRawTreeMCSPPrefixFields.toPrefixInput ... : PrefixInput ... := ...
+
+theorem parse_encodeTreeMCSPPrefixFields ... :
+  parseTreeMCSPPrefixInput threshold codec
+    (encodeTreeMCSPPrefixFields codec fields)
+  = some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields)
+```
+
+The proof attempt was deliberately kept parser/encoder-local: no R1-C work, no
+NP-membership theorem, no extraction theorem, no lower-bound endpoint, and no
+changes to the parser semantics were attempted.
+
+## 2. Where it broke
+
+The proof broke before the parser reaches the dependent `PrefixInput` equality:
+the repository currently lacks the bit-arithmetic decode lemmas needed to make
+Lean reduce the encoder/parser composition.  Even the first field theorem,
+
+```lean
+readNatBE (encodeTreeMCSPPrefixFields codec fields) 0 tagLen = some treePrefixTag
+```
+
+requires repeatedly expanding the recursive `readNatBE`, proving all byte-offset
+bounds into `treeMCSPPrefixM`, and normalizing the `natBitBE` arithmetic for the
+constant tag.  A direct `simp`/`norm_num` proof does not close because
+`readNatBE` remains as a recursive call after the first unfolding, and the goal
+still contains the encoded vector with dependent offset proofs.
+
+The later fields need stronger missing facts:
+
+* a generic theorem that `readNatBE` inverts `natBitBE` for values below the
+  selected width;
+* a theorem that `decodeGammaAux?`/`decodeGamma?` inverts `gammaBit`, including
+  the unary-zero search and payload-width arithmetic;
+* slice lemmas saying `sliceBits?` over the encoded layout returns the original
+  dependent vectors `fields.x` and `fields.p`;
+* an all-zero suffix lemma saying `allZeroSlice?` accepts the implicit encoder
+  padding after the active prefix.
+
+Without these lemmas, the full proof degenerates into a large hand-unrolling of
+recursive readers and dependent casts rather than a maintainable canonical
+round-trip theorem.
+
+## 3. Local vs global obstruction
+
+This is a **local proof-library obstruction**, not a global design obstruction.
+The parser and encoder layouts appear aligned with the P1P-02 convention:
+
+```text
+tag ++ gamma(n+1) ++ x ++ i ++ p ++ zero-pad
+```
+
+The obstruction is that the current Lean module defines the executable readers
+and encoders, but it does not yet expose reusable inversion lemmas for those
+executables.  No change to the global P-vs-NP target, no trust-root change, and
+no parser redesign appears necessary.
+
+## 4. Which decode/slice lemma failed
+
+The first failing lemma was the tag reader lemma:
+
+```lean
+readNatBE (encodeTreeMCSPPrefixFields codec fields) 0 tagLen = some treePrefixTag
+```
+
+The attempted direct proof unfolded
+`readNatBE`, `readBit?`, `encodeTreeMCSPPrefixFields`, `tagLen`,
+`treePrefixTag`, and `natBitBE`, and supplied bounds for offsets `0` through
+`7` into `treeMCSPPrefixM`.  Lean still left a residual recursive
+`readNatBE ... 1 7` subgoal over the encoded vector rather than normalizing the
+whole byte read.
+
+The gamma inversion lemma was not reached in a completed proof.  It is expected
+to be the hardest local lemma because it must relate the search loop in
+`decodeGammaAux?` to the declarative split inside `gammaBit`.
+
+## 5. Whether the problem is gammaBit/readNatBE mismatch, dependent casts, proof irrelevance, or parser design
+
+The blocker is primarily **missing `readNatBE`/`gammaBit` inversion lemmas plus
+dependent-cast normalization**, not an observed parser-design mismatch.
+
+More specifically:
+
+* **`readNatBE`/`natBitBE`:** the module needs a reusable theorem of the form
+  `readNatBE (fun j => natBitBE value width j) 0 width = some value`, with an
+  explicit range hypothesis such as `value < 2 ^ width`.  The index field will
+  then use `fields.prefixLength_le` plus a `bitLength` upper-bound lemma.
+* **`gammaBit`/`decodeGamma?`:** the module needs a theorem that Elias-gamma
+  decoding of the encoded `n + 1` returns `(n, gammaLen n)`.  This will likely
+  require separate lemmas for the leading zero run, the terminator bit, and the
+  payload read.
+* **Dependent casts/proof irrelevance:** after the executable readers are
+  inverted, the final `some` equality will still need extensional equality for
+  dependent vectors returned by `sliceBits?`, plus proof irrelevance for the
+  `prefixLength_le` proof produced by the parser versus `fields.prefixLength_le`.
+* **Parser design:** no concrete parser-design mismatch was found.  The parser
+  rejects bad tags, enforces exact `m = treeMCSPPrefixM codec n`, slices the
+  table and witness-prefix fields, and validates zero padding as required by the
+  design note.
+
+## 6. Recommended next move
+
+Land a small parser-serialization proof-library PR before retrying the full
+round trip.  The recommended order is:
+
+1. Prove a generic recursive reader lemma for `readNatBE` over `natBitBE` at a
+   zero offset, with a range hypothesis.
+2. Prove `Nat` arithmetic support for `bitLength`, especially
+   `n < 2 ^ bitLength n` for positive `n` and the corresponding consequence for
+   `i ≤ W n` read through `idxWidth codec.witnessBits n`.
+3. Prove `decodeGamma?` inverts `gammaBit` by first proving a focused
+   `decodeGammaAux?` theorem for the exact zero-prefix length.
+4. Prove layout-local `sliceBits?` lemmas for the `x`, `p`, and zero-pad
+   regions of `encodeTreeMCSPPrefixFields`.
+5. Only then add `CanonicalRawTreeMCSPPrefixFields.toPrefixInput` and the final
+   `parse_encodeTreeMCSPPrefixFields` theorem, using structure extensionality
+   and proof irrelevance for the parser-produced bound proof.
+
+No `sorry`, `admit`, `axiom`, `opaque`, `native_decide`, parser weakening, or
+forbidden endpoint work should be introduced in the next attempt.


### PR DESCRIPTION
### Motivation
- Record a structured failure for task `P1P-02L3` when the intended canonical parser/encoder round-trip proof could not be completed due to local proof-library gaps, so the repository has an explicit, auditable failure artifact instead of a partial or unsound proof.

### Description
- Add `seed_packs/phase1_20engineer_parallel_dispatch/failures/P1P_02L3_gpt55.md` documenting what was attempted, the exact place the proof broke, the classification as a local proof-library obstruction (not a parser-design or global target issue), and recommended next steps. 
- The failure note identifies the first blocking lemma (`readNatBE (encodeTreeMCSPPrefixFields codec fields) 0 tagLen = some treePrefixTag`) and enumerates the missing inversion/slice lemmas (`readNatBE`/`natBitBE`, `decodeGamma?`/`gammaBit`, `sliceBits?`, and `allZeroSlice?`) required to finish the round-trip theorem.

### Testing
- Built the codebase with `lake build PnP3 Pnp4`, which completed successfully. 
- Ran the repository health script `./scripts/check.sh`, which returned a passing check-suite. 
- Verified there are no proof holes with `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4`, which reported no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e4d9e4fc832bb5ad26e869eca658)