### PR TITLE
hInDag triviality probe L0 — add inconclusive report (gpt55)

### DIFF
--- a/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
+++ b/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
@@ -1,0 +1,81 @@
+# L0 hInDag triviality probe — gpt55
+
+## Classification
+
+Infrastructure / audit probe.  This work does **not** reduce
+`SearchMCSPWeakLowerBound` or `VerifiedNPDAGLowerBoundSource`, and it is not
+reported as P-vs-NP mainline progress.
+
+## Required-reading confirmation
+
+Read and checked:
+
+- `RESEARCH_CONSTITUTION.md`, especially Rule 1, Rule 6, and Rule 16.
+- `STATUS.md`.
+- `seed_packs/hInDag_triviality_probe_L0/README.md`.
+- `seed_packs/hInDag_triviality_probe_D0/reports/D0_hindag_triviality_gpt55.md`.
+- `pnp3/Magnification/CanonicalAsymptoticTrackData.lean`.
+- `pnp3/Models/Model_PartialMCSP.lean`.
+- `pnp3/Complexity/Interfaces.lean`, especially the concrete `DagCircuit`,
+  `DagGate`, `DagWire`, `DagCircuit.eval`, `DagCircuit.size`, and
+  `InPpolyDAG` definitions.
+- `pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean`, for the local
+  `constFalseDag` pattern only.
+- `pnp3/Tests/FormulaSupportBoundsFalsifiabilityProbe.lean`, as a template
+  only; it was not imported or edited.
+- `pnp3/Magnification/FinalResultMainline.lean`, for the downstream `hInDag`
+  consumers.
+
+## Attempted L0-A construction
+
+The intended fixed-slice witness reduces to the following finite hardwiring
+lemma:
+
+```lean
+∀ {n : Nat} (f : Bitstring n → Bool),
+  ∃ C : DagCircuit n, ∀ x, DagCircuit.eval C x = f x
+```
+
+Together with `constFalseDag` off the unique active length
+`partialInputLen p`, this would make `InPpolyDAG (gapPartialMCSP_Language p)`
+polynomially bounded by a constant depending only on `p`.
+
+The constant-false part is straightforward, and the off-slice semantic fact is
+immediate from `gapPartialMCSP_Language`, whose `dite` returns `false` when the
+input length is not `partialInputLen p`.
+
+The blocker is the `DagCircuit` truth-table construction itself.  The existing
+formula proof in `FormulaSupportBoundsFalsifiabilityProbe.lean` cannot be
+imported by this seed pack, and it targets `FormulaCircuit`, not `DagCircuit`.
+A direct DAG analogue needs one of the following pieces of infrastructure:
+
+1. A recursive DAG input-renaming operation that lifts a `DagCircuit n` to
+   `DagCircuit (n+1)` while preserving evaluation under `Fin.succ`.
+2. A sequential DAG append/offset operation that embeds two already-built DAGs
+   into a single larger DAG and proves that shifted wires evaluate as before.
+3. A formula-to-DAG tree expansion theorem proving that every
+   `FormulaCircuit n` has an extensionally equivalent `DagCircuit n`, after
+   which the already-known recursive truth-table formula could be copied
+   without importing the refuted-predicate test file.
+
+In all three approaches, the dependent index on `DagGate n i.1` forces a
+nontrivial amount of cast/offset bookkeeping.  The proof is plausible, but it
+is substantive infrastructure rather than a clean ≤200 LOC staging probe.
+Landing an incomplete or overly compressed file would risk either introducing a
+fragile proof artifact or weakening the audit hygiene constraints.
+
+## Hygiene audit
+
+No Lean staging file was landed, so the import and declaration-name audits are
+vacuously clean for `pnp3/Tests/HInDagTrivialityProbe.lean`.
+
+No forbidden route endpoints, trust-root edits, JSONL/NoGo/spec edits, axioms,
+`sorry`, `admit`, or `native_decide` were added.
+
+## Command log
+
+- `./scripts/check.sh` was run from the repository root and passed.
+
+## Verdict
+
+**INCONCLUSIVE_NEEDS_FULL_SESSION**


### PR DESCRIPTION
### Motivation
- Record the L0 audit of the hInDag triviality probe (handle `gpt55`) documenting why the ≤200 LOC DAG truth-table hardwiring witness cannot be cleanly landed in L0 and the probe is `INCONCLUSIVE_NEEDS_FULL_SESSION`.

### Description
- Add the report `seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md` summarizing the attempted fixed-slice construction, the required DAG rename/append or formula→DAG expansion infrastructure, hygiene checks, and the final verdict; no other files (and no Lean staging file) were modified or landed.

### Testing
- Ran `./scripts/check.sh` from the repository root and the build + repository hygiene checks completed successfully (CI-local `check.sh`: PASS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5690ff9c832b98b415b6767158fb)