### PR TITLE
Add L0 hInDag triviality probe — fixed-slice DAG hardwiring witness

### DIFF
--- a/pnp3/Tests/HInDagTrivialityProbe.lean
+++ b/pnp3/Tests/HInDagTrivialityProbe.lean
@@ -1,0 +1,159 @@
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Complexity.PsubsetPpolyInternal.TreeToStraight
+
+/-!
+L0 probe: fixed-slice hardwiring for `gapPartialMCSP_Language` into the
+canonical DAG interface.  This is an upper-bound/triviality probe only; it is
+not lower-bound progress toward `P ≠ NP`.
+-/
+
+namespace Pnp3
+namespace Tests
+namespace HInDagTrivialityProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+open Internal.PsubsetPpoly
+open Internal.PsubsetPpoly.StraightLine
+
+/-- One-gate constant-false DAG used on all non-active lengths. -/
+private def constFalseDag (n : Nat) : DagCircuit n where
+  gates := 1
+  gate := fun _ => .const false
+  output := .gate ⟨0, Nat.lt.base 0⟩
+
+@[simp] private theorem constFalseDag_eval {n : Nat} (x : Bitstring n) :
+    DagCircuit.eval (constFalseDag n) x = false := by
+  simp [constFalseDag, DagCircuit.eval, DagCircuit.eval.evalGateAt]
+
+/-- Rename inputs in a tree circuit. -/
+private def treeRename {m n : Nat} (σ : Fin m → Fin n) :
+    Boolcube.Circuit m → Boolcube.Circuit n
+  | .var i => .var (σ i)
+  | .const b => .const b
+  | .not c => .not (treeRename σ c)
+  | .and c₁ c₂ => .and (treeRename σ c₁) (treeRename σ c₂)
+  | .or c₁ c₂ => .or (treeRename σ c₁) (treeRename σ c₂)
+
+private theorem treeRename_eval {m n : Nat} (σ : Fin m → Fin n)
+    (c : Boolcube.Circuit m) (x : Bitstring n) :
+    Boolcube.Circuit.eval (treeRename σ c) x =
+      Boolcube.Circuit.eval c (fun i => x (σ i)) := by
+  induction c with
+  | var i => rfl
+  | const b => rfl
+  | not c ih => simp [treeRename, Boolcube.Circuit.eval, ih]
+  | and c₁ c₂ ih₁ ih₂ => simp [treeRename, Boolcube.Circuit.eval, ih₁, ih₂]
+  | or c₁ c₂ ih₁ ih₂ => simp [treeRename, Boolcube.Circuit.eval, ih₁, ih₂]
+
+/-- Truth-table tree circuit, used as a compact authoring layer for the DAG. -/
+private def ttTree : ∀ {n : Nat}, (Bitstring n → Bool) → Boolcube.Circuit n
+  | 0, f => .const (f (fun i => Fin.elim0 i))
+  | n + 1, f =>
+      let c0 := ttTree (fun x : Bitstring n => f (Fin.cases false x))
+      let c1 := ttTree (fun x : Bitstring n => f (Fin.cases true x))
+      .or
+        (.and (.not (.var ⟨0, Nat.zero_lt_succ n⟩)) (treeRename Fin.succ c0))
+        (.and (.var ⟨0, Nat.zero_lt_succ n⟩) (treeRename Fin.succ c1))
+
+private theorem ttTree_eval :
+    ∀ {n : Nat} (f : Bitstring n → Bool) (x : Bitstring n),
+      Boolcube.Circuit.eval (ttTree f) x = f x
+  | 0, f, x => by
+      show f (fun i => Fin.elim0 i) = f x
+      congr 1
+      funext i
+      exact Fin.elim0 i
+  | n + 1, f, x => by
+      simp only [ttTree, Boolcube.Circuit.eval, treeRename_eval]
+      have ih0 := ttTree_eval (fun y : Bitstring n => f (Fin.cases false y))
+        (fun i => x (Fin.succ i))
+      have ih1 := ttTree_eval (fun y : Bitstring n => f (Fin.cases true y))
+        (fun i => x (Fin.succ i))
+      rw [ih0, ih1]
+      have hx : ∀ b, x ⟨0, Nat.zero_lt_succ n⟩ = b →
+          (Fin.cases (n := n) b (fun i => x (Fin.succ i)) : Bitstring (n + 1)) = x := by
+        intro b hb
+        funext i
+        induction i using Fin.cases with
+        | zero => exact hb.symm
+        | succ j => rfl
+      cases h0 : x ⟨0, Nat.zero_lt_succ n⟩ <;>
+        simp only [Bool.not_false, Bool.not_true, Bool.true_and,
+          Bool.false_and, Bool.or_false, Bool.false_or] <;>
+        rw [hx _ h0]
+
+/-- DAG truth-table hardwiring obtained by compiling the tree to straight-line form. -/
+private noncomputable def ttDag {n : Nat} (f : Bitstring n → Bool) : DagCircuit n :=
+  let cc := compileTree (ttTree f)
+  Complexity.StraightLineAdapter.toDag
+    (Complexity.StraightLineAdapter.withOutput cc.ckt cc.out)
+
+private theorem ttDag_eval {n : Nat} (f : Bitstring n → Bool) (x : Bitstring n) :
+    DagCircuit.eval (ttDag f) x = f x := by
+  rw [ttDag]
+  let cc := compileTree (ttTree f)
+  calc
+    DagCircuit.eval
+        (Complexity.StraightLineAdapter.toDag
+          (Complexity.StraightLineAdapter.withOutput cc.ckt cc.out)) x
+        = Complexity.StraightLineAdapter.eval
+          (Complexity.StraightLineAdapter.withOutput cc.ckt cc.out) x := rfl
+    _ = Complexity.StraightLineAdapter.evalWire cc.ckt x cc.out := rfl
+    _ = StraightLine.evalWire cc.ckt x cc.out :=
+        adapter_evalWire_eq_evalWire cc.ckt x cc.out
+    _ = Boolcube.Circuit.eval (ttTree f) x := by
+        exact StraightLine.compileTreeWireSemantics (ttTree f) x
+    _ = f x := ttTree_eval f x
+
+/-- Per-slice DAG witness: one hardwired truth-table DAG at the active length. -/
+noncomputable def fixedSlice_gapPartialMCSP_in_PpolyDAG (p : GapPartialMCSPParams) :
+    InPpolyDAG (gapPartialMCSP_Language p) := by
+  classical
+  let N := partialInputLen p
+  let C := ttDag (gapPartialMCSP_Language p N)
+  let K := DagCircuit.size C
+  refine
+    { polyBound := fun m => if m = N then K else 2
+      polyBound_poly := ?_
+      family := fun m => if h : m = N then h ▸ C else constFalseDag m
+      family_size_le := ?_
+      correct := ?_ }
+  · refine ⟨K + 2, ?_⟩
+    intro m
+    by_cases h : m = N
+    · subst h
+      have h₁ : C.size ≤ C.size + 2 := by omega
+      have h₂ : C.size + 2 ≤ N ^ (C.size + 2) + (C.size + 2) :=
+        Nat.le_add_left _ _
+      simpa [K] using le_trans h₁ h₂
+    · have : 2 ≤ m ^ (K + 2) + (K + 2) := by omega
+      simpa [h] using this
+  · intro m
+    by_cases h : m = N
+    · subst h
+      simp [K]
+    · simp [h, constFalseDag, DagCircuit.size]
+  · intro m x
+    by_cases h : m = N
+    · subst h
+      simpa [C] using ttDag_eval (gapPartialMCSP_Language p N) x
+    · have hm : m ≠ partialInputLen p := by simpa [N] using h
+      simp [h, hm, gapPartialMCSP_Language]
+
+/-- Canonical route hypothesis surface; the premise is fixed-slice hardwiring. -/
+noncomputable def hInDag_for_canonicalAsymptoticHAsym :
+    ∀ n β,
+      InPpolyDAG
+        (gapPartialMCSP_Language
+          ((eventualGapSliceFamily_of_asymptotic
+              canonicalAsymptoticHAsym).paramsOf n β)) := by
+  intro n β
+  exact fixedSlice_gapPartialMCSP_in_PpolyDAG _
+
+end HInDagTrivialityProbe
+end Tests
+end Pnp3

--- a/seed_packs/hInDag_triviality_probe_L0/failures/check_coordinator_reset.md
+++ b/seed_packs/hInDag_triviality_probe_L0/failures/check_coordinator_reset.md
@@ -1,0 +1,29 @@
+# `./scripts/check.sh` coordinator reset observation
+
+Command: `./scripts/check.sh`
+
+Observed twice on 2026-05-18 UTC.  In both runs, the full Lean build and the
+preceding governance/audit checks passed through Step 12.d, then Step 12.e
+(`coordinator HTTP service e2e`) failed during parallel `/v1/result` submission
+with:
+
+```text
+ConnectionResetError: [Errno 104] Connection reset by peer
+```
+
+The second run also showed:
+
+```text
+[test_coordinator] OK   /v1/health
+[test_coordinator] OK   /v1/manifest
+[test_coordinator] OK   /v1/task role-mismatch -> 403
+[test_coordinator] OK   /v1/task x N=20 -> 20 distinct ids
+```
+
+Exit code: `1`.
+
+Local Lean check for the staged probe succeeded separately:
+
+```sh
+lake env lean pnp3/Tests/HInDagTrivialityProbe.lean
+```

--- a/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
+++ b/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
@@ -1,0 +1,75 @@
+# L0 hInDag triviality probe — gpt55
+
+## Progress classification
+
+Infrastructure / audit probe.  This file proves an upper-bound/triviality
+premise for a downstream route.  It does **not** reduce
+`VerifiedNPDAGLowerBoundSource` or `SearchMCSPWeakLowerBound`, and it is not
+reported as P-vs-NP mainline progress.
+
+## Landed artifact
+
+Landed Lean staging file:
+
+- `pnp3/Tests/HInDagTrivialityProbe.lean` (159 LOC)
+
+The staging file imports the requested interfaces plus
+`Complexity.PsubsetPpolyInternal.TreeToStraight`.  The extra import is used only
+as a proof-producing authoring adapter from tree Boolean circuits to the
+canonical `DagCircuit` interface; it avoids importing refuted-predicate tests.
+
+## Lean result
+
+The probe constructs:
+
+- local `constFalseDag` for non-active lengths;
+- local truth-table tree circuits `ttTree` with correctness lemma
+  `ttTree_eval`;
+- local DAG hardwiring `ttDag`, obtained through the existing transparent
+  straight-line-to-DAG adapter, with correctness lemma `ttDag_eval`;
+- `fixedSlice_gapPartialMCSP_in_PpolyDAG`, a per-slice `InPpolyDAG` witness for
+  every `gapPartialMCSP_Language p`;
+- `hInDag_for_canonicalAsymptoticHAsym`, the canonical route hypothesis surface.
+
+Lean surface note: `InPpolyDAG L` is a structure in `Type`, not a proposition,
+so Lean requires these two exported inhabitants to be `def` declarations rather
+than `theorem` declarations.  The semantic content is the requested closed
+inhabitant of the structure.
+
+Noncomputability note: `ttDag` goes through the repository's existing
+`compileTree`, which is marked `noncomputable`, and the fixed-slice witness
+mentions the existing noncomputable `gapPartialMCSP_Language`.  No `axiom`,
+`sorry`, `admit`, `opaque`, or `native_decide` is introduced.
+
+## Audits performed
+
+Commands run:
+
+```sh
+lake env lean pnp3/Tests/HInDagTrivialityProbe.lean
+rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions" pnp3/Tests/HInDagTrivialityProbe.lean
+rg -n "\b(axiom|sorry|admit|native_decide|opaque)\b" pnp3/Tests/HInDagTrivialityProbe.lean
+./scripts/check.sh
+```
+
+The forbidden refuted-predicate surface audit returned no matches.  The local
+forbidden-keyword scan returned no `axiom`, `sorry`, `admit`, `native_decide`,
+or `opaque` declarations.
+
+`./scripts/check.sh` was run twice.  Both runs passed the full Lean build and
+governance checks through Step 12.d, then failed at Step 12.e with a coordinator
+HTTP parallel-result `ConnectionResetError: [Errno 104] Connection reset by
+peer`; the observation is recorded in
+`seed_packs/hInDag_triviality_probe_L0/failures/check_coordinator_reset.md`.
+
+## Conclusion-side status
+
+The landed hInDag premise is now trivial by fixed-slice hardwiring.  L0 did not
+settle the separate conclusion-side question for
+`IsoStrongFamilyEventually`/promise-YES certificates under that hardwired
+premise.  That conclusion-side question remains research-open within this L0
+scope.
+
+Recommended next action: `open_isoStrong_conclusion_audit_D0`.
+
+RED_HINDAG_TRIVIAL_BUT_CONCLUSION_OPEN


### PR DESCRIPTION
### Motivation

- Provide the L0-A fixed-slice attack: show `gapPartialMCSP_Language p` is trivially in the repo's DAG non-uniform class for each fixed `p`, so downstream `hInDag` hypotheses can be instantiated with a hardwired witness.  
- Avoid importing refuted-predicate infrastructure by building a compact, self-contained DAG truth-table witness and expose the canonical `hInDag` surface for the canonical asymptotic instance.

### Description

- Add `pnp3/Tests/HInDagTrivialityProbe.lean` which defines a local one-gate `constFalseDag`, a recursive truth-table tree `ttTree`, and a compiled DAG hardwiring `ttDag` via the repository's `compileTree` / `StraightLineAdapter.toDag` path.  
- Provide `fixedSlice_gapPartialMCSP_in_PpolyDAG : ∀ p, InPpolyDAG (gapPartialMCSP_Language p)` as a per-slice witness (polyBound/family/correctness) and the canonical surface `hInDag_for_canonicalAsymptoticHAsym` that instantiates the asymptotic route hypothesis at the hardwired witness.  
- Keep definitions `noncomputable` where they depend on existing noncomputable components (`compileTree`, `gapPartialMCSP_Language`); do not introduce `axiom`, `sorry`, `admit`, `opaque`, or `native_decide`.  
- Add the seed-pack report `seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md` (verdict `RED_HINDAG_TRIVIAL_BUT_CONCLUSION_OPEN`) and record a coordinator e2e failure observation under `seed_packs/hInDag_triviality_probe_L0/failures/check_coordinator_reset.md`.

### Testing

- `lake env lean pnp3/Tests/HInDagTrivialityProbe.lean` — PASS (local type-check of the staged probe).
- `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions" pnp3/Tests/HInDagTrivialityProbe.lean` — PASS (no forbidden refuted-predicate imports).
- `rg -n "\b(axiom|sorry|admit|native_decide|opaque)\b" pnp3/Tests/HInDagTrivialityProbe.lean` — PASS (no forbidden keywords introduced).
- `./scripts/check.sh` — executed twice: both runs completed the full Lean build and governance/audit checks through Step 12.d successfully, but the coordinator HTTP e2e test (Step 12.e) failed both times with a parallel-result `ConnectionResetError: [Errno 104] Connection reset by peer`; this observation is recorded in `seed_packs/hInDag_triviality_probe_L0/failures/check_coordinator_reset.md` (build and repo checks otherwise succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b568f78d4832b9509680cac0cdf3c)