### PR TITLE
hInDag triviality L0 probe: land fixed-slice DAG hardwiring witness

### DIFF
--- a/pnp3/Tests/HInDagTrivialityProbe.lean
+++ b/pnp3/Tests/HInDagTrivialityProbe.lean
@@ -1,0 +1,121 @@
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Complexity.PsubsetPpolyInternal.Simulation
+
+namespace Pnp3
+namespace Tests
+namespace HInDagTrivialityProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+
+
+/-!
+This L0 probe is infrastructure/audit work, not lower-bound progress.  The
+single mathematical point is benign hardwiring: at a fixed input length every
+Boolean slice has a non-uniform DAG, and `gapPartialMCSP_Language` is
+definitionally false away from its encoded slice.
+-/
+
+/-- One-gate constant-false DAG used off the single relevant slice. -/
+private def constFalseDag (n : Nat) : DagCircuit n where
+  gates := 1
+  gate := fun _ => .const false
+  output := .gate ⟨0, Nat.lt.base 0⟩
+
+@[simp] private theorem constFalseDag_size {n : Nat} :
+    DagCircuit.size (constFalseDag n) = 2 := by
+  simp [constFalseDag, DagCircuit.size]
+
+@[simp] private theorem constFalseDag_eval {n : Nat} (x : Bitstring n) :
+    DagCircuit.eval (constFalseDag n) x = false := by
+  simp [constFalseDag, DagCircuit.eval, DagCircuit.eval.evalGateAt]
+
+/--
+Truth-table DAG obtained by compiling the existing finite tree truth-table
+circuit.  This is `noncomputable` only because the imported truth-table builder
+enumerates the finite Boolean cube using classical finite-set machinery; no
+unbounded oracle or new assumption is introduced.
+-/
+private noncomputable def ttDag {n : Nat} (f : Bitstring n → Bool) : DagCircuit n :=
+  let c := Pnp3.Internal.PsubsetPpoly.Simulation.Boolcube.Circuit.truthTableCircuit f
+  let cc := Pnp3.Internal.PsubsetPpoly.StraightLine.compileTree c
+  Pnp3.Complexity.StraightLineAdapter.toDag
+    (Pnp3.Complexity.StraightLineAdapter.withOutput cc.ckt cc.out)
+
+/-- Correctness of the truth-table DAG. -/
+private theorem ttDag_eval {n : Nat} (f : Bitstring n → Bool) (x : Bitstring n) :
+    DagCircuit.eval (ttDag f) x = f x := by
+  classical
+  let c := Pnp3.Internal.PsubsetPpoly.Simulation.Boolcube.Circuit.truthTableCircuit f
+  let cc := Pnp3.Internal.PsubsetPpoly.StraightLine.compileTree c
+  have hWire :
+      Pnp3.Internal.PsubsetPpoly.StraightLine.evalWire (C := cc.ckt) (x := x) cc.out =
+        Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval c x := by
+    simpa [cc] using Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeWireSemantics c x
+  have hTree : Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval c x = f x :=
+    Pnp3.Internal.PsubsetPpoly.Simulation.Boolcube.Circuit.eval_truthTableCircuit f x
+  change Pnp3.Complexity.StraightLineAdapter.evalWire cc.ckt x cc.out = f x
+  rw [Pnp3.Internal.PsubsetPpoly.StraightLine.adapter_evalWire_eq_evalWire]
+  exact hWire.trans hTree
+
+/--
+Per-slice `InPpolyDAG` witness by hardwiring the only non-false length.  The
+noncomputability is inherited from `ttDag`, i.e. from a bounded truth-table
+enumeration at the fixed length `partialInputLen p`.
+-/
+noncomputable def fixedSlice_gapPartialMCSP_in_PpolyDAG
+    (p : GapPartialMCSPParams) :
+    InPpolyDAG (gapPartialMCSP_Language p) := by
+  classical
+  let n₀ := partialInputLen p
+  let c₀ : DagCircuit n₀ := ttDag (gapPartialMCSP_Language p n₀)
+  let c₀_size : Nat := DagCircuit.size c₀
+  refine {
+    polyBound := fun m => if m = n₀ then c₀_size else 2
+    polyBound_poly := ?_
+    family := fun m => if hm : m = n₀ then hm ▸ c₀ else constFalseDag m
+    family_size_le := ?_
+    correct := ?_
+  }
+  · refine ⟨c₀_size + 2, ?_⟩
+    intro m
+    by_cases hm : m = n₀
+    · simp [hm]
+      exact Nat.le_trans (by omega : c₀_size ≤ c₀_size + 2)
+        (Nat.le_add_left _ _)
+    · simp [hm]
+      exact Nat.le_trans (by omega : 2 ≤ c₀_size + 2) (Nat.le_add_left _ _)
+  · intro m
+    by_cases hm : m = n₀
+    · subst hm
+      simp [c₀_size]
+    · simp [hm]
+  · intro m x
+    by_cases hm : m = n₀
+    · subst hm
+      simp only
+      exact ttDag_eval (gapPartialMCSP_Language p n₀) x
+    · have hLang : gapPartialMCSP_Language p m x = false := by
+        simp [gapPartialMCSP_Language, n₀, hm]
+      simp [hm, hLang]
+
+/--
+The route hypothesis surface at the canonical asymptotic instantiation.  The
+value is noncomputable only because each fixed slice reuses the bounded
+truth-table hardwiring witness above.
+-/
+noncomputable def hInDag_for_canonicalAsymptoticHAsym :
+    ∀ n β,
+      InPpolyDAG
+        (gapPartialMCSP_Language
+          ((eventualGapSliceFamily_of_asymptotic
+              canonicalAsymptoticHAsym).paramsOf n β)) := by
+  intro n β
+  exact fixedSlice_gapPartialMCSP_in_PpolyDAG _
+
+end HInDagTrivialityProbe
+end Tests
+end Pnp3

--- a/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
+++ b/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
@@ -1,0 +1,103 @@
+# L0 hInDag triviality probe — gpt55
+
+## Classification
+
+Infrastructure / route-audit probe.  This work does **not** reduce
+`SearchMCSPWeakLowerBound` or `VerifiedNPDAGLowerBoundSource`, and it should not
+be reported as P-vs-NP mainline lower-bound progress.  It proves a benign
+non-uniform upper-bound/triviality witness for the `hInDag` premise used by the
+canonical asymptotic route surface.
+
+## Landed Lean artifact
+
+Landed staging file:
+
+```text
+pnp3/Tests/HInDagTrivialityProbe.lean
+```
+
+The file is 121 lines, below the 200-LOC cap.  It contains:
+
+- a local `constFalseDag` plus size/evaluation lemmas;
+- a local `ttDag`, implemented by reusing the existing finite Boolean-cube
+  truth-table tree circuit and the existing straight-line-to-DAG adapter;
+- `ttDag_eval`, proved by composing the imported truth-table correctness,
+  compile-tree wire semantics, and straight-line adapter wire semantics;
+- `fixedSlice_gapPartialMCSP_in_PpolyDAG`, an `InPpolyDAG` witness for every
+  fixed `gapPartialMCSP_Language p`;
+- `hInDag_for_canonicalAsymptoticHAsym`, the canonical route-premise surface.
+
+Lean note: `InPpolyDAG L` is a structure/type in this repository, not a `Prop`,
+so the two public witness surfaces are implemented as `noncomputable def`s
+rather than `theorem`s.  The noncomputability is explicitly documented in the
+file and is inherited from bounded finite truth-table enumeration of a fixed
+slice; no oracle, axiom, `sorry`, `admit`, or `native_decide` is introduced.
+
+## Construction summary
+
+The fixed-slice witness uses the standard hardwiring split:
+
+1. At the unique encoded length `partialInputLen p`, use `ttDag` for the Boolean
+   function `gapPartialMCSP_Language p (partialInputLen p)`.
+2. At every other length, use the one-gate `constFalseDag`.
+3. Correctness off-slice is immediate because `gapPartialMCSP_Language` unfolds
+   to `false` when the input length differs from `partialInputLen p`.
+4. Polynomial boundedness is trivial because there is only one hardwired
+   exceptional length; the proof uses the constant size of the selected DAG as
+   a polynomial exponent slack.
+
+## Audits performed
+
+- Staging LOC: `wc -l pnp3/Tests/HInDagTrivialityProbe.lean` returned `121`.
+- Kernel check: `lake env lean pnp3/Tests/HInDagTrivialityProbe.lean` passed.
+- Refuted-carrier string audit:
+  `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions" pnp3/Tests/HInDagTrivialityProbe.lean`
+  returned no matches.
+- Full repository check: `./scripts/check.sh` passed after the Lean file was
+  landed.
+
+## Declaration names audited
+
+- `constFalseDag`
+- `constFalseDag_size`
+- `constFalseDag_eval`
+- `ttDag`
+- `ttDag_eval`
+- `fixedSlice_gapPartialMCSP_in_PpolyDAG`
+- `hInDag_for_canonicalAsymptoticHAsym`
+
+## Imports audited
+
+```lean
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Complexity.PsubsetPpolyInternal.Simulation
+```
+
+No import from `Magnification.LocalityProvider_Partial`, no import of
+`pnp3/Tests/FormulaSupportBoundsFalsifiabilityProbe.lean`, and no import under
+`pnp3/RefutedPredicates/` was added.
+
+## Conclusion-side status
+
+The `hInDag` premise at the canonical instantiation is now trivially inhabited
+by hardwired non-uniform DAGs.  This does **not** by itself settle the downstream
+`IsoStrongFamilyEventually` / promise-YES conclusion under the hardwired premise.
+No small Lean argument or structural contradiction proving/refuting that
+conclusion was found in L0 scope, and this file intentionally does not claim
+any endpoint, source theorem, or `P ≠ NP` consequence.
+
+Next action: open `isoStrong_conclusion_audit_D0` to classify the conclusion
+side with the now-landed hardwired `hInDag` witness.
+
+## Scope compliance
+
+- Edited only the authorized staging Lean file and this report.
+- No pnp4 files were changed.
+- No `axiom`, `sorry`, `admit`, or `native_decide` was added.
+- No JSONL / NoGoLog / spec / `known_guards` / trust-root file was edited.
+- No `ResearchGapWitness`, `VerifiedNPDAGLowerBoundSource`, endpoint, or
+  unconditional `P ≠ NP` claim was added.
+
+RED_HINDAG_TRIVIAL_BUT_CONCLUSION_OPEN


### PR DESCRIPTION
### Motivation
- Provide an L0 scoped probe for the `hInDag` triviality question by landing a small, self-contained fixed-slice DAG hardwiring witness for `gapPartialMCSP_Language` so downstream asymptotic route hypotheses can be audited under a concrete non-uniform witness. 
- Follow the seed-pack hygiene constraints: avoid any imports of refuted-predicate carriers and keep the change compact (≤200 LOC) and audit-only (no endpoint / P ≠ NP claim). 

### Description
- Add `pnp3/Tests/HInDagTrivialityProbe.lean`, which defines a one-gate `constFalseDag` for off-slice lengths and a `ttDag` built by compiling the existing tree truth-table circuit through the repository straight-line compiler and the `StraightLineAdapter`, together with the correctness lemma `ttDag_eval`.
- Implement a per-slice `InPpolyDAG` witness `fixedSlice_gapPartialMCSP_in_PpolyDAG` that hardwires `ttDag` at the single encoded length and uses `constFalseDag` elsewhere, and expose the canonical surface `hInDag_for_canonicalAsymptoticHAsym` by instantiation of that witness.
- Use `noncomputable def` for the exposed witness values because `InPpolyDAG` is a concrete witness-structure (not a `Prop`) and the construction reuses bounded truth-table enumeration; document the noncomputability and keep the file self-contained and free of `axiom`/`sorry`/`admit`/`native_decide`.
- Add the L0 report `seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md` with the executive verdict `RED_HINDAG_TRIVIAL_BUT_CONCLUSION_OPEN` and the recommended next action `open_isoStrong_conclusion_audit_D0`.

### Testing
- Type-checked the new staging file with `lake env lean pnp3/Tests/HInDagTrivialityProbe.lean`, which succeeded. 
- Verified the probe did not import any forbidden refuted-predicate carriers with `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions" pnp3/Tests/HInDagTrivialityProbe.lean` (no matches). 
- Confirmed the file size is within the L0 cap with `wc -l pnp3/Tests/HInDagTrivialityProbe.lean` (121 lines). 
- Ran the repository full checks via `./scripts/check.sh`, which completed successfully on the modified tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b568f78d4832b9509680cac0cdf3c)