### PR TITLE
P1P-02L₄ slice port + accumulated reviews/governance into main

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -258,6 +258,73 @@ theorem readNatBE_natBEField_zero
             omega
           _ = value := hdecomp
 
+/--
+One-step big-endian digit identity used by the slice reader proof.
+
+Selecting the `k`-th big-endian digit (i.e. `a / 2^k % 2`) and adding `a % 2^k`
+recovers `a % 2^(k+1)`.  This is the arithmetic core of the inductive step in
+`readNatBE_natBEField_slice` below.
+
+Ported from PR #1338 to make sub-slice reads of `natBEField` available without
+re-deriving them from `readNatBE_eq_of_readBit_eq` at every call site.
+-/
+theorem be_digit_step (a k : Nat) :
+    (if a / 2 ^ k % 2 = 1 then 2 ^ k else 0) + a % 2 ^ k =
+      a % 2 ^ (k + 1) := by
+  have hpow2 : 2 ^ (k + 1) = 2 ^ k * 2 := by
+    rw [Nat.pow_succ]
+  have hq : (a % (2 ^ k * 2)) / 2 ^ k = a / 2 ^ k % 2 := by
+    simpa using (Nat.mod_mul_right_div_self a (2 ^ k) 2)
+  have hr : (a % (2 ^ k * 2)) % 2 ^ k = a % 2 ^ k := by
+    exact Nat.mod_mul_right_mod a (2 ^ k) 2
+  have hq_lt : (a / 2 ^ k) % 2 < 2 := Nat.mod_lt _ (by decide : 0 < 2)
+  have hq_cases : a / 2 ^ k % 2 = 0 ∨ a / 2 ^ k % 2 = 1 := by
+    omega
+  calc
+    (if a / 2 ^ k % 2 = 1 then 2 ^ k else 0) + a % 2 ^ k
+        = (a % (2 ^ k * 2)) / 2 ^ k * 2 ^ k +
+            (a % (2 ^ k * 2)) % 2 ^ k := by
+            rcases hq_cases with hzero | hone
+            · simp [hzero, hq, hr]
+            · simp [hone, hq, hr]
+    _ = a % (2 ^ k * 2) := by
+          rw [Nat.div_add_mod']
+    _ = a % 2 ^ (k + 1) := by
+          rw [hpow2]
+
+/--
+Reading a bounded sub-slice of a stand-alone big-endian field returns exactly
+the natural represented by that slice: the quotient drops the low bits to the
+right of the slice; the modulo forgets the high bits to the left of it.
+
+This generalises `readNatBE_natBEField_zero` (the `offset = 0`, `len = width`
+case) and is the lemma a future P1P-02L₅ worker needs to decode the Elias-gamma
+payload, which lives at a non-zero offset inside its enclosing field.
+
+Ported from PR #1338 to extend the proof library landed by PR #1339.
+-/
+theorem readNatBE_natBEField_slice
+    (value width offset len : Nat)
+    (hfit : offset + len ≤ width) :
+    readNatBE (natBEField value width) offset len =
+      some ((value / 2 ^ (width - (offset + len))) % 2 ^ len) := by
+  induction len generalizing offset with
+  | zero =>
+      simp [readNatBE, Nat.mod_one]
+  | succ k ih =>
+      have hoff : offset < width := by omega
+      have hfitRest : offset + 1 + k ≤ width := by omega
+      let shift := width - (offset + (k + 1))
+      have hsub : width - 1 - offset = shift + k := by omega
+      have hrest : width - (offset + 1 + k) = shift := by omega
+      have hpowadd : 2 ^ (shift + k) = 2 ^ shift * 2 ^ k := by
+        rw [Nat.pow_add]
+      simp [readNatBE, readBit?, natBEField, natBitBE, hoff,
+        ih (offset + 1) hfitRest, hsub, hrest, hpowadd]
+      rw [show width - (offset + (k + 1)) = shift by rfl]
+      rw [← Nat.div_div_eq_div_mul]
+      exact be_digit_step (value / 2 ^ shift) k
+
 /-- Values bounded by the witness length fit in the parser's index-width field. -/
 theorem prefixLength_lt_two_pow_idxWidth
     {W : Nat → Nat} {n i : Nat}

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -50,6 +50,8 @@ def check_C_DAG : CircuitFamilyClass :=
 #print axioms Pnp4.Frontier.ContractExpansion.bitLength_pos_of_pos
 #print axioms Pnp4.Frontier.ContractExpansion.nat_lt_two_pow_bitLength
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_natBEField_zero
+#print axioms Pnp4.Frontier.ContractExpansion.be_digit_step
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_natBEField_slice
 #print axioms Pnp4.Frontier.ContractExpansion.prefixLength_lt_two_pow_idxWidth
 #print axioms Pnp4.Frontier.ContractExpansion.tableLen_le_treeMCSPPrefixM
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
@@ -2483,6 +2485,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_eq_of_readBit_eq
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_natBEField_tail
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_natBEField_zero
+#print axioms Pnp4.Frontier.ContractExpansion.be_digit_step
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_natBEField_slice
 #print axioms Pnp4.Frontier.ContractExpansion.prefixLength_lt_two_pow_idxWidth
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encode_tag
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -200,6 +200,8 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_eq_of_readBit_eq
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_natBEField_tail
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_natBEField_zero
+#print axioms Pnp4.Frontier.ContractExpansion.be_digit_step
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_natBEField_slice
 #print axioms Pnp4.Frontier.ContractExpansion.prefixLength_lt_two_pow_idxWidth
 #print axioms Pnp4.Frontier.ContractExpansion.tableLen_le_treeMCSPPrefixM
 #check Pnp4.Frontier.ContractExpansion.natBEField

--- a/seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md
@@ -1,0 +1,138 @@
+# Audit 2026-05-17 — plan reduction from 19 tasks to reduced wave of 6
+
+## Verdict
+
+**RED** on the 19-task dispatch plan as written in commits `63fa68b` and `6397c1b`.
+
+**GREEN** on a reduced first wave of **A02 + A07 + A08 + A09 + A10 + X01** (6 tasks).
+
+**AMBER** on X02 — only after X01 lands AND X02 spec is rewritten to align with the runtime convention already in `pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionLanguageRuntime.lean`.
+
+**DEFERRED this phase** — L01, L02, B01, B02, B03, K01, K02. Task files retained as record but flagged with a DEFERRED header. Not dispatchable until specific issues below are addressed.
+
+This memo supersedes the dispatch sizing in `README.md` and the engineer count / ID scheme in `COMMON_WORKER_INSTRUCTIONS.md`. Both files have been rewritten alongside this memo.
+
+## Structural flaws identified
+
+### Flaw 1 — Metadata inconsistency (disabling bug)
+
+`COMMON_WORKER_INSTRUCTIONS.md` was authored before the 20→19 revision and uses the original `E<NN>` ID scheme throughout:
+
+- "engineer E<NN> in a parallel dispatch of 20 independent tasks" (L3)
+- `tasks/E<NN>_*.md` (L36) — these files do not exist; actual files are `A01..A10`, `B01..B03`, `K01..K02`, `L01..L02`, `X01..X02`.
+- branch convention `khanukov/phase1-E<NN>-<handle>` (L16)
+- failures path `failures/E<NN>_<handle>.md` (L270)
+- PR title `Phase 1 E<NN>: <title>` (L24)
+- diapason-based reading sections: `E14-E16` (barrier), `E17-E18` (kill-machine), `E19-E20` (contract expansion), `E01-E13` (Phase A) — these IDs do not match any task in the revised plan.
+
+Net effect: any engineer reading the binding common doc would use the wrong naming scheme, fail to locate their task file, and follow wrong branch/PR/failure conventions. This is disabling, not cosmetic.
+
+### Flaw 2 — Plan internally contradicts itself
+
+`README.md` revision rationale (L7–11) says Phase 0 audit must come first so subsequent dispatches target real gaps. But L114 says "NO engineer is blocked on another. All 19 tasks dispatch-able NOW." If Phase 0 audit synthesis is the gating signal, Phases 2–5 cannot dispatch in parallel with Phase 0 — they must wait for Phase 0 output.
+
+Additionally, README L25/L101/L157/L198 openly anticipate a second wave "Phase 1+" of 5–15 more tasks before the first wave is even reviewed. A closeout plan should not commit to expanding before evaluating.
+
+### Flaw 3 — "Independent at merge time" is false
+
+Every Lean task per COMMON §4.3 + §4.4 modifies:
+
+- `lakefile.lean` (one `Glob.one` line per new module)
+- `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean` (one `check_<name>` wrapper per public signature)
+- `pnp4/Pnp4/Tests/AxiomsAudit.lean` (one `#print axioms` line per theorem)
+
+Multiple parallel Lean PRs will collide on those three files. Operator merge load is not "~6 hours for 19 PRs" if every Lean PR needs a rebase. Reduced wave mitigates this: only X01 is Lean among the 6 active tasks; the 5 audit tasks are markdown-only.
+
+### Flaw 4 — Specific task design bugs
+
+**X02 — runtime convention mismatch.** Task spec uses `M := fun n => n`:
+
+```
+m = (treeMCSPPrefixParserConcrete encoding 0 (fun n => n)).M input.n
+```
+
+But `pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionLanguageRuntime.lean:18-21` already fixes the ambient-length convention:
+
+```
+treeMCSPPrefixAmbientLength overhead witnessBits padBits n
+  = Pnp3.Models.Partial.tableLen n + overhead n + witnessBits n + padBits n
+```
+
+`length_convention` theorem in X02 as specified cannot be proven against the live runtime unless X02 is rewritten to target `treeMCSPPrefixAmbientLength`, not `M(n) = n`. **X02 is buggy as written**; before any reactivation it must be rewritten to consume the existing ambient-length convention.
+
+**L01 — bibliographic identifier suspect.** L01 cites Hirahara, "Non-Black-Box Worst-Case to Average-Case Reductions within NP", FOCS 2018, as `arXiv:1804.05985`. The arXiv ID for Hirahara's FOCS 2018 paper is `1808.06848`; `1804.05985` is a different paper. Before any reactivation L01 must verify the source theorem statement against the correct arXiv version and confirm what is actually being formalized.
+
+**B02 / B03 — placeholder-heavy specs.** B02 explicitly allows placeholder relativized predicates and placeholder oracles; its honest caveat acknowledges that making them concrete would require multi-month oracle-TM machinery. B03 defines `algebrizes` as a placeholder, allows `algebraicExtension := True`, and asks only for `True`-valued theorems. These are wrapper surfaces, not kernel-checked barrier theorems. They run against the repo's own anti-circularity discipline (NoGo log NOGO-000008 / 000009 style) and would consume operator review hours without producing operator-decision-useful artifacts.
+
+**K01 / K02 — typed rubrics, not theorem engines.** K01 reduces NoGo applicability to a hand-coded `List (String × NoGoApplicability)` over a `ProofSafetyCertificate` whose fields are bare `Prop`s. K02 stores barrier evidence as `String`. Useful as a documentation/program-management layer once routes are settled — not on the critical path now.
+
+### Flaw 5 — Plan not framed as closeout
+
+The repository's own strategic documents (FP3b retrospective, D0 polynomial-time-formalism scoping) recommend a narrow tranche centered on the actual bottleneck: the math-level `ResearchGapWitness` source, with optional X01-style formalism investment for resumability. The 19-task plan opens 5 new programmatic surfaces (literature, barriers, kill-machine, contract expansion ×2, audits) — none of which alone advances the real bottleneck.
+
+## What the reduced wave is
+
+| ID | Task | Type | Reason for keep |
+|---|---|---|---|
+| **A02** | Audit `pnp3/Magnification/FinalResult*.lean` (6 files, ~4,091 LOC) | markdown audit | Verifies how the active wrapper consumes `ResearchGapWitness`; optional but high-signal for operator visibility |
+| **A07** | Audit `pnp4/Pnp4/AlgorithmsToLowerBounds/` (24 files) | markdown audit | Where AC⁰[p] + MCSP infrastructure lives; live strategy surface |
+| **A08** | Audit `pnp4/Pnp4/Frontier/` incl. `ContractExpansion/` | markdown audit | Where R1-A/B/B1/B2/B2a packaged source-theorem layer lives |
+| **A09** | Audit `outputs/nogolog.jsonl` formal_witness validation | markdown audit | Checks NoGo witnesses match kernel-checked theorems |
+| **A10** | Cross-cutting `_Partial`/`_Legacy`/`TODO`/`Classical.choose` inventory | markdown audit | Repo-wide placeholder map |
+| **X01** | `PolyTimeVerifierSpec` + bridge to `NP_TM`, with toy instance | Lean implementation | D0 memo recommends exactly this narrow bridge; only Lean task in the wave |
+
+All audit tasks (A02, A07, A08, A09, A10) produce markdown reports only — zero shared-file collisions. X01 is the single Lean task, so no parallel merge conflict on `lakefile.lean` / `AxiomsAudit.lean` / `AlgorithmsToLowerBoundsSurfaceTests.lean` within this wave.
+
+## What is deferred and why (per task)
+
+| ID | Status | Specific issue |
+|---|---|---|
+| L01 | DEFERRED | Cited arXiv ID `1804.05985` does not match Hirahara FOCS 2018; correct ID is `1808.06848`. Before reactivation: verify source theorem statement against correct paper. Possibly should be markdown-only literature D0 first. |
+| L02 | DEFERRED | Not on critical path; Pich-Santhanam unprovability is a long-horizon investment not aligned with current bottleneck. Re-evaluate after wave 1 synthesis. |
+| B01 | DEFERRED | Razborov-Rudich barrier as pnp4 extension produces typed surface, not P-vs-NP closeout signal. Lower priority than X01. |
+| B02 | DEFERRED | Spec explicitly authorizes placeholder oracles; honest caveat admits multi-month effort for concrete instances. Not currently useful. |
+| B03 | DEFERRED | Spec defines `algebrizes` as `True`-typed placeholder; theorems are `trivial`. Wrapper surface, not kernel-checked barrier. |
+| K01 | DEFERRED | Hand-coded NoGo applicability list over bare-Prop certificate; useful as documentation layer post-closeout, not now. |
+| K02 | DEFERRED | Barrier evidence stored as `String`; classification rubric, not theorem-producing engine. |
+| X02 | DEFERRED until X01 lands AND spec rewritten | Current spec uses `M := fun n => n` which is incompatible with the live `treeMCSPPrefixAmbientLength` convention. Rewrite required before dispatch. |
+
+Original task files are retained under `tasks/` with a DEFERRED header citing this memo, so the design record is preserved.
+
+## What is dropped (not deferred)
+
+- "Phase 1+" preemptive sizing of 5–15 additional tasks: removed from `README.md`. Wave 2 (if any) is an operator decision after wave 1 synthesis, not a pre-committed expansion.
+- Phase-2/3/4/5 framing: collapsed. The reduced wave is "5 audits + 1 narrow bridge"; no programmatic surface beyond that.
+
+## Wave 2 (provisional)
+
+After wave 1 lands and operator synthesizes:
+
+- If audits confirm no hidden shorter route and X01 ships clean → **stop**. The bottleneck is math-level, not engineering. Wait for a new lower-bound idea (Hirahara/magnification/AC⁰ route) before opening new infrastructure.
+- If X01 ships clean AND there is operator interest in continuing contract-expansion → dispatch **rewritten X02** explicitly gated on X01 and aligned with `treeMCSPPrefixAmbientLength`.
+- L01 may be revived only as markdown-only literature D0 with corrected bibliography first.
+
+## Integration policy for shared files
+
+For wave 1 only X01 touches Lean. But to prevent future-wave collisions, the integration operator (not engineers) will own three files:
+
+- `lakefile.lean`
+- `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean`
+- `pnp4/Pnp4/Tests/AxiomsAudit.lean`
+
+Engineers list **what** their PR needs added to these files in the PR description (one `Glob.one` line, one `check_<name>` wrapper, one `#print axioms` line). The integration operator applies the patches centrally during merge. This avoids the original plan's hidden merge-time conflict zone.
+
+## What this memo does not do
+
+- Does not retract earlier closed work (R1-A/B/B1/B2/B2a, falsifiability audit, FP3b retrospective, D0 scoping). All of that is good.
+- Does not promote anything to `accepted`.
+- Does not edit trust-root files.
+- Does not claim the math-level bottleneck is now closer.
+
+## Cross-references
+
+- `seed_packs/phase1_20engineer_parallel_dispatch/README.md` (rewritten)
+- `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` (rewritten)
+- `seed_packs/phase1_20engineer_parallel_dispatch/tasks/{L01,L02,B01,B02,B03,K01,K02,X02}_*.md` (DEFERRED headers added)
+- `pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionLanguageRuntime.lean` (live runtime convention X02 must align with)
+- `seed_packs/first_move_search_2026/reports/fp3b_epoch_strategic_retrospective_claudeopus.md` (FP3b closeout context)
+- `seed_packs/polynomial_time_formalism_scoping_D0/reports/D0_four_way_review_and_synthesis_claudeopus.md` (D0 X01 rationale)

--- a/seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md
@@ -1,13 +1,12 @@
-# Common worker instructions — Phase 1 reduced wave (6 engineers)
+# Common worker instructions — Phase 1 wave 1 synthesis (A11)
 
-You are **one of 6 engineers** in a reduced parallel dispatch. Read this file once before starting your specific task file.
+You are the **A11 synthesis engineer**. Wave 1 audits (A01–A10) are complete and merged to main. A11 is the only active task: it reads all 10 audit reports and produces an operator-decision memo for wave 2.
 
-Active task IDs are:
+Active task ID: **A11 only.**
 
-- **Audit (markdown only):** A02, A07, A08, A09, A10
-- **Lean bridge:** X01
+L01, L02, B01, B02, B03, K01, K02, X01, X02 are **blocked** pending A11 + operator decision. Do not dispatch them.
 
-This file replaces the earlier 20-engineer / `E<NN>`-scheme instructions. If you see references in other documents to `E<NN>` IDs, ignore them — they predate the 2026-05-17 plan reduction (see `AUDIT_2026-05-17_PLAN_REDUCTION.md`).
+If you see references in other documents to `E<NN>` IDs, ignore them — they predate the 2026-05-17 plan reduction.
 
 This file is binding. Violations result in operator rejection.
 
@@ -15,7 +14,7 @@ This file is binding. Violations result in operator rejection.
 
 ## 1. Identity and scope
 
-Pick **one** task ID from the active list above. Don't take more than one. Don't change tasks mid-flight.
+The active task is **A11**. Don't pick any other task; the deferred task files (L01..L02, B01..B03, K01..K02, X01..X02) exist as record for A11 to read, not for direct dispatch.
 
 Your branch name **must** follow this convention:
 
@@ -345,6 +344,6 @@ Scope violations: none / <list>
 - **Time-box at 1.5× the estimate.** If exceeding, write a failure report.
 - **Self-attack before submitting.** 10 minutes minimum.
 - **One task per engineer.** Don't grab multiple.
-- **Active IDs are A02, A07, A08, A09, A10, X01 only.** All other task files in `tasks/` are DEFERRED — do not pick them.
+- **The only active ID is A11.** All other task files in `tasks/` are wave-1 record (A01–A10 completed and merged) or wave-2 candidates blocked on A11 (L01–L02, B01–B03, K01–K02, X01–X02). Do not pick any of them.
 
 Good luck. Reduced wave is intentional — fewer, higher-yield tasks for faster operator decision.

--- a/seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md
@@ -1,27 +1,34 @@
-# Common worker instructions — Phase 1 20-engineer parallel dispatch
+# Common worker instructions — Phase 1 reduced wave (6 engineers)
 
-You are **engineer E<NN>** in a parallel dispatch of 20 independent tasks. Read this file once before starting your specific task file at `tasks/E<NN>_*.md`.
+You are **one of 6 engineers** in a reduced parallel dispatch. Read this file once before starting your specific task file.
 
-This is binding. Violations result in operator rejection.
+Active task IDs are:
+
+- **Audit (markdown only):** A02, A07, A08, A09, A10
+- **Lean bridge:** X01
+
+This file replaces the earlier 20-engineer / `E<NN>`-scheme instructions. If you see references in other documents to `E<NN>` IDs, ignore them — they predate the 2026-05-17 plan reduction (see `AUDIT_2026-05-17_PLAN_REDUCTION.md`).
+
+This file is binding. Violations result in operator rejection.
 
 ---
 
 ## 1. Identity and scope
 
-Pick **one** task ID. Don't take more than one. Don't change tasks mid-flight.
+Pick **one** task ID from the active list above. Don't take more than one. Don't change tasks mid-flight.
 
 Your branch name **must** follow this convention:
 
 ```
-khanukov/phase1-E<NN>-<short-handle>
+khanukov/phase1-<ID>-<short-handle>
 ```
 
-Example: `khanukov/phase1-E07-codex-gpt55`
+Example: `khanukov/phase1-A07-codex-gpt55` or `khanukov/phase1-X01-claudeopus`.
 
 Your PR title:
 
 ```
-Phase 1 E<NN>: <task title from README.md task list>
+Phase 1 <ID>: <task title from README.md task list>
 ```
 
 ---
@@ -32,65 +39,59 @@ Before you start:
 
 1. **`RESEARCH_CONSTITUTION.md`** — binding discipline.
 2. **`seed_packs/phase1_20engineer_parallel_dispatch/README.md`** — phase overview, dependencies, acceptance criteria.
-3. **`seed_packs/first_move_search_2026/reports/fp3b_epoch_strategic_retrospective_claudeopus.md`** — context for why this phase exists. Read §3 (what was accomplished), §6 (the gap), §11 (honest framing). You do not need to read the full FP3b history; the retrospective is sufficient.
-4. **Your specific task file** at `seed_packs/phase1_20engineer_parallel_dispatch/tasks/E<NN>_*.md`.
+3. **`seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md`** — context for why this wave is reduced.
+4. **`seed_packs/first_move_search_2026/reports/fp3b_epoch_strategic_retrospective_claudeopus.md`** — context for the broader phase. Read §3 (what was accomplished), §6 (the gap), §11 (honest framing). Full FP3b history is not required.
+5. **Your specific task file** at `seed_packs/phase1_20engineer_parallel_dispatch/tasks/<ID>_*.md`.
 
-If your task touches pnp3 / pnp4 Lean code:
+If your task is X01 (touches Lean):
 
-5. **`pnp3/Complexity/Interfaces.lean`** — trust-root types you must import but never modify.
-6. **`pnp4/Pnp4/AlgorithmsToLowerBounds/BasicCircuitClasses.lean`** — pnp4 `CircuitFamilyClass` and `BitVec` conventions.
+6. **`pnp3/Complexity/Interfaces.lean`** — trust-root types you must import but never modify.
+7. **`pnp3/Complexity/PsubsetPpolyInternal/TuringEncoding.lean`** — TM model used in the bridge.
+8. **`seed_packs/polynomial_time_formalism_scoping_D0/reports/D0_polynomial_time_formalism_gpt55.md`** — V4 of the D0 scoping, which X01 implements.
+9. **`seed_packs/polynomial_time_formalism_scoping_D0/reports/D0_four_way_review_and_synthesis_claudeopus.md`** — synthesis memo with the chosen design.
 
-If your task touches barrier files (E14-E16):
-
-7. **`pnp3/Barrier/NaturalProofs.lean`, `pnp3/Barrier/Relativization.lean`, `pnp3/Barrier/Algebrization.lean`, `pnp3/Barrier/Bypass.lean`** — existing trust-root barrier interfaces. **Read only; do not modify.** Your new content goes under `pnp4/Pnp4/Barriers/`.
-
-If your task touches kill-machine infra (E17-E18):
-
-8. **`outputs/nogolog.jsonl`** — existing NoGoLog entries (NOGO-000005 through 000009). Read structure; do not append.
-
-If your task touches contract_expansion (E19-E20):
-
-9. **`pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionLanguage.lean`**
-10. **`pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionLanguageNP.lean`**
-11. **`pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionLanguageRuntime.lean`**
-12. **`pnp4/Pnp4/Frontier/SearchMCSPMagnification.lean`** for `NP_TM` interface (read only).
+Audit tasks (A02, A07, A08, A09, A10) only need the files they are auditing, plus the universal items above.
 
 ---
 
 ## 3. Universal forbidden scope
 
-The following are **forbidden across all 20 tasks**. Violations are operator-rejection-level.
+The following are **forbidden across all 6 tasks**. Violations are operator-rejection-level.
 
 ### 3.1 Trust-root edits (HARD FORBIDDEN)
 
 - `pnp3/Complexity/Interfaces.lean` — read only.
 - `pnp3/Complexity/PsubsetPpolyInternal/**` — read only.
 - `pnp3/Magnification/UnconditionalResearchGap.lean` — read only.
-- `pnp3/Barrier/**` — read only. New barriers go under `pnp4/Pnp4/Barriers/`.
-- `pnp3/Magnification/AuditRoutes/**` — read only. Existing audit routes are frozen.
+- `pnp3/Barrier/**` — read only.
+- `pnp3/Magnification/AuditRoutes/**` — read only.
+- `pnp3/Magnification/*_Partial.lean` — read only this wave.
+- `pnp3/Magnification/FinalResult*.lean` — read only (A02 audits these; does **not** edit them).
+- `pnp3/LowerBounds/*_Partial.lean` — read only this wave.
 - `pnp4/Pnp4/AlgorithmsToLowerBounds/BridgeToPpolyDAG.lean` — read only.
 - `pnp4/Pnp4/Frontier/SearchMCSPMagnification.lean` — read only.
 - `pnp4/Pnp4/Frontier/CompressionMagnification.lean` — read only.
 - `pnp4/Pnp4/Frontier/PvsNPBridgeRequirements.lean` — read only.
+- `pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionLanguage*.lean` (R1-B, R1-B1, R1-B2a) — read only.
 
-If your task **appears** to require trust-root edits, you have **misread the task**. Re-read your task file; the deliverable is always in a new file path.
+If your task **appears** to require trust-root edits, you have **misread the task**. Re-read your task file; the deliverable is always at a new file path.
 
-### 3.2 Forbidden Lean constructs
+### 3.2 Forbidden Lean constructs (X01 only; audits produce no Lean)
 
 In every Lean file you write or modify:
 
 - ❌ `sorry`
 - ❌ `admit`
-- ❌ `axiom` (unless your task file **explicitly** authorizes it; none do in Phase 1)
+- ❌ `axiom`
 - ❌ `opaque`
-- ❌ `Fact` (typeclass-payload pattern; forbidden by Rule 16)
+- ❌ `Fact` (typeclass-payload pattern)
 - ❌ `Classical.choose` in core definitions (acceptable in derived proofs only if standard exponent extraction; document explicitly)
 - ❌ `decide` in places that take more than ~1 second to elaborate
 - ❌ `native_decide`
 
 ### 3.3 Forbidden registry / spec edits
 
-- ❌ `outputs/nogolog.jsonl` — no new entries.
+- ❌ `outputs/nogolog.jsonl` — no new entries (A09 audits; does not append).
 - ❌ `outputs/attempts.jsonl` — no edits.
 - ❌ `spec/known_guards.toml` — no edits.
 - ❌ `spec/wave_*.toml` — no edits.
@@ -101,10 +102,10 @@ In every Lean file you write or modify:
 
 - ❌ `SourceTheorem` / `gap_from_*` / `ResearchGapWitness` / `NP_not_subset_PpolyDAG` / `P_ne_NP` — no construction, no claim.
 - ❌ FP-4 work — gated separately.
-- ❌ "Proves P ≠ NP" / "advances P-vs-NP" — never in commit messages, PR descriptions, or code comments.
+- ❌ "Proves P ≠ NP" / "advances P-vs-NP" — never in commit messages, PR descriptions, code comments, or audit reports.
 - ❌ Any unconditional complexity separation claim.
 
-Phase 1 is **infrastructure only**. Do not overclaim.
+This wave is **infrastructure + operator situational awareness only**. Do not overclaim.
 
 ---
 
@@ -112,108 +113,83 @@ Phase 1 is **infrastructure only**. Do not overclaim.
 
 These apply to **every** task. Your task file adds task-specific items on top.
 
-### 4.1 Build hygiene
+### 4.1 For audit tasks (A02, A07, A08, A09, A10)
+
+1. **Markdown report** at exact path `seed_packs/phase1_20engineer_parallel_dispatch/audit_reports/<ID>_<area>_<handle>.md`.
+2. **No Lean edits anywhere.** Run `git diff origin/main -- "*.lean"` → must be empty.
+3. **No edits to `outputs/`, `spec/`, or `Candidates/`.**
+4. Report must include required sections per your task file (typically: file inventory, signature surface, gap inventory, recommendations, honest caveats).
+5. Claims about file state must be reproducible from the cited commit SHA.
+
+### 4.2 For X01
 
 1. `lake build PnP3 Pnp4` — must pass from the repository root.
 2. `./scripts/check.sh` — must pass.
-3. `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` — must return **no output** across the whole repo (not just your files).
+3. `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` — must return **no output** across the whole repo.
+4. New Lean modules at exact paths specified in `tasks/X01_polytimeverifierspec_bridge.md`.
+5. Doc-comment at top of each new module: states D0 scoping reference, declares infrastructure-only scope (not P ≠ NP progress).
 
-### 4.2 File placement
+### 4.3 Shared-file conventions for X01
 
-Your new Lean module(s) **must** be at the exact path(s) specified in your task file. If your task specifies:
+X01 needs additions to three project-shared files:
 
-```
-pnp4/Pnp4/Literature/AtseriasMuller2025/Definitions.lean
-```
+- `lakefile.lean` — one `Glob.one` line per new module.
+- `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean` — one `check_<name>` wrapper per public signature in your task's "Expected signatures" list.
+- `pnp4/Pnp4/Tests/AxiomsAudit.lean` — one `#print axioms` line per theorem in your task.
 
-then you create exactly that file. Don't reorganize.
+**You apply these patches directly in your PR.** Within wave 1 X01 is the only Lean task, so no parallel-merge collision is expected. If a collision arises with concurrent operator-side work, rebase rather than retarget.
 
-### 4.3 Lakefile registration
-
-Every new Lean module you create must be added to `lakefile.lean` via one `Glob.one` line:
-
-```
-Glob.one `Pnp4.Literature.AtseriasMuller2025.Definitions,
-```
-
-Match the existing pattern in `lakefile.lean`.
-
-### 4.4 Test surface
-
-For every public theorem or structure your task lists in "Expected signatures":
-
-1. Add one `check_<name>` wrapper to `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean`:
-
-   ```
-   def check_<name> : <signature> := <expression>
-   ```
-
-   This lets the test surface verify the name is accessible from a separate module.
-
-2. Add one `#print axioms` line for each **theorem** (not every definition) to `pnp4/Pnp4/Tests/AxiomsAudit.lean`. Match existing patterns.
-
-### 4.5 Module documentation
+### 4.4 Module documentation (X01)
 
 Every new Lean module must have a `/-! ... -/` doc-comment at the top stating:
 
-- The literature source (paper, year, arXiv/DOI), if Phase A.
+- The D0 scoping reference (V4 chosen, `d367652`).
 - That this is infrastructure, **not** a proof of any unconditional complexity statement.
-- That the contents may be used by future kill-machine routes but do not themselves advance P-vs-NP.
+- That the bridge enables resumability of the contract-expansion track and does not itself advance `NP_not_subset_PpolyDAG`.
 
 Example template:
 
 ```
 /-!
-# <Module title>
+# PolyTimeVerifierSpec
 
-Formalization of <theorem name> from <Author Year> (<verifiable identifier>).
+Implementation of the polynomial-time verifier spec + bridge to `NP_TM`,
+per D0 polynomial-time formalism scoping (V4 selected, `d367652`) and the
+four-way synthesis memo (`d3676520`).
 
-**Scope:** infrastructure for the kill-machine and future audit routes. This
-module proves a specific literature theorem (or stages it as a typed surface);
-it does not by itself reduce `SearchMCSPWeakLowerBound`, construct
-`VerifiedNPDAGLowerBoundSource`, or advance `NP_not_subset_PpolyDAG`.
+**Scope:** infrastructure bridge for the contract-expansion track. This module
+defines a typed surface that consumes verifiable polynomial-time data and
+produces an `NP_TM L` witness. It does **not** by itself reduce
+`SearchMCSPWeakLowerBound`, construct `ResearchGapWitness`, or advance
+`NP_not_subset_PpolyDAG`.
 -/
 ```
 
-### 4.6 No `Classical.choose` in literature definitions
-
-For Phase A tasks (E01-E13):
-
-- The **structure definitions** and **theorem statements** must be free of `Classical.choose`.
-- The `def` instances and theorem **proofs** may use `Classical.choose` **only** if it's a standard polynomial-exponent extraction (e.g., `Classical.choose h.polyBound_poly` where `h.polyBound_poly : ∃ c, ...`).
-- Such use must be documented in a 1-line comment.
-
-For Phase B tasks (E14-E16):
-
-- Razborov-Rudich barrier may use `Classical.choose` in the construction of the diagonal adversary (this is mathematically necessary). Document it.
-
-### 4.7 Trust-root unchanged
+### 4.5 Trust-root unchanged (all tasks)
 
 After your work:
 
 - `git diff origin/main pnp3/Complexity/Interfaces.lean` must be empty.
 - `git diff origin/main pnp3/Barrier/` must be empty.
 - `git diff origin/main pnp3/Magnification/UnconditionalResearchGap.lean` must be empty.
+- `git diff origin/main pnp3/Magnification/AuditRoutes/` must be empty.
+- For audit tasks: `git diff origin/main -- "*.lean"` must be empty.
 
-If your `git diff` shows changes to these files, your PR will be rejected. No exceptions.
+If any of these diffs is non-empty for your task, the PR will be rejected.
 
 ---
 
 ## 5. Self-attack discipline
 
-Before opening your PR, you **must** run a 10-minute self-attack:
+Before opening your PR, run a 10-minute self-attack:
 
-1. **Read your own deliverable as if you were an adversary trying to falsify it.** Is there a way the theorem you proved is vacuous? Does it accidentally smuggle a stronger assumption than the literature requires?
-
-2. **Check that you did not formalize a circular interface.** A structure with field `proven_NP_not_subset_PpolyDAG : Prop` would technically compile but is circular. If your task involves bridging literature to a target like `NP_TM`, ensure the bridge is genuine, not a renaming.
-
-3. **Verify your `#print axioms` output is clean.** New theorems should only depend on standard Mathlib axioms (`propext`, `Classical.choice`, `Quot.sound`) plus the explicit literature axioms your task authorizes. If you see unexpected axioms, debug before submitting.
-
+1. **Read your own deliverable as an adversary.** For audits: are file-state claims actually reproducible from cited SHAs, or did you accidentally over-summarize? For X01: is the bridge a renaming, or does it actually produce an `NP L` witness consuming concrete polynomial-time data?
+2. **Check that you did not formalize a circular interface.** A `PolyTimeVerifierSpec` with a field `proven_in_NP : Prop` would technically compile but is circular. The bridge must genuinely extract poly-time verification data, not assert membership.
+3. **Verify `#print axioms`.** New X01 theorems should depend only on standard Mathlib axioms (`propext`, `Classical.choice`, `Quot.sound`) plus whatever the D0 memo authorizes.
 4. **Check the test surface compiles.** `lake build` on the test files specifically.
+5. **Verify doc-comment honesty.** No "this module proves a step toward P ≠ NP" language.
 
-5. **Verify the doc-comment honestly describes what you proved.** No "this module proves a step toward P ≠ NP" language.
-
-If self-attack reveals problems, fix them or write a `failures/E<NN>_<handle>.md` report (see §10 below).
+If self-attack reveals problems, fix them or write a `failures/<ID>_<handle>.md` report (§10).
 
 ---
 
@@ -222,42 +198,52 @@ If self-attack reveals problems, fix them or write a `failures/E<NN>_<handle>.md
 You don't coordinate with other engineers directly. The operator does.
 
 - If another engineer's PR lands first and conflicts with your file paths, **do not** retarget. Report via failure report.
-- If you need a definition from another engineer's pending work, **do not** assume it will land. Write your task self-containedly; the operator will resolve dependencies during integration.
+- If you need a definition from another engineer's pending work, **do not** assume it will land. Write your task self-containedly.
+
+Within this wave the only Lean task is X01, so audit/audit collisions cannot occur (different markdown paths), and audit/X01 collisions cannot occur (audits produce no Lean).
 
 ---
 
 ## 7. Time budget
 
-Each task has an estimated time in the README task list. If you exceed 1.5× the estimate without a clean Lean module to show, **stop and write a structured failure report** (see §10).
+Each task has an estimated time in the README task list. If you exceed 1.5× the estimate without a clean deliverable, **stop and write a structured failure report** (§10).
 
-Don't grind past 1.5× — the operator wants signals about infeasibility, not heroic effort on an under-scoped task.
+Don't grind past 1.5× — operator wants signals about infeasibility, not heroic effort on an under-scoped task.
 
 ---
 
 ## 8. Required commands
 
-Run before opening your PR:
+### For audit tasks
+
+```bash
+git diff origin/main -- "*.lean"                                # must be empty
+git diff origin/main pnp3/Barrier/                              # must be empty
+git diff origin/main pnp3/Magnification/UnconditionalResearchGap.lean  # must be empty
+ls seed_packs/phase1_20engineer_parallel_dispatch/audit_reports/  # your report must appear
+```
+
+### For X01
 
 ```bash
 lake build PnP3 Pnp4
 ./scripts/check.sh
-rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4
-git diff origin/main pnp3/Complexity/Interfaces.lean       # must be empty
-git diff origin/main pnp3/Barrier/                          # must be empty
+rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4                # must be empty
+git diff origin/main pnp3/Complexity/Interfaces.lean            # must be empty
+git diff origin/main pnp3/Barrier/                              # must be empty
 git diff origin/main pnp3/Magnification/UnconditionalResearchGap.lean  # must be empty
 ```
 
-All commands must succeed (or for `rg` and `git diff`, return empty).
+All commands must succeed (or for `rg` / `git diff`, return empty).
 
 ---
 
 ## 9. PR submission
 
-1. Push your branch: `git push -u origin khanukov/phase1-E<NN>-<handle>`.
+1. Push your branch: `git push -u origin khanukov/phase1-<ID>-<handle>`.
 2. Open PR to `main`.
-3. PR title: `Phase 1 E<NN>: <task title>`.
-4. PR description must include the structured output template from the README §"Output template — every PR".
-5. Tag the PR with label `phase1-engineer-NN` if labels are configured.
+3. PR title: `Phase 1 <ID>: <task title>`.
+4. PR description uses §12 template.
 
 Do **not** request review unless your self-attack (§5) is clean.
 
@@ -265,81 +251,83 @@ Do **not** request review unless your self-attack (§5) is clean.
 
 ## 10. Failure protocol
 
-If you cannot complete your task within scope, write a failure report:
+If you cannot complete your task within scope, write a failure report at:
 
-`seed_packs/phase1_20engineer_parallel_dispatch/failures/E<NN>_<handle>.md`
+`seed_packs/phase1_20engineer_parallel_dispatch/failures/<ID>_<handle>.md`
 
 With **exactly four sections**:
 
-1. **What was attempted.** Concrete Lean code tried; high-level approach; time spent.
-2. **Where it broke.** Lean error verbatim, or precise mathematical / interface obstruction.
+1. **What was attempted.** Concrete approach; high-level recipe; time spent.
+2. **Where it broke.** Lean error verbatim (X01) or precise audit-scope obstruction (audits).
 3. **Local vs global obstruction.**
-   - `Local`: another engineer with a different approach might succeed; the task as specified is feasible.
+   - `Local`: another engineer with a different approach might succeed.
    - `Global`: the task as specified is unimplementable in the current repo state; needs operator scope revision.
 4. **What an integrator must know.** Specific recipe for redispatching or pivoting.
 
-PR the failure report only (no Lean changes). Operator decides on redispatch or scope revision.
+PR the failure report only (no Lean changes). Operator decides on redispatch.
 
 ---
 
 ## 11. Honest reporting
 
-Every PR description **must** include a "Honest caveats" line. Examples of good honest caveats:
+Every PR description **must** include a "Honest caveats" line. Examples of good caveats:
 
-- "The theorem proves the bound for the codec-induced case only; the abstract-encoding case remains as a `Prop`-staged obligation."
-- "The `Classical.choose` in line 84 extracts the polynomial exponent from `polyBound_poly`; this is standard but introduces `Classical.choice` into the axiom surface."
-- "The structure has 9 fields; 3 are real `∀`-quantified theorems, 6 are `Prop` placeholders for future runtime / serialization work."
-- "I did not verify that the literature theorem holds verbatim; I formalized the statement under the assumption that AM 2025 v1 §2 Theorem 1 is correctly stated in the arXiv PDF."
+- "The audit covers the 24 files in `AlgorithmsToLowerBounds/` at SHA `<x>`; one file (`<name>`) was skimmed not deep-read."
+- "X01's toy verifier uses the empty language to keep `runTimeBound` trivially provable; a non-trivial language is left for follow-up."
+- "The `Classical.choose` in line 84 extracts the polynomial exponent from `polyBound_poly`; standard usage."
+- "I did not verify all 24 `#print axioms` outputs match; I sampled 4 representative ones."
 
-Examples of dishonest framing to avoid:
+Dishonest framing to avoid:
 
 - ❌ "This module advances toward P ≠ NP."
-- ❌ "Successfully formalized AM 2025 Theorem 1." (when only the statement is typed, not proved)
-- ❌ "No caveats." (when there are clearly staged obligations)
+- ❌ "Audit complete." (when sections are skimmed)
+- ❌ "No caveats." (when there are clearly limitations)
 
-Honest framing is **rewarded**. The operator merges honest partial completions; the operator rejects dishonest "complete" claims.
+Honest framing is **rewarded**. Operator merges honest partial completions; rejects dishonest "complete" claims.
 
 ---
 
 ## 12. Universal output format (for your PR description)
 
 ```text
-Task: E<NN> <title>
+Task: <ID> <title>
 Engineer handle: <your-handle>
-Branch: khanukov/phase1-E<NN>-<handle>
+Branch: khanukov/phase1-<ID>-<handle>
 Commit: <sha>
 
 Files added/modified:
   - <list>
 
 Acceptance criteria (universal):
-  [x] lake build PnP3 Pnp4 → green
-  [x] ./scripts/check.sh → green
-  [x] rg sorry|admit -g"*.lean" pnp3 pnp4 → empty
   [x] No trust-root edits (verified via git diff)
-  [x] lakefile.lean updated with one Glob.one line
-  [x] Smoke test in AlgorithmsToLowerBoundsSurfaceTests.lean
-  [x] #print axioms entries in AxiomsAudit.lean
-  [x] Module doc-comment honestly describes scope
+  [x] Audit-only: no Lean edits (git diff origin/main -- "*.lean" empty)
+      OR Lean-task: lake build PnP3 Pnp4 → green;
+                    ./scripts/check.sh → green;
+                    rg sorry|admit -g"*.lean" pnp3 pnp4 → empty;
+                    lakefile.lean updated with Glob.one line(s);
+                    smoke test in AlgorithmsToLowerBoundsSurfaceTests.lean;
+                    #print axioms entries in AxiomsAudit.lean
+  [x] Module/report doc-comment honestly describes scope
 
 Acceptance criteria (task-specific):
   [x] / [ ] <each item from your task file>
 
-Lean signatures landed:
+For X01 — Lean signatures landed:
   - <name> : <type>
   - ...
+
+For audits — Report sections:
+  - File inventory: <count> files, <LOC> total
+  - Signature surface: <summary>
+  - Gap inventory: <summary>
+  - Recommendations: <summary>
 
 Honest caveats:
   - <list any place where deliverable falls short of literal task spec, or where
     you took a design liberty>
 
 Commands run:
-  - lake build PnP3 Pnp4 → <status>
-  - ./scripts/check.sh → <status>
-  - rg sorry|admit -g*.lean pnp3 pnp4 → <status>
-  - git diff origin/main pnp3/Complexity/Interfaces.lean → empty
-  - git diff origin/main pnp3/Barrier/ → empty
-  - git diff origin/main pnp3/Magnification/UnconditionalResearchGap.lean → empty
+  - <list per §8>
 
 Self-attack notes:
   - <what you checked and concluded during your 10-minute adversarial review>
@@ -351,11 +339,12 @@ Scope violations: none / <list>
 
 ## 13. Final reminders
 
-- **Phase 1 is infrastructure**, not P ≠ NP progress. Don't overclaim.
+- **This wave is infrastructure + operator situational awareness**, not P ≠ NP progress. Don't overclaim.
 - **Trust-root files are read-only.** No exceptions.
 - **Honest partial completion is good**; dishonest "complete" is rejected.
 - **Time-box at 1.5× the estimate.** If exceeding, write a failure report.
 - **Self-attack before submitting.** 10 minutes minimum.
 - **One task per engineer.** Don't grab multiple.
+- **Active IDs are A02, A07, A08, A09, A10, X01 only.** All other task files in `tasks/` are DEFERRED — do not pick them.
 
-Good luck. The kill-machine framework relies on each engineer producing exactly what their task file specifies — no more, no less.
+Good luck. Reduced wave is intentional — fewer, higher-yield tasks for faster operator decision.

--- a/seed_packs/phase1_20engineer_parallel_dispatch/README.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/README.md
@@ -1,152 +1,83 @@
-# Phase 1 — Reduced wave (6 tasks)
+# Phase 1 — Wave 1 status (post-audit landing)
 
 ## Status
 
-**OPEN** for dispatch. 5 markdown audits + 1 narrow Lean bridge. Tasks run independently.
+**Wave 1 audits: LANDED.** 9 of 10 audit reports merged to main (commits `833f93c`..`9545867`). A08 missing (no worker dispatched). X01 not yet dispatched.
 
-This file was reduced from 19 tasks per `AUDIT_2026-05-17_PLAN_REDUCTION.md` (read first if you are an operator deciding on dispatch).
+The reduced-wave plan written in `AUDIT_2026-05-17_PLAN_REDUCTION.md` (kept A02, A07, A09, A10 + X01, with A02 optional) was pre-empted by an operator dispatch of all 10 audits before that plan reduction landed on main. The 5 originally-deferred audits (A01, A03, A04, A05, A06) also completed and were merged because they are markdown-only with zero shared-file collision cost; merging them expands operator situational awareness without slowing anything.
 
-## Why a reduced wave
+This file is now a status board, not a dispatch spec.
 
-The earlier 19-task plan was an infrastructure program rather than a closeout program: it opened 5 programmatic surfaces (audits, literature, barriers, kill-machine, contract expansion) and pre-committed a wave 2 of 5–15 more tasks. The repository's own strategic documents (FP3b retrospective; D0 polynomial-time-formalism scoping) point in a much narrower direction: the active gap is mathematical (`ResearchGapWitness` source), not engineering, and the one infrastructure investment that is on the critical path is the `PolyTimeVerifierSpec → NP_TM` bridge.
+## What landed (wave 1)
 
-Reduced wave keeps only:
+| ID | Report | Lines | Verdict | Key finding |
+|---|---|---|---|---|
+| A01 | `audit_reports/A01_pnp3_magnification_partial_codex.md` | 466 | PARTIAL_BUT_USEFUL | `FormulaSupportRestrictionBoundsPartial` legacy/refuted-risk; `_fromPipeline` predicates safer staged replacement; 42 `Classical.choose` in `LocalityProvider_Partial.lean`. |
+| A02 | `audit_reports/A02_pnp3_finalresult_auditor.md` | 493 | PARTIAL_BUT_USEFUL | Pipeline complete only modulo `ResearchGapWitness`; canonical conditional endpoints kernel-wired; refuted/vacuous quarantine routes (`RefutedRoute_*`/`Vacuous_*`) named visibly; no pnp4 adapter to `ResearchGapWitness`. |
+| A03 | `audit_reports/A03_pnp3_ac0_bridges_gpt55.md` | 470 | PARTIAL_BUT_USEFUL | `FormulaSemanticMultiSwitchingProvider` audit-marked refuted-channel; internal singleton provider satisfies empty-witness route; `AsymptoticDAGCollapse` is only conditional DAG endpoint. |
+| A04 | `audit_reports/A04_pnp3_barrier_gpt55.md` | 598 | PARTIAL_BUT_USEFUL | 4 trust-root barrier files ~200 LOC; `BarrierBypassPackage` is Prop wrapper not certificate; no active bypass-witness constructions. |
+| A05 | `audit_reports/A05_pnp3_lowerbounds_codex.md` | 372 | PARTIAL_BUT_USEFUL | Kernel-checked anti-checker + locality contradictions for partial-MCSP; DAG/stable-restriction chain with conditional `NP_not_subset_PpolyDAG` endpoints; `FailedRoute_*` legacy quarantine. |
+| A06 | `audit_reports/A06_pnp3_models_complexity_codex.md` | 568 | PARTIAL_BUT_USEFUL | Kernel-checked partial truth-table + decision/promise surfaces + `P_subset_PpolyDAG` upper-bound route; fixed-slice DAG→Formula hardwiring theorem not-to-be-overgeneralized. |
+| A07 | `audit_reports/A07_pnp4_algorithmstolowebounds_codex.md` | 581 | PARTIAL_BUT_USEFUL | 24 files ~6,687 LOC; kernel-checked finite-slice MCSP + coin + masking + local-PRG transfer; published lower bounds packaged as contract structures (Prop fields); no `VerifiedNPDAGLowerBoundSource` construction. |
+| **A08** | **MISSING** | — | — | **No worker dispatched** for `pnp4/Pnp4/Frontier/` incl. ContractExpansion. Needs separate dispatch. |
+| A09 | `audit_reports/A09_nogolog_formal_witnesses_codex.md` | 312 | PARTIAL_BUT_USEFUL | All 8 non-null `formal_witness` entries point to existing kernel-checked declarations; NOGO-000002/000004/000005 use stale line anchors; NOGO-000003 is `needs_review` with no witness. |
+| A10 | `audit_reports/A10_partial_legacy_markers_codex.md` | 1,266 | PARTIAL_BUT_USEFUL | Repo-wide scan: 34 `_Partial`/`_Legacy`, 37 `placeholder`, 24 TODO|FIXME|XXX|HACK, 274 `Classical.choose`, 505 `noncomputable def`, 13 axiom doc-refs. Hotspots: `LocalityProvider_Partial`, `Facts_Switching`, `Simulation`, `FinalResultMainline`, `FinalResultAuditRoutes`, `UnconditionalResearchGap` (noncomputable `researchGapWitness` placeholder). |
 
-- the audits with the highest operator-decision yield (live theorem surfaces, NoGoLog integrity, placeholder inventory);
-- the one Lean bridge endorsed by the D0 memo.
+Cross-cutting consensus across all 9 reports: **no audit found a hidden shorter route to `P != NP` or to `NP_not_subset_PpolyDAG`**. The mathematical gap remains the bottleneck.
 
-Everything else is deferred. See `AUDIT_2026-05-17_PLAN_REDUCTION.md` for per-task rationale.
+Closed duplicates: PR #1299, PR #1305 (alternate A01 codex variants). PR #1306 selected.
+
+## What is still pending
+
+### Pending — needs dispatch
+
+| ID | Task | Status |
+|---|---|---|
+| A08 | Audit `pnp4/Pnp4/Frontier/*` incl. `ContractExpansion/` (~1,200 LOC) | **No worker dispatched in wave 1.** Operator should dispatch separately. Task file at `tasks/A08_audit_pnp4_frontier.md` is still valid. |
+| X01 | `PolyTimeVerifierSpec` + bridge to `NP_TM` (Option B.1 from D0) | **Not yet dispatched.** Task file at `tasks/X01_polytimeverifierspec_bridge.md` is still valid. Only Lean task in the wave. |
+
+### Deferred (no marginal value this phase)
+
+L01, L02, B01, B02, B03, K01, K02, X02 — see per-task `DEFERRED` headers in `tasks/` and per-task rationale in `AUDIT_2026-05-17_PLAN_REDUCTION.md`. X02 specifically requires rewriting the spec to consume `treeMCSPPrefixAmbientLength` before reactivation.
+
+## Wave 2 (provisional, operator decision)
+
+After A08 + X01 land, wave 2 is an operator decision:
+- **Stop** if audits confirm no hidden shorter route and X01 + A08 ship clean. Engineering closeout complete; bottleneck is math-level (`ResearchGapWitness` source).
+- **Dispatch rewritten X02** if operator wants to continue contract-expansion; X02 spec must be rewritten to consume `treeMCSPPrefixAmbientLength` (the live runtime convention in `PrefixExtensionLanguageRuntime.lean`), and gated on X01 merged.
+
+No pre-commitment to wave 2.
+
+## Cross-cutting operator-decision items from the 9 audits
+
+These were surfaced as Phase 1+ recommendations across multiple audit reports; the operator can choose to act, defer, or ignore:
+
+1. **NoGoLog anchor repair (from A09).** Update line anchors for NOGO-000002, NOGO-000004, NOGO-000005; decide whether NOGO-000003 needs a formal witness or remains `needs_review`.
+2. **Provider/Default quarantine (from A01, A03, A10).** Many `hasDefault*` / `default*` provider names in `LocalityProvider_Partial.lean` and AC0 bridges create hidden-payload risk if used as ambient facts. Consider rename/quarantine pass.
+3. **Old vs `_fromPipeline` support-bounds visibility (from A01, A03).** `FormulaSupportRestrictionBoundsPartial` is documented as inconsistent/refuted but compatibility theorems still callable. Markdown quarantine note proposed.
+4. **pnp3↔pnp4 MCSP crosswalk (from A06, A07).** No adapter currently exists between pnp3 `gapPartialMCSP_Language` and pnp4 `SearchMCSPCompressionProblem`. A markdown crosswalk would prevent duplicate engineering.
+5. **`RefutedRoute_*` naming review (from A02).** Some pipeline-aware wrappers in `FinalResultAuditRoutes.lean` have `RefutedRoute_` names but comments call them non-ex-falso. Naming/documentation cleanup proposed.
+
+Each is markdown-only or low-risk Lean test; none change the math-level bottleneck.
 
 ## Repository reality (recap)
 
-`UnconditionalResearchGap.lean` already proves `P_ne_NP_final (gap : ResearchGapWitness) : P_ne_NP`. The remaining mathematical gap is producing a non-vacuous `ResearchGapWitness` — a real proof of `NP_not_subset_PpolyDAG`. This phase does not attempt that; it audits the surrounding surface and adds one resumability-enabling bridge.
-
-| Area | Status |
-|---|---|
-| `pnp3/` axiom-clean (0 sorry / 0 admit / 0 axiom-decl) | ✓ |
-| `pnp4/` fully clean (0 sorry / 0 admit / 0 axiom / 0 Fact / 0 opaque) | ✓ |
-| Falsifiability audit closed (5 legacy routes proven vacuous) | ✓ |
-| Trust roots intact (`Interfaces.lean`, `UnconditionalResearchGap.lean`, `Barrier/*`) | ✓ |
-| Contract-expansion infra through R1-B2a runtime | ✓ |
-| Non-vacuous `ResearchGapWitness` source | ✗ (math-level, not in scope this phase) |
-
-## Engineer dispatch
-
-You are one of 6 engineers. Take **ONE** task by ID. Don't take more than one.
-
-### Common reading (everyone)
-
-1. `RESEARCH_CONSTITUTION.md` — discipline rules; binding.
-2. `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` — universal rules.
-3. `seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md` — context for why this wave is reduced.
-4. **Your specific task file** in `tasks/<ID>_*.md`.
-5. (Audit tasks only) The files you're auditing — read carefully.
-
-### Task list
-
-#### Audit tasks (5 tasks, markdown-only)
-
-| ID | Audit area | LOC scope | Time |
-|---|---|---|---|
-| [A02](tasks/A02_audit_pnp3_finalresult.md) | `pnp3/Magnification/FinalResult*.lean` (6 files) | ~4,091 | 1 wk |
-| [A07](tasks/A07_audit_pnp4_algorithmstolowebounds.md) | `pnp4/Pnp4/AlgorithmsToLowerBounds/` (24 files) | ~6,700 | 1 wk |
-| [A08](tasks/A08_audit_pnp4_frontier.md) | `pnp4/Pnp4/Frontier/*` incl. `ContractExpansion/` | ~1,200 | 1 wk |
-| [A09](tasks/A09_audit_nogolog_formal_witnesses.md) | `outputs/nogolog.jsonl` formal_witness validation | — | 3 days |
-| [A10](tasks/A10_audit_partial_legacy_markers.md) | Cross-cutting `_Partial`/`_Legacy`/`TODO`/`Classical.choose` inventory | — | 3 days |
-
-Output: each audit lands one markdown report at `seed_packs/phase1_20engineer_parallel_dispatch/audit_reports/<ID>_<area>_<handle>.md`.
-
-No Lean edits, no shared-file collisions.
-
-#### Lean task (1 task)
-
-| ID | Title | Time | Difficulty |
-|---|---|---|---|
-| [X01](tasks/X01_polytimeverifierspec_bridge.md) | `PolyTimeVerifierSpec` + bridge to `NP_TM` (Option B.1 from D0) | 3 wks | medium |
-
-X01 touches `lakefile.lean`, `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean`, and `pnp4/Pnp4/Tests/AxiomsAudit.lean`. Within this wave X01 is the only Lean task, so no parallel-merge collision.
-
-### Deferred tasks (not dispatchable this wave)
-
-The following task files exist under `tasks/` for record but are marked DEFERRED. **Do not pick one of these.** See `AUDIT_2026-05-17_PLAN_REDUCTION.md` for per-task reasoning.
-
-- `A01`, `A03`, `A04`, `A05`, `A06` — deferred lower-yield audits; maintainability not shortest-path.
-- `L01`, `L02` — deferred. L01 has bibliographic ID error (`1804.05985` is not Hirahara FOCS 2018); needs rewrite.
-- `B01`, `B02`, `B03` — deferred. B02/B03 are placeholder/`True`-typed wrapper surfaces; B01 lower priority than X01.
-- `K01`, `K02` — deferred. Typed rubrics, not theorem engines.
-- `X02` — deferred until X01 lands AND spec rewritten. Current spec uses `M := fun n => n` which is incompatible with the live `treeMCSPPrefixAmbientLength` convention in `PrefixExtensionLanguageRuntime.lean`.
-
-### Dependency graph
-
-```
-A02, A07, A08, A09, A10 — all independent markdown audits.
-X01 — independent of all audits; only Lean task this wave.
-No engineer is blocked on another.
-```
-
-After wave 1 lands and operator synthesizes, wave 2 is an operator decision:
-- **Stop** if audits confirm no hidden shorter route and X01 is the only worthwhile bridge; or
-- **Dispatch rewritten X02** explicitly gated on X01.
-
-## Acceptance criteria — universal
-
-See `COMMON_WORKER_INSTRUCTIONS.md` §4. Summary:
-
-1. ✅ Files at exact paths specified in the task.
-2. ✅ For audit tasks: markdown report at expected path with all required sections.
-3. ✅ For X01: `lake build PnP3 Pnp4` passes; `./scripts/check.sh` passes; `rg "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` empty.
-4. ✅ For X01: smoke test in `AlgorithmsToLowerBoundsSurfaceTests.lean` + `#print axioms` line in `AxiomsAudit.lean`.
-5. ✅ PR description uses structured template from COMMON §12.
-6. ✅ No edits to forbidden files (see COMMON §3.1).
-
-Operator review target: **~20 minutes per audit PR**, **~45 minutes for X01 PR**.
-
-## Forbidden scope — universal
-
-See `COMMON_WORKER_INSTRUCTIONS.md` §3. Summary:
-
-- No edits to `pnp3/Complexity/Interfaces.lean`, `pnp3/Complexity/PsubsetPpolyInternal/**`, `pnp3/Magnification/UnconditionalResearchGap.lean`, `pnp3/Barrier/**`, `pnp3/Magnification/AuditRoutes/**`.
-- No edits to existing `pnp3/Magnification/*_Partial.lean`, `FinalResult*.lean`, `AC0*Bridge.lean` files.
-- For X01: no `sorry` / `admit` / `axiom` / `opaque` / `Fact` / typeclass-payload.
-- No `Classical.choose` in core definitions (acceptable in derived proofs if standard exponent extraction; document).
-- No `SourceTheorem_*` / `gap_from_*` / `ResearchGapWitness` / `NP_not_subset_PpolyDAG` / `P_ne_NP` claims.
-- No `ProvenanceFilter_v1` promotion.
-- No new NoGoLog entries.
-
-## What this phase does NOT do
-
-- No P-vs-NP proof.
-- No `ResearchGapWitness` construction.
-- No new endpoint or final theorem.
-- No claim that any audit or X01 advances the math-level bottleneck.
-
-This wave is **operator situational awareness + one resumability bridge**. Nothing more.
-
-## Re-dispatch / failure protocol
-
-If you cannot complete your task within scope, write a structured failure report at:
-
-`seed_packs/phase1_20engineer_parallel_dispatch/failures/<ID>_<your-handle>.md`
-
-Four sections: What was attempted / Where it broke / Local vs global obstruction / What an integrator must know.
+`UnconditionalResearchGap.lean` proves `P_ne_NP_final (gap : ResearchGapWitness) : P_ne_NP`. The mathematical bottleneck is a non-vacuous `ResearchGapWitness` source — equivalent to a real proof of `NP_not_subset_PpolyDAG`. Wave 1 audits confirm this remains the only mathematical gap; engineering is otherwise compartmentalized and axiom-clean (`pnp3`: 0 sorry, 0 admit, 0 axiom-decl; `pnp4`: fully clean).
 
 ## Cross-references
 
 - `RESEARCH_CONSTITUTION.md` — overarching discipline.
-- `seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md` — why this wave is reduced.
+- `seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md` — original reduction memo (now superseded by this status board for wave 1 outcomes).
 - `seed_packs/first_move_search_2026/reports/fp3b_epoch_strategic_retrospective_claudeopus.md` — FP3b context.
 - `seed_packs/polynomial_time_formalism_scoping_D0/reports/D0_four_way_review_and_synthesis_claudeopus.md` — X01 rationale.
-- `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` — required reading.
+- `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` — required reading for A08/X01 workers.
 
 ## Status header
 
 ```
-Wave: 1 (reduced)
-Engineers: 6 (parallel)
-  - Audits (markdown): 5 (A02, A07, A08, A09, A10)
-  - Lean bridge: 1 (X01)
-Wave 2 status: operator decision after wave 1 synthesis (no pre-commitment)
-Estimated wall-clock: 3 weeks (X01-bound; audits land within 1 week)
-Operator review load: ~5 × 20 min + 1 × 45 min ≈ 2.5 operator-hours
-Outcome: operator-decision-useful snapshot of live theorem surface + one D0-aligned bridge
+Wave: 1 (audits landed; A08 + X01 still pending)
+Audits landed: 9 of 10 (A01, A02, A03, A04, A05, A06, A07, A09, A10)
+Audits missing: 1 (A08 — needs separate dispatch)
+Lean tasks pending: 1 (X01)
+Wave 2: operator decision after A08 + X01 synthesis (no pre-commitment)
 ```

--- a/seed_packs/phase1_20engineer_parallel_dispatch/README.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/README.md
@@ -1,83 +1,79 @@
-# Phase 1 — Wave 1 status (post-audit landing)
+# Phase 1 — Wave 1 audits complete; A11 synthesis pending
 
 ## Status
 
-**Wave 1 audits: LANDED.** 9 of 10 audit reports merged to main (commits `833f93c`..`9545867`). A08 missing (no worker dispatched). X01 not yet dispatched.
-
-The reduced-wave plan written in `AUDIT_2026-05-17_PLAN_REDUCTION.md` (kept A02, A07, A09, A10 + X01, with A02 optional) was pre-empted by an operator dispatch of all 10 audits before that plan reduction landed on main. The 5 originally-deferred audits (A01, A03, A04, A05, A06) also completed and were merged because they are markdown-only with zero shared-file collision cost; merging them expands operator situational awareness without slowing anything.
-
-This file is now a status board, not a dispatch spec.
+**Wave 1 audits: 10 of 10 landed.** A11 synthesis is the **next active task**. No L/B/K/X dispatch until A11 lands and operator decides.
 
 ## What landed (wave 1)
 
 | ID | Report | Lines | Verdict | Key finding |
 |---|---|---|---|---|
 | A01 | `audit_reports/A01_pnp3_magnification_partial_codex.md` | 466 | PARTIAL_BUT_USEFUL | `FormulaSupportRestrictionBoundsPartial` legacy/refuted-risk; `_fromPipeline` predicates safer staged replacement; 42 `Classical.choose` in `LocalityProvider_Partial.lean`. |
-| A02 | `audit_reports/A02_pnp3_finalresult_auditor.md` | 493 | PARTIAL_BUT_USEFUL | Pipeline complete only modulo `ResearchGapWitness`; canonical conditional endpoints kernel-wired; refuted/vacuous quarantine routes (`RefutedRoute_*`/`Vacuous_*`) named visibly; no pnp4 adapter to `ResearchGapWitness`. |
+| A02 | `audit_reports/A02_pnp3_finalresult_auditor.md` | 493 | PARTIAL_BUT_USEFUL | Pipeline complete only modulo `ResearchGapWitness`; canonical conditional endpoints kernel-wired; refuted/vacuous quarantine routes named visibly; no pnp4 adapter to `ResearchGapWitness`. |
 | A03 | `audit_reports/A03_pnp3_ac0_bridges_gpt55.md` | 470 | PARTIAL_BUT_USEFUL | `FormulaSemanticMultiSwitchingProvider` audit-marked refuted-channel; internal singleton provider satisfies empty-witness route; `AsymptoticDAGCollapse` is only conditional DAG endpoint. |
 | A04 | `audit_reports/A04_pnp3_barrier_gpt55.md` | 598 | PARTIAL_BUT_USEFUL | 4 trust-root barrier files ~200 LOC; `BarrierBypassPackage` is Prop wrapper not certificate; no active bypass-witness constructions. |
 | A05 | `audit_reports/A05_pnp3_lowerbounds_codex.md` | 372 | PARTIAL_BUT_USEFUL | Kernel-checked anti-checker + locality contradictions for partial-MCSP; DAG/stable-restriction chain with conditional `NP_not_subset_PpolyDAG` endpoints; `FailedRoute_*` legacy quarantine. |
 | A06 | `audit_reports/A06_pnp3_models_complexity_codex.md` | 568 | PARTIAL_BUT_USEFUL | Kernel-checked partial truth-table + decision/promise surfaces + `P_subset_PpolyDAG` upper-bound route; fixed-slice DAG→Formula hardwiring theorem not-to-be-overgeneralized. |
-| A07 | `audit_reports/A07_pnp4_algorithmstolowebounds_codex.md` | 581 | PARTIAL_BUT_USEFUL | 24 files ~6,687 LOC; kernel-checked finite-slice MCSP + coin + masking + local-PRG transfer; published lower bounds packaged as contract structures (Prop fields); no `VerifiedNPDAGLowerBoundSource` construction. |
-| **A08** | **MISSING** | — | — | **No worker dispatched** for `pnp4/Pnp4/Frontier/` incl. ContractExpansion. Needs separate dispatch. |
+| A07 | `audit_reports/A07_pnp4_algorithmstolowebounds_codex.md` | 581 | PARTIAL_BUT_USEFUL | 24 files ~6,687 LOC; kernel-checked finite-slice MCSP + coin + masking + local-PRG transfer; published lower bounds packaged as contract structures; no `VerifiedNPDAGLowerBoundSource` construction. |
+| A08 | `audit_reports/A08_pnp4_frontier_codex.md` | 568 | (operator-dispatched outside main wave) | pnp4/Pnp4/Frontier/* incl. ContractExpansion audited. |
 | A09 | `audit_reports/A09_nogolog_formal_witnesses_codex.md` | 312 | PARTIAL_BUT_USEFUL | All 8 non-null `formal_witness` entries point to existing kernel-checked declarations; NOGO-000002/000004/000005 use stale line anchors; NOGO-000003 is `needs_review` with no witness. |
-| A10 | `audit_reports/A10_partial_legacy_markers_codex.md` | 1,266 | PARTIAL_BUT_USEFUL | Repo-wide scan: 34 `_Partial`/`_Legacy`, 37 `placeholder`, 24 TODO|FIXME|XXX|HACK, 274 `Classical.choose`, 505 `noncomputable def`, 13 axiom doc-refs. Hotspots: `LocalityProvider_Partial`, `Facts_Switching`, `Simulation`, `FinalResultMainline`, `FinalResultAuditRoutes`, `UnconditionalResearchGap` (noncomputable `researchGapWitness` placeholder). |
+| A10 | `audit_reports/A10_partial_legacy_markers_codex.md` | 1,266 | PARTIAL_BUT_USEFUL | Repo-wide scan: 34 `_Partial`/`_Legacy`, 37 `placeholder`, 274 `Classical.choose`, 505 `noncomputable def`. Hotspots: `LocalityProvider_Partial`, `Facts_Switching`, `Simulation`, `FinalResultMainline`, `FinalResultAuditRoutes`, `UnconditionalResearchGap`. |
 
-Cross-cutting consensus across all 9 reports: **no audit found a hidden shorter route to `P != NP` or to `NP_not_subset_PpolyDAG`**. The mathematical gap remains the bottleneck.
+Total audit volume: ~5,694 lines of markdown across 10 reports.
 
-Closed duplicates: PR #1299, PR #1305 (alternate A01 codex variants). PR #1306 selected.
+Closed duplicates: PR #1299, #1305 (alternate A01 codex variants; #1306 selected).
 
-## What is still pending
+## What is next — A11 synthesis (only active task)
 
-### Pending — needs dispatch
+| ID | Task | Time | Type |
+|---|---|---|---|
+| [A11](tasks/A11_wave1_synthesis.md) | Synthesis of A01–A10 + wave-2 decision memo | 1 wk | markdown-only |
 
-| ID | Task | Status |
-|---|---|---|
-| A08 | Audit `pnp4/Pnp4/Frontier/*` incl. `ContractExpansion/` (~1,200 LOC) | **No worker dispatched in wave 1.** Operator should dispatch separately. Task file at `tasks/A08_audit_pnp4_frontier.md` is still valid. |
-| X01 | `PolyTimeVerifierSpec` + bridge to `NP_TM` (Option B.1 from D0) | **Not yet dispatched.** Task file at `tasks/X01_polytimeverifierspec_bridge.md` is still valid. Only Lean task in the wave. |
+**A11 is gating.** It is the synthesis pass that turns 10 audit reports into a single operator-decision memo: cross-audit consensus map, refuted/vacuous quarantine inventory, math-level bottleneck status per candidate path, wave-2 decision matrix per deferred task (L01, L02, B01, B02, B03, K01, K02, X01, X02), prioritized cross-cutting cleanup items, and a single recommended wave-2 size (0–N).
 
-### Deferred (no marginal value this phase)
+Until A11 lands and the operator decides based on it, **no L/B/K/X dispatch happens**.
 
-L01, L02, B01, B02, B03, K01, K02, X02 — see per-task `DEFERRED` headers in `tasks/` and per-task rationale in `AUDIT_2026-05-17_PLAN_REDUCTION.md`. X02 specifically requires rewriting the spec to consume `treeMCSPPrefixAmbientLength` before reactivation.
+## Deferred — pending A11 outcome
 
-## Wave 2 (provisional, operator decision)
+The following 9 task files exist under `tasks/` with DEFERRED headers. **Do not dispatch any of these.** A11 will recommend per-task whether to dispatch, defer further, or cancel.
 
-After A08 + X01 land, wave 2 is an operator decision:
-- **Stop** if audits confirm no hidden shorter route and X01 + A08 ship clean. Engineering closeout complete; bottleneck is math-level (`ResearchGapWitness` source).
-- **Dispatch rewritten X02** if operator wants to continue contract-expansion; X02 spec must be rewritten to consume `treeMCSPPrefixAmbientLength` (the live runtime convention in `PrefixExtensionLanguageRuntime.lean`), and gated on X01 merged.
+- L01, L02 (literature: Hirahara search-to-decision MCSP, Pich-Santhanam unprovability)
+- B01, B02, B03 (barriers: Razborov-Rudich, Relativization, Algebrization — pnp4 extensions)
+- K01, K02 (kill-machine: cross-route NoGo checker, pre-dispatch barrier classifier)
+- X01 (PolyTimeVerifierSpec + NP_TM bridge — D0-endorsed)
+- X02 (concrete tree-MCSP parser — spec needs rewrite to consume `treeMCSPPrefixAmbientLength`)
 
-No pre-commitment to wave 2.
+X01 is the only Lean task; it remains gated on A11 even though no audit directly contradicts dispatching it — wave-1 evidence may change the priority or scope.
 
-## Cross-cutting operator-decision items from the 9 audits
+## Cross-cutting consensus from wave 1 (pre-synthesis snapshot)
 
-These were surfaced as Phase 1+ recommendations across multiple audit reports; the operator can choose to act, defer, or ignore:
+This is a quick snapshot only; A11 will produce the authoritative synthesis.
 
-1. **NoGoLog anchor repair (from A09).** Update line anchors for NOGO-000002, NOGO-000004, NOGO-000005; decide whether NOGO-000003 needs a formal witness or remains `needs_review`.
-2. **Provider/Default quarantine (from A01, A03, A10).** Many `hasDefault*` / `default*` provider names in `LocalityProvider_Partial.lean` and AC0 bridges create hidden-payload risk if used as ambient facts. Consider rename/quarantine pass.
-3. **Old vs `_fromPipeline` support-bounds visibility (from A01, A03).** `FormulaSupportRestrictionBoundsPartial` is documented as inconsistent/refuted but compatibility theorems still callable. Markdown quarantine note proposed.
-4. **pnp3↔pnp4 MCSP crosswalk (from A06, A07).** No adapter currently exists between pnp3 `gapPartialMCSP_Language` and pnp4 `SearchMCSPCompressionProblem`. A markdown crosswalk would prevent duplicate engineering.
-5. **`RefutedRoute_*` naming review (from A02).** Some pipeline-aware wrappers in `FinalResultAuditRoutes.lean` have `RefutedRoute_` names but comments call them non-ex-falso. Naming/documentation cleanup proposed.
+- **No hidden shorter route.** No audit found a path that bypasses the math-level `ResearchGapWitness` bottleneck.
+- **Engineering is compartmentalized and axiom-clean.** pnp3: 0 sorry, 0 admit, 0 axiom-decl, 6 opaque, 9 Fact (staged routes); pnp4: fully clean.
+- **Refuted/vacuous routes are well-quarantined but still callable.** A02, A03, A05 all flag the same support-bounds and singleton-provider risks.
+- **No pnp4↔pnp3 final-boundary adapter** from `VerifiedNPDAGLowerBoundSource` to `ResearchGapWitness` (A02, A07, A08).
+- **NoGoLog integrity is mostly intact** with 3 stale anchors and 1 `needs_review` entry to clean up (A09).
+- **Cross-cutting hotspots:** `LocalityProvider_Partial.lean`, `Facts_Switching.lean`, AC0 multiswitching provider surfaces (A01, A03, A10).
 
-Each is markdown-only or low-risk Lean test; none change the math-level bottleneck.
+A11 will turn these into a wave-2 decision and a prioritized cleanup list.
 
 ## Repository reality (recap)
 
-`UnconditionalResearchGap.lean` proves `P_ne_NP_final (gap : ResearchGapWitness) : P_ne_NP`. The mathematical bottleneck is a non-vacuous `ResearchGapWitness` source — equivalent to a real proof of `NP_not_subset_PpolyDAG`. Wave 1 audits confirm this remains the only mathematical gap; engineering is otherwise compartmentalized and axiom-clean (`pnp3`: 0 sorry, 0 admit, 0 axiom-decl; `pnp4`: fully clean).
-
-## Cross-references
-
-- `RESEARCH_CONSTITUTION.md` — overarching discipline.
-- `seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md` — original reduction memo (now superseded by this status board for wave 1 outcomes).
-- `seed_packs/first_move_search_2026/reports/fp3b_epoch_strategic_retrospective_claudeopus.md` — FP3b context.
-- `seed_packs/polynomial_time_formalism_scoping_D0/reports/D0_four_way_review_and_synthesis_claudeopus.md` — X01 rationale.
-- `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` — required reading for A08/X01 workers.
+`UnconditionalResearchGap.lean` proves `P_ne_NP_final (gap : ResearchGapWitness) : P_ne_NP`. The mathematical bottleneck is a non-vacuous `ResearchGapWitness` source — equivalent to a real proof of `NP_not_subset_PpolyDAG`. Wave 1 audits confirm this remains the only mathematical gap.
 
 ## Status header
 
 ```
-Wave: 1 (audits landed; A08 + X01 still pending)
-Audits landed: 9 of 10 (A01, A02, A03, A04, A05, A06, A07, A09, A10)
-Audits missing: 1 (A08 — needs separate dispatch)
-Lean tasks pending: 1 (X01)
-Wave 2: operator decision after A08 + X01 synthesis (no pre-commitment)
+Wave: 1 (audits complete)
+Audits landed: 10 of 10 (A01–A10)
+Next active task: A11 synthesis (markdown-only, 1 week, gating)
+Wave 2 (L/B/K/X): blocked on A11 + operator decision
 ```
+
+## Cross-references
+
+- `seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md` — pre-audit reduction memo (now superseded by wave-1 evidence; A11 produces the post-audit decision).
+- `seed_packs/first_move_search_2026/reports/fp3b_epoch_strategic_retrospective_claudeopus.md` — FP3b context.
+- `seed_packs/polynomial_time_formalism_scoping_D0/reports/D0_four_way_review_and_synthesis_claudeopus.md` — X01 rationale (still relevant post-A11 if X01 is dispatched).
+- `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` — required reading for the A11 worker.

--- a/seed_packs/phase1_20engineer_parallel_dispatch/README.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/README.md
@@ -1,174 +1,126 @@
-# Phase 1 — Parallel dispatch (19 tasks across 5 phases)
+# Phase 1 — Reduced wave (6 tasks)
 
 ## Status
 
-**OPEN** for parallel dispatch. All tasks are independent and run concurrently.
+**OPEN** for dispatch. 5 markdown audits + 1 narrow Lean bridge. Tasks run independently.
 
-## Critical revision (post-audit)
+This file was reduced from 19 tasks per `AUDIT_2026-05-17_PLAN_REDUCTION.md` (read first if you are an operator deciding on dispatch).
 
-This dispatch plan was **revised** after discovering substantial existing infrastructure in `pnp3/Magnification/*_Partial.lean`, `pnp3/Magnification/FinalResult*.lean`, `pnp3/LowerBounds/*_Partial.lean`, and `pnp4/Pnp4/AlgorithmsToLowerBounds/*` (~24 files). The original 20-task plan would have duplicated existing work.
+## Why a reduced wave
 
-**The revised plan front-loads a Phase 0 audit** to map what's actually done, what's partial, what's missing — so subsequent dispatches target real gaps.
+The earlier 19-task plan was an infrastructure program rather than a closeout program: it opened 5 programmatic surfaces (audits, literature, barriers, kill-machine, contract expansion) and pre-committed a wave 2 of 5–15 more tasks. The repository's own strategic documents (FP3b retrospective; D0 polynomial-time-formalism scoping) point in a much narrower direction: the active gap is mathematical (`ResearchGapWitness` source), not engineering, and the one infrastructure investment that is on the critical path is the `PolyTimeVerifierSpec → NP_TM` bridge.
 
-## Classification
+Reduced wave keeps only:
 
-**Infrastructure / kill-machine acceleration / repo state mapping.**
+- the audits with the highest operator-decision yield (live theorem surfaces, NoGoLog integrity, placeholder inventory);
+- the one Lean bridge endorsed by the D0 memo.
 
-This phase is **not** P-vs-NP mainline progress. It accelerates the kill-machine by:
+Everything else is deferred. See `AUDIT_2026-05-17_PLAN_REDUCTION.md` for per-task rationale.
 
-1. **Phase 0** — comprehensive audit of existing repo infrastructure (10 tasks).
-2. **Phase 2** — formalize literature genuinely missing from repo (2 tasks).
-3. **Phase 3** — extend minimal barrier interfaces to kernel-checked theorems (3 tasks).
-4. **Phase 4** — industrial-scale kill-machine tooling (2 tasks).
-5. **Phase 5** — complete contract_expansion implementation per D0 scoping (2 tasks).
+## Repository reality (recap)
 
-After Phase 1 lands, Phase 1+ (completion of partial work) can be dispatched based on Phase 0 audit findings. **Phase 1+ size is conditional on audit results** (likely 5-15 additional tasks).
+`UnconditionalResearchGap.lean` already proves `P_ne_NP_final (gap : ResearchGapWitness) : P_ne_NP`. The remaining mathematical gap is producing a non-vacuous `ResearchGapWitness` — a real proof of `NP_not_subset_PpolyDAG`. This phase does not attempt that; it audits the surrounding surface and adds one resumability-enabling bridge.
 
-## What the repo already has (per pre-dispatch audit)
-
-| Area | Files | LOC | Status |
-| --- | --- | --- | --- |
-| `pnp3/Magnification/*_Partial.lean` | 6 | ~4,474 | Substantively complete for partial-MCSP variant |
-| `pnp3/Magnification/FinalResult*.lean` | 6 | ~4,091 | Main pipeline; needs `ResearchGapWitness` instance |
-| `pnp3/LowerBounds/*_Partial.lean` | 2 | ~2,290 | AntiChecker + formula LB chain |
-| `pnp3/Barrier/*.lean` | 4 | ~200 | Minimal interfaces; need pnp4-side extensions |
-| `pnp4/Pnp4/AlgorithmsToLowerBounds/` | 24 | ? | AC⁰[p] + MCSP infrastructure |
-| `pnp4/Pnp4/Frontier/ContractExpansion/` | 4 | ~700 | R1-A, R1-B, R1-B1, R1-B2a |
-
-`UnconditionalResearchGap.lean` confirms: `P_ne_NP_final (gap : ResearchGapWitness) : P_ne_NP` is **already proven**. The only mathematically meaningful gap is producing a `ResearchGapWitness` instance — i.e., a real proof of `NP_not_subset_PpolyDAG`.
+| Area | Status |
+|---|---|
+| `pnp3/` axiom-clean (0 sorry / 0 admit / 0 axiom-decl) | ✓ |
+| `pnp4/` fully clean (0 sorry / 0 admit / 0 axiom / 0 Fact / 0 opaque) | ✓ |
+| Falsifiability audit closed (5 legacy routes proven vacuous) | ✓ |
+| Trust roots intact (`Interfaces.lean`, `UnconditionalResearchGap.lean`, `Barrier/*`) | ✓ |
+| Contract-expansion infra through R1-B2a runtime | ✓ |
+| Non-vacuous `ResearchGapWitness` source | ✗ (math-level, not in scope this phase) |
 
 ## Engineer dispatch
 
-You are one of 19 engineers. Take **ONE** task by ID. Don't take more than one.
+You are one of 6 engineers. Take **ONE** task by ID. Don't take more than one.
 
 ### Common reading (everyone)
 
-Before starting your task:
-
 1. `RESEARCH_CONSTITUTION.md` — discipline rules; binding.
-2. `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` — universal rules for this phase.
-3. **Your specific task file** in `tasks/<ID>_*.md`.
-4. (If your task is Phase 0 audit) The files you're auditing — read carefully.
+2. `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` — universal rules.
+3. `seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md` — context for why this wave is reduced.
+4. **Your specific task file** in `tasks/<ID>_*.md`.
+5. (Audit tasks only) The files you're auditing — read carefully.
 
 ### Task list
 
-#### Phase 0 — Repo audit (10 tasks, all markdown-only)
+#### Audit tasks (5 tasks, markdown-only)
 
 | ID | Audit area | LOC scope | Time |
-| --- | --- | --- | --- |
-| [A01](tasks/A01_audit_pnp3_magnification_partial.md) | `pnp3/Magnification/*_Partial.lean` (6 files) | ~4,474 | 1 wk |
+|---|---|---|---|
 | [A02](tasks/A02_audit_pnp3_finalresult.md) | `pnp3/Magnification/FinalResult*.lean` (6 files) | ~4,091 | 1 wk |
-| [A03](tasks/A03_audit_pnp3_ac0_bridges.md) | `pnp3/Magnification/AC0*.lean` + `Asymptotic*Collapse.lean` (~6 files) | ~1,500 | 1 wk |
-| [A04](tasks/A04_audit_pnp3_barrier.md) | `pnp3/Barrier/` (4 files) | ~200 | 3 days |
-| [A05](tasks/A05_audit_pnp3_lowerbounds.md) | `pnp3/LowerBounds/` (incl `_Partial`) | ~2,290 | 1 wk |
-| [A06](tasks/A06_audit_pnp3_models_complexity.md) | `pnp3/Models/` + non-trust-root `pnp3/Complexity/` | varies | 1 wk |
-| [A07](tasks/A07_audit_pnp4_algorithmstolowebounds.md) | `pnp4/Pnp4/AlgorithmsToLowerBounds/` (24 files) | ? | 1 wk |
-| [A08](tasks/A08_audit_pnp4_frontier.md) | `pnp4/Pnp4/Frontier/*` (incl. ContractExpansion) | ~1,000 | 1 wk |
+| [A07](tasks/A07_audit_pnp4_algorithmstolowebounds.md) | `pnp4/Pnp4/AlgorithmsToLowerBounds/` (24 files) | ~6,700 | 1 wk |
+| [A08](tasks/A08_audit_pnp4_frontier.md) | `pnp4/Pnp4/Frontier/*` incl. `ContractExpansion/` | ~1,200 | 1 wk |
 | [A09](tasks/A09_audit_nogolog_formal_witnesses.md) | `outputs/nogolog.jsonl` formal_witness validation | — | 3 days |
-| [A10](tasks/A10_audit_partial_legacy_markers.md) | Cross-cutting search for `_Partial`/`_Legacy`/`TODO`/placeholder | — | 3 days |
+| [A10](tasks/A10_audit_partial_legacy_markers.md) | Cross-cutting `_Partial`/`_Legacy`/`TODO`/`Classical.choose` inventory | — | 3 days |
 
-**Phase 0 output:** each audit lands one markdown report at `seed_packs/phase1_20engineer_parallel_dispatch/audit_reports/<ID>_<area>_<handle>.md` with required sections (see task file).
+Output: each audit lands one markdown report at `seed_packs/phase1_20engineer_parallel_dispatch/audit_reports/<ID>_<area>_<handle>.md`.
 
-#### Phase 2 — Literature genuinely missing (2 tasks)
+No Lean edits, no shared-file collisions.
 
-| ID | Title | Time | Difficulty |
-| --- | --- | --- | --- |
-| [L01](tasks/L01_hirahara_search_to_decision.md) | Hirahara search-to-decision MCSP surface | 2 wks | high |
-| [L02](tasks/L02_pich_santhanam_unprovability.md) | Pich-Santhanam bounded arithmetic unprovability surface | 3 wks | high |
-
-#### Phase 3 — Barriers as kernel-checked theorems (3 tasks)
+#### Lean task (1 task)
 
 | ID | Title | Time | Difficulty |
-| --- | --- | --- | --- |
-| [B01](tasks/B01_razborov_rudich_barrier.md) | Razborov-Rudich natural proofs barrier — pnp4 extension | 3 wks | high |
-| [B02](tasks/B02_relativization_barrier.md) | Relativization (BGS) barrier — concrete oracle witnesses | 3 wks | high |
-| [B03](tasks/B03_algebrization_barrier.md) | Algebrization (Aaronson-Wigderson) barrier | 3 wks | high |
+|---|---|---|---|
+| [X01](tasks/X01_polytimeverifierspec_bridge.md) | `PolyTimeVerifierSpec` + bridge to `NP_TM` (Option B.1 from D0) | 3 wks | medium |
 
-#### Phase 4 — Industrial kill-machine (2 tasks)
+X01 touches `lakefile.lean`, `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean`, and `pnp4/Pnp4/Tests/AxiomsAudit.lean`. Within this wave X01 is the only Lean task, so no parallel-merge collision.
 
-| ID | Title | Time | Difficulty |
-| --- | --- | --- | --- |
-| [K01](tasks/K01_cross_route_nogo_checker.md) | Cross-route NoGo applicability checker library | 2 wks | medium |
-| [K02](tasks/K02_pre_dispatch_barrier_classifier.md) | Pre-dispatch barrier classification tool | 2 wks | medium |
+### Deferred tasks (not dispatchable this wave)
 
-#### Phase 5 — Contract expansion completion (2 tasks)
+The following task files exist under `tasks/` for record but are marked DEFERRED. **Do not pick one of these.** See `AUDIT_2026-05-17_PLAN_REDUCTION.md` for per-task reasoning.
 
-| ID | Title | Time | Difficulty |
-| --- | --- | --- | --- |
-| [X01](tasks/X01_polytimeverifierspec_bridge.md) | PolyTimeVerifierSpec + bridge to NP_TM (Option B.1) | 3 wks | medium |
-| [X02](tasks/X02_concrete_tree_mcsp_parser.md) | Concrete tree-MCSP parser implementation + runtime proofs | 4 wks | medium-high |
-
-#### (Future) Phase 1+ — Completion of partial work
-
-**Dispatched conditionally after Phase 0 audits land.** Size depends on findings. Likely 5-15 additional tasks targeting specific gaps in `pnp3/Magnification/*_Partial.lean`, `FinalResult*.lean`, and `pnp4/Pnp4/AlgorithmsToLowerBounds/`.
+- `A01`, `A03`, `A04`, `A05`, `A06` — deferred lower-yield audits; maintainability not shortest-path.
+- `L01`, `L02` — deferred. L01 has bibliographic ID error (`1804.05985` is not Hirahara FOCS 2018); needs rewrite.
+- `B01`, `B02`, `B03` — deferred. B02/B03 are placeholder/`True`-typed wrapper surfaces; B01 lower priority than X01.
+- `K01`, `K02` — deferred. Typed rubrics, not theorem engines.
+- `X02` — deferred until X01 lands AND spec rewritten. Current spec uses `M := fun n => n` which is incompatible with the live `treeMCSPPrefixAmbientLength` convention in `PrefixExtensionLanguageRuntime.lean`.
 
 ### Dependency graph
 
 ```
-Phase 0 (A01-A10): all independent of each other.
-Phase 2 (L01-L02): independent of all.
-Phase 3 (B01-B03): independent of all.
-Phase 4 (K01-K02): K01/K02 independent. Both benefit from A04+A09 landing but don't block.
-Phase 5 (X01-X02): X02 benefits from X01; both independent of A/L/B/K.
-
-NO engineer is blocked on another. All 19 tasks dispatch-able NOW.
-
-Phase 1+ completion tasks dispatched AFTER Phase 0 audits land.
+A02, A07, A08, A09, A10 — all independent markdown audits.
+X01 — independent of all audits; only Lean task this wave.
+No engineer is blocked on another.
 ```
+
+After wave 1 lands and operator synthesizes, wave 2 is an operator decision:
+- **Stop** if audits confirm no hidden shorter route and X01 is the only worthwhile bridge; or
+- **Dispatch rewritten X02** explicitly gated on X01.
 
 ## Acceptance criteria — universal
 
-For every task:
+See `COMMON_WORKER_INSTRUCTIONS.md` §4. Summary:
 
 1. ✅ Files at exact paths specified in the task.
-2. ✅ For Lean tasks: `lake build PnP3 Pnp4` passes; `./scripts/check.sh` passes.
-3. ✅ `rg sorry|admit -g"*.lean" pnp3 pnp4` empty.
-4. ✅ For audit tasks: markdown report at expected path with all required sections.
-5. ✅ For Lean tasks: smoke tests + `#print axioms` entries where applicable.
-6. ✅ PR description uses structured template from COMMON.
-7. ✅ No edits to forbidden files (see COMMON).
+2. ✅ For audit tasks: markdown report at expected path with all required sections.
+3. ✅ For X01: `lake build PnP3 Pnp4` passes; `./scripts/check.sh` passes; `rg "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` empty.
+4. ✅ For X01: smoke test in `AlgorithmsToLowerBoundsSurfaceTests.lean` + `#print axioms` line in `AxiomsAudit.lean`.
+5. ✅ PR description uses structured template from COMMON §12.
+6. ✅ No edits to forbidden files (see COMMON §3.1).
 
-Operator review target: **< 15 minutes per landed task** for Phase 2-5; **< 30 minutes** for Phase 0 audits (longer because audit reports contain more synthesis).
+Operator review target: **~20 minutes per audit PR**, **~45 minutes for X01 PR**.
 
 ## Forbidden scope — universal
 
-See `COMMON_WORKER_INSTRUCTIONS.md`. Summary:
+See `COMMON_WORKER_INSTRUCTIONS.md` §3. Summary:
 
-- No edits to `pnp3/Complexity/Interfaces.lean`, `pnp3/Magnification/UnconditionalResearchGap.lean`, `pnp3/Barrier/*` (trust roots).
-- No edits to existing `pnp3/Magnification/*_Partial.lean`, `FinalResult*.lean`, `AC0*Bridge.lean` files. **Even though Phase 0 audits them, Phase 0 tasks produce markdown reports — NOT Lean edits.** Phase 1+ (separate dispatch) may edit them after operator approval.
-- No `sorry` / `admit` / `axiom` / `opaque` / `Fact` / typeclass-payload in committed Lean.
+- No edits to `pnp3/Complexity/Interfaces.lean`, `pnp3/Complexity/PsubsetPpolyInternal/**`, `pnp3/Magnification/UnconditionalResearchGap.lean`, `pnp3/Barrier/**`, `pnp3/Magnification/AuditRoutes/**`.
+- No edits to existing `pnp3/Magnification/*_Partial.lean`, `FinalResult*.lean`, `AC0*Bridge.lean` files.
+- For X01: no `sorry` / `admit` / `axiom` / `opaque` / `Fact` / typeclass-payload.
 - No `Classical.choose` in core definitions (acceptable in derived proofs if standard exponent extraction; document).
-- No `SourceTheorem_*` / `gap_from_*` / `ResearchGapWitness` / FP-4 / final endpoint / P ≠ NP claim.
+- No `SourceTheorem_*` / `gap_from_*` / `ResearchGapWitness` / `NP_not_subset_PpolyDAG` / `P_ne_NP` claims.
 - No `ProvenanceFilter_v1` promotion.
-- No new NoGoLog entries (operator-side action only).
-
-## Output template — every PR
-
-See `COMMON_WORKER_INSTRUCTIONS.md` §12.
-
-## Operator review process
-
-Each completed task lands as one PR to `main`. Operator:
-
-1. Reads the PR description and verifies the acceptance checklist.
-2. For Phase 0 audits: spot-checks 2-3 file-state claims against repo reality.
-3. For Phase 2-5: spot-checks Lean signatures.
-4. Either merges or requests specific changes.
-5. Phase 0 audits inform the **Phase 1+ dispatch decision**.
-
-Target: 2-3 audits + 1-2 implementation PRs merged per operator-day during active dispatch.
+- No new NoGoLog entries.
 
 ## What this phase does NOT do
 
-* No P-vs-NP proof.
-* No `ResearchGapWitness` construction.
-* No new endpoint or final theorem.
-* No claim that magnification reaches a strong enough lower bound on its own.
+- No P-vs-NP proof.
+- No `ResearchGapWitness` construction.
+- No new endpoint or final theorem.
+- No claim that any audit or X01 advances the math-level bottleneck.
 
-Phase 1 is **strictly infrastructure + repo state mapping**. Its value:
-- Phase 0 audits prevent duplicate work in subsequent dispatches.
-- Phase 2-5 add genuinely missing infrastructure.
-- Phase 1+ (post-audit) completes existing partial work where viable.
+This wave is **operator situational awareness + one resumability bridge**. Nothing more.
 
 ## Re-dispatch / failure protocol
 
@@ -180,23 +132,21 @@ Four sections: What was attempted / Where it broke / Local vs global obstruction
 
 ## Cross-references
 
-* `RESEARCH_CONSTITUTION.md` — overarching discipline.
-* `seed_packs/first_move_search_2026/reports/fp3b_epoch_strategic_retrospective_claudeopus.md` — context for why this phase exists.
-* `seed_packs/polynomial_time_formalism_scoping_D0/reports/D0_four_way_review_and_synthesis_claudeopus.md` — context for X01/X02.
-* `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` — required reading.
+- `RESEARCH_CONSTITUTION.md` — overarching discipline.
+- `seed_packs/phase1_20engineer_parallel_dispatch/AUDIT_2026-05-17_PLAN_REDUCTION.md` — why this wave is reduced.
+- `seed_packs/first_move_search_2026/reports/fp3b_epoch_strategic_retrospective_claudeopus.md` — FP3b context.
+- `seed_packs/polynomial_time_formalism_scoping_D0/reports/D0_four_way_review_and_synthesis_claudeopus.md` — X01 rationale.
+- `seed_packs/phase1_20engineer_parallel_dispatch/COMMON_WORKER_INSTRUCTIONS.md` — required reading.
 
 ## Status header
 
 ```
-Phase: 1 (initial dispatch)
-Engineers: 19 (parallel)
-  - Phase 0 audit: 10
-  - Phase 2 literature: 2
-  - Phase 3 barriers: 3
-  - Phase 4 kill-machine: 2
-  - Phase 5 contract expansion: 2
-Phase 1+ (conditional, post-audit): 5-15 additional tasks
-Estimated wall-clock to complete Phase 1 initial dispatch: 4 weeks (with full parallelism)
-Operator review load Phase 1 initial: ~19 PRs × ~20 min = ~6 operator-hours
-Outcome: complete repo state map + targeted infrastructure additions, ready for Phase 1+ completion dispatches
+Wave: 1 (reduced)
+Engineers: 6 (parallel)
+  - Audits (markdown): 5 (A02, A07, A08, A09, A10)
+  - Lean bridge: 1 (X01)
+Wave 2 status: operator decision after wave 1 synthesis (no pre-commitment)
+Estimated wall-clock: 3 weeks (X01-bound; audits land within 1 week)
+Operator review load: ~5 × 20 min + 1 × 45 min ≈ 2.5 operator-hours
+Outcome: operator-decision-useful snapshot of live theorem surface + one D0-aligned bridge
 ```

--- a/seed_packs/phase1_20engineer_parallel_dispatch/docs/P1P_02L2_operator_review_claudeopus.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/docs/P1P_02L2_operator_review_claudeopus.md
@@ -1,0 +1,230 @@
+# P1P-02L₂ operator review
+
+Task: P1P-02L₂ operator review
+Handle: claudeopus
+Branch: main (review against `a20440c` merged via PR #1330)
+Commit reviewed: `a20440c48432ceec6cc30d123495dd1cc0adaa2f`
+Review file: `seed_packs/phase1_20engineer_parallel_dispatch/docs/P1P_02L2_operator_review_claudeopus.md`
+
+## 1. Executive verdict
+
+**approve_P1P02L2**
+
+The landing is sound. All 7 declarations enumerated in the task scope (`CanonicalRawTreeMCSPPrefixFields`, `natBitBE`, `gammaBit`, `encodeTreeMCSPPrefixFields`, `encodeTreeMCSPPrefixFields_length_convention`, `parseTreeMCSPPrefixInput_length_convention`, `treeMCSPRuntimeAwarePrefixParser`) are present, kernel-checked, computable, and honestly scoped. No NP membership, no source theorem, no R1-C, no theorem-as-field tricks. The `parser_polynomial_time_in_M` field is exposed as a caller-supplied `Prop` parameter — not faked with `True` or `trivial`. The math-level bottleneck (`ResearchGapWitness`) is unchanged.
+
+The one mild wart is the trivial `encodeTreeMCSPPrefixFields_length_convention := by rfl` (literally `X = X`), which adds no information but is correctly documented as a result-type statement. Not a defect.
+
+## 2. What landed
+
+| Name | Kind | Lines | Sound? |
+|---|---|---|---|
+| `CanonicalRawTreeMCSPPrefixFields codec` | structure (5 fields: `n`, `x`, `i`, `prefixLength_le`, `p`) | 115-122 | ✓ — clean separation of raw fields from `PrefixInput`'s arbitrary `tag`/`padBits`/`pad`; obtains the bound `i ≤ codec.witnessBits n` from the struct, not from inversion |
+| `natBitBE (value width : Nat) (j : Fin width) : Bool` | computable def | 125-126 | ✓ — MSB-first big-endian: `j=0` gives bit `2^(width-1)`. Verified by hand: `natBitBE 178 8` = `[1,0,1,1,0,0,1,0]` matches P1P-02 tag `0b10110010` |
+| `gammaBit (n : Nat) (j : Fin (gammaLen n)) : Bool` | computable def with dependent type | 135-145 | ✓ — Elias-gamma MSB-first: `zeros = bitLength(n+1)-1` leading zero bits, then bits of `(n+1)` in `bitLength(n+1)` bits big-endian. Terminator bit at `j=zeros` is automatically `1` because `(n+1) ≥ 2^(bitLength(n+1)-1)` makes its MSB true. Type-cast `rw [hlen] at j` is unusual but standard Lean 4 dependent-Fin pattern; `omega` proof of arithmetic side-condition is fine. |
+| `encodeTreeMCSPPrefixFields codec fields : PrefixBitVec (treeMCSPPrefixM codec fields.n)` | computable def | 156-181 | ✓ — exact P1P-02 layout via nested `if hX : j.1 < ...` dispatchers. Tag/gamma/x/i/p slices reach the correct field encoders. Inactive pad bits (j.1 ≥ pOffset + i) return `false`. Output length is `M(fields.n)` by result type |
+| `encodeTreeMCSPPrefixFields_length_convention` | theorem | 184-189 | ⚠️ **TRIVIAL** — proves `M(fields.n) = M(fields.n)` by `rfl`. Documents result-type length but conveys no algorithmic content. Not a defect; mildly wasteful. |
+| `parseTreeMCSPPrefixInput_length_convention` | theorem | 284-351 | ✓ — case analysis through all 11 success-branch checks of the parser; on success branch extracts `decoded.1 = input.n` definitionally and uses `_hlen` hypothesis directly |
+| `treeMCSPRuntimeAwarePrefixParser` | def of `RuntimeAwarePrefixParser` | 371-385 | ✓ — wires 3 of 4 fields with real content; `parser_polynomial_time_in_M` honestly exposed as caller-supplied `Prop` parameter |
+
+## 3. Scope audit
+
+| Item | Status |
+|---|---|
+| No NP membership theorem | ✓ |
+| No R1-C | ✓ |
+| No `PpolyDAG → BoundedSearchSolver` | ✓ |
+| No `target.noBoundedSolver` contradiction | ✓ |
+| No `VerifiedNPDAGLowerBoundSource` | ✓ |
+| No `ResearchGapWitness` | ✓ |
+| No `SourceTheorem` | ✓ |
+| No `gap_from` | ✓ |
+| No endpoint | ✓ |
+| No P≠NP claim | ✓ |
+| No JSONL/spec/NoGoLog edits | ✓ — only `PrefixParserConvention.lean` + 2 test files modified |
+
+Doc-comments explicitly state infrastructure-only scope: "intentionally just serialization infrastructure: it uses no `Classical.choose`, no noncomputable parser inversion, and no runtime or NP-membership claim" (encoder) and "does not manufacture a `True` runtime proof and does not claim NP membership" (runtime-aware constructor).
+
+## 4. Computability / hidden payload audit
+
+| Check | Status | Note |
+|---|---|---|
+| No `Classical.choose` in encoder/parser | ✓ | Verified by full file read |
+| No `noncomputable` encoder/parser | ✓ | All defs are `def`, not `noncomputable def`. Encoder body uses pure dispatcher with `if hX : ...` decidable propositions |
+| No `axiom` | ✓ | |
+| No `opaque` | ✓ | |
+| No `Fact` / typeclass payload | ✓ | |
+| No `native_decide` | ✓ | |
+| No hidden solver | ✓ | `treeMCSPRuntimeAwarePrefixParser` does not consume or construct a `BoundedSearchSolver` |
+
+The `gammaBit` definition's `rw [hlen] at j; omega` proof of a `Fin`-bound arithmetic side-condition is a legitimate kernel-checked dependent-type maneuver, not a hidden noncomputable construction. `omega` produces decidable arithmetic proofs.
+
+## 5. Encoder audit
+
+| Component | Classification | Notes |
+|---|---|---|
+| `natBitBE` | **sound** | MSB-first convention; produces `Bool` from `Nat`-arithmetic decidable predicate; hand-verified on `treePrefixTag = 178` |
+| `gammaBit` | **sound** | Implements the P1P-02 design: zeros prefix + terminator + payload. The terminator at `j = zeros` falls out of `natBitBE` because MSB of `n+1` is 1. Dependent `Fin` arithmetic via `rw [hlen] at j; omega` is a known-correct Lean 4 pattern. |
+| `encodeTreeMCSPPrefixFields` | **sound** | Layout matches P1P-02 §2 exactly: `tag (8 bits) + gamma(n+1) + x (tableLen n) + i (idxWidth bits) + p (i bits) + zero pad (W(n)−i bits)`. Each branch type-checks via `omega` arithmetic. The fallthrough `else false` covers exactly the inactive pad region `[pOffset + i, M(n))`, which by `fields.prefixLength_le : i ≤ W(n)` has length `W(n) − i ≥ 0`. |
+| Output length | **sound** | `PrefixBitVec (treeMCSPPrefixM codec fields.n)` by result type. Definitional. |
+| Zero pad behavior | **sound** | Inactive region (j.1 ≥ pOffset + fields.i) returns `false`. Matches "pad bits required zero" from P1P-02 §2.7. |
+| Use of `Fin` indices | **sound** | `natBitBE` takes `Fin width`, `gammaBit` takes `Fin (gammaLen n)`, internal sub-field indexers use `Fin (tableLen n)`, `Fin (idxWidth ... n)`, `Fin fields.i`. Type-safe; ready for round-trip equational reasoning in P1P-02L₃. |
+| Match to P1P-02 layout | **sound** | Field order, sizes, MSB convention, zero pad all match P1P-02 design. The `n` field uses Elias-gamma (per P1P-02 §2), not unary or one-hot. |
+
+**Minor encoder observation:** `encodeTreeMCSPPrefixFields_length_convention` is `(M(fields.n)) = M(fields.n) := by rfl`. This is trivially true by reflexivity — the LHS and RHS are literally the same term. The theorem is **documentation of the result type**, not an algorithmic fact. A future P1P-02L₃ may add a more substantive companion theorem (e.g., "parse-encode round-trip preserves canonical fields"), at which point this trivial theorem could be removed or kept as a deprecated alias.
+
+## 6. Length-convention theorem audit
+
+### `parseTreeMCSPPrefixInput_length_convention`
+
+**Statement:** `parseTreeMCSPPrefixInput threshold codec y = some input → m = treeMCSPPrefixM codec input.n`.
+
+**Proof structure** (~60 lines, nested `cases` + `by_cases`):
+
+1. `unfold parseTreeMCSPPrefixInput at h` exposes the `do` block.
+2. 11 levels of `cases` / `by_cases` walking each guard in the parser:
+   - `htagRead`: tag-read success/failure
+   - `htag`: tag equality
+   - `hgamma`: gamma-decode success/failure
+   - `hlen`: ambient-length equality
+   - `hx`: x-slice success/failure
+   - `hiRead`: i-read success/failure
+   - `hi`: i-bound check
+   - `hp`: p-slice success/failure
+   - `hpad`: pad-slice success/failure
+   - `hzero`: zero-pad-check read success/failure
+   - `hz`: zero-pad value equals `true`
+3. On every failure branch: `simp [hX] at h` reduces `h` to `none = some input` and discharges via `at h` contradiction.
+4. On the unique success branch: `cases h` extracts the structure equality `input = {tag := tag, n := decoded.1, ...}`, then `exact hlen` discharges the goal because `input.n = decoded.1` by structure projection.
+
+**Is it soundly proved?** Yes. Every parser branch is handled. The crucial step — that the constructed `PrefixInput` has `input.n = decoded.1` definitionally — is implicit in `cases h` which pattern-matches on the structure constructor.
+
+**Does it really establish `m = treeMCSPPrefixM codec input.n`?** Yes. On success, `hlen : m = treeMCSPPrefixM codec decoded.1` and `input.n = decoded.1`, giving `m = treeMCSPPrefixM codec input.n`.
+
+**Does it depend on hidden assumptions?** No. No `Classical.choose`, no `axiom`, no proof-irrelevance hack, no `sorry`, no `admit`. Pure structural unfolding + decidable case splits + Option-monad simp lemmas. `#print axioms` would show only standard Mathlib axioms (`propext`, `Classical.choice`, `Quot.sound`) inherited from the `PrefixExtensionLanguage` boundary.
+
+**Minor stylistic note:** The proof is verbose but readable. A future cleanup could potentially compress via `simp_all` or a custom tactic, but the explicit case structure documents which parser branch produces which contradiction. Not a defect.
+
+## 7. RuntimeAwarePrefixParser audit
+
+### `treeMCSPRuntimeAwarePrefixParser`
+
+```lean
+def treeMCSPRuntimeAwarePrefixParser
+    (threshold : Nat → Nat)
+    (codec : TreeCircuitWitnessCodec threshold)
+    (parser_polynomial_time_in_M : Prop) :
+    RuntimeAwarePrefixParser ... (treeMCSPPrefixM codec) where
+  parser := treeMCSPConcretePrefixParser threshold codec
+  parser_polynomial_time_in_M := parser_polynomial_time_in_M
+  malformed_inputs_rejected := by
+    intro m y hparse
+    exact parseTreeMCSPPrefixInput_malformed_rejected threshold codec y hparse
+  length_convention_matches_M := by
+    intro m y input hparse
+    exact parseTreeMCSPPrefixInput_length_convention threshold codec y input hparse
+```
+
+| Field | Source | Real / faked |
+|---|---|---|
+| `parser` | `treeMCSPConcretePrefixParser threshold codec` | **real** — wraps the actual computable parser |
+| `parser_polynomial_time_in_M` | function parameter (caller supplied) | **honestly staged** — the constructor takes a `Prop` from the caller and stores it. The constructor itself does NOT inject `True`, `trivial`, or any default proof. Caller is forced to make an explicit choice. |
+| `malformed_inputs_rejected` | proof via `parseTreeMCSPPrefixInput_malformed_rejected` | **real** — discharges via the kernel-checked theorem from P1P-02L |
+| `length_convention_matches_M` | proof via `parseTreeMCSPPrefixInput_length_convention` | **real** — discharges via the kernel-checked theorem from P1P-02L₂ (this PR) |
+
+**Are `malformed_inputs_rejected` and `length_convention_matches_M` real?** Yes. Both fields invoke kernel-checked theorems whose proofs are independent of the wrapper.
+
+**Is `parser_polynomial_time_in_M` honestly staged as a parameter?** Yes. The constructor signature `(parser_polynomial_time_in_M : Prop)` makes the obligation explicit and unavoidable. A caller who wants to use the wrapper must supply this `Prop` themselves; the constructor does not manufacture it.
+
+**Is any runtime field faked with `True` or `trivial`?** No. The constructor refuses to fake. This is the **honest pattern** A11 anti-faking discipline asked for.
+
+**Subtle anti-faking concern (caveat, not defect):** A caller could pass `parser_polynomial_time_in_M := True` and the constructor would accept it. That would create a runtime-aware wrapper with a trivially-true polynomial-time field. However:
+- This is the **caller's** responsibility, not the constructor's. The constructor honestly exposes the obligation.
+- Any future task instantiating this wrapper must be reviewed for whether it supplies a meaningful `Prop`.
+- The current commit does **not** itself instantiate the wrapper — there's no `def myRuntimeAware := treeMCSPRuntimeAwarePrefixParser ... True` in the codebase. The wrapper exists as a constructor only.
+
+This is acceptable: the construct is honest at its definition site, and any misuse downstream would be caught by reviewing the call site.
+
+## 8. Does this unlock P1P-02L₃?
+
+**yes_open_P1P02L3_roundtrip**
+
+All prerequisites for the canonical parse-encode round-trip theorem are in place:
+
+| Prerequisite | Status |
+|---|---|
+| Real computable encoder | ✓ `encodeTreeMCSPPrefixFields` |
+| Real computable parser | ✓ `parseTreeMCSPPrefixInput` (from P1P-02L) |
+| Canonical fields structure decoupled from `PrefixInput` | ✓ `CanonicalRawTreeMCSPPrefixFields` (avoids `prefixLength_le` proof-irrelevance friction my earlier review flagged) |
+| `Fin`-indexed bit encoders | ✓ `natBitBE`, `gammaBit` with dependent `Fin` arguments |
+| Length convention | ✓ `parseTreeMCSPPrefixInput_length_convention` |
+| Trust-root frozen | ✓ all R1-B/B1/B2a files unchanged |
+
+P1P-02L₃ would need to prove:
+1. **Gamma round-trip:** `decodeGamma? (encodeAtOffset (gammaBit n) startOffset) startOffset = some (n, gammaLen n)` for an ambient string where positions `[startOffset, startOffset + gammaLen n)` are written via `gammaBit n`.
+2. **`natBitBE` round-trip:** `readNatBE (encodeAtOffset (natBitBE value width) startOffset) startOffset width = some value` for an ambient string with the `natBitBE`-encoded value at the right offset.
+3. **Slice round-trip:** for a field encoded via `fields.x : PrefixBitVec (tableLen n)` placed at offset `xOffset`, `sliceBits? (encoded) xOffset (tableLen n) = some fields.x` (extensional equality argument over `Fin`).
+4. **Main theorem:** `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields) = some <canonical_input_from_fields>` where `<canonical_input_from_fields>` is the `PrefixInput` constructed canonically from `fields`.
+
+The `prefixLength_le` proof-irrelevance friction my earlier review predicted is **mitigated** by `CanonicalRawTreeMCSPPrefixFields`: the encoder takes a struct that already carries the bound, and the parser produces a `PrefixInput` whose `prefixLength_le` is `hi` (the decoded check). Round-trip equality at this field reduces to showing both bounds prove the same `Prop` proposition, which is automatic by `Subsingleton.elim` for `Prop` proofs.
+
+**Estimated difficulty:** medium-high. ~200-400 LOC. The gamma round-trip lemma is the most complex sub-proof; the rest is mechanical. No API blocker, no governance gate, no math-research dependency.
+
+## 9. Recommended next action
+
+**open_P1P02L3_roundtrip**
+
+Dispatch one Lean worker on **P1P-02L₃ — canonical parse-encode round-trip** against the merged `a20440c`. Specific scope:
+
+1. **Add auxiliary lemmas** to `PrefixParserConvention.lean`:
+   - `natBitBE_readNatBE_round_trip`: for an ambient string with `natBitBE value width`-pattern at offset, `readNatBE` recovers `value`.
+   - `gammaBit_decodeGamma_round_trip`: for an ambient string with `gammaBit n`-pattern at offset, `decodeGamma?` returns `some (n, gammaLen n)`.
+   - `sliceBits_encode_round_trip`: encoder slice equals the original field bit-for-bit.
+   - `allZeroSlice_pad_zero`: the zero-pad region encoded via the `else: false` branch satisfies `allZeroSlice? = some true`.
+2. **Prove main theorem:**
+   ```
+   theorem parseTreeMCSPPrefixInput_encode_round_trip
+       (threshold : Nat → Nat) (codec : TreeCircuitWitnessCodec threshold)
+       (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+       parseTreeMCSPPrefixInput threshold codec
+         (encodeTreeMCSPPrefixFields codec fields)
+       = some (canonicalInputOfFields codec fields)
+   ```
+   where `canonicalInputOfFields` is a new computable helper that builds the `PrefixInput` from a `CanonicalRawTreeMCSPPrefixFields`.
+3. **Optional follow-up theorem:** a `Subsingleton.elim`-based extensional equality showing that any `PrefixInput` produced by parsing an encoder output is equal to the canonical one constructed from the raw fields.
+4. **Surface tests** + `#print axioms` entries for new theorems.
+
+**Explicit forbidden scope** for the P1P-02L₃ worker (same as P1P-02L and L₂):
+- No `PrefixExtensionLanguage_in_NP`
+- No `parser_polynomial_time_in_M` instantiation
+- No `RuntimeAwareTreeCircuitCodec` / `TreeMCSPPrefixRuntimeBudget` full instantiation
+- No `SearchMCSPMagnificationContract` field discharge
+- No `ResearchGapWitness`, no `VerifiedNPDAGLowerBoundSource`, no source theorem
+- No `Classical.choose` in any new parser-side or encoder-side definition
+- No JSONL/spec/known_guards/NoGoLog edits
+- The trivial `encodeTreeMCSPPrefixFields_length_convention` may be retained or removed; if removed, document why (mild deprecation).
+
+After P1P-02L₃ lands, the parser convention surface is complete. Next operator decision is whether to attempt X01 (PolyTimeVerifierSpec) with anti-faking design review, or pause engineering and recognize the math-level gap. P1P-02L₃ itself does not change the math-level bottleneck.
+
+## Commands run
+
+| Command | Result |
+|---|---|
+| `git log --oneline -5` | confirmed `a20440c` is HEAD on main containing P1P-02L₂ |
+| `wc -l pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` | 391 lines (was 202 after P1P-02L; +189 lines for P1P-02L₂, matches PR #1330 description of 188 lines added) |
+| Full file read | confirmed no `sorry`, `admit`, `axiom`, `opaque`, `Fact`, `Classical.choose`, `noncomputable`, `native_decide` introduced by P1P-02L₂ |
+| `lake build PnP3 Pnp4` | **not run** (review-only; trust upstream PR check that built green per #1330 description) |
+| `./scripts/check.sh` | **not run** (review-only; trust upstream PR check) |
+| `rg -n "\bsorry\b\|\badmit\b" -g"*.lean" pnp3 pnp4` | **not run** (review-only; trust upstream PR check) |
+
+## Scope violations
+
+none
+
+## Honest caveats
+
+- I trusted the upstream PR's claim that `lake build PnP3 Pnp4` and `./scripts/check.sh` pass on the merged commit. I did not re-execute these.
+- The `gammaBit` correctness audit was structural (verified that zero-prefix + terminator + payload structure is correct), not via exhaustive proof. Hand-verification was done for `treePrefixTag = 178` to confirm `natBitBE` MSB convention.
+- The trivial `encodeTreeMCSPPrefixFields_length_convention := by rfl` was flagged as a minor wart but not a defect. It's correct (LHS = RHS by definition). A more substantive companion theorem (encoder length matches the canonical raw fields' `n`) is implicit in the result type.
+- I did not exhaustively verify every `omega` arithmetic step inside `encodeTreeMCSPPrefixFields`'s nested `if hX : ...` dispatchers. `omega` is decidable and produces kernel-checked proofs, so the only failure mode would be an unsatisfiable goal — which `lake build` would catch.
+- The "subtle anti-faking concern" about callers passing `parser_polynomial_time_in_M := True` to the runtime-aware wrapper is acknowledged as a caveat (caller responsibility), not a defect (constructor honesty). The current commit does not itself misuse the wrapper.
+- A second adversarial review by a different handle would strengthen confidence in the encoder/parser layout match against P1P-02 §2, especially around the `idxWidth(codec.witnessBits n)` field width when `codec.witnessBits n = 0`. The current code has `idxWidth W n := bitLength (W n)` which gives `idxWidth ... = 0` when `W n = 0`, yielding an empty i-field — consistent with P1P-02 §2.7 ("If `W(n) = 0`, this field is empty and decodes to `0`"). I did not trace this edge case through the encoder/parser explicitly.

--- a/seed_packs/phase1_20engineer_parallel_dispatch/docs/P1P_02L_operator_review_claudeopus.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/docs/P1P_02L_operator_review_claudeopus.md
@@ -1,0 +1,215 @@
+# P1P-02L operator review
+
+Task: P1P-02L operator review
+Handle: claudeopus
+Branch: main (review runs against `d100d33` merged via PR #1323)
+Commit reviewed: `d100d335337e83aec453dc30bb54bde06f7a4b79`
+Review file: `seed_packs/phase1_20engineer_parallel_dispatch/docs/P1P_02L_operator_review_claudeopus.md`
+
+## 1. Executive verdict
+
+**approve_P1P02L**
+
+The landing is sound. It is the first **real computable** parser in the contract-expansion track and is honestly scoped: no R1-C, no `PrefixExtensionLanguage_in_NP`, no source-theorem promotion, no theorem-as-field tricks. The missing theorems (`length_convention`, `encode`, canonical round-trip) are local proof-engineering follow-ups that are well-defined against the real parser body; they do not indicate a faulty landing.
+
+The math-level bottleneck (non-vacuous `ResearchGapWitness`) is unchanged. This is contract-expansion infrastructure, not P≠NP progress.
+
+## 2. What landed
+
+| Name | Kind | Sound? |
+|---|---|---|
+| `treePrefixTag : Nat := 178` | def, constant | ✓ |
+| `tagLen : Nat := 8` | def, constant | ✓ |
+| `bitLength : Nat → Nat` | def, `if n=0 then 0 else Nat.log2 n + 1` | ✓ |
+| `gammaLen (n : Nat) : Nat := 2 * bitLength (n+1) - 1` | def | ✓ (matches P1P-02) |
+| `idxWidth (W : Nat → Nat) (n : Nat) : Nat := bitLength (W n)` | def | ✓ (note: takes `W : Nat → Nat`, not the codec; call site uses `idxWidth codec.witnessBits n`) |
+| `treeMCSPPrefixM codec n` | def | ✓ matches P1P-02: `tagLen + gammaLen n + tableLen n + idxWidth(codec, n) + witnessBits n` |
+| `readBit? y offset : Option Bool` | computable def | ✓ |
+| `readNatBE y offset width : Option Nat` | computable def, big-endian MSB-first | ✓ |
+| `sliceBits? y offset width : Option (PrefixBitVec width)` | computable def, dependent slice | ✓ |
+| `allZeroSlice? y offset width : Option Bool` | computable def | ✓ |
+| `decodeGammaAux? y offset fuel zeros : Option (Nat × Nat)` | computable def, structural recursion on `fuel` | ✓ |
+| `decodeGamma? y offset := decodeGammaAux? y offset (m+1) 0` | computable def | ✓ (fuel bound `m+1` is safe; any valid gamma code at offset `≤ m` has length `≤ m`) |
+| `CanonicalTreeMCSPPrefixInput codec input` | Prop predicate (conjunction of 4 conditions) | ✓ |
+| `parseTreeMCSPPrefixInput threshold codec y : Option (PrefixInput ... m)` | **computable** def using `do` monad | ✓ |
+| `treeMCSPConcretePrefixParser threshold codec : PrefixParser ...` | def, packages `parseTreeMCSPPrefixInput` into R1-B `PrefixParser` interface | ✓ |
+| `tableLen_le_treeMCSPPrefixM` | theorem, by `unfold; omega` | ✓ |
+| `parseTreeMCSPPrefixInput_bad_tag` | theorem, by `simp` | ✓ (narrow: assumes tag was successfully read) |
+| `parseTreeMCSPPrefixInput_malformed_rejected` | theorem, instantiates `PrefixExtensionLanguage_rejects_malformed` | ✓ |
+
+Surface-test wrappers and `#print axioms` entries added to `AlgorithmsToLowerBoundsSurfaceTests.lean` and `AxiomsAudit.lean`.
+
+## 3. Scope audit
+
+| Item | Status |
+|---|---|
+| No R1-C | ✓ |
+| No `PrefixExtensionLanguage_in_NP` | ✓ |
+| No `PpolyDAG → BoundedSearchSolver` | ✓ |
+| No `target.noBoundedSolver` | ✓ |
+| No `VerifiedNPDAGLowerBoundSource` | ✓ |
+| No `ResearchGapWitness` | ✓ |
+| No `SourceTheorem` | ✓ |
+| No `gap_from` | ✓ |
+| No endpoint | ✓ |
+| No P≠NP claim | ✓ |
+| No JSONL/spec/known_guards edits | ✓ (only `lakefile.lean` Glob line + 2 test files) |
+
+All scope discipline preserved. The doc-comment on `parseTreeMCSPPrefixInput` explicitly states "It does not assert any polynomial-time verifier theorem or NP-membership result."
+
+## 4. Computability / hidden payload audit
+
+| Check | Status | Note |
+|---|---|---|
+| Parser is computable | ✓ | `def parseTreeMCSPPrefixInput ... := do ...` over `Option` monad |
+| No `Classical.choose` | ✓ | None present in this file |
+| No `noncomputable` parser | ✓ | All helpers and the main parser are `def`, not `noncomputable def` |
+| No `axiom` | ✓ | |
+| No `opaque` | ✓ | |
+| No `Fact` / typeclass payload | ✓ | |
+| No `native_decide` | ✓ | |
+| No hidden solver | ✓ | Parser does not construct or consume a `BoundedSearchSolver` |
+
+All decidability conditions inside the `do` block (`tag = treePrefixTag`, `m = treeMCSPPrefixM codec n`, `i ≤ codec.witnessBits n`, `padZero = true`) are kernel-decidable (`Nat.decEq`, `Nat.decLe`, `Bool` decEq), so the parser is genuinely computable, not "computable in spirit".
+
+The consumed `PrefixExtensionLanguage` itself remains `noncomputable` (via `classical`), but that is part of R1-B's accepted boundary; the parser does not introduce new noncomputability.
+
+## 5. Parser semantics audit
+
+| Step | Description | Classification |
+|---|---|---|
+| 1. tag check | Read first 8 bits as MSB-first big-endian unsigned natural; reject unless equal to `treePrefixTag = 178` | **sound** |
+| 2. gamma decode | `decodeGamma? y tagLen` starting at offset 8; returns `(n, consumedGamma)` | **sound** with caveat: parser uses `consumedGamma` returned by decoder rather than recomputing `gammaLen n`. By construction of `decodeGammaAux?`, on success `consumedGamma = 2*zeros + 1` where `zeros = bitLength(n+1) - 1`, so `consumedGamma = gammaLen n`. **needs proof follow-up** to make this lemma explicit when proving length_convention. |
+| 3. ambient length check | `if _hlen : m = treeMCSPPrefixM codec n` | **sound** |
+| 4. x slicing | `sliceBits? y xOffset (tableLen n)` at `xOffset = tagLen + consumedGamma` | **sound** modulo `consumedGamma = gammaLen n` lemma |
+| 5. i decode | `readNatBE y iOffset (idxWidth codec.witnessBits n)` | **sound** |
+| 6. `i ≤ witnessBits n` check | `if hi : i ≤ codec.witnessBits n` | **sound** — this exact `hi` is used as the `prefixLength_le` field of the returned `PrefixInput`, preserving type safety |
+| 7. p slicing | `sliceBits? y pOffset i` | **sound** |
+| 8. pad slicing | `sliceBits? y padOffset padWidth` where `padWidth = codec.witnessBits n - i` | **sound** |
+| 9. all-zero pad check | `allZeroSlice? y padOffset padWidth` then `if _hpad : padZero = true` | **sound** but mildly redundant: the same bits are read by both `sliceBits?` (for `pad` value) and `allZeroSlice?` (for the check). Functionally correct; minor inefficiency. |
+| 10. PrefixInput construction | All fields filled with their dependent values | **sound** (depends crucially on `_hlen`, `hi`, and the slicing bounds for type checking) |
+
+**Minor observation:** `pad` is constructed as the slice value from step 8, and `padZero` is enforced separately. Step 9 could be folded into step 8 if a future cleanup wants to avoid re-reading the same bytes, but this is not a correctness issue.
+
+**No semantic bugs detected.** The parser implements exactly the P1P-02 convention.
+
+## 6. Theorem soundness audit
+
+### `tableLen_le_treeMCSPPrefixM`
+
+| Check | Status |
+|---|---|
+| Statement matches P1P-02 intent | ✓ — directly states `tableLen n ≤ M(n)` |
+| Proof soundness | ✓ — `unfold treeMCSPPrefixM; omega` over a definitional sum of `Nat`s; trivially valid |
+| Useful for `TreeMCSPPrefixRuntimeBudget` | ✓ — directly discharges `tableLen_le_M : ∀ n, tableLen n ≤ M n` field when the budget is instantiated with `M := treeMCSPPrefixM codec` |
+| Useful for `RuntimeAwarePrefixParser` | indirect (no field of this name there, but enables future polynomial bounds) |
+
+### `parseTreeMCSPPrefixInput_bad_tag`
+
+| Check | Status |
+|---|---|
+| Statement matches P1P-02 intent | ✓ — explicit malformed-tag rejection |
+| Proof soundness | ✓ — `simp [parseTreeMCSPPrefixInput, htag, hbad]` unfolds the do-bind and reduces the `if` on `tag = treePrefixTag` to `false` |
+| Useful as a building block | partial — narrow to the case where `readNatBE` already succeeded. Does not cover `m < 8` case (where `readNatBE` itself returns `none` and the do-bind short-circuits). Both cases are necessary for a full "wrong tag ⟹ none" lemma; this PR only covers half. **Minor gap.** |
+
+The narrow case is what's actually needed for the malformed-rejection chain (since the `m < 8` case is already covered by the do-bind short-circuit at the level of `readNatBE`), so this is not a defect — but a future cleanup could add `parseTreeMCSPPrefixInput_short_input` for completeness.
+
+### `parseTreeMCSPPrefixInput_malformed_rejected`
+
+| Check | Status |
+|---|---|
+| Statement matches P1P-02 intent | ✓ — exactly the parser-failure ⟹ language-rejection arrow |
+| Proof soundness | ✓ — directly applies `PrefixExtensionLanguage_rejects_malformed` from `PrefixExtensionLanguage.lean` |
+| Useful for `TreeMCSPPrefixRuntimeBudget` | ✓ — directly discharges the `malformed_inputs_rejected` field |
+| Useful for `RuntimeAwarePrefixParser` | ✓ — same field name |
+
+Strongest of the three theorems by reuse value. Cleanly composes with R1-B abstract infrastructure.
+
+## 7. Missing theorem audit
+
+### A. `parseTreeMCSPPrefixInput_length_convention`
+
+**Statement:** `parse y = some input → m = treeMCSPPrefixM codec input.n`
+
+- **Local proof engineering?** Yes. Case analysis on the parser's `do` block: on every success branch, the parser explicitly checks `_hlen : m = treeMCSPPrefixM codec n` and assigns `input.n := n`, so the equation holds definitionally on success. Requires one auxiliary lemma `decodeGamma?_success_consumedGamma : decodeGamma? y offset = some (n, c) → c = gammaLen n` (already true by the structure of `decodeGammaAux?`).
+- **Global type/API blocker?** None. The R1-B `PrefixParser` interface and `RuntimeAwarePrefixParser.length_convention_matches_M` field type signatures already accept exactly this statement.
+- **Likely next task?** Yes. Should be P1P-02L₂ step 1.
+- **Estimated difficulty:** medium. ~50-100 lines: one helper lemma for the gamma decoder, then a case-split on the parser body.
+
+### B. `encodeTreeMCSPPrefixInput`
+
+**Need:** computable `encode : PrefixInput → PrefixBitVec (treeMCSPPrefixM codec input.n)` (or similar dependent shape).
+
+- **Local proof engineering?** Mostly. Requires defining a few new helpers: `natField` (or `natMSBBits` — already prototyped in closed PR #1326), `gammaField` (Elias-gamma bits for `n+1` — already prototyped in closed PR #1324 line 78-86), then a field-by-field encoder via `match` on bit positions.
+- **Global type/API blocker?** None. The `PrefixBitVec m := AlgorithmsToLowerBounds.BitVec m` is just `Fin m → Bool`, so encoding is a `fun j => ...` with a case-split on `j.val`'s position within field boundaries.
+- **Likely next task?** Yes. Should be P1P-02L₂ step 2. Reference design: closed PR #1324 (real `encodeTreeMCSPPrefixInput` via match on bit positions, lines 88-119 of that diff) and closed PR #1326 (slice readers + MSB bit helpers, lines 73-104 of that diff).
+- **Estimated difficulty:** medium-low. ~80-150 lines.
+
+### C. Parse-encode canonical round-trip
+
+**Statement:** for `input` satisfying `CanonicalTreeMCSPPrefixInput codec input`, `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixInput input) = some input`.
+
+- **Local proof engineering?** Yes. Walks the parser body step by step:
+  1. `readNatBE` on the tag field of the encoding recovers `treePrefixTag` (encoder MSB-first ↔ decoder MSB-first).
+  2. `decodeGamma?` on the gamma field of the encoding recovers `(input.n, gammaLen input.n)` — this is the hardest sub-lemma; requires showing `decodeGammaAux?` correctly walks the unary-then-payload structure.
+  3. `sliceBits?` on the x/p/pad slices recovers the bit-vector exactly (encoder writes, decoder reads — should be a Fin-extensionality argument).
+  4. `readNatBE` on the i field recovers `input.i` (same MSB-first round-trip as tag).
+  5. `allZeroSlice?` on the pad slice returns `true` (because canonical inputs require pad bits zero).
+  6. Final `PrefixInput` constructor reproduces all fields of `input` (this is where the structure-extensionality of `PrefixInput` matters; needs `prefixLength_le` proof irrelevance).
+- **Global type/API blocker?** None expected, but **proof irrelevance of dependent fields** (`prefixLength_le : input.i ≤ codec.witnessBits input.n`) might require either `Subsingleton`-based reasoning or `cast`-with-`Eq.refl`-irrelevance, which can be tedious in Lean 4. This is the only place where Lean friction might significantly inflate the estimate.
+- **Likely next task?** Yes. Should be P1P-02L₂ step 3.
+- **Estimated difficulty:** medium-high. ~150-300 lines depending on `prefixLength_le` proof-irrelevance friction. The gamma decoder round-trip is the most non-trivial sub-lemma; the rest is mechanical.
+
+**Total P1P-02L₂ estimate:** 2-4 days of focused Lean engineering, ~400-600 lines of Lean, no math content beyond what's already in P1P-02.
+
+## 8. Does this unlock P1P-02L₂?
+
+**yes_open_P1P02L2**
+
+All three follow-ups are local proof engineering against a real parser, with no API blocker, no governance gate, no out-of-scope dependency, no math-research dependency. The encoder design has prototypes in closed PRs #1324 and #1326 that can be referenced. The length_convention theorem follows directly from the parser body's `_hlen` check.
+
+## 9. Recommended next action
+
+**open_P1P02L2_length_encoder_roundtrip**
+
+Dispatch one Lean worker on `P1P-02L₂ — encoder + length convention + canonical round-trip` against the merged `d100d33`. Specific scope:
+
+1. **Add** `natMSBBits : (width value : Nat) → PrefixBitVec width` and `gammaField : (n : Nat) → PrefixBitVec (gammaLen n)` helpers (or refer to closed PR #1326's `natMSBBit`/`natMSBBits`/`gammaBits` definitions for the design template).
+2. **Add** computable `encodeTreeMCSPPrefixInput : PrefixInput ... m → PrefixBitVec m` (gated on `CanonicalTreeMCSPPrefixInput` or providing an alternative `encodeTreeMCSPPrefixCanonical` taking raw `(n, x, i, h_i, p)` tuple — see closed PR #1324 line 88-119 for prototype).
+3. **Prove** `parseTreeMCSPPrefixInput_length_convention`. Add an auxiliary lemma `decodeGammaAux?_success_consumedGamma_eq_gammaLen` first.
+4. **Prove** canonical round-trip `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixInput input) = some input` for canonical inputs.
+5. **Wire** the new theorems through `RuntimeAwarePrefixParser.length_convention_matches_M` and `TreeMCSPPrefixRuntimeBudget.length_convention_matches_M` field instantiations, but only as derived definitions — do **not** instantiate the budget fully (other staged runtime fields stay `Prop` obligations).
+
+**Explicit forbidden scope** for the P1P-02L₂ worker (same as P1P-02L):
+- No `PrefixExtensionLanguage_in_NP`
+- No `parser_polynomial_time_in_M` instantiation (that needs X01-style polynomial-time formalism)
+- No `RuntimeAwareTreeCircuitCodec` / `TreeMCSPPrefixRuntimeBudget` full instantiation
+- No `SearchMCSPMagnificationContract` field discharge
+- No `ResearchGapWitness`, no `VerifiedNPDAGLowerBoundSource`, no source theorem
+- No `Classical.choose` in any parser-side definition (keep parser computable)
+- No JSONL/spec/known_guards/NoGoLog edits
+
+## Commands run
+
+| Command | Result |
+|---|---|
+| `git log --oneline -5` | confirmed `d100d33` is HEAD on main containing P1P-02L; consistent with claimed commit SHA |
+| `wc -l pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` | 202 lines (matches PR #1323 description) |
+| `grep -E "axiom\|sorry\|admit\|noncomputable\|opaque\|native_decide\|Classical.choose" pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` | no matches (full file read confirms; only `Classical`-free `def`s and theorems) |
+| `lake build PnP3 Pnp4` | **not run** (review-only; trust upstream PR check that built green per #1323 description) |
+| `./scripts/check.sh` | **not run** (review-only; trust upstream PR check) |
+| `rg -n "\bsorry\b\|\badmit\b" -g"*.lean" pnp3 pnp4` | **not run** (review-only; trust upstream PR check) |
+
+The three build/audit commands were not re-executed as part of this review since the PR was already merged with `lake build` green per the PR description. If the operator wants independent re-verification, the standard `./scripts/check.sh` invocation suffices.
+
+## Scope violations
+
+none
+
+## Honest caveats
+
+- I trusted the upstream PR's claim that `lake build PnP3 Pnp4` and `./scripts/check.sh` pass on the merged commit. I did not re-execute these.
+- The audit of `decodeGammaAux?` correctness (specifically, that `consumedGamma = gammaLen n` on success and that `decodeGamma?` correctly decodes any well-formed gamma code) was structural, not by exhaustive proof. The lemma needed for P1P-02L₂ length_convention will provide the kernel-checked confirmation.
+- I did not audit whether the parser's pad-zero check is semantically equivalent to the `CanonicalTreeMCSPPrefixInput` pad-zero predicate. The connection is intuitively clear (parser checks ambient bits at `padOffset..padOffset+padWidth` are zero; `CanonicalTreeMCSPPrefixInput` requires `input.pad k = false` for `k : Fin padBits`), but a fully proven `parser_success → canonical` lemma would make this rigorous. It is not currently part of P1P-02L's surface; it is implicit in the future round-trip theorem of P1P-02L₂.
+- The narrow scope of `parseTreeMCSPPrefixInput_bad_tag` (assuming tag was successfully read) is a minor coverage gap but not a defect, since the `m < 8` case is handled by the do-bind short-circuit in the parser body.
+- This review is the synthesis of one operator pass. A second adversarial review by a different handle would tighten the audit of the gamma decoder's edge cases (e.g., what happens at offset boundaries near `m`).

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A01_audit_pnp3_magnification_partial.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A01_audit_pnp3_magnification_partial.md
@@ -1,5 +1,11 @@
 # A01: Audit `pnp3/Magnification/*_Partial.lean`
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: lower-yield audit; the `_Partial` files are largely covered by the
+> cross-cutting marker inventory A10, and partial-route consumption is covered
+> by A02. Not on the shortest path to wave-1 objectives.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** A01 | **Phase:** 0 — Repo audit | **Estimated:** 1 week | **Difficulty:** medium | **Type:** markdown-only
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A03_audit_pnp3_ac0_bridges.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A03_audit_pnp3_ac0_bridges.md
@@ -1,5 +1,10 @@
 # A03: Audit `pnp3/Magnification/AC0*.lean` + `Asymptotic*Collapse.lean`
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: scope overlap with A07 (`pnp4/Pnp4/AlgorithmsToLowerBounds/`) and A08
+> (`pnp4/Pnp4/Frontier/`), both of which already cover AC⁰/MCSP/bridge surfaces.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** A03 | **Phase:** 0 | **Estimated:** 1 week | **Difficulty:** medium | **Type:** markdown-only
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A04_audit_pnp3_barrier.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A04_audit_pnp3_barrier.md
@@ -1,5 +1,10 @@
 # A04: Audit `pnp3/Barrier/`
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: only 4 trust-root files (~200 LOC); minimal audit yield; deferred barrier
+> tasks B01-B03 are also deferred this wave so the audit has no consumer.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** A04 | **Phase:** 0 | **Estimated:** 3 days | **Difficulty:** low-medium | **Type:** markdown-only
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A05_audit_pnp3_lowerbounds.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A05_audit_pnp3_lowerbounds.md
@@ -1,5 +1,11 @@
 # A05: Audit `pnp3/LowerBounds/`
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: `_Partial` files are largely covered by A10's cross-cutting inventory;
+> deeper audit of LowerBounds is maintainability not shortest-path. Re-evaluate
+> after wave-1 synthesis if AC⁰[p] routes become critical.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** A05 | **Phase:** 0 | **Estimated:** 1 week | **Difficulty:** medium | **Type:** markdown-only
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A06_audit_pnp3_models_complexity.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A06_audit_pnp3_models_complexity.md
@@ -1,5 +1,11 @@
 # A06: Audit `pnp3/Models/` + non-trust-root `pnp3/Complexity/`
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: broad audit of model + complexity layers; valuable for maintainability
+> but not shortest-path to wave-1 objectives. Trust-root files in `pnp3/Complexity/`
+> are already protected by build invariants.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** A06 | **Phase:** 0 | **Estimated:** 1 week | **Difficulty:** medium | **Type:** markdown-only
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A11_wave1_synthesis.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/A11_wave1_synthesis.md
@@ -1,0 +1,198 @@
+# A11: Synthesis of wave 1 audits (A01–A10) — operator decision memo
+
+**Engineer:** A11 | **Wave:** 1 — Synthesis (post-audit) | **Estimated:** 1 week | **Difficulty:** medium-high | **Type:** markdown-only
+
+## Goal
+
+Read all 10 wave-1 audit reports (A01–A10) and produce **one operator-decision memo** that synthesizes them into:
+
+1. A repo-wide map of what is kernel-checked vs staged vs refuted vs legacy.
+2. A consolidated **cross-cutting recommendations list** with priorities.
+3. A clear **wave-2 decision matrix**: which (if any) of L/B/K/X tracks should be reactivated, in what order, with what scope rewrites, and why.
+4. An honest verdict on whether engineering wave 1 has changed the operator's understanding of the math-level bottleneck (`ResearchGapWitness` source).
+
+This is the **gating task** before any L/B/K/X dispatch. Until A11 lands and the operator decides, no wave-2 dispatch happens.
+
+## Source material — required reading
+
+All 10 wave-1 audit reports under `seed_packs/phase1_20engineer_parallel_dispatch/audit_reports/`:
+
+* `A01_pnp3_magnification_partial_codex.md` (466 lines, codex)
+* `A02_pnp3_finalresult_auditor.md` (493 lines, auditor)
+* `A03_pnp3_ac0_bridges_gpt55.md` (470 lines, gpt55)
+* `A04_pnp3_barrier_gpt55.md` (598 lines, gpt55)
+* `A05_pnp3_lowerbounds_codex.md` (372 lines, codex)
+* `A06_pnp3_models_complexity_codex.md` (568 lines, codex)
+* `A07_pnp4_algorithmstolowebounds_codex.md` (581 lines, codex)
+* `A08_pnp4_frontier_codex.md` (568 lines, codex)
+* `A09_nogolog_formal_witnesses_codex.md` (312 lines, codex)
+* `A10_partial_legacy_markers_codex.md` (1,266 lines, codex)
+
+Plus the original deferred-task files (`tasks/L01..L02`, `B01..B03`, `K01..K02`, `X01..X02`) and the reduction memo (`AUDIT_2026-05-17_PLAN_REDUCTION.md`) to understand what was deferred and why.
+
+Plus trust-root files (read-only): `pnp3/Complexity/Interfaces.lean`, `pnp3/Magnification/UnconditionalResearchGap.lean`, `pnp3/Barrier/*`.
+
+Total reading volume: ~5,700 lines of audit markdown + design memos. Plan for a real week of close reading; do not skim.
+
+## Deliverable
+
+```
+seed_packs/phase1_20engineer_parallel_dispatch/audit_reports/A11_wave1_synthesis_<handle>.md
+```
+
+**One file, markdown only.** No Lean edits, no NoGoLog edits, no trust-root touches.
+
+### Required sections
+
+#### 1. Executive verdict (1 paragraph + 1 sentence)
+
+One of: `WAVE_1_COMPLETE_NO_NEW_ROUTE` / `WAVE_1_COMPLETE_NEW_DIRECTION_FOUND` / `WAVE_1_REVEALS_ENGINEERING_GAPS_FIRST` / `WAVE_1_INCOMPLETE_NEEDS_RE_DISPATCH`.
+
+Followed by one sentence stating whether the math-level bottleneck (non-vacuous `ResearchGapWitness` source) is closer, unchanged, or further away after wave 1.
+
+#### 2. Cross-audit consensus map
+
+For each architectural area (Magnification, FinalResult, AC0 bridges, LowerBounds, Models/Complexity, AlgorithmsToLowerBounds, Frontier/ContractExpansion, NoGoLog), summarize the consensus or disagreement across the audit reports that touch it. Use a table:
+
+| Area | A01 | A02 | A03 | A04 | A05 | A06 | A07 | A08 | A09 | A10 | Consensus |
+
+Mark cells with one of: `none` / `summary` / `kernel-checked` / `staged` / `refuted` / `legacy` / `hotspot`. The Consensus column is a 1-2 sentence synthesis.
+
+#### 3. Refuted / vacuous / legacy quarantine inventory
+
+Cross-cutting list of every refuted / vacuous / legacy route flagged in two or more audits. For each, list:
+- declaration name(s)
+- audit reports that flag it
+- recommended action: `keep quarantined` / `rename` / `add guard test` / `delete after migration` / `operator decision`
+
+This should at minimum address:
+- `FormulaSupportRestrictionBoundsPartial` and `_of_old` migration bridges (A01, A03)
+- `FormulaSemanticMultiSwitchingProvider` and singleton-route internal provider (A03)
+- `Vacuous_P_ne_NP_via_*` and `VacuousFinalPayloadProvider` (A02)
+- `MagnificationAssumptions` legacy support-bounds carrier (A02)
+- Default/`hasDefault*` provider flags (A01, A03, A10)
+- Stale NoGoLog anchors NOGO-000002/000004/000005 and the `needs_review` entry NOGO-000003 (A09)
+- `LegacyStraight*` naming in pnp3/Complexity (A06)
+- `FailedRoute_*` modules in pnp3/LowerBounds (A05)
+
+#### 4. Math-level bottleneck status
+
+For each of the following candidate paths to a non-vacuous `ResearchGapWitness`, classify as:
+- `path closed` (audit shows no traction or formally refuted)
+- `path open with known mathematical content` (e.g., real lower-bound theorem still needed)
+- `path open with engineering content` (e.g., bridge or adapter still needed but math content exists)
+- `path unclassified` (insufficient evidence in wave 1)
+
+Candidate paths:
+1. AC0/locality → formula/real separation → DAG (per A03 / A01)
+2. Anti-checker → asymptotic locality/IsoStrongRoute → DAG (per A02)
+3. Search-MCSP magnification → DAG (per A07 / A08)
+4. Contract-expansion / prefix-extension language → NP_TM → DAG (per A08)
+5. AC0[p] / coin lower bounds → restricted P/poly source → DAG (per A07)
+6. Fixed-slice / fixedParams + uniformProvenance (per A02, A10)
+7. Pich-Santhanam unprovability (per L02 deferral)
+8. Hirahara search-to-decision MCSP (per L01 deferral)
+
+State which (if any) path is most promising for further investigation given current repository state.
+
+#### 5. Wave-2 decision matrix
+
+For each of the 8 deferred tasks (L01, L02, B01, B02, B03, K01, K02, X02) plus X01 (still pending), make a recommendation:
+
+| Task | Current status | Wave-1 evidence | Recommendation | Conditions |
+
+Recommendations must be one of:
+- `DISPATCH wave 2` (and state in what order and with what scope changes)
+- `DISPATCH after spec rewrite` (state what rewrite)
+- `DEFER beyond wave 2` (state the dependency that would unlock it)
+- `CANCEL` (state why audit evidence kills the task)
+
+X01 is a special case: it is the only narrow engineering bridge endorsed by D0 scoping. State whether the audits provide a reason to dispatch it now, dispatch it conditionally, or cancel/rewrite it.
+
+#### 6. Cross-cutting operator-decision items
+
+Consolidated list of every actionable, markdown-only or low-risk Lean cleanup task surfaced by the 10 audits. Prioritize: H (high, blocks wave-2 quality) / M (medium, improves hygiene) / L (low, nice to have).
+
+At minimum address:
+- NoGoLog anchor repair (A09)
+- Provider/Default quarantine pass (A01, A03, A10)
+- `_fromPipeline` vs old support-bounds visibility (A01, A03)
+- pnp3↔pnp4 MCSP crosswalk (A06, A07)
+- `RefutedRoute_*` naming review in FinalResultAuditRoutes (A02)
+- Frontier/ContractExpansion source-theorem packaging (A08)
+- `FailedRoute_*` module cleanup recommendations (A05)
+
+#### 7. Honest caveats
+
+Where the synthesis is uncertain, say so. In particular:
+- Where audits disagree on whether a route is refuted or only weak.
+- Where the audit coverage was partial (e.g., A01's 85% coverage of `LocalityProvider_Partial.lean`).
+- Where math-level claims would require external literature verification not done in wave 1.
+
+#### 8. Recommended wave-2 size
+
+State a single number: how many tasks (0–N) the operator should dispatch in wave 2 based on this synthesis. With one sentence of justification.
+
+If the answer is 0, state the conditions under which wave 2 should ever be reopened.
+
+## Acceptance criteria
+
+### Universal (per `COMMON_WORKER_INSTRUCTIONS.md`)
+
+- Markdown report at exact path `seed_packs/phase1_20engineer_parallel_dispatch/audit_reports/A11_wave1_synthesis_<handle>.md`.
+- No Lean edits (`git diff origin/main -- "*.lean"` must be empty).
+- No NoGoLog edits, no spec edits, no trust-root touches.
+- Honest caveats line in PR description.
+- Self-attack: read your own synthesis adversarially; check that no claim about "consensus" is actually one audit projected onto the others; check that recommendations cite specific audit evidence.
+
+### Task-specific
+
+- [ ] All 10 audit reports cited at least once each by name + section/finding.
+- [ ] Executive verdict is exactly one of the 4 stated options.
+- [ ] Cross-audit consensus map covers all 8 architectural areas listed.
+- [ ] Refuted/vacuous/legacy inventory covers all 8 minimum items.
+- [ ] Math-level bottleneck section classifies all 8 candidate paths.
+- [ ] Wave-2 decision matrix covers all 9 tasks (L01, L02, B01, B02, B03, K01, K02, X01, X02).
+- [ ] Cross-cutting items list covers all 7 minimum items, prioritized H/M/L.
+- [ ] Recommended wave-2 size is a single explicit number with justification.
+- [ ] PR description uses the structured template from COMMON §12.
+
+### Honest framing requirements
+
+- ❌ Do not claim that wave 1 changes the public endpoint `P_ne_NP_final (gap : ResearchGapWitness)`. It does not.
+- ❌ Do not promote any audit recommendation to "this proves a step toward P ≠ NP". They are all infrastructure recommendations.
+- ❌ Do not pretend confidence about wave-2 timing — synthesis is a snapshot, not a roadmap commitment.
+- ✅ Do say explicitly if the synthesis suggests **stop** ("audits confirm no shorter route; bottleneck is math-level; do not dispatch wave 2 until new math content appears").
+- ✅ Do flag specific places where audit reports contradict each other, if any.
+
+## Scope
+
+### Allowed
+
+- New markdown report at the exact path above.
+- Reading all files in `audit_reports/`, all task files, the reduction memo, trust-root files.
+- Reading `outputs/nogolog.jsonl` to cross-check A09's stale-anchor claims.
+- Targeted `rg` searches for cited declaration names to verify they exist.
+
+### Forbidden
+
+- Universal forbidden scope from `COMMON_WORKER_INSTRUCTIONS.md` §3.
+- ❌ Editing audit reports A01–A10 (they are frozen as wave-1 record).
+- ❌ Editing `tasks/L01..L02`, `B01..B03`, `K01..K02`, `X01..X02` task files — wave-2 dispatch decisions go in the A11 memo, not in those files.
+- ❌ Updating the dispatch README or COMMON_WORKER_INSTRUCTIONS — the operator does that based on A11.
+- ❌ Producing wave-2 task specifications — A11 is a decision memo, not a dispatch.
+- ❌ Editing `outputs/nogolog.jsonl` even to fix the stale anchors A09 flagged — those are separate cleanup tasks gated on operator decision.
+
+## Output
+
+PR title: `Phase 1 A11: wave 1 synthesis + wave 2 decision memo`
+
+PR body uses the structured template; verdict line and recommended-wave-2-size line must be in the body for operator quick-read.
+
+## Why this is gating
+
+The 10 wave-1 audits produced ~5,700 lines of markdown. Operator review of each individually is feasible but operator decision on the next move requires cross-cutting synthesis — which audit, what is the new evidence, does any path change priority. A11 is the synthesis pass that turns the 10-report corpus into a single actionable operator-decision memo.
+
+Without A11, dispatching L/B/K/X would be flying blind: the deferred-task memos (`AUDIT_2026-05-17_PLAN_REDUCTION.md`) predate the audits and cannot reflect their evidence.
+
+After A11 lands and the operator decides, wave 2 (if any) gets a new dispatch spec; if the operator decides stop, A11 is the closeout document for the engineering phase.

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/B01_razborov_rudich_barrier.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/B01_razborov_rudich_barrier.md
@@ -1,5 +1,12 @@
 # B01: Razborov-Rudich natural proofs barrier — pnp4 extension
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: produces a typed barrier surface that does not reduce current decision
+> uncertainty. Lower priority than X01 (D0-aligned bridge). May be revisited
+> after wave-1 synthesis if a barrier-resistant route becomes the operator
+> focus.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** B01 | **Phase:** 3 — Barriers | **Estimated:** 3 weeks | **Difficulty:** high
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/B02_relativization_barrier.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/B02_relativization_barrier.md
@@ -1,5 +1,12 @@
 # B02: Relativization (BGS) barrier — concrete oracle witnesses
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: spec explicitly authorizes placeholder relativized predicates and
+> placeholder oracles; honest caveat acknowledges that making them concrete
+> would require multi-month oracle-TM machinery. Wrapper surface, not a
+> kernel-checked barrier theorem. Cancelled this phase.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** B02 | **Phase:** 3 — Barriers | **Estimated:** 3 weeks | **Difficulty:** high
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/B03_algebrization_barrier.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/B03_algebrization_barrier.md
@@ -1,5 +1,11 @@
 # B03: Algebrization (Aaronson-Wigderson) barrier — pnp4 extension
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: spec defines `algebrizes` as `True`-typed placeholder, allows
+> `algebraicExtension := True`, and the named theorems are `trivial`. This is a
+> wrapper surface, not a kernel-checked barrier theorem. Cancelled this phase.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** B03 | **Phase:** 3 — Barriers | **Estimated:** 3 weeks | **Difficulty:** high
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/K01_cross_route_nogo_checker.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/K01_cross_route_nogo_checker.md
@@ -1,5 +1,12 @@
 # K01: Cross-route NoGo applicability checker library
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: NoGo applicability is reduced to a hand-coded `List (String × NoGoApplicability)`
+> over a `ProofSafetyCertificate` whose fields are bare `Prop`s. Typed rubric,
+> not a theorem-producing engine. Useful as documentation/program-management
+> after routes are settled; not on shortest path now.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** K01 | **Phase:** 4 — Kill-machine | **Estimated:** 2 weeks | **Difficulty:** medium
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/K02_pre_dispatch_barrier_classifier.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/K02_pre_dispatch_barrier_classifier.md
@@ -1,5 +1,11 @@
 # K02: Pre-dispatch barrier classification tool
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: barrier evidence stored as `String`; classification rubric, not a
+> theorem-producing engine. Has value as a downstream documentation layer once
+> live route questions are settled; not on shortest path now.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** K02 | **Phase:** 4 — Kill-machine | **Estimated:** 2 weeks | **Difficulty:** medium
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/L01_hirahara_search_to_decision.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/L01_hirahara_search_to_decision.md
@@ -1,5 +1,13 @@
 # L01: Hirahara search-to-decision MCSP surface
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: bibliographic ID error. Spec cites `arXiv:1804.05985` for Hirahara
+> "Non-Black-Box Worst-Case to Average-Case Reductions within NP" (FOCS 2018),
+> but the correct arXiv ID for that paper is `1808.06848`. Before reactivation:
+> verify which paper / which theorem statement is actually being formalized,
+> and consider re-routing as a markdown-only literature D0 first.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** L01 | **Phase:** 2 — Literature | **Estimated:** 2 weeks | **Difficulty:** high
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/L02_pich_santhanam_unprovability.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/L02_pich_santhanam_unprovability.md
@@ -1,5 +1,11 @@
 # L02: Pich-Santhanam bounded arithmetic unprovability surface
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reason: long-horizon literature investment not on shortest path to the active
+> bottleneck. May be revived if a feasible-unprovability angle becomes the
+> operator focus.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** L02 | **Phase:** 2 — Literature | **Estimated:** 3 weeks | **Difficulty:** high
 
 ## Goal

--- a/seed_packs/phase1_20engineer_parallel_dispatch/tasks/X02_concrete_tree_mcsp_parser.md
+++ b/seed_packs/phase1_20engineer_parallel_dispatch/tasks/X02_concrete_tree_mcsp_parser.md
@@ -1,5 +1,22 @@
 # X02: Concrete tree-MCSP parser implementation + runtime proofs
 
+> **DEFERRED (2026-05-17 plan reduction).** Not dispatchable in the current wave.
+> Reasons:
+> 1. Spec uses `M := fun n => n` in `length_convention` / `malformed_rejected`,
+>    but the live runtime in
+>    `pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionLanguageRuntime.lean`
+>    fixes the ambient-length convention as
+>    `treeMCSPPrefixAmbientLength overhead witnessBits padBits n
+>     = tableLen n + overhead n + witnessBits n + padBits n`.
+>    The theorem signatures as written do not align with that convention and
+>    cannot be proved against the current runtime layer.
+> 2. X02 is gated on X01 landing; even with a corrected spec it must not run
+>    in parallel with X01.
+> Before reactivation: rewrite signatures to consume `treeMCSPPrefixAmbientLength`
+> (or some explicitly stated ambient-length convention from R1-B2a) and gate
+> dispatch on X01 merged + reviewed.
+> See `AUDIT_2026-05-17_PLAN_REDUCTION.md`.
+
 **Engineer:** X02 | **Phase:** 5 — Contract expansion | **Estimated:** 4 weeks | **Difficulty:** medium-high | **Benefits from:** X01 landing
 
 ## Goal


### PR DESCRIPTION
## Summary

Bundles the accumulated dev-branch work into main. Three operator-decision artefacts plus the P1P-02L₄ slice-lemma port.

## Lean changes

**`pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean`** (+67 LOC):

Ports two theorems verbatim from the closed P1P-02L₄ alternative PR #1338:

- **`be_digit_step (a k : Nat)`** — one-step big-endian digit identity:  
  `(if a/2^k % 2 = 1 then 2^k else 0) + a % 2^k = a % 2^(k+1)`. Arithmetic core for the slice reader induction.

- **`readNatBE_natBEField_slice (value width offset len) (hfit : offset + len ≤ width)`** — most-general inversion lemma:  
  `readNatBE (natBEField value width) offset len = some ((value / 2^(width − (offset + len))) % 2^len)`.

**Why now:** the P1P-02L₅ worker on the Elias-gamma decoder round-trip needs to read sub-slices at non-zero offsets within the encoded gamma field (the payload starts after the unary terminator). `_slice` gives this directly; without it the worker would have to re-derive equivalent via `readNatBE_eq_of_readBit_eq` + `readNatBE_natBEField_zero` (~15-20 lines).

**No conflict** with existing `readNatBE_natBEField_zero` (#1339): both are proven independently, neither depends on the other.

Surface tests + axiom audit entries updated.

## Markdown / governance changes

These were accumulated on the dev branch during the P1P track work:

- `docs/P1P_02L_operator_review_claudeopus.md` (215 lines) — operator review of P1P-02L parser landing. Verdict: `approve_P1P02L`.
- `docs/P1P_02L2_operator_review_claudeopus.md` (230 lines) — operator review of P1P-02L₂ encoder + length-convention + RuntimeAwarePrefixParser wiring. Verdict: `approve_P1P02L2`.
- `tasks/A11_wave1_synthesis.md` (198 lines) — A11 synthesis task spec (was dispatched and landed; spec preserved as record).
- `AUDIT_2026-05-17_PLAN_REDUCTION.md` (138 lines) — pre-audit plan reduction memo (historical record from before A11 synthesis).
- `README.md` and `COMMON_WORKER_INSTRUCTIONS.md` — current state board reflecting wave 1 audits complete + P1P track progress + A11 status table. Subsumes and reconciles the governance errata from P1P-01.
- Per-task DEFERRED headers added to deprecated tasks (A01/A03/A04/A05/A06/B01/B02/B03/K01/K02/L01/L02/X02) — historical record of why each was deferred.

## Test plan

- [ ] `lake build PnP3 Pnp4` passes (verifies slice port compiles against #1339's existing infrastructure)
- [ ] `./scripts/check.sh` passes (verifies all 17 governance checks remain green)
- [ ] `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` returns empty
- [ ] No trust-root edits: `pnp3/Complexity/Interfaces.lean`, `pnp3/Magnification/UnconditionalResearchGap.lean`, `pnp3/Barrier/*` unchanged

The Lean port (`be_digit_step` + `_slice`) is verbatim from PR #1338 which built green in its own CI. The parent context (`natBitBE`, `natBEField`, `readNatBE`, `readBit?` definitions) is identical between #1338 and main post #1339. Local environment in the operator session does not have lake/lean installed, so CI verification on this PR is the authoritative build check.

## Honest caveats

- This PR does not advance unconditional P≠NP. The math-level bottleneck (non-vacuous `ResearchGapWitness`) is unchanged.
- The full canonical parse-encode round-trip theorem (P1P-02L₅) is still open. This PR lands one of the missing inversion lemmas (`_slice`) that makes the remaining gamma-decoder proof tractable.
- Local `lake build`/`check.sh` could not be executed in the operator session; CI is the build check.

https://claude.ai/code/session_01NiyDeSzJN6LnUfkLynhsV9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiyDeSzJN6LnUfkLynhsV9)_