### PR TITLE
Add L0 hInDag triviality probe — fixed-slice truth-table DAG witness

### DIFF
--- a/pnp3/Tests/HInDagTrivialityProbe.lean
+++ b/pnp3/Tests/HInDagTrivialityProbe.lean
@@ -1,0 +1,152 @@
+import Complexity.Interfaces
+import Complexity.PsubsetPpolyInternal.TreeToStraight
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+
+namespace Pnp3
+namespace Tests
+namespace HInDagTrivialityProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+
+noncomputable section
+
+/-- One-gate constant-false DAG used off the unique encoded slice. -/
+private def constFalseDag (n : Nat) : DagCircuit n where
+  gates := 1
+  gate := fun _ => DagGate.const false
+  output := DagWire.gate ⟨0, by simp⟩
+
+@[simp] private theorem constFalseDag_size {n : Nat} :
+    DagCircuit.size (constFalseDag n) = 2 := by
+  simp [constFalseDag, DagCircuit.size]
+
+@[simp] private theorem constFalseDag_eval {n : Nat} (x : Bitstring n) :
+    DagCircuit.eval (constFalseDag n) x = false := by
+  simp [constFalseDag, DagCircuit.eval, DagCircuit.eval.evalGateAt]
+
+/-- Rename inputs in a tree circuit.  This keeps the truth-table recursion tiny. -/
+private def treeRename {m n : Nat} (σ : Fin m → Fin n) :
+    Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit m → Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit n
+  | .var i => .var (σ i)
+  | .const b => .const b
+  | .not c => .not (treeRename σ c)
+  | .and c d => .and (treeRename σ c) (treeRename σ d)
+  | .or c d => .or (treeRename σ c) (treeRename σ d)
+
+private theorem treeRename_eval {m n : Nat} (σ : Fin m → Fin n)
+    (c : Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit m) (x : Bitstring n) :
+    Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval (treeRename σ c) x = Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval c (fun i => x (σ i)) := by
+  induction c with
+  | var i => rfl
+  | const b => rfl
+  | not c ih => simp [treeRename, Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval, ih]
+  | and c d ihc ihd => simp [treeRename, Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval, ihc, ihd]
+  | or c d ihc ihd => simp [treeRename, Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval, ihc, ihd]
+
+/-- Tree truth table for one fixed input length, later compiled to a DAG. -/
+private def ttTree : ∀ {n : Nat}, (Bitstring n → Bool) → Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit n
+  | 0, f => .const (f (fun i => Fin.elim0 i))
+  | n + 1, f =>
+      let c0 := ttTree (fun x : Bitstring n => f (Fin.cases false x))
+      let c1 := ttTree (fun x : Bitstring n => f (Fin.cases true x))
+      .or (.and (.not (.var ⟨0, Nat.zero_lt_succ n⟩)) (treeRename Fin.succ c0))
+          (.and (.var ⟨0, Nat.zero_lt_succ n⟩) (treeRename Fin.succ c1))
+
+private theorem ttTree_eval : ∀ {n : Nat} (f : Bitstring n → Bool) (x : Bitstring n),
+    Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval (ttTree f) x = f x
+  | 0, f, x => by
+      show f (fun i => Fin.elim0 i) = f x
+      congr 1
+      funext i
+      exact Fin.elim0 i
+  | n + 1, f, x => by
+      simp only [ttTree, Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval, treeRename_eval]
+      have h0 := ttTree_eval (fun y : Bitstring n => f (Fin.cases false y))
+        (fun i => x (Fin.succ i))
+      have h1 := ttTree_eval (fun y : Bitstring n => f (Fin.cases true y))
+        (fun i => x (Fin.succ i))
+      rw [h0, h1]
+      have hx : ∀ b, x ⟨0, Nat.zero_lt_succ n⟩ = b →
+          (Fin.cases (n := n) b (fun i => x (Fin.succ i)) : Bitstring (n + 1)) = x := by
+        intro b hb
+        funext i
+        induction i using Fin.cases with
+        | zero => exact hb.symm
+        | succ j => rfl
+      cases h : x ⟨0, Nat.zero_lt_succ n⟩
+      · simp [hx false h]
+      · simp [hx true h]
+
+/-- Compile the tree truth table into the canonical DAG interface. -/
+private def ttDag {n : Nat} (f : Bitstring n → Bool) : DagCircuit n :=
+  Pnp3.Complexity.StraightLineAdapter.toDag (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeCircuit (ttTree f))
+
+private theorem compiled_tree_eval {n : Nat} (c : Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit n) (x : Bitstring n) :
+    DagCircuit.eval (Pnp3.Complexity.StraightLineAdapter.toDag (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeCircuit c)) x = Pnp3.Internal.PsubsetPpoly.Boolcube.Circuit.eval c x := by
+  have hAdapter : Pnp3.Complexity.StraightLineAdapter.eval (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeCircuit c) x = Pnp3.Internal.PsubsetPpoly.StraightLine.eval (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeCircuit c) x :=
+    Pnp3.Internal.PsubsetPpoly.StraightLine.adapter_eval_eq_eval (C := Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeCircuit c) (x := x)
+  have hWire : Pnp3.Internal.PsubsetPpoly.StraightLine.eval (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeCircuit c) x =
+      Pnp3.Internal.PsubsetPpoly.StraightLine.evalWire (C := (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTree c).ckt) (x := x) (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTree c).out := by
+    simpa [Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeCircuit] using
+      (Pnp3.Internal.PsubsetPpoly.StraightLine.eval_withOutput_eq_evalWire
+        (C := (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTree c).ckt)
+        (out := (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTree c).out) (x := x))
+  exact hAdapter.trans (hWire.trans (Pnp3.Internal.PsubsetPpoly.StraightLine.compileTreeWireSemantics c x))
+
+private theorem ttDag_eval {n : Nat} (f : Bitstring n → Bool) (x : Bitstring n) :
+    DagCircuit.eval (ttDag f) x = f x := by
+  exact (compiled_tree_eval (ttTree f) x).trans (ttTree_eval f x)
+
+/-- Every fixed partial-MCSP slice has a DAG family by hardwiring its truth table. -/
+def fixedSlice_gapPartialMCSP_in_PpolyDAG (p : GapPartialMCSPParams) :
+    InPpolyDAG (gapPartialMCSP_Language p) := by
+  classical
+  let n0 := Models.partialInputLen p
+  let c0 : DagCircuit n0 := ttDag (gapPartialMCSP_Language p n0)
+  let c0Size : Nat := DagCircuit.size c0
+  refine {
+    polyBound := fun m => if m = n0 then c0Size else 2
+    polyBound_poly := ?_
+    family := fun m => if h : m = n0 then (h ▸ c0 : DagCircuit m) else constFalseDag m
+    family_size_le := ?_
+    correct := ?_
+  }
+  · refine ⟨c0Size + 2, ?_⟩
+    intro m
+    by_cases hm : m = n0
+    · simp [hm]
+      omega
+    · simp [hm]
+      omega
+  · intro m
+    by_cases hm : m = n0
+    · subst hm
+      simp [c0Size]
+    · simp [hm]
+  · intro m x
+    by_cases hm : m = n0
+    · subst hm
+      simp only [dif_pos]
+      exact ttDag_eval (gapPartialMCSP_Language p n0) x
+    · have hLang : gapPartialMCSP_Language p m x = false := by
+        unfold gapPartialMCSP_Language
+        exact dif_neg hm
+      simp [hm, hLang]
+
+def hInDag_for_canonicalAsymptoticHAsym :
+    ∀ n β,
+      InPpolyDAG
+        (gapPartialMCSP_Language
+          ((eventualGapSliceFamily_of_asymptotic
+              canonicalAsymptoticHAsym).paramsOf n β)) := by
+  intro n β
+  exact fixedSlice_gapPartialMCSP_in_PpolyDAG _
+
+end
+
+end HInDagTrivialityProbe
+end Tests
+end Pnp3

--- a/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
+++ b/seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md
@@ -1,0 +1,74 @@
+# L0 hInDag triviality probe — gpt55
+
+## Classification
+
+Infrastructure / audit probe.  This file proves an upper-bound premise used by
+a route audit; it is not lower-bound mainline progress toward `P != NP`.
+
+## Lean result
+
+Landed `pnp3/Tests/HInDagTrivialityProbe.lean` with 152 source lines.
+
+The staged file proves the canonical hInDag premise by fixed-slice truth-table
+hardwiring:
+
+- `constFalseDag`: one-gate false DAG for off-slice lengths.
+- `ttTree` / `ttTree_eval`: recursive tree truth-table construction for an
+  arbitrary fixed-length Boolean function.
+- `ttDag` / `ttDag_eval`: compilation of that tree truth table through the
+  existing straight-line-to-DAG adapter, yielding a `DagCircuit` that computes
+  the arbitrary fixed-length function.
+- `fixedSlice_gapPartialMCSP_in_PpolyDAG`: for any `GapPartialMCSPParams p`,
+  hardwire the sole live slice `partialInputLen p` with `ttDag` and use
+  `constFalseDag` elsewhere.
+- `hInDag_for_canonicalAsymptoticHAsym`: instantiate the fixed-slice theorem on
+  every canonical asymptotic slice.
+
+## Import / hygiene audit
+
+Imports in the staged file:
+
+```lean
+import Complexity.Interfaces
+import Complexity.PsubsetPpolyInternal.TreeToStraight
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+```
+
+Forbidden import audit:
+
+- No import of `Magnification.LocalityProvider_Partial`.
+- No import of `pnp3/Tests/FormulaSupportBoundsFalsifiabilityProbe.lean`.
+- No import under `pnp3/RefutedPredicates/`.
+- No refuted-predicate carrier import.
+
+Forbidden-token audit on the staged file found no matches for:
+
+```text
+FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions
+```
+
+Kernel-hygiene audit on the staged file found no `axiom`, `opaque`, `sorry`,
+`admit`, `native_decide`, or `noncomputable def` token.
+
+## Conclusion-side classification
+
+The hInDag premise is now trivial at the canonical instantiation: the fixed
+slice can be hardwired by an arbitrary truth-table DAG family.  This does not
+settle the downstream iso-strong / promise-YES conclusion.  The L0 construction
+only supplies an upper-bound witness for each fixed language slice; it does not
+produce a small Lean counterexample to the conclusion and does not discharge the
+conclusion structurally.
+
+Therefore the conclusion-side question remains open in this L0 scope and should
+be audited separately under the hardwired `hInDag` premise.
+
+## Commands run
+
+- `lake build PnP3` — pass; built the pnp3 library before direct elaboration.
+- `lake env lean pnp3/Tests/HInDagTrivialityProbe.lean` — pass.
+- `wc -l pnp3/Tests/HInDagTrivialityProbe.lean` — 152 lines.
+- `rg -n "sorry|admit|native_decide|axiom|opaque|noncomputable def|FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions" pnp3/Tests/HInDagTrivialityProbe.lean` — no matches.
+- `./scripts/check.sh` — pass.
+
+**`RED_HINDAG_TRIVIAL_BUT_CONCLUSION_OPEN`**


### PR DESCRIPTION
### Motivation

- Provide an L0-scoped DAG-side witness showing that each fixed `gapPartialMCSP_Language` slice admits a non-uniform `InPpolyDAG` family by truth-table hardwiring, so the canonical `hInDag` hypothesis collapses to a concrete instantiation.
- Use a local, small construction to avoid importing refuted-predicate infrastructure and to stay within the seed-pack L0 hygiene constraints.
- Produce a concise audit artifact that documents the outcome and classifies the downstream conclusion under the hardwired witness.

### Description

- Add `pnp3/Tests/HInDagTrivialityProbe.lean` which defines a local `constFalseDag`, a recursive tree truth-table builder `ttTree` with correctness `ttTree_eval`, and a DAG witness `ttDag` compiled via the existing straight-line `compileTreeCircuit` adapter with correctness `ttDag_eval`.
- Implement `fixedSlice_gapPartialMCSP_in_PpolyDAG (p : GapPartialMCSPParams)` that hardwires the single live slice `partialInputLen p` with `ttDag` and uses `constFalseDag` off-slice, producing an `InPpolyDAG` witness; then instantiate the canonical surface as `hInDag_for_canonicalAsymptoticHAsym`.
- Restrict imports to `Complexity.Interfaces`, `Complexity.PsubsetPpolyInternal.TreeToStraight`, `Models.Model_PartialMCSP`, and `Magnification.CanonicalAsymptoticTrackData`, and add the seed-pack report `seed_packs/hInDag_triviality_probe_L0/reports/L0_hindag_triviality_gpt55.md` recording the verdict `RED_HINDAG_TRIVIAL_BUT_CONCLUSION_OPEN`.

### Testing

- Ran `lake build PnP3` and the build completed successfully. 
- Elaborated the staged file with `lake env lean pnp3/Tests/HInDagTrivialityProbe.lean` which type-checked successfully. 
- Ran repository checks `./scripts/check.sh` which completed and reported `PASS`. 
- Verified hygiene with `rg` checks for forbidden tokens and placeholders (`sorry|admit|native_decide|axiom|opaque|noncomputable def` and `FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions`) and found no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b5690ff9c832b98b415b6767158fb)