### PR TITLE
Add parse_encodeTreeMCSPPrefixFields round-trip theorem and test updates

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -1084,15 +1084,11 @@ theorem parse_encodeTreeMCSPPrefixFields_field_obligations
     allZeroSlice_encode_pad codec fields⟩
 
 /--
-P1P-02L3 partial-progress marker.
+P1P-02L3 partial-progress marker retained as a small field-obligation smoke test.
 
-The full canonical theorem
-`parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields)
- = some (fields.toPrefixInput codec)` remains open.  The landed partial lemmas
-above isolate the already-verified tag, table slice, and active-prefix slice;
-the remaining proof work is the generic Elias-gamma round trip and big-endian
-index-field round trip, plus dependent proof-field normalization in the final
-`PrefixInput` equality.
+The full canonical theorem now lands below as
+`parse_encodeTreeMCSPPrefixFields`; this narrower conjunction remains useful for
+call sites that only need the older tag/table/prefix slice facts.
 -/
 theorem parse_encodeTreeMCSPPrefixFields_partial_obligation
     {threshold : Nat → Nat}
@@ -1170,6 +1166,27 @@ def parseTreeMCSPPrefixInput
       none
   else
     none
+
+/--
+The canonical encoder is a right inverse of the concrete tree-MCSP prefix parser.
+
+This is the final P1P-02 parser/encoder assembly theorem: the previously proved
+field inversion lemmas discharge each executable parser step, and the only
+remaining dependent-field issue is the proof object for the active-prefix bound,
+which is erased by proof irrelevance inside the final `PrefixInput` record.
+-/
+theorem parse_encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    parseTreeMCSPPrefixInput threshold codec
+      (encodeTreeMCSPPrefixFields codec fields) =
+    some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields) := by
+  unfold parseTreeMCSPPrefixInput
+  simp [readNatBE_encode_tag codec fields, decodeGamma_encodeTreeMCSPPrefixFields codec fields,
+    sliceBits_encode_x codec fields, readNatBE_encode_i codec fields,
+    fields.prefixLength_le, sliceBits_encode_p codec fields, sliceBits_encode_pad codec fields,
+    allZeroSlice_encode_pad codec fields, CanonicalRawTreeMCSPPrefixFields.toPrefixInput]
 
 /-- The concrete parser packaged in the existing `PrefixParser` interface. -/
 def treeMCSPConcretePrefixParser

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2504,6 +2504,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -219,6 +219,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected


### PR DESCRIPTION
### Motivation
- Close the P1P-02 parser/encoder round-trip by proving that the concrete parser is a right inverse of the canonical encoder for tree-MCSP prefix fields. 

### Description
- Add `theorem parse_encodeTreeMCSPPrefixFields` to `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean`, proving `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields) = some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields)` by unfolding the parser do-block and discharging each field via the existing encoder-local lemmas. 
- The proof reuses the existing field lemmas `readNatBE_encode_tag`, `decodeGamma_encodeTreeMCSPPrefixFields`, `sliceBits_encode_x`, `readNatBE_encode_i`, `sliceBits_encode_p`, `sliceBits_encode_pad`, and `allZeroSlice_encode_pad` and resolves the dependent `prefixLength_le` proof by relying on proof irrelevance/structure extensionality in the final record equality. 
- Small bookkeeping edits to the surrounding comment (retain the P1P-02L3 marker as a field-obligation note) and to test helper prints so the new theorem surface is referenced by the axioms/test audit outputs.

### Testing
- Built the affected libraries with `lake build Pnp4` and `lake build PnP3 Pnp4`, and the builds completed successfully. 
- The repository test/audit surfaces were updated to reference the new theorem and the overall `Tests`/`AxiomsAudit` targets were rebuilt; the build logs show successful completion with only unrelated linter warnings. 
- No `sorry`/`admit`/`axiom`/`native_decide` was introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a97d49cf8832b9c4762486c33471a)