### PR TITLE
Prove canonical prefix parser round-trip

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -1171,6 +1171,40 @@ def parseTreeMCSPPrefixInput
   else
     none
 
+/--
+The canonical encoder is a right inverse of the concrete parser.
+
+This is the final P1P-02 parser/encoder assembly theorem: the executable
+parser accepts the exact byte/gamma/table/index/witness layout emitted by
+`encodeTreeMCSPPrefixFields` and reconstructs the canonical `PrefixInput`
+record represented by the raw fields.  The proof is intentionally just
+serialization proof engineering; it does not prove NP membership, witness
+extraction, or any lower-bound endpoint.
+-/
+theorem parse_encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    parseTreeMCSPPrefixInput threshold codec
+      (encodeTreeMCSPPrefixFields codec fields) =
+    some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields) := by
+  unfold parseTreeMCSPPrefixInput
+  rw [readNatBE_encode_tag codec fields]
+  simp
+  rw [decodeGamma_encodeTreeMCSPPrefixFields codec fields]
+  simp
+  rw [sliceBits_encode_x codec fields]
+  simp
+  rw [readNatBE_encode_i codec fields]
+  simp [fields.prefixLength_le]
+  rw [sliceBits_encode_p codec fields]
+  simp
+  rw [sliceBits_encode_pad codec fields]
+  simp
+  rw [allZeroSlice_encode_pad codec fields]
+  simp
+  rfl
+
 /-- The concrete parser packaged in the existing `PrefixParser` interface. -/
 def treeMCSPConcretePrefixParser
     (threshold : Nat → Nat)

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2504,6 +2504,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -219,6 +219,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected


### PR DESCRIPTION
### Motivation
- Finish the P1P-02 serialization layer by proving the canonical parser/encoder round-trip so the parser is a right-inverse of the encoder for canonical raw tree-MCSP prefix fields.

### Description
- Add `theorem parse_encodeTreeMCSPPrefixFields` in `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` proving `parseTreeMCSPPrefixInput threshold codec (encodeTreeMCSPPrefixFields codec fields) = some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields)` and keep the proof local to the parser/encoder serialization layer. 
- The proof unfolds the parser do-block and rewrites each parser action using existing encoder inversion lemmas: `readNatBE_encode_tag`, `decodeGamma_encodeTreeMCSPPrefixFields` (via the gamma auxiliaries), `sliceBits_encode_x`, `readNatBE_encode_i`, `sliceBits_encode_p`, `sliceBits_encode_pad`, and `allZeroSlice_encode_pad`, resolving the length and prefix-bound branches definitionally and closing by `rfl`.
- Register the new theorem in the pnp4 public surface/axiom-audit files by adding `#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields` to `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean` and `pnp4/Pnp4/Tests/AxiomsAudit.lean` so the audit/surface tests reflect the new surface lemma.

### Testing
- Ran `lake build PnP3 Pnp4` and the module `Pnp4.Frontier.ContractExpansion.PrefixParserConvention` built successfully with the new theorem (Lean build passed).
- Ran the repository checks via `./scripts/check.sh` and the full check suite completed successfully (all check steps passed).
- Verified no proof holes or banned constructs with `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` (no occurrences found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a97d80438832b963c1331be712dd8)