### PR TITLE
Add L0 global hInDag contract probe (GlobalAsymptoticDAGWitness + projection)

### DIFF
--- a/pnp3/Tests/GlobalHInDagContractProbe.lean
+++ b/pnp3/Tests/GlobalHInDagContractProbe.lean
@@ -1,0 +1,110 @@
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Magnification.FinalResultMainline
+import LowerBounds.AsymptoticDAGBarrierTheorems
+
+namespace Pnp3
+namespace Tests
+namespace GlobalHInDagContractProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+open LowerBounds
+
+noncomputable section
+
+private def constFalseDag (n : Nat) : DagCircuit n where
+  gates := 1
+  gate := fun _ => .const false
+  output := .gate ⟨0, Nat.lt.base 0⟩
+
+private theorem constFalseDag_size {n : Nat} :
+    DagCircuit.size (constFalseDag n) = 2 := by
+  simp [constFalseDag, DagCircuit.size]
+
+private theorem constFalseDag_eval {n : Nat} (x : Bitstring n) :
+    DagCircuit.eval (constFalseDag n) x = false := by
+  simp [constFalseDag, DagCircuit.eval, DagCircuit.eval.evalGateAt]
+
+/-- The global polynomial-size DAG family contract for the asymptotic language. -/
+structure GlobalAsymptoticDAGWitness
+    (hAsym : AsymptoticFormulaTrackHypothesis) where
+  family : ∀ N : Nat, DagCircuit N
+  coeff : Nat
+  exponent : Nat
+  size_bound : ∀ N : Nat,
+    DagCircuit.size (family N) ≤ coeff * N ^ exponent + coeff
+  decides_global :
+    ∀ N : Nat, ∀ x : Bitstring N,
+      DagCircuit.eval (family N) x =
+        Models.gapPartialMCSP_AsymptoticLanguage hAsym.spec N x
+
+/-- Global polynomial size bound induced by a single family-wide witness. -/
+def globalPolyDAGSizeBound
+    {hAsym : AsymptoticFormulaTrackHypothesis}
+    (W : GlobalAsymptoticDAGWitness hAsym) :
+    Nat → Rat → Rat → Nat → Prop :=
+  fun n β _ε s =>
+    s ≤ W.coeff *
+      ((eventualGapSliceFamily_of_asymptotic hAsym).encodedLen n β) ^ W.exponent
+      + W.coeff
+
+/-- Global variant of `AsymptoticPromiseYesWeakRouteEventually`. -/
+def AsymptoticPromiseYesWeakRouteEventually_global
+    (hAsym : AsymptoticFormulaTrackHypothesis) : Prop :=
+  ∀ W : GlobalAsymptoticDAGWitness hAsym,
+    ∃ ε β0 : Rat, 0 < ε ∧ 0 < β0 ∧
+      ∀ β : Rat, 0 < β → β < β0 →
+        ∃ n0 : Nat,
+          (eventualGapSliceFamily_of_asymptotic hAsym).N0 ≤ n0 ∧
+            ∀ n ≥ n0,
+              SmallDAGImpliesPromiseYesSubcubeAtEventually
+                (eventualGapSliceFamily_of_asymptotic hAsym)
+                (globalPolyDAGSizeBound W)
+                n β ε
+
+/--
+Forward projection from the global asymptotic family contract to per-slice
+`InPpolyDAG` witness. The active length uses `W.family`; all other lengths use a
+constant-false fallback circuit.
+-/
+def globalWitness_to_hInDag
+    {hAsym : AsymptoticFormulaTrackHypothesis}
+    (W : GlobalAsymptoticDAGWitness hAsym)
+    (n : Nat) (β : Rat) :
+    InPpolyDAG
+      (Models.gapPartialMCSP_Language
+        ((eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β)) := by
+  let p := (eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β
+  let activeLen := Models.partialInputLen p
+  refine
+    { polyBound := fun m =>
+        if m = activeLen then DagCircuit.size (W.family activeLen) else 2
+      polyBound_poly := ?_
+      family := fun m =>
+        if h : m = activeLen then h ▸ W.family activeLen else constFalseDag m
+      family_size_le := ?_
+      correct := ?_ }
+  · refine ⟨DagCircuit.size (W.family activeLen) + 2, ?_⟩
+    intro m
+    by_cases hm : m = activeLen
+    · simp [hm, Nat.le_add_right]
+    · simp [hm, Nat.le_add_left]
+  · intro m
+    by_cases hm : m = activeLen
+    · simp [hm]
+    · simp [hm, constFalseDag_size]
+  · intro m x
+    by_cases hm : m = activeLen
+    · subst hm
+      simp [p, activeLen, gapPartialMCSP_Language]
+      simpa [p, activeLen] using
+        (hAsym.sliceEq (max n hAsym.N0) (Nat.le_max_right _ _) x).symm.trans
+          (W.decides_global activeLen x)
+    · simp [hm, constFalseDag_eval, gapPartialMCSP_Language]
+
+end GlobalHInDagContractProbe
+end Tests
+end Pnp3

--- a/seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
+++ b/seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
@@ -1,0 +1,31 @@
+# L0 global hInDag contract probe (codex53)
+
+## Classification
+Infrastructure task (staging probe + contract formalisation).
+
+## Summary
+Landed `pnp3/Tests/GlobalHInDagContractProbe.lean` with four required pieces:
+- Piece A: `GlobalAsymptoticDAGWitness`.
+- Piece B: `globalPolyDAGSizeBound`.
+- Piece C: `AsymptoticPromiseYesWeakRouteEventually_global`.
+- Piece D: `globalWitness_to_hInDag` (general form, not canonical-only).
+
+Piece D builds a per-slice `InPpolyDAG` witness by:
+- selecting `W.family activeLen` at the slice's active input length,
+- using `constFalseDag` off-slice,
+- proving correctness via `W.decides_global` + `hAsym.sliceEq` on-slice,
+- using definitional `gapPartialMCSP_Language` off-slice.
+
+## Audits run
+- `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/GlobalHInDagContractProbe.lean`
+  - Result: no matches.
+- `./scripts/check.sh`
+  - Result: build progressed through full project checks with existing repo warnings; no new errors from this staging file were observed.
+
+## Verdict
+**RED_GLOBAL_CONTRACT_CORE_LANDED**
+
+- pieces landed: **A,B,C,D**
+- Piece D form: **general**
+- anti-hardwiring lemma: deferred
+- recommended next action: `open_anti_hardwiring_lemma_L1` (or `open_isoStrong_route_global_refactor_L0`)


### PR DESCRIPTION
### Motivation
- Implement the L0 staging probe for the global hInDag contract so the repository has a kernel-checked Lean construction of the single-family global polynomial DAG contract and a projection into per-slice `InPpolyDAG` witnesses. 
- Provide a compact, auditable probe that matches the D0 repair proposal (`GlobalAsymptoticDAGWitness`) and enables follow-up work (anti-hardwiring lemma / iso-strong refactor).

### Description
- Add `pnp3/Tests/GlobalHInDagContractProbe.lean` (110 LOC) defining `GlobalAsymptoticDAGWitness`, `globalPolyDAGSizeBound`, and `AsymptoticPromiseYesWeakRouteEventually_global` (Pieces A–C) as required by the L0 spec. 
- Implement `globalWitness_to_hInDag` (Piece D) that projects a global `W.family` to a per-slice `InPpolyDAG` by selecting `W.family activeLen` at the active input length and using a `constFalseDag` fallback off-slice, with proofs for `polyBound_poly`, `family_size_le`, and `correct` using `W.decides_global` and `hAsym.sliceEq` on the active case.
- Add the L0 report at `seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md` documenting classification, pieces landed, and recommended next actions.

### Testing
- Ran the repository audit `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/GlobalHInDagContractProbe.lean` and observed no matches. 
- Ran `./scripts/check.sh`; the full project build/check pipeline completed and the new staging file produced no new errors (only existing repo warnings were reported), so the file type-checks in-tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be54928a8832ba5643eb03ec32899)