### PR TITLE
Add final parse/encode round‑trip theorem parse_encodeTreeMCSPPrefixFields

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -1086,13 +1086,11 @@ theorem parse_encodeTreeMCSPPrefixFields_field_obligations
 /--
 P1P-02L3 partial-progress marker.
 
-The full canonical theorem
-`parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields)
- = some (fields.toPrefixInput codec)` remains open.  The landed partial lemmas
-above isolate the already-verified tag, table slice, and active-prefix slice;
-the remaining proof work is the generic Elias-gamma round trip and big-endian
-index-field round trip, plus dependent proof-field normalization in the final
-`PrefixInput` equality.
+Historical P1P-02L3 partial-progress marker.
+
+The final round-trip theorem now appears below the parser definition.  This
+older bundled obligation remains as a compact smoke theorem for the earliest
+field layer: tag reading, table slicing, and active-prefix slicing.
 -/
 theorem parse_encodeTreeMCSPPrefixFields_partial_obligation
     {threshold : Nat → Nat}
@@ -1170,6 +1168,32 @@ def parseTreeMCSPPrefixInput
       none
   else
     none
+
+/--
+The canonical encoder is a right-inverse for the concrete parser.
+
+This theorem is the final parser/encoder assembly step for the P1P-02 layout:
+the preceding field lemmas discharge each executable reader/slicer, and this
+proof only sequences the parser branches and normalizes the dependent record
+that the parser constructs.
+-/
+theorem parse_encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    parseTreeMCSPPrefixInput threshold codec
+      (encodeTreeMCSPPrefixFields codec fields) =
+    some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields) := by
+  simp [parseTreeMCSPPrefixInput,
+    readNatBE_encode_tag codec fields,
+    decodeGamma_encodeTreeMCSPPrefixFields codec fields,
+    sliceBits_encode_x codec fields,
+    readNatBE_encode_i codec fields,
+    fields.prefixLength_le,
+    sliceBits_encode_p codec fields,
+    sliceBits_encode_pad codec fields,
+    allZeroSlice_encode_pad codec fields,
+    CanonicalRawTreeMCSPPrefixFields.toPrefixInput]
 
 /-- The concrete parser packaged in the existing `PrefixParser` interface. -/
 def treeMCSPConcretePrefixParser

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2504,6 +2504,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -219,6 +219,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected


### PR DESCRIPTION
### Motivation

- Close the remaining P1P-02 parser/encoder assembly work by proving that the canonical encoder is a right‑inverse of the concrete parser for the tree‑MCSP prefix layout.

### Description

- Add `theorem parse_encodeTreeMCSPPrefixFields` to `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean`, proving
  `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields) = some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields)` by sequencing the parser branches and using the existing field inversion lemmas.
- Replace the old P1P-02L3 partial-progress comment with a short historical note and move the final theorem to appear after the parser definition so it can unfold correctly.
- Update test/audit scaffolding to reference the new theorem by inserting `#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields` into `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean` and `pnp4/Pnp4/Tests/AxiomsAudit.lean` so the audit surface includes the new lemma.
- The new proof reuses the already-landed field lemmas such as `readNatBE_encode_tag`, `decodeGamma_encodeTreeMCSPPrefixFields`, `sliceBits_encode_x`, `readNatBE_encode_i`, `sliceBits_encode_p`, `sliceBits_encode_pad`, and `allZeroSlice_encode_pad` and collapses the parser via `simp` to the expected `PrefixInput` record.

### Testing

- Built the modified file and its dependents using `lake build Pnp4.Frontier.ContractExpansion.PrefixParserConvention`, iterated a quick local fix when the initial insertion location caused a compile error, and then ran `lake build PnP3 Pnp4`; the final build completed successfully.
- The repository test/audit surfaces were updated and the build output shows `Pnp4.Tests.AxiomsAudit` and `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests` include the new theorem in their printed-axioms surface; no new `sorry`/`admit`/`axiom` was added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a97d49cf8832b9c4762486c33471a)