### PR TITLE
Prove canonical prefix parser round trip

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -1084,15 +1084,12 @@ theorem parse_encodeTreeMCSPPrefixFields_field_obligations
     allZeroSlice_encode_pad codec fields⟩
 
 /--
-P1P-02L3 partial-progress marker.
+P1P-02L3 partial-progress marker retained for downstream users.
 
-The full canonical theorem
-`parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields)
- = some (fields.toPrefixInput codec)` remains open.  The landed partial lemmas
-above isolate the already-verified tag, table slice, and active-prefix slice;
-the remaining proof work is the generic Elias-gamma round trip and big-endian
-index-field round trip, plus dependent proof-field normalization in the final
-`PrefixInput` equality.
+The full canonical theorem `parse_encodeTreeMCSPPrefixFields` below now closes
+the parser/encoder round trip.  This narrower bundled obligation remains useful
+for callers that only need the original tag/table/prefix slice facts without
+opening the complete parser proof.
 -/
 theorem parse_encodeTreeMCSPPrefixFields_partial_obligation
     {threshold : Nat → Nat}
@@ -1170,6 +1167,27 @@ def parseTreeMCSPPrefixInput
       none
   else
     none
+
+/--
+The canonical raw-field encoder is accepted by the concrete tree-MCSP prefix parser.
+
+This is the final P1P-02 parser/encoder round-trip: the proof only unfolds the
+parser far enough to expose its executable field reads, then rewrites each read
+with the field-local inversion lemmas above.  The resulting record equality is
+handled by extensionality; proof fields are discharged by proof irrelevance.
+-/
+theorem parse_encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    parseTreeMCSPPrefixInput threshold codec
+      (encodeTreeMCSPPrefixFields codec fields) =
+    some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields) := by
+  simp [parseTreeMCSPPrefixInput, readNatBE_encode_tag codec fields,
+    decodeGamma_encodeTreeMCSPPrefixFields codec fields, sliceBits_encode_x codec fields,
+    readNatBE_encode_i codec fields, fields.prefixLength_le, sliceBits_encode_p codec fields,
+    sliceBits_encode_pad codec fields, allZeroSlice_encode_pad codec fields,
+    CanonicalRawTreeMCSPPrefixFields.toPrefixInput]
 
 /-- The concrete parser packaged in the existing `PrefixParser` interface. -/
 def treeMCSPConcretePrefixParser

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2504,6 +2504,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -219,6 +219,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected


### PR DESCRIPTION
### Motivation
- Close the P1P-02 parser/encoder gap by proving that the canonical encoder is accepted by the concrete parser and yields the canonical `PrefixInput` record. 
- Reuse the previously-landed inversion and slice lemmas so the proof is a straightforward rewrite of parser reads into encoder-local facts.

### Description
- Add `theorem parse_encodeTreeMCSPPrefixFields` to `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean`, showing `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields) = some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields)`.
- Update the nearby P1P-02L3 comment to reflect that the full round-trip theorem is now landed, and add the theorem to the pnp4 public-axiom/ surface checks in `pnp4/Pnp4/Tests/AxiomsAudit.lean` and `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean`.
- The final proof unfolds the parser enough to expose the do-block reads and rewrites each read using the existing encoder-local lemmas `readNatBE_encode_tag`, `decodeGamma_encodeTreeMCSPPrefixFields` (via `decodeGammaAux` transport), `sliceBits_encode_x`, `readNatBE_encode_i`, `sliceBits_encode_p`, `sliceBits_encode_pad`, and `allZeroSlice_encode_pad`, then simplifies to the target record.

### Testing
- Ran `lake build PnP3 Pnp4` and the build succeeded (module and dependency build completed). 
- Ran `./scripts/check.sh` and the repository checks (full CI-style checks and smoke tests) completed successfully with no failures. 
- Scanned for proof holes with `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no occurrences.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a97d49cf8832b9c4762486c33471a)