### PR TITLE
P1P-02L6: add parser-field lemmas for encoded tree‑MCSP prefix (gamma, index, pad)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -641,6 +641,159 @@ theorem readNatBE_encode_tag
     _ = some treePrefixTag := by
       exact readNatBE_natBEField_zero treePrefixTag tagLen (by norm_num [treePrefixTag, tagLen])
 
+
+
+/-- The encoded Elias-gamma region exposes exactly the standalone `gammaBit` field. -/
+theorem readBit_encode_gamma
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec)
+    {t : Nat} (ht : t < gammaLen fields.n) :
+    readBit? (encodeTreeMCSPPrefixFields codec fields) (tagLen + t) =
+      some (gammaBit fields.n ⟨t, ht⟩) := by
+  unfold readBit?
+  have hm : tagLen + t < treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM
+    omega
+  have hnotTag : ¬ tagLen + t < tagLen := by omega
+  have hGamma : tagLen + t < tagLen + gammaLen fields.n := by omega
+  simp [hm, encodeTreeMCSPPrefixFields, hnotTag, hGamma]
+
+/-- The encoded index region exposes exactly the standalone big-endian `i` field. -/
+theorem readBit_encode_i
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec)
+    {t : Nat} (ht : t < idxWidth codec.witnessBits fields.n) :
+    readBit? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n + t) =
+      some (natBitBE fields.i (idxWidth codec.witnessBits fields.n) ⟨t, ht⟩) := by
+  unfold readBit?
+  have hm : tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n + t <
+      treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM
+    omega
+  have hnotTag : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n + t <
+      tagLen := by omega
+  have hnotGamma : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n + t <
+      tagLen + gammaLen fields.n := by omega
+  have hnotX : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n + t <
+      tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n := by omega
+  have hI : tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n + t <
+      tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+        idxWidth codec.witnessBits fields.n := by omega
+  simp [hm, encodeTreeMCSPPrefixFields, hnotTag, hnotGamma, hnotX, hI]
+
+/-- The gamma payload read inside the full encoder matches the standalone gamma payload read. -/
+theorem readNatBE_encode_gamma_payload
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    readNatBE (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + bitLength (fields.n + 1))
+      (bitLength (fields.n + 1) - 1) =
+    some ((fields.n + 1) % 2 ^ (bitLength (fields.n + 1) - 1)) := by
+  calc
+    readNatBE (encodeTreeMCSPPrefixFields codec fields)
+        (tagLen + bitLength (fields.n + 1))
+        (bitLength (fields.n + 1) - 1) =
+        readNatBE (fun j : Fin (gammaLen fields.n) => gammaBit fields.n j)
+          (bitLength (fields.n + 1)) (bitLength (fields.n + 1) - 1) := by
+      apply readNatBE_eq_of_readBit_eq
+      intro t ht
+      have hGamma : bitLength (fields.n + 1) + t < gammaLen fields.n := by
+        rw [gammaLen_eq_zeros_add_bitLength]
+        omega
+      rw [show tagLen + bitLength (fields.n + 1) + t =
+          tagLen + (bitLength (fields.n + 1) + t) by omega]
+      rw [readBit_encode_gamma codec fields hGamma]
+      unfold readBit?
+      simp [hGamma]
+    _ = some ((fields.n + 1) % 2 ^ (bitLength (fields.n + 1) - 1)) := by
+      exact readNatBE_gammaBit_payload fields.n
+
+/-- General in-place gamma decoder invariant for the gamma region of the full encoder. -/
+theorem decodeGammaAux_encodeTreeMCSPPrefixFields_from
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec)
+    (fuel zeros : Nat)
+    (hzeros : zeros ≤ bitLength (fields.n + 1) - 1)
+    (hfuel : bitLength (fields.n + 1) - 1 - zeros < fuel) :
+    decodeGammaAux? (encodeTreeMCSPPrefixFields codec fields)
+      tagLen fuel zeros = some (fields.n, gammaLen fields.n) := by
+  induction fuel generalizing zeros with
+  | zero => omega
+  | succ fuel' ih =>
+      rw [decodeGammaAux?]
+      have hzg : zeros < gammaLen fields.n := by
+        rw [gammaLen_eq_zeros_add_bitLength]
+        exact Nat.lt_of_le_of_lt hzeros
+          (Nat.lt_add_of_pos_right (bitLength_pos_of_pos (Nat.succ_pos fields.n)))
+      have hread : readBit? (encodeTreeMCSPPrefixFields codec fields) (tagLen + zeros) =
+          some (gammaBit fields.n ⟨zeros, hzg⟩) := by
+        exact readBit_encode_gamma codec fields hzg
+      rw [hread]
+      by_cases hz : zeros < bitLength (fields.n + 1) - 1
+      · have hbit : gammaBit fields.n ⟨zeros, hzg⟩ = false := by
+          exact gammaBit_zero_prefix fields.n hz
+        simp [hbit]
+        apply ih
+        · omega
+        · omega
+      · have hzeq : zeros = bitLength (fields.n + 1) - 1 := by omega
+        subst hzeq
+        simp [gammaBit_terminator]
+        have hLpos : 0 < bitLength (fields.n + 1) :=
+          bitLength_pos_of_pos (Nat.succ_pos fields.n)
+        rw [show tagLen + (bitLength (fields.n + 1) - 1) + 1 =
+          tagLen + bitLength (fields.n + 1) by omega]
+        rw [readNatBE_encode_gamma_payload codec fields]
+        simp only [Option.bind_some, Option.some.injEq, Prod.mk.injEq]
+        constructor
+        · have hv := gamma_payload_value fields.n
+          omega
+        · rw [gammaLen_eq_two_mul_zeros_add_one]
+
+/-- The full encoder decodes its in-place Elias-gamma `n + 1` field at `tagLen`. -/
+theorem decodeGamma_encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    decodeGamma? (encodeTreeMCSPPrefixFields codec fields) tagLen =
+      some (fields.n, gammaLen fields.n) := by
+  unfold decodeGamma?
+  apply decodeGammaAux_encodeTreeMCSPPrefixFields_from
+  · omega
+  · unfold treeMCSPPrefixM
+    have hlen : gammaLen fields.n = 2 * (bitLength (fields.n + 1) - 1) + 1 :=
+      gammaLen_eq_two_mul_zeros_add_one fields.n
+    omega
+
+/-- The full encoder's fixed-width index field reads back the raw active-prefix length. -/
+theorem readNatBE_encode_i
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    readNatBE (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n)
+      (idxWidth codec.witnessBits fields.n) =
+    some fields.i := by
+  calc
+    readNatBE (encodeTreeMCSPPrefixFields codec fields)
+        (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n)
+        (idxWidth codec.witnessBits fields.n) =
+        readNatBE (natBEField fields.i (idxWidth codec.witnessBits fields.n)) 0
+          (idxWidth codec.witnessBits fields.n) := by
+      apply readNatBE_eq_of_readBit_eq
+      intro t ht
+      rw [readBit_encode_i codec fields ht]
+      unfold readBit? natBEField
+      simp [ht]
+    _ = some fields.i := by
+      exact readNatBE_natBEField_zero fields.i (idxWidth codec.witnessBits fields.n)
+        (prefixLength_lt_two_pow_idxWidth fields.prefixLength_le)
+
 /-- The encoded truth-table slice is exactly the raw `x` field. -/
 theorem sliceBits_encode_x
     {threshold : Nat → Nat}
@@ -697,6 +850,147 @@ theorem sliceBits_encode_p
           idxWidth codec.witnessBits fields.n + fields.i := by
     exact Nat.add_lt_add_left j.2 _
   simp [hnotTag, hnotGamma, hnotX, hnotI, hp]
+
+
+
+/-- Every bit in the encoder's inactive witness suffix is canonical zero padding. -/
+theorem readBit_encode_pad
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec)
+    {t : Nat} (ht : t < codec.witnessBits fields.n - fields.i) :
+    readBit? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+        idxWidth codec.witnessBits fields.n + fields.i + t) =
+      some false := by
+  unfold readBit?
+  have hi : fields.i ≤ codec.witnessBits fields.n := fields.prefixLength_le
+  have hm : tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + t <
+      treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM
+    omega
+  have hnotTag : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + t < tagLen := by omega
+  have hnotGamma : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + t < tagLen + gammaLen fields.n := by omega
+  have hnotX : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + t <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n := by omega
+  have hnotI : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + t <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+          idxWidth codec.witnessBits fields.n := by omega
+  have hnotP : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + t <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+          idxWidth codec.witnessBits fields.n + fields.i := by omega
+  simp [hm, encodeTreeMCSPPrefixFields, hnotTag, hnotGamma, hnotX, hnotI, hnotP]
+
+/-- A reader-level all-zero checker accepts any slice whose bits all read as `false`. -/
+theorem allZeroSlice_eq_true_of_readBit_false
+    {m : Nat} (y : PrefixBitVec m) (offset width : Nat)
+    (h : ∀ t : Nat, t < width → readBit? y (offset + t) = some false) :
+    allZeroSlice? y offset width = some true := by
+  induction width generalizing offset with
+  | zero =>
+      simp [allZeroSlice?]
+  | succ k ih =>
+      rw [allZeroSlice?]
+      have h0 : readBit? y offset = some false := by
+        simpa using h 0 (Nat.zero_lt_succ k)
+      rw [h0]
+      have hrec : allZeroSlice? y (offset + 1) k = some true := by
+        apply ih
+        intro t ht
+        have := h (t + 1) (Nat.succ_lt_succ ht)
+        simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using this
+      rw [hrec]
+      simp
+
+/-- The encoded inactive witness suffix slices out as an all-false padding vector. -/
+theorem sliceBits_encode_pad
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+        idxWidth codec.witnessBits fields.n + fields.i)
+      (codec.witnessBits fields.n - fields.i) =
+    some (fun _ : Fin (codec.witnessBits fields.n - fields.i) => false) := by
+  unfold sliceBits?
+  have hi : fields.i ≤ codec.witnessBits fields.n := fields.prefixLength_le
+  have hWithin : tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i +
+        (codec.witnessBits fields.n - fields.i) ≤ treeMCSPPrefixM codec fields.n := by
+    unfold treeMCSPPrefixM
+    omega
+  simp [hWithin]
+  funext j
+  unfold encodeTreeMCSPPrefixFields
+  have hnotTag : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + j.1 < tagLen := by omega
+  have hnotGamma : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + j.1 < tagLen + gammaLen fields.n := by omega
+  have hnotX : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + j.1 <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n := by omega
+  have hnotI : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + j.1 <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+          idxWidth codec.witnessBits fields.n := by omega
+  have hnotP : ¬ tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+      idxWidth codec.witnessBits fields.n + fields.i + j.1 <
+        tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+          idxWidth codec.witnessBits fields.n + fields.i := by omega
+  simp [hnotTag, hnotGamma, hnotX, hnotI, hnotP]
+
+/-- The parser's all-zero padding check accepts the encoder's inactive witness suffix. -/
+theorem allZeroSlice_encode_pad
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    allZeroSlice? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+        idxWidth codec.witnessBits fields.n + fields.i)
+      (codec.witnessBits fields.n - fields.i) =
+    some true := by
+  apply allZeroSlice_eq_true_of_readBit_false
+  intro t ht
+  exact readBit_encode_pad codec fields ht
+
+/-- Collected parser-field facts for the canonical tree-MCSP prefix encoder. -/
+theorem parse_encodeTreeMCSPPrefixFields_field_obligations
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    readNatBE (encodeTreeMCSPPrefixFields codec fields) 0 tagLen = some treePrefixTag ∧
+    decodeGamma? (encodeTreeMCSPPrefixFields codec fields) tagLen =
+      some (fields.n, gammaLen fields.n) ∧
+    sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n) (Pnp3.Models.Partial.tableLen fields.n) = some fields.x ∧
+    readNatBE (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n)
+      (idxWidth codec.witnessBits fields.n) = some fields.i ∧
+    sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+        idxWidth codec.witnessBits fields.n) fields.i = some fields.p ∧
+    sliceBits? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+        idxWidth codec.witnessBits fields.n + fields.i)
+      (codec.witnessBits fields.n - fields.i) =
+      some (fun _ : Fin (codec.witnessBits fields.n - fields.i) => false) ∧
+    allZeroSlice? (encodeTreeMCSPPrefixFields codec fields)
+      (tagLen + gammaLen fields.n + Pnp3.Models.Partial.tableLen fields.n +
+        idxWidth codec.witnessBits fields.n + fields.i)
+      (codec.witnessBits fields.n - fields.i) = some true := by
+  exact ⟨readNatBE_encode_tag codec fields,
+    decodeGamma_encodeTreeMCSPPrefixFields codec fields,
+    sliceBits_encode_x codec fields,
+    readNatBE_encode_i codec fields,
+    sliceBits_encode_p codec fields,
+    sliceBits_encode_pad codec fields,
+    allZeroSlice_encode_pad codec fields⟩
 
 /--
 P1P-02L3 partial-progress marker.

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2499,8 +2499,19 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #print axioms Pnp4.Frontier.ContractExpansion.decodeGamma_gammaBit
 #print axioms Pnp4.Frontier.ContractExpansion.prefixLength_lt_two_pow_idxWidth
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encode_tag
+#print axioms Pnp4.Frontier.ContractExpansion.readBit_encode_gamma
+#print axioms Pnp4.Frontier.ContractExpansion.readBit_encode_i
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encode_gamma_payload
+#print axioms Pnp4.Frontier.ContractExpansion.decodeGammaAux_encodeTreeMCSPPrefixFields_from
+#print axioms Pnp4.Frontier.ContractExpansion.decodeGamma_encodeTreeMCSPPrefixFields
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encode_i
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
+#print axioms Pnp4.Frontier.ContractExpansion.readBit_encode_pad
+#print axioms Pnp4.Frontier.ContractExpansion.allZeroSlice_eq_true_of_readBit_false
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_pad
+#print axioms Pnp4.Frontier.ContractExpansion.allZeroSlice_encode_pad
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_field_obligations
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -215,8 +215,19 @@ end Pnp4
 #check Pnp4.Frontier.ContractExpansion.CanonicalRawTreeMCSPPrefixFields.toPrefixInput
 #print axioms Pnp4.Frontier.ContractExpansion.encodeTreeMCSPPrefixFields_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encode_tag
+#print axioms Pnp4.Frontier.ContractExpansion.readBit_encode_gamma
+#print axioms Pnp4.Frontier.ContractExpansion.readBit_encode_i
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encode_gamma_payload
+#print axioms Pnp4.Frontier.ContractExpansion.decodeGammaAux_encodeTreeMCSPPrefixFields_from
+#print axioms Pnp4.Frontier.ContractExpansion.decodeGamma_encodeTreeMCSPPrefixFields
+#print axioms Pnp4.Frontier.ContractExpansion.readNatBE_encode_i
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
+#print axioms Pnp4.Frontier.ContractExpansion.readBit_encode_pad
+#print axioms Pnp4.Frontier.ContractExpansion.allZeroSlice_eq_true_of_readBit_false
+#print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_pad
+#print axioms Pnp4.Frontier.ContractExpansion.allZeroSlice_encode_pad
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_field_obligations
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention


### PR DESCRIPTION
### Motivation

- The full `parse` / `encode` round-trip was blocked by missing in-place transport and inversion lemmas for the encoded fields (Elias-gamma, index field, and implicit zero padding). 
- These are ambient parser/serialization infrastructure facts required before attempting the dependent `PrefixInput` equality; the PR intentionally avoids the final dependent round-trip theorem. 
- Provide compact, reusable lemmas that let the parser read fields from the encoder output without re-proving standalone encodings.

### Description

- Added in-place transport lemmas that expose encoder bits as standalone fields: `readBit_encode_gamma`, `readBit_encode_i`, and `readNatBE_encode_gamma_payload` in `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean`.
- Proved in-place gamma decoder invariants and inversion: `decodeGammaAux_encodeTreeMCSPPrefixFields_from` and `decodeGamma_encodeTreeMCSPPrefixFields` using the existing standalone gamma facts.
- Added index- and padding-related lemmas: `readNatBE_encode_i`, `readBit_encode_pad`, `sliceBits_encode_pad`, and `allZeroSlice_encode_pad`, and a collector theorem `parse_encodeTreeMCSPPrefixFields_field_obligations` that bundles the ambient field obligations without doing the final dependent equality.
- Wired new public theorem surfaces into tests/audit surface files by updating `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean` and `pnp4/Pnp4/Tests/AxiomsAudit.lean` to list the new lemma names.

### Testing

- Ran `lake build PnP3 Pnp4` and the `Pnp4.Frontier.ContractExpansion.PrefixParserConvention` module built successfully. 
- Ran the repository CI-style check `./scripts/check.sh` and it completed with all checks passing. 
- Searched for proof holes with `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found none.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a2387b6b0832b96818fa874cade7f)