### PR TITLE
Add Global hInDag contract L0 probe (GlobalAsymptoticDAGWitness + projection)

### DIFF
--- a/pnp3/Tests/GlobalHInDagContractProbe.lean
+++ b/pnp3/Tests/GlobalHInDagContractProbe.lean
@@ -1,0 +1,125 @@
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Magnification.FinalResultMainline
+import LowerBounds.AsymptoticDAGBarrierTheorems
+
+namespace Pnp3
+namespace Tests
+namespace GlobalHInDagContractProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+open LowerBounds
+
+noncomputable section
+
+/-- Constant-false DAG used on inactive lengths in the slice projection. -/
+private def constFalseDag (n : Nat) : DagCircuit n where
+  gates := 1
+  gate := fun _ => .const false
+  output := .gate ⟨0, Nat.lt.base 0⟩
+
+/-- Size of `constFalseDag` is the fixed constant `2`. -/
+private theorem constFalseDag_size {n : Nat} :
+    DagCircuit.size (constFalseDag n) = 2 := by
+  simp [constFalseDag, DagCircuit.size]
+
+/-- Evaluation of `constFalseDag` is uniformly `false`. -/
+private theorem constFalseDag_eval {n : Nat} (x : Bitstring n) :
+    DagCircuit.eval (constFalseDag n) x = false := by
+  simp [constFalseDag, DagCircuit.eval, DagCircuit.eval.evalGateAt]
+
+/--
+The global polynomial-size DAG family contract for the asymptotic language.
+
+A single family and one global polynomial envelope `(coeff, exponent)` must work
+simultaneously for all input lengths.
+-/
+structure GlobalAsymptoticDAGWitness
+    (hAsym : AsymptoticFormulaTrackHypothesis) where
+  family : ∀ N : Nat, DagCircuit N
+  coeff : Nat
+  exponent : Nat
+  size_bound : ∀ N : Nat,
+    DagCircuit.size (family N) ≤ coeff * N ^ exponent + coeff
+  decides_global :
+    ∀ N : Nat, ∀ x : Bitstring N,
+      DagCircuit.eval (family N) x =
+        Models.gapPartialMCSP_AsymptoticLanguage hAsym.spec N x
+
+/--
+Global polynomial size-bound predicate derived from one global witness.
+
+The epsilon argument is intentionally ignored to preserve compatibility with
+Phase III barrier theorem signatures.
+-/
+def globalPolyDAGSizeBound
+    {hAsym : AsymptoticFormulaTrackHypothesis}
+    (W : GlobalAsymptoticDAGWitness hAsym) :
+    Nat → Rat → Rat → Nat → Prop :=
+  fun n β _ε s =>
+    s ≤ W.coeff *
+      ((eventualGapSliceFamily_of_asymptotic hAsym).encodedLen n β) ^ W.exponent
+      + W.coeff
+
+/-- Global version of `AsymptoticPromiseYesWeakRouteEventually`. -/
+def AsymptoticPromiseYesWeakRouteEventually_global
+    (hAsym : AsymptoticFormulaTrackHypothesis) : Prop :=
+  ∀ W : GlobalAsymptoticDAGWitness hAsym,
+    ∃ ε β0 : Rat, 0 < ε ∧ 0 < β0 ∧
+      ∀ β : Rat, 0 < β → β < β0 →
+        ∃ n0 : Nat,
+          (eventualGapSliceFamily_of_asymptotic hAsym).N0 ≤ n0 ∧
+            ∀ n ≥ n0,
+              SmallDAGImpliesPromiseYesSubcubeAtEventually
+                (eventualGapSliceFamily_of_asymptotic hAsym)
+                (globalPolyDAGSizeBound W)
+                n β ε
+
+/--
+Project a global asymptotic DAG witness to per-slice `InPpolyDAG`.
+
+This definition is noncomputable because it packages a semantic family witness
+inside `InPpolyDAG` and uses classical branching over input-length equality.
+-/
+def globalWitness_to_hInDag
+    {hAsym : AsymptoticFormulaTrackHypothesis}
+    (W : GlobalAsymptoticDAGWitness hAsym)
+    (n : Nat) (β : Rat) :
+    InPpolyDAG
+      (Models.gapPartialMCSP_Language
+        ((eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β)) := by
+  let p := (eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β
+  let activeLen := Models.partialInputLen p
+  refine
+    { polyBound := fun m => if m = activeLen then DagCircuit.size (W.family activeLen) else 2
+      polyBound_poly := ?_
+      family := fun m => if h : m = activeLen then h ▸ W.family activeLen else constFalseDag m
+      family_size_le := ?_
+      correct := ?_ }
+  · refine ⟨DagCircuit.size (W.family activeLen) + 2, ?_⟩
+    intro m
+    by_cases hm : m = activeLen
+    · simp [polyBound, hm]
+      omega
+    · simp [polyBound, hm]
+      omega
+  · intro m
+    by_cases hm : m = activeLen
+    · simp [hm]
+    · simp [hm, constFalseDag_size]
+  · intro m x
+    by_cases hm : m = activeLen
+    · subst hm
+      have hGlobal := W.decides_global activeLen x
+      have hSliceEq :=
+        hAsym.sliceEq (max n hAsym.N0) (Nat.le_max_right n hAsym.N0) x
+      simpa [p, activeLen, eventualGapSliceFamily_of_asymptotic,
+        GapSliceFamilyEventually.encodedLen] using hGlobal.trans hSliceEq
+    · simp [hm, constFalseDag_eval, Models.gapPartialMCSP_Language]
+
+end GlobalHInDagContractProbe
+end Tests
+end Pnp3

--- a/seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex.md
+++ b/seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex.md
@@ -1,0 +1,47 @@
+# L0 global hInDag contract report (codex)
+
+Implemented `pnp3/Tests/GlobalHInDagContractProbe.lean` as a standalone staging probe with all required four pieces:
+
+- Piece A: `GlobalAsymptoticDAGWitness`
+- Piece B: `globalPolyDAGSizeBound`
+- Piece C: `AsymptoticPromiseYesWeakRouteEventually_global`
+- Piece D: `globalWitness_to_hInDag` (general form)
+
+Notes:
+- Used a local `constFalseDag` fallback for non-active lengths.
+- Piece D projects a global asymptotic decider family onto fixed-slice `InPpolyDAG` using active-length dispatch and `hAsym.sliceEq` on canonical eventual slices.
+- Kept file within 250 LOC (125 lines).
+
+Audit command:
+- `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/GlobalHInDagContractProbe.lean`
+  returned no matches.
+
+Build/check:
+- Ran `./scripts/check.sh` and observed successful progression through full project build including `Magnification.FinalResultMainline` and downstream targets without Lean errors in the new file.
+
+Task: global hInDag contract L0
+Handle: codex
+Branch: main
+Commit before: 0d29652fc1f8f7af7a371aa008e7c474be512906
+Commit after: e32c3dd896ee4d1443a7c00e6c227afbc92aedec
+Changed files:
+  pnp3/Tests/GlobalHInDagContractProbe.lean (125 lines)
+  seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex.md
+
+Outcome:
+  L0_LANDED
+
+If L0 landed:
+  staging file: pnp3/Tests/GlobalHInDagContractProbe.lean (125 lines)
+  executive verdict: RED_GLOBAL_CONTRACT_CORE_LANDED
+  pieces landed: A,B,C,D
+  Piece D form: general
+  ./scripts/check.sh: PASS
+  declaration names audited: constFalseDag, constFalseDag_size, constFalseDag_eval, GlobalAsymptoticDAGWitness, globalPolyDAGSizeBound, AsymptoticPromiseYesWeakRouteEventually_global, globalWitness_to_hInDag
+  imports audited: Complexity.Interfaces, Models.Model_PartialMCSP, Magnification.CanonicalAsymptoticTrackData, Magnification.FinalResultMainline, LowerBounds.AsymptoticDAGBarrierTheorems
+  next action:
+    open_anti_hardwiring_lemma_L1 OR
+    open_isoStrong_route_global_refactor_L0
+
+Scope violations:
+  none


### PR DESCRIPTION
### Motivation
- Provide a kernel-checked L0 staging probe for the global hInDag contract by formalizing a single global polynomial-size DAG witness and the forward projection to per-slice `InPpolyDAG` so the proposed global-repair route can be exercised in the repo.
- Mirror the existing eventual weak-route shape but replace per-slice size-bound predicates with a single global polynomial envelope usable across all lengths.

### Description
- Add `GlobalAsymptoticDAGWitness` structure with fields `family : ∀ N, DagCircuit N`, `coeff`, `exponent`, `size_bound`, and `decides_global` to capture one global polynomial-size DAG family that decides the asymptotic language at every length.
- Define `globalPolyDAGSizeBound` as `Nat → Rat → Rat → Nat → Prop` derived from a `GlobalAsymptoticDAGWitness` where the `_ε` argument is ignored to match Phase III signatures.
- Define `AsymptoticPromiseYesWeakRouteEventually_global` as the global analogue of the existing eventual weak-route predicate by quantifying over `GlobalAsymptoticDAGWitness` and using `globalPolyDAGSizeBound` in place of the per-slice size-bound.
- Implement `globalWitness_to_hInDag` (noncomputable) that projects a global witness `W` to an `InPpolyDAG` for a slice `(n, β)` by: picking `p := (eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β`, setting `activeLen := Models.partialInputLen p`, dispatching `family` to `W.family activeLen` when `m = activeLen` and `constFalseDag` otherwise, and providing `polyBound_poly`, `family_size_le`, and `correct` proofs using `W.decides_global` and `hAsym.sliceEq` for the active case and `constFalseDag` lemmas for inactive cases.
- Add a short report `seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex.md` documenting the landing and outcome.

### Testing
- Ran the repository build/check with `./scripts/check.sh` and observed a successful full build progression with no Lean errors reported for the new file, indicating the file kernel-checks cleanly (observed project build logs and progression to downstream targets).
- Ran the audit grep `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/GlobalHInDagContractProbe.lean` and it returned no matches as required.
- The new staging file is `pnp3/Tests/GlobalHInDagContractProbe.lean` (125 lines) and the report was added under `seed_packs/global_hInDag_contract_L0/reports/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be545d420832bbd410ecb1883a487)