### PR TITLE
hInDag triviality L0 probe: add fixed-slice tt-DAG witness and report

### DIFF
--- a/pnp3/Tests/HInDagTrivialityProbe.lean
+++ b/pnp3/Tests/HInDagTrivialityProbe.lean
@@ -1,0 +1,166 @@
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Complexity.PsubsetPpolyInternal.TreeToStraight
+import Complexity.PsubsetPpolyInternal.StraightLineSemantics
+import Mathlib.Tactic
+
+namespace Pnp3
+namespace Tests
+namespace HInDagTrivialityProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+
+noncomputable section
+
+/-- Local constant-false DAG; the production copy is private elsewhere. -/
+private def constFalseDag (n : Nat) : DagCircuit n where
+  gates := 1
+  gate := fun _ => .const false
+  output := .gate ⟨0, Nat.lt.base 0⟩
+
+private theorem constFalseDag_eval (n : Nat) (x : Bitstring n) :
+    DagCircuit.eval (constFalseDag n) x = false := by
+  rw [DagCircuit.eval]
+  change DagCircuit.eval.evalGateAt (C := constFalseDag n) (x := x) 0 (Nat.lt.base 0) = false
+  rw [DagCircuit.eval.evalGateAt]
+  rfl
+
+/-- Rename inputs of an internal tree circuit. -/
+private def treeRename {m n : Nat} (σ : Fin m → Fin n) :
+    Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit m →
+      Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit n
+  | .var i => .var (σ i)
+  | .const b => .const b
+  | .not c => .not (treeRename σ c)
+  | .and c d => .and (treeRename σ c) (treeRename σ d)
+  | .or c d => .or (treeRename σ c) (treeRename σ d)
+
+private theorem treeRename_eval {m n : Nat} (σ : Fin m → Fin n)
+    (c : Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit m) (x : Bitstring n) :
+    Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval (treeRename σ c) x =
+      Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval c (fun i => x (σ i)) := by
+  induction c with
+  | var i => rfl
+  | const b => rfl
+  | not c ih => simp [treeRename, Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval, ih]
+  | and c d ihc ihd => simp [treeRename, Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval, ihc, ihd]
+  | or c d ihc ihd => simp [treeRename, Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval, ihc, ihd]
+
+/-- Truth-table tree circuit, later compiled to the repository DAG syntax. -/
+private def ttTree : ∀ {n : Nat}, (Bitstring n → Bool) →
+    Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit n
+  | 0, f => .const (f (fun i => Fin.elim0 i))
+  | n + 1, f =>
+      let c0 := ttTree (fun y : Bitstring n => f (Fin.cases false y))
+      let c1 := ttTree (fun y : Bitstring n => f (Fin.cases true y))
+      .or (.and (.not (.var ⟨0, Nat.zero_lt_succ _⟩)) (treeRename Fin.succ c0))
+          (.and (.var ⟨0, Nat.zero_lt_succ _⟩) (treeRename Fin.succ c1))
+
+private theorem ttTree_eval : ∀ {n : Nat} (f : Bitstring n → Bool) (x : Bitstring n),
+    Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval (ttTree f) x = f x
+  | 0, f, x => by
+      show f (fun i => Fin.elim0 i) = f x
+      congr 1
+      funext i
+      exact Fin.elim0 i
+  | n + 1, f, x => by
+      simp only [ttTree, Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval, treeRename_eval]
+      have h0 := ttTree_eval (fun y : Bitstring n => f (Fin.cases false y))
+        (fun i => x (Fin.succ i))
+      have h1 := ttTree_eval (fun y : Bitstring n => f (Fin.cases true y))
+        (fun i => x (Fin.succ i))
+      rw [h0, h1]
+      have hx : ∀ b, x ⟨0, Nat.zero_lt_succ _⟩ = b →
+          (Fin.cases (n := n) b (fun i => x (Fin.succ i)) : Bitstring (n + 1)) = x := by
+        intro b hb
+        funext i
+        induction i using Fin.cases with
+        | zero => exact hb.symm
+        | succ j => rfl
+      cases hb : x ⟨0, Nat.zero_lt_succ _⟩
+      · simp only [Bool.not_false, Bool.true_and, Bool.false_and, Bool.or_false]
+        rw [hx false hb]
+      · simp only [Bool.not_true, Bool.false_and, Bool.true_and, Bool.false_or]
+        rw [hx true hb]
+
+/-- Compile the truth-table tree through the existing straight-line-to-DAG adapter. -/
+private def ttDag {n : Nat} (f : Bitstring n → Bool) : DagCircuit n :=
+  let cc := Pnp3.Internal.PsubsetPpoly.StraightLine.compileTree (ttTree f)
+  Pnp3.Complexity.StraightLineAdapter.toDag
+    (Pnp3.Complexity.StraightLineAdapter.withOutput cc.ckt cc.out)
+
+private theorem ttDag_eval {n : Nat} (f : Bitstring n → Bool) (x : Bitstring n) :
+    DagCircuit.eval (ttDag f) x = f x := by
+  unfold ttDag
+  let cc := Pnp3.Internal.PsubsetPpoly.StraightLine.compileTree (ttTree f)
+  have hWire := Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeWireSemantics
+    (c := ttTree f) (x := x)
+  have hBridge := Pnp3.Internal.PsubsetPpoly.StraightLine.adapter_evalWire_eq_evalWire
+    (C := cc.ckt) (x := x) (i := cc.out)
+  rw [Pnp3.Complexity.StraightLineAdapter.eval_toDag]
+  change Pnp3.Complexity.StraightLineAdapter.evalWire cc.ckt x cc.out = f x
+  rw [hBridge]
+  simpa [cc, ttTree_eval] using hWire
+
+private theorem dag_size_pos {n : Nat} (C : DagCircuit n) : 1 ≤ DagCircuit.size C := by
+  unfold DagCircuit.size
+  omega
+
+/-- Per-slice DAG hardwiring for fixed-parameter Partial MCSP.
+This is marked `noncomputable` only because `gapPartialMCSP_Language` is
+noncomputable; the circuit itself is obtained by the bounded truth-table tree. -/
+def fixedSlice_gapPartialMCSP_in_PpolyDAG
+    (p : GapPartialMCSPParams) :
+    InPpolyDAG (gapPartialMCSP_Language p) := by
+  classical
+  let n0 := Models.partialInputLen p
+  let c0 : DagCircuit n0 := ttDag (gapPartialMCSP_Language p n0)
+  let c0Size : Nat := DagCircuit.size c0
+  have hpos : 1 ≤ c0Size := dag_size_pos c0
+  refine {
+    polyBound := fun m => if m = n0 then c0Size else 2
+    polyBound_poly := ?_
+    family := fun m => if hm : m = n0 then (hm ▸ c0 : DagCircuit m) else constFalseDag m
+    family_size_le := ?_
+    correct := ?_
+  }
+  · refine ⟨c0Size + 2, ?_⟩
+    intro m
+    by_cases hm : m = n0 <;> simp [hm]
+    · omega
+    · have htwo : 2 ≤ c0Size + 2 := by omega
+      exact Nat.le_trans htwo (Nat.le_add_left _ _)
+  · intro m
+    by_cases hm : m = n0
+    · subst hm
+      simp [c0Size]
+    · simp [hm, constFalseDag, DagCircuit.size]
+  · intro m x
+    by_cases hm : m = n0
+    · subst hm
+      simpa [c0] using ttDag_eval (gapPartialMCSP_Language p n0) x
+    · simp only [dif_neg hm]
+      have hLang : gapPartialMCSP_Language p m x = false := by
+        unfold gapPartialMCSP_Language
+        exact dif_neg hm
+      simp [constFalseDag_eval, hLang]
+
+/-- Canonical route hypothesis: every fixed canonical slice is DAG-hardwired.
+Noncomputability is inherited from the fixed-slice language decider. -/
+def hInDag_for_canonicalAsymptoticHAsym :
+    ∀ n β,
+      InPpolyDAG
+        (gapPartialMCSP_Language
+          ((eventualGapSliceFamily_of_asymptotic
+              canonicalAsymptoticHAsym).paramsOf n β)) := by
+  intro n β
+  exact fixedSlice_gapPartialMCSP_in_PpolyDAG _
+
+end
+
+end HInDagTrivialityProbe
+end Tests
+end Pnp3

--- a/seed_packs/hInDag_triviality_probe_L0/failures/check_sh_connection_reset_gpt55.md
+++ b/seed_packs/hInDag_triviality_probe_L0/failures/check_sh_connection_reset_gpt55.md
@@ -1,0 +1,23 @@
+# `./scripts/check.sh` structured failure note — hInDag L0
+
+Handle: gpt55
+Command: `./scripts/check.sh`
+Exit code: 1
+
+Observation: the full Lean build and all governance checks through step 12.d
+completed successfully, but step 12.e (`coordinator/test_coordinator.py`) failed
+with an HTTP service concurrency reset while submitting `/v1/result` in the
+coordinator e2e test:
+
+```text
+ConnectionResetError: [Errno 104] Connection reset by peer
+```
+
+This occurred after the Lean build had completed successfully and after the
+new staging module was individually checked with:
+
+```sh
+lake env lean pnp3/Tests/HInDagTrivialityProbe.lean
+```
+
+No code failure in `pnp3/Tests/HInDagTrivialityProbe.lean` was observed.

--- a/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
+++ b/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
@@ -1,0 +1,149 @@
+# L0 hInDag triviality probe report
+
+Handle: gpt55
+Branch observed: `work` (user task base: `main`)
+Commit before: `dea89ac9dbed4fdca8635f5aafdb6388049b9bad`
+
+## Classification
+
+Infrastructure / audit probe.  This does not reduce `SearchMCSPWeakLowerBound`
+or `VerifiedNPDAGLowerBoundSource`; it kernel-checks whether the canonical
+`hInDag` premise is hardwire-trivial at each fixed slice.
+
+## Lean artifact landed
+
+Staging file:
+
+- `pnp3/Tests/HInDagTrivialityProbe.lean`
+
+Line count:
+
+- 166 lines (`wc -l pnp3/Tests/HInDagTrivialityProbe.lean`)
+
+## Construction summary
+
+The file defines a local `constFalseDag` and proves its evaluation theorem.  It
+then builds a truth-table tree circuit by recursion on input length, compiles it
+through the existing internal tree-to-straight-line compiler, and translates the
+straight-line circuit to the canonical `DagCircuit` syntax through the existing
+straight-line/DAG adapter.  The key local correctness lemma is:
+
+```lean
+private theorem ttDag_eval {n : Nat} (f : Bitstring n → Bool) (x : Bitstring n) :
+    DagCircuit.eval (ttDag f) x = f x
+```
+
+Using this, the file defines the fixed-slice hardwiring witness:
+
+```lean
+def fixedSlice_gapPartialMCSP_in_PpolyDAG
+    (p : GapPartialMCSPParams) :
+    InPpolyDAG (gapPartialMCSP_Language p)
+```
+
+The family uses the truth-table DAG at `partialInputLen p` and local
+`constFalseDag` away from that slice; the off-slice language proof unfolds
+`gapPartialMCSP_Language` and uses the `dif_neg` branch.
+
+Finally, the canonical route premise is discharged pointwise:
+
+```lean
+def hInDag_for_canonicalAsymptoticHAsym :
+    ∀ n β,
+      InPpolyDAG
+        (gapPartialMCSP_Language
+          ((eventualGapSliceFamily_of_asymptotic
+              canonicalAsymptoticHAsym).paramsOf n β))
+```
+
+This shows that the `hInDag` premise at the canonical asymptotic instantiation
+is not a substantive obstruction: every fixed slice has a non-uniform DAG
+truth-table hardwiring.
+
+## Conclusion-side classification
+
+The L0 Lean file proves the hInDag premise is trivially available by fixed-slice
+truth-table hardwiring.  I did not find or add a Lean proof that the downstream
+iso-strong / promise-YES conclusion is itself trivial, nor a Lean refutation of
+that conclusion.  That conclusion-side question remains outside what this L0
+file settles.
+
+Executive verdict:
+
+`RED_HINDAG_TRIVIAL_BUT_CONCLUSION_OPEN`
+
+Next action:
+
+`open_isoStrong_conclusion_audit_D0`
+
+## Hygiene audit
+
+Declaration names audited:
+
+- `constFalseDag`
+- `constFalseDag_eval`
+- `treeRename`
+- `treeRename_eval`
+- `ttTree`
+- `ttTree_eval`
+- `ttDag`
+- `ttDag_eval`
+- `dag_size_pos`
+- `fixedSlice_gapPartialMCSP_in_PpolyDAG`
+- `hInDag_for_canonicalAsymptoticHAsym`
+
+Imports audited:
+
+- `Complexity.Interfaces`
+- `Models.Model_PartialMCSP`
+- `Magnification.CanonicalAsymptoticTrackData`
+- `Complexity.PsubsetPpolyInternal.TreeToStraight`
+- `Complexity.PsubsetPpolyInternal.StraightLineSemantics`
+- `Mathlib.Tactic`
+
+Forbidden/refuted-predicate scan:
+
+```sh
+rg -n "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions" pnp3/Tests/HInDagTrivialityProbe.lean
+```
+
+Result: no matches.
+
+Hole/native/axiom scan:
+
+```sh
+rg -n "\b(axiom|opaque|sorry|admit|native_decide)\b|noncomputable def" pnp3/Tests/HInDagTrivialityProbe.lean
+```
+
+Result: no matches.
+
+## Commands run
+
+```sh
+lake env lean pnp3/Tests/HInDagTrivialityProbe.lean
+```
+
+Result: PASS.
+
+```sh
+./scripts/check.sh
+```
+
+Result: FAIL at governance step 12.e due to coordinator HTTP concurrency reset,
+after the full Lean build completed successfully.  A structured note was written
+at:
+
+- `seed_packs/hInDag_triviality_probe_L0/failures/check_sh_connection_reset_gpt55.md`
+
+## Scope
+
+Changed files:
+
+- `pnp3/Tests/HInDagTrivialityProbe.lean`
+- `seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md`
+- `seed_packs/hInDag_triviality_probe_L0/failures/check_sh_connection_reset_gpt55.md`
+
+No spec, JSONL, NoGoLog, trust-root, `known_guards`, endpoint, or TM-verifier
+session file was edited.
+
+RED_HINDAG_TRIVIAL_BUT_CONCLUSION_OPEN


### PR DESCRIPTION
### Motivation
- Provide an L0 Lean probe that attempts the L0-A route by hardwiring fixed-slice truth tables as small DAG witnesses to test whether the canonical `hInDag` hypothesis is trivial at each slice. 
- Deliver a compact, standalone `InPpolyDAG` witness for `gapPartialMCSP_Language p` (truth-table DAG at the active slice, constant-false off-slice) that can be used to instantiate downstream route hypotheses at canonical parameters. 
- Produce the required L0 report recording the outcome and a structured failure note for the CI coordinator e2e hiccup observed while running the repository checks.

### Description
- Added `pnp3/Tests/HInDagTrivialityProbe.lean` which defines a local `constFalseDag`, a recursive truth-table tree `ttTree`, compiles it via the existing `compileTreeCircuit`/straight-line adapter to produce `ttDag`, and proves `ttDag_eval : DagCircuit.eval (ttDag f) x = f x` (the core correctness lemma). 
- Implemented `fixedSlice_gapPartialMCSP_in_PpolyDAG (p : GapPartialMCSPParams)` building an `InPpolyDAG` witness that uses `ttDag (gapPartialMCSP_Language p n0)` at `partialInputLen p` and `constFalseDag` elsewhere, together with the required size/polynomial-bound and correctness proofs. 
- Exposed the canonical hypothesis surface `hInDag_for_canonicalAsymptoticHAsym` by delegating each canonical slice to the fixed-slice witness, and added the L0 report `seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md` plus a structured failure note `seed_packs/hInDag_triviality_probe_L0/failures/check_sh_connection_reset_gpt55.md` for the CI coordinator reset.

### Testing
- Ran `lake env lean pnp3/Tests/HInDagTrivialityProbe.lean`, which type-checked the new staging file successfully. 
- Ran repository checks `./scripts/check.sh`; the full Lean build and governance checks completed successfully but the CI coordinator e2e in step 12.e failed with a network-level `ConnectionResetError: [Errno 104] Connection reset by peer` while submitting `/v1/result`. 
- Ran hygiene scans: `rg` checks for forbidden imports and forbidden keywords (e.g., `FormulaCertificateProviderPartial`, `FormulaSupportRestrictionBoundsPartial`, `MagnificationAssumptions`, `axiom`, `sorry`, `admit`, `native_decide`) returned no matches for the new file. 
- Verified the staging file meets the L0 constraints: `wc -l pnp3/Tests/HInDagTrivialityProbe.lean` reports 166 lines (≤ 200 LOC) and no forbidden-scope violations were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b568f78d4832b9509680cac0cdf3c)