### PR TITLE
Add canonical prefix parser round trip

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -1171,6 +1171,34 @@ def parseTreeMCSPPrefixInput
   else
     none
 
+
+/--
+The canonical raw-field encoder is a right inverse of the concrete parser.
+
+This theorem is purely parser/serialization infrastructure: it assembles the
+already-localized field reader lemmas for the tag, gamma-coded target length,
+truth-table slice, active-prefix-length field, active witness-prefix slice, and
+zero-padding check.  After those rewrites, Lean's proof irrelevance normalizes
+the parser-produced bound proof against the bound stored in the raw fields.
+-/
+theorem parse_encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    parseTreeMCSPPrefixInput threshold codec
+      (encodeTreeMCSPPrefixFields codec fields) =
+    some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields) := by
+  simp [parseTreeMCSPPrefixInput,
+    readNatBE_encode_tag codec fields,
+    decodeGamma_encodeTreeMCSPPrefixFields codec fields,
+    sliceBits_encode_x codec fields,
+    readNatBE_encode_i codec fields,
+    fields.prefixLength_le,
+    sliceBits_encode_p codec fields,
+    sliceBits_encode_pad codec fields,
+    allZeroSlice_encode_pad codec fields,
+    CanonicalRawTreeMCSPPrefixFields.toPrefixInput]
+
 /-- The concrete parser packaged in the existing `PrefixParser` interface. -/
 def treeMCSPConcretePrefixParser
     (threshold : Nat → Nat)

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2504,6 +2504,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -219,6 +219,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected


### PR DESCRIPTION
### Motivation
- Provide the final parser/encoder round-trip for the tree-MCSP prefix convention so the encoder is a right-inverse of the concrete parser and callers can rely on a canonical `PrefixInput` representation.
- Assemble previously-landed field-level lemmas (tag, Elias-gamma, table/index/prefix slices, padding) into a single, reusable theorem to close P1P-02L7 parser/serialization infrastructure work.

### Description
- Add `theorem parse_encodeTreeMCSPPrefixFields` in `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` proving `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields) = some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields)` by rewriting with existing field lemmas and simplifying the parser do-block.
- The proof leverages the existing lemmas `readNatBE_encode_tag`, `decodeGamma_encodeTreeMCSPPrefixFields`, `sliceBits_encode_x`, `readNatBE_encode_i`, `sliceBits_encode_p`, `sliceBits_encode_pad`, and `allZeroSlice_encode_pad` and relies on simplification + proof-irrelevance for the dependent proof field.
- Register the new theorem in the public surface/axiom-audit listings by updating `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean` and `pnp4/Pnp4/Tests/AxiomsAudit.lean` so the new lemma appears in the axiom-surface dumps.

### Testing
- Ran a full build `lake build PnP3 Pnp4`, which completed successfully after adding the theorem and surface registrations.
- Ran the repository check `./scripts/check.sh`, which completed successfully (all checks passed in the script run used during the rollout).
- Searched for proof holes with `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4`, with no matches found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a97d80438832b963c1331be712dd8)