### PR TITLE
Add canonical prefix parser round trip

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -1084,15 +1084,12 @@ theorem parse_encodeTreeMCSPPrefixFields_field_obligations
     allZeroSlice_encode_pad codec fields⟩
 
 /--
-P1P-02L3 partial-progress marker.
+P1P-02L3 partial-progress marker retained for downstream surface tests.
 
-The full canonical theorem
-`parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields)
- = some (fields.toPrefixInput codec)` remains open.  The landed partial lemmas
-above isolate the already-verified tag, table slice, and active-prefix slice;
-the remaining proof work is the generic Elias-gamma round trip and big-endian
-index-field round trip, plus dependent proof-field normalization in the final
-`PrefixInput` equality.
+The full canonical round-trip theorem has since landed as
+`parse_encodeTreeMCSPPrefixFields`; this older bundled obligation remains useful
+for callers that only need the first tag/table/prefix slices without unfolding
+the full parser proof.
 -/
 theorem parse_encodeTreeMCSPPrefixFields_partial_obligation
     {threshold : Nat → Nat}
@@ -1170,6 +1167,27 @@ def parseTreeMCSPPrefixInput
       none
   else
     none
+
+/-- The canonical raw-field encoder is a right inverse of the concrete parser. -/
+theorem parse_encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    parseTreeMCSPPrefixInput threshold codec
+      (encodeTreeMCSPPrefixFields codec fields) =
+    some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields) := by
+  unfold parseTreeMCSPPrefixInput
+  rw [readNatBE_encode_tag codec fields]
+  rw [decodeGamma_encodeTreeMCSPPrefixFields codec fields]
+  simp [treePrefixTag]
+  rw [sliceBits_encode_x codec fields]
+  rw [readNatBE_encode_i codec fields]
+  simp
+  refine ⟨fields.prefixLength_le, ?_⟩
+  rw [sliceBits_encode_p codec fields]
+  rw [sliceBits_encode_pad codec fields]
+  rw [allZeroSlice_encode_pad codec fields]
+  simp [CanonicalRawTreeMCSPPrefixFields.toPrefixInput, treePrefixTag]
 
 /-- The concrete parser packaged in the existing `PrefixParser` interface. -/
 def treeMCSPConcretePrefixParser

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2504,6 +2504,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -219,6 +219,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected


### PR DESCRIPTION
### Motivation
- Close the remaining parser/encoder gap by proving the canonical round-trip for the tree-MCSP prefix serialization so the encoder is a right-inverse of the concrete parser. 
- Surface the full canonical theorem for downstream tests and callers that need the committed byte/gamma/table/index/witness layout to be provably invertible. 

### Description
- Add `theorem parse_encodeTreeMCSPPrefixFields` in `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` proving
  `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields) = some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields)` by unfolding the parser and rewriting with encoder-side lemmas. 
- Proof strategy: unfold `parseTreeMCSPPrefixInput`, rewrite using `readNatBE_encode_tag` and `decodeGamma_encodeTreeMCSPPrefixFields`, discharge the length/branch conditions, rewrite `sliceBits`/`readNatBE`/`allZeroSlice` field lemmas, supply `fields.prefixLength_le` for the `i` bound, and finish by simplifying to the `PrefixInput` record. 
- Update the P1P-02L3 partial-obligation comment to acknowledge the new full theorem while retaining the helper obligation for callers. 
- Register the new theorem in the pnp4 audit/surface test files by printing its axioms in `pnp4/Pnp4/Tests/AxiomsAudit.lean` and `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean` so it appears in surface dumps. 

### Testing
- Ran `lake build PnP3 Pnp4` which type-checked the changed module and the rest of the tree (build completed successfully). 
- Ran `./scripts/check.sh`; an initial run encountered a transient coordinator HTTP e2e `ConnectionResetError` during Step 12.e after the Lean build, then a re-run of `./scripts/check.sh` completed successfully and reported `All checks passed.` 
- Ran a repository scan `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` to ensure no `sorry`/`admit` were introduced; none were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a97d80438832b963c1331be712dd8)