### PR TITLE
Add L0 global hInDag contract probe with forward projection

### DIFF
--- a/pnp3/Tests/GlobalHInDagContractProbe.lean
+++ b/pnp3/Tests/GlobalHInDagContractProbe.lean
@@ -1,0 +1,121 @@
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Magnification.FinalResultMainline
+import LowerBounds.AsymptoticDAGBarrierTheorems
+
+namespace Pnp3
+namespace Tests
+namespace GlobalHInDagContractProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+open LowerBounds
+
+noncomputable section
+
+/-- A tiny fallback DAG used away from the active encoded input length. -/
+private def constFalseDag (n : Nat) : DagCircuit n where
+  gates := 1
+  gate := fun _ => .const false
+  output := .gate ⟨0, Nat.lt.base 0⟩
+
+private theorem constFalseDag_size {n : Nat} :
+    DagCircuit.size (constFalseDag n) = 2 := by
+  simp [constFalseDag, DagCircuit.size]
+
+private theorem constFalseDag_eval {n : Nat} (x : Bitstring n) :
+    DagCircuit.eval (constFalseDag n) x = false := by
+  simp [constFalseDag, DagCircuit.eval, DagCircuit.eval.evalGateAt]
+
+/-- The global polynomial-size DAG family contract for the asymptotic language. -/
+structure GlobalAsymptoticDAGWitness
+    (hAsym : AsymptoticFormulaTrackHypothesis) where
+  family : ∀ N : Nat, DagCircuit N
+  coeff : Nat
+  exponent : Nat
+  size_bound : ∀ N : Nat,
+    DagCircuit.size (family N) ≤ coeff * N ^ exponent + coeff
+  decides_global :
+    ∀ N : Nat, ∀ x : Bitstring N,
+      DagCircuit.eval (family N) x =
+        Models.gapPartialMCSP_AsymptoticLanguage hAsym.spec N x
+
+/-- Global polynomial size-bound predicate derived from a global family contract. -/
+def globalPolyDAGSizeBound
+    {hAsym : AsymptoticFormulaTrackHypothesis}
+    (W : GlobalAsymptoticDAGWitness hAsym) :
+    Nat → Rat → Rat → Nat → Prop :=
+  fun n β _ε s =>
+    s ≤ W.coeff *
+      ((eventualGapSliceFamily_of_asymptotic hAsym).encodedLen n β) ^ W.exponent
+      + W.coeff
+
+/-- Global version of `AsymptoticPromiseYesWeakRouteEventually`. -/
+def AsymptoticPromiseYesWeakRouteEventually_global
+    (hAsym : AsymptoticFormulaTrackHypothesis) : Prop :=
+  ∀ W : GlobalAsymptoticDAGWitness hAsym,
+    ∃ ε β0 : Rat, 0 < ε ∧ 0 < β0 ∧
+      ∀ β : Rat, 0 < β → β < β0 →
+        ∃ n0 : Nat,
+          (eventualGapSliceFamily_of_asymptotic hAsym).N0 ≤ n0 ∧
+            ∀ n ≥ n0,
+              SmallDAGImpliesPromiseYesSubcubeAtEventually
+                (eventualGapSliceFamily_of_asymptotic hAsym)
+                (globalPolyDAGSizeBound W)
+                n β ε
+
+/--
+Forward projection from one global DAG-family contract to per-slice `InPpolyDAG`.
+
+This definition is noncomputable because it packages size/equality reasoning over
+an abstract family of circuits provided by `W`.
+-/
+def globalWitness_to_hInDag
+    {hAsym : AsymptoticFormulaTrackHypothesis}
+    (W : GlobalAsymptoticDAGWitness hAsym)
+    (n : Nat) (β : Rat) :
+    InPpolyDAG
+      (Models.gapPartialMCSP_Language
+        ((eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β)) := by
+  let p := (eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β
+  let activeLen := Models.partialInputLen p
+  refine
+    { polyBound := fun m =>
+        m ^ (DagCircuit.size (W.family activeLen) + 2) +
+          (DagCircuit.size (W.family activeLen) + 2)
+      polyBound_poly := by
+        refine ⟨DagCircuit.size (W.family activeLen) + 2, ?_⟩
+        intro m
+        rfl
+      family := fun m =>
+        if h : m = activeLen then h ▸ W.family activeLen else constFalseDag m
+      family_size_le := by
+        intro m
+        by_cases hm : m = activeLen
+        · subst hm
+          have hk : DagCircuit.size (W.family activeLen) ≤ DagCircuit.size (W.family activeLen) + 2 := by omega
+          simpa using le_trans hk (Nat.le_add_left _ _)
+        · simp [hm, constFalseDag_size]
+          omega
+      correct := by
+        intro m x
+        by_cases hm : m = activeLen
+        · subst hm
+          simp
+          calc
+            DagCircuit.eval (W.family activeLen) x
+                = gapPartialMCSP_AsymptoticLanguage hAsym.spec activeLen x :=
+                  W.decides_global activeLen x
+            _ = gapPartialMCSP_Language p activeLen x := by
+                  simpa [p, activeLen, eventualGapSliceFamily_of_asymptotic]
+                    using hAsym.sliceEq (max n hAsym.N0) (Nat.le_max_right _ _) x
+        · have hneq : m ≠ partialInputLen p := by simpa [activeLen] using hm
+          have hnot : ¬(m = partialInputLen ((eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β)) := by
+            simpa [p] using hneq
+          simp [hm, constFalseDag_eval, gapPartialMCSP_Language, hnot] }end
+
+end GlobalHInDagContractProbe
+end Tests
+end Pnp3

--- a/seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
+++ b/seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
@@ -1,0 +1,30 @@
+Task: global hInDag contract L0
+Handle: codex53
+Branch: main
+Commit before: 0d29652
+Commit after: 1458f28
+Changed files:
+  pnp3/Tests/GlobalHInDagContractProbe.lean (117 lines)
+  seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
+
+Outcome:
+  L0_LANDED
+
+If L0 landed:
+  staging file: pnp3/Tests/GlobalHInDagContractProbe.lean (117 lines)
+  executive verdict: RED_GLOBAL_CONTRACT_CORE_LANDED
+  pieces landed: A,B,C,D
+  Piece D form: general
+  ./scripts/check.sh: PASS (full repository check run completed during session)
+  declaration names audited: constFalseDag, constFalseDag_size, constFalseDag_eval,
+    GlobalAsymptoticDAGWitness, globalPolyDAGSizeBound,
+    AsymptoticPromiseYesWeakRouteEventually_global, globalWitness_to_hInDag
+  imports audited: Complexity.Interfaces, Models.Model_PartialMCSP,
+    Magnification.CanonicalAsymptoticTrackData, Magnification.FinalResultMainline,
+    LowerBounds.AsymptoticDAGBarrierTheorems
+  next action:
+    open_anti_hardwiring_lemma_L1 OR
+    open_isoStrong_route_global_refactor_L0
+
+Scope violations:
+  none


### PR DESCRIPTION
### Motivation
- Implement the proposed global polynomial-size DAG-family contract to repair the global hInDag contract surface for the asymptotic track so the magnification route can use a single shared polynomial bound across lengths. 
- Provide a bridge from a global-family witness to the per-slice `InPpolyDAG` witness required by the eventual-slice route so the global contract can be consumed by existing small-DAG / promise-YES machinery. 
- Produce a minimal L0 staging probe (≤250 LOC target) that is kernel-checkable and suitable for follow-up work (anti-hardwiring lemma / stronger refactor).

### Description
- Add `pnp3/Tests/GlobalHInDagContractProbe.lean` which defines a small fallback DAG and implements Piece A–D of the requested contract: `GlobalAsymptoticDAGWitness`, `globalPolyDAGSizeBound`, `AsymptoticPromiseYesWeakRouteEventually_global`, and `globalWitness_to_hInDag`.
- `globalWitness_to_hInDag` builds an `InPpolyDAG` for a slice `(n, β)` by using `W.family activeLen` at the active encoded length and a tiny `constFalseDag` elsewhere, with proofs for the polynomial bound, family size bound, and per-length correctness that use `W.decides_global` and `hAsym.sliceEq` to connect the asymptotic global language to the per-slice language.
- Include a short helper `constFalseDag` and its size/evaluation lemmas used when the global family is not applicable on non-active lengths.
- Add the required L0 report file `seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md` documenting the L0 outcome and the staged file.

### Testing
- Ran `lake env lean pnp3/Tests/GlobalHInDagContractProbe.lean` to kernel-check the staging file (iteratively fixed proof obligations during development) and it typechecks.
- Ran the repository-wide check via `./scripts/check.sh` during the session; the full build completed successfully in this environment.
- Ran an audit grep `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/GlobalHInDagContractProbe.lean` and confirmed there are no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be54928a8832ba5643eb03ec32899)