### PR TITLE
Add canonical prefix parser round trip

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -1171,6 +1171,44 @@ def parseTreeMCSPPrefixInput
   else
     none
 
+
+/--
+The canonical parser accepts the canonical encoder and reconstructs exactly the
+raw-field `PrefixInput` view.
+
+This is the final parser/encoder assembly theorem for the P1P-02 convention. It
+uses the already-localized field inversion lemmas for the tag, gamma-encoded
+parameter, table slice, active-prefix length, active witness-prefix slice, and
+zero padding; the only dependent-record wrinkle is the parser's freshly-created
+`i ≤ witnessBits n` proof, which is identified with the raw-field proof by proof
+irrelevance.
+-/
+theorem parse_encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    parseTreeMCSPPrefixInput threshold codec
+      (encodeTreeMCSPPrefixFields codec fields) =
+    some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields) := by
+  unfold parseTreeMCSPPrefixInput
+  rw [readNatBE_encode_tag codec fields]
+  simp [treePrefixTag]
+  rw [decodeGamma_encodeTreeMCSPPrefixFields codec fields]
+  simp only [Option.bind_some]
+  simp
+  rw [sliceBits_encode_x codec fields]
+  simp only [Option.bind_some]
+  rw [readNatBE_encode_i codec fields]
+  simp [fields.prefixLength_le]
+  rw [sliceBits_encode_p codec fields]
+  simp only [Option.bind_some]
+  rw [sliceBits_encode_pad codec fields]
+  simp only [Option.bind_some]
+  rw [allZeroSlice_encode_pad codec fields]
+  simp only [Option.bind_some]
+  simp
+  rfl
+
 /-- The concrete parser packaged in the existing `PrefixParser` interface. -/
 def treeMCSPConcretePrefixParser
     (threshold : Nat → Nat)

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -60,6 +60,7 @@ def check_C_DAG : CircuitFamilyClass :=
 #print axioms Pnp4.Frontier.ContractExpansion.decodeGammaAux_gammaBit_from_at
 #print axioms Pnp4.Frontier.ContractExpansion.prefixLength_lt_two_pow_idxWidth
 #print axioms Pnp4.Frontier.ContractExpansion.tableLen_le_treeMCSPPrefixM
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -219,6 +219,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected


### PR DESCRIPTION
### Motivation

- Close the final P1P-02 parser/encoder assembly step by proving that the concrete prefix parser accepts the encoder output and reconstructs the canonical raw-field `PrefixInput` view, removing the last local blocker in the parser/encoder library.

### Description

- Add `theorem parse_encodeTreeMCSPPrefixFields` to `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` proving `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields) = some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields)` by unfolding the parser do-block and rewrites against the field lemmas.
- The proof rewrites sequentially with the existing inversion lemmas (`readNatBE_encode_tag`, `decodeGamma_encodeTreeMCSPPrefixFields` / `decodeGammaAux...`, `sliceBits_encode_x`, `readNatBE_encode_i`, `sliceBits_encode_p`, `sliceBits_encode_pad`, `allZeroSlice_encode_pad`), uses `fields.prefixLength_le` for the index bound branch, and closes the dependent-record equality via simplification and proof-irrelevance.
- Register the new theorem in the pnp4 public/axiom-audit surfaces by updating `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean` and `pnp4/Pnp4/Tests/AxiomsAudit.lean` so the symbol appears in the audit dumps.

### Testing

- Built the updated module with `lake build Pnp4.Frontier.ContractExpansion.PrefixParserConvention` which succeeded. 
- Performed full repository builds `lake build PnP3 Pnp4` and ran the repository check script `./scripts/check.sh`, and the CI-style checks completed successfully (including smoke probes, surface/axiom audit, and verification steps).
- Ran a proof-hole scan `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` which reported no `sorry`/`admit` instances in the active pnp3/pnp4 code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a97d49cf8832b9c4762486c33471a)