### PR TITLE
Add canonical toPrefixInput and partial parse/encode lemmas for tree‑MCSP prefix

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -188,6 +188,129 @@ theorem encodeTreeMCSPPrefixFields_length_convention
     (treeMCSPPrefixM codec fields.n) = treeMCSPPrefixM codec fields.n := by
   rfl
 
+/--
+Canonical parsed input represented by canonical raw fields.
+
+This is the target object for the intended parser/encoder round trip: it uses
+the fixed tree-prefix tag, copies the raw `n`, truth table `x`, active prefix
+length `i`, bound proof, and prefix payload `p`, and fills the inactive suffix
+with exactly `codec.witnessBits n - i` zero bits.  The definition is fully
+computable and does not invert the parser.
+-/
+def CanonicalRawTreeMCSPPrefixFields.toPrefixInput
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    PrefixInput
+      (treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec))
+      (treeMCSPPrefixM codec fields.n) where
+  tag := treePrefixTag
+  n := fields.n
+  x := fields.x
+  i := fields.i
+  prefixLength_le := fields.prefixLength_le
+  p := fields.p
+  padBits := codec.witnessBits fields.n - fields.i
+  pad := fun _ => false
+
+/-- The first committed decoder lemma for P1P-02L3: the encoder writes the byte tag. -/
+theorem readNatBE_encode_tag
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    readNatBE (encodeTreeMCSPPrefixFields codec fields) 0 tagLen = some treePrefixTag := by
+  have h0 : 0 < treeMCSPPrefixM codec fields.n := by unfold treeMCSPPrefixM tagLen; omega
+  have h1 : 1 < treeMCSPPrefixM codec fields.n := by unfold treeMCSPPrefixM tagLen; omega
+  have h2 : 2 < treeMCSPPrefixM codec fields.n := by unfold treeMCSPPrefixM tagLen; omega
+  have h3 : 3 < treeMCSPPrefixM codec fields.n := by unfold treeMCSPPrefixM tagLen; omega
+  have h4 : 4 < treeMCSPPrefixM codec fields.n := by unfold treeMCSPPrefixM tagLen; omega
+  have h5 : 5 < treeMCSPPrefixM codec fields.n := by unfold treeMCSPPrefixM tagLen; omega
+  have h6 : 6 < treeMCSPPrefixM codec fields.n := by unfold treeMCSPPrefixM tagLen; omega
+  have h7 : 7 < treeMCSPPrefixM codec fields.n := by unfold treeMCSPPrefixM tagLen; omega
+  simp [readNatBE, readBit?, encodeTreeMCSPPrefixFields, tagLen, treePrefixTag, natBitBE,
+    h0, h1, h2, h3, h4, h5, h6, h7]
+
+/-- The encoded truth-table slice is exactly the raw `x` field. -/
+theorem sliceBits_encode_x
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n) (Pnp3.Models.Partial.tableLen fields.n) =
+      some fields.x := by
+  unfold sliceBits?
+  have hWithin : tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n ≤
+      treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM
+    omega
+  simp [hWithin]
+  funext j
+  unfold encodeTreeMCSPPrefixFields
+  have hnotTag : ¬ tagLen + gammaLen fields.n + j.1 < tagLen := by omega
+  have hx : tagLen + gammaLen fields.n + j.1 <
+      tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n := by
+    exact Nat.add_lt_add_left j.2 (tagLen + gammaLen fields.n)
+  simp [hnotTag, hx]
+
+/-- The encoded active witness-prefix slice is exactly the raw `p` field. -/
+theorem sliceBits_encode_p
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+        idxWidth codec.witnessBits fields.n) fields.i =
+      some fields.p := by
+  unfold sliceBits?
+  have hWithin : tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i ≤ treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM
+    exact Nat.add_le_add_left fields.prefixLength_le _
+  simp [hWithin]
+  funext j
+  unfold encodeTreeMCSPPrefixFields
+  have hnotTag : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + j.1 < tagLen := by omega
+  have hnotGamma : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + j.1 < tagLen + gammaLen fields.n := by omega
+  have hnotX : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + j.1 <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n := by omega
+  have hnotI : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + j.1 <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+          idxWidth codec.witnessBits fields.n := by omega
+  have hp : tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + j.1 <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+          idxWidth codec.witnessBits fields.n + fields.i := by
+    exact Nat.add_lt_add_left j.2 _
+  simp [hnotTag, hnotGamma, hnotX, hnotI, hp]
+
+/--
+P1P-02L3 partial-progress marker.
+
+The full canonical theorem
+`parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields)
+ = some (fields.toPrefixInput codec)` remains open.  The landed partial lemmas
+above isolate the already-verified tag, table slice, and active-prefix slice;
+the remaining proof work is the generic Elias-gamma round trip and big-endian
+index-field round trip, plus dependent proof-field normalization in the final
+`PrefixInput` equality.
+-/
+theorem parse_encodeTreeMCSPPrefixFields_partial_obligation
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    readNatBE (encodeTreeMCSPPrefixFields codec fields) 0 tagLen = some treePrefixTag ∧
+      sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+        (tagLen + gammaLen fields.n) (Pnp3.Models.Partial.tableLen fields.n) = some fields.x ∧
+      sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+        (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+          idxWidth codec.witnessBits fields.n) fields.i = some fields.p := by
+  exact ⟨readNatBE_encode_tag codec fields, sliceBits_encode_x codec fields,
+    sliceBits_encode_p codec fields⟩
+
 /-- Predicate recording the canonical zero-padding convention for parsed inputs. -/
 def CanonicalTreeMCSPPrefixInput
     {threshold : Nat → Nat}

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2471,7 +2471,12 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 
 #check Pnp4.Frontier.ContractExpansion.CanonicalRawTreeMCSPPrefixFields
 #check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields
+#check Pnp4.Frontier.ContractExpansion.CanonicalRawTreeMCSPPrefixFields.toPrefixInput
 #print axioms Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields_length_convention
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encode_tag
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -198,7 +198,12 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.tableLen_le_treeMCSPPrefixM
 #check Pnp4.Frontier.ContractExpansion.CanonicalRawTreeMCSPPrefixFields
 #check Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields
+#check Pnp4.Frontier.ContractExpansion.CanonicalRawTreeMCSPPrefixFields.toPrefixInput
 #print axioms Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields_length_convention
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encode_tag
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected


### PR DESCRIPTION
### Motivation
- Provide the canonical parsed-object for the P1P-02 tree-MCSP prefix convention and make first formal progress toward the `parse(encode(fields))` round-trip for canonical raw fields. 
- Land small, reusable decode lemmas (tag/table/prefix slices) so subsequent work can focus on Elias‑gamma, index-field, pad zeroing, and dependent-field normalization needed to close the full round-trip. 

### Description
- Add `CanonicalRawTreeMCSPPrefixFields.toPrefixInput` which constructs the canonical `PrefixInput` from raw fields with `tag := treePrefixTag`, `padBits := codec.witnessBits n - i`, and an all-zero `pad`. 
- Add and prove `readNatBE_encode_tag` showing the encoder writes the byte tag. 
- Add and prove `sliceBits_encode_x` showing the encoded truth-table slice decodes to `fields.x`. 
- Add and prove `sliceBits_encode_p` showing the encoded active witness-prefix slice decodes to `fields.p`. 
- Add `parse_encodeTreeMCSPPrefixFields_partial_obligation`, a short theorem bundling the landed lemmas and a document comment explaining the remaining blocked pieces (Elias-gamma round-trip, big-endian index round-trip, pad zero-check, dependent proof-field equality). 
- Register the new public surfaces in module test/audit scaffolding so the new lemmas are visible to repository surface checks. 

### Testing
- `lake build PnP3 Pnp4` completed successfully (Lean build passed). 
- `./scripts/check.sh` ran and the Lean build, hygiene, and policy checks passed, but the coordinator HTTP e2e test failed with a transient `ConnectionResetError: [Errno 104] Connection reset by peer` (this is an external e2e harness failure and not a Lean proof error). 
- Search for proof-holes (`rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4`) returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09e4d9e4fc832bb5ad26e869eca658)