### PR TITLE
Add parse_encodeTreeMCSPPrefixFields canonical parser/encoder round-trip theorem

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean
@@ -1171,6 +1171,36 @@ def parseTreeMCSPPrefixInput
   else
     none
 
+/--
+The canonical encoder is a right inverse for the concrete tree-MCSP prefix parser.
+
+This theorem is purely parser/serialization infrastructure: it assembles the
+previous field-level inversion lemmas for the tag, gamma length, truth table,
+active-prefix length, active-prefix payload, and zero padding.
+-/
+theorem parse_encodeTreeMCSPPrefixFields
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (fields : CanonicalRawTreeMCSPPrefixFields codec) :
+    parseTreeMCSPPrefixInput threshold codec
+      (encodeTreeMCSPPrefixFields codec fields) =
+    some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec fields) := by
+  unfold parseTreeMCSPPrefixInput
+  rw [readNatBE_encode_tag codec fields]
+  simp
+  rw [decodeGamma_encodeTreeMCSPPrefixFields codec fields]
+  simp
+  rw [sliceBits_encode_x codec fields]
+  simp
+  rw [readNatBE_encode_i codec fields]
+  simp [fields.prefixLength_le]
+  rw [sliceBits_encode_p codec fields]
+  simp
+  rw [sliceBits_encode_pad codec fields]
+  simp
+  rw [allZeroSlice_encode_pad codec fields]
+  simp [CanonicalRawTreeMCSPPrefixFields.toPrefixInput]
+
 /-- The concrete parser packaged in the existing `PrefixParser` interface. -/
 def treeMCSPConcretePrefixParser
     (threshold : Nat → Nat)

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2504,6 +2504,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -219,6 +219,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_x
 #print axioms Pnp4.Frontier.ContractExpansion.sliceBits_encode_p
 #print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields_partial_obligation
+#print axioms Pnp4.Frontier.ContractExpansion.parse_encodeTreeMCSPPrefixFields
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_bad_tag
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_length_convention
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected


### PR DESCRIPTION
### Motivation

- Finalize the parser/encoder round-trip for the tree-MCSP prefix convention by assembling the field-level inversion lemmas into a single canonical theorem that the encoder is a right-inverse of the parser.

### Description

- Added `theorem parse_encodeTreeMCSPPrefixFields` to `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean` which unfolds `parseTreeMCSPPrefixInput` and rewrites each parser bind using the existing encoder/decoder field lemmas to reach `CanonicalRawTreeMCSPPrefixFields.toPrefixInput`.
- The proof composes the following field lemmas: `readNatBE_encode_tag`, `decodeGamma_encodeTreeMCSPPrefixFields`, `sliceBits_encode_x`, `readNatBE_encode_i`, `sliceBits_encode_p`, `sliceBits_encode_pad`, and `allZeroSlice_encode_pad` to discharge the do-block branches and the padding check.
- Registered the new theorem in the public/axiom surfaces by adding print entries to `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean` and `pnp4/Pnp4/Tests/AxiomsAudit.lean` so the surface dumps include the landed theorem.
- Files changed: `pnp4/Pnp4/Frontier/ContractExpansion/PrefixParserConvention.lean`, `pnp4/Pnp4/Tests/AxiomsAudit.lean`, and `pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean`.

### Testing

- Ran `lake build PnP3 Pnp4` which built the modified modules and completed successfully.
- Ran the repository audit script `./scripts/check.sh` which completed all checks and reported success (all CI steps passed).
- Scanned for proof holes with `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no occurrences, confirming no admitted gaps were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a97d80438832b963c1331be712dd8)