### PR TITLE
Add global hInDag contract L0 probe

### DIFF
--- a/pnp3/Tests/GlobalHInDagContractProbe.lean
+++ b/pnp3/Tests/GlobalHInDagContractProbe.lean
@@ -1,0 +1,121 @@
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Magnification.FinalResultMainline
+import LowerBounds.AsymptoticDAGBarrierTheorems
+
+namespace Pnp3
+namespace Tests
+namespace GlobalHInDagContractProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+open LowerBounds
+
+noncomputable section
+
+/-- Constant-false DAG used on non-active lengths in the projection witness. -/
+private def constFalseDag (n : Nat) : DagCircuit n where
+  gates := 1
+  gate := fun _ => .const false
+  output := .gate ⟨0, Nat.lt.base 0⟩
+
+private theorem constFalseDag_size {n : Nat} :
+    DagCircuit.size (constFalseDag n) = 2 := by
+  simp [constFalseDag, DagCircuit.size]
+
+private theorem constFalseDag_eval {n : Nat} (x : Bitstring n) :
+    DagCircuit.eval (constFalseDag n) x = false := by
+  simp [constFalseDag, DagCircuit.eval, DagCircuit.eval.evalGateAt]
+
+/--
+The global polynomial-size DAG family contract for the asymptotic language.
+A single pair `(coeff, exponent)` controls all input lengths.
+-/
+structure GlobalAsymptoticDAGWitness
+    (hAsym : AsymptoticFormulaTrackHypothesis) where
+  family : ∀ N : Nat, DagCircuit N
+  coeff : Nat
+  exponent : Nat
+  size_bound : ∀ N : Nat,
+    DagCircuit.size (family N) ≤ coeff * N ^ exponent + coeff
+  decides_global :
+    ∀ N : Nat, ∀ x : Bitstring N,
+      DagCircuit.eval (family N) x =
+        Models.gapPartialMCSP_AsymptoticLanguage hAsym.spec N x
+
+/--
+Global polynomial size-bound predicate derived from
+`GlobalAsymptoticDAGWitness`. The epsilon parameter is intentionally unused to
+match the route signature.
+-/
+def globalPolyDAGSizeBound
+    {hAsym : AsymptoticFormulaTrackHypothesis}
+    (W : GlobalAsymptoticDAGWitness hAsym) :
+    Nat → Rat → Rat → Nat → Prop :=
+  fun n β _ε s =>
+    s ≤ W.coeff *
+      ((eventualGapSliceFamily_of_asymptotic hAsym).encodedLen n β) ^ W.exponent
+      + W.coeff
+
+/-- Global version of `AsymptoticPromiseYesWeakRouteEventually`. -/
+def AsymptoticPromiseYesWeakRouteEventually_global
+    (hAsym : AsymptoticFormulaTrackHypothesis) : Prop :=
+  ∀ W : GlobalAsymptoticDAGWitness hAsym,
+    ∃ ε β0 : Rat, 0 < ε ∧ 0 < β0 ∧
+      ∀ β : Rat, 0 < β → β < β0 →
+        ∃ n0 : Nat,
+          (eventualGapSliceFamily_of_asymptotic hAsym).N0 ≤ n0 ∧
+            ∀ n ≥ n0,
+              SmallDAGImpliesPromiseYesSubcubeAtEventually
+                (eventualGapSliceFamily_of_asymptotic hAsym)
+                (globalPolyDAGSizeBound W)
+                n β ε
+
+/--
+Forward projection from a global asymptotic DAG family to per-slice `InPpolyDAG`.
+The construction is noncomputable because it packages Type-level witnesses.
+-/
+def globalWitness_to_hInDag
+    {hAsym : AsymptoticFormulaTrackHypothesis}
+    (W : GlobalAsymptoticDAGWitness hAsym)
+    (n : Nat) (β : Rat) :
+    InPpolyDAG
+      (Models.gapPartialMCSP_Language
+        ((eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β)) := by
+  let p := (eventualGapSliceFamily_of_asymptotic hAsym).paramsOf n β
+  let activeLen := Models.partialInputLen p
+  refine
+    { polyBound := fun m =>
+        if m = activeLen then DagCircuit.size (W.family activeLen) else 2
+      polyBound_poly := ?_
+      family := fun m =>
+        if h : m = activeLen then h ▸ W.family activeLen else constFalseDag m
+      family_size_le := ?_
+      correct := ?_ }
+  · refine ⟨DagCircuit.size (W.family activeLen) + 2, ?_⟩
+    intro m
+    by_cases hm : m = activeLen
+    · simp [hm]
+    · simp [hm]
+  · intro m
+    by_cases hm : m = activeLen
+    · simp [hm]
+    · simp [hm, constFalseDag_size]
+  · intro m x
+    by_cases hm : m = activeLen
+    · subst hm
+      simp only [dif_pos rfl]
+      calc
+        DagCircuit.eval (W.family activeLen) x
+            = Models.gapPartialMCSP_AsymptoticLanguage hAsym.spec activeLen x :=
+              W.decides_global activeLen x
+        _ = Models.gapPartialMCSP_Language p activeLen x := by
+              simpa [p, activeLen, eventualGapSliceFamily_of_asymptotic]
+                using hAsym.sliceEq (max n hAsym.N0) (Nat.le_max_right _ _) x
+    · simp [hm, constFalseDag_eval, Models.gapPartialMCSP_Language, p, activeLen]
+
+end GlobalHInDagContractProbe
+end Tests
+end Pnp3

--- a/seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
+++ b/seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
@@ -1,0 +1,14 @@
+# L0 global hInDag contract report (codex53)
+
+- Classification: Infrastructure (contract surface repair/probe).
+- Landed pieces: A, B, C, D (general form).
+- Piece D style: global family projected to slice-local `InPpolyDAG` by active-length selection and `constFalseDag` off-slice.
+- Anti-hardwiring lemma: deferred.
+- Audit grep: no forbidden tokens matched in staging file.
+- Check: `./scripts/check.sh` executed successfully in this environment (long build with pre-existing warnings outside this patch).
+
+## Notes
+
+The file `pnp3/Tests/GlobalHInDagContractProbe.lean` introduces the global witness contract and its forward projection without importing the prior triviality probe; all constructions are local to the staging file.
+
+Verdict: **RED_GLOBAL_CONTRACT_CORE_LANDED**.


### PR DESCRIPTION
### Motivation

- Implement the L0 Lean probe that lands the proposed global polynomial-size DAG family contract as a kernel-checked scaffold for the asymptotic track.  
- Provide a forward projection from a single global family to per-slice `InPpolyDAG` instances so the asymptotic route can be connected to slice-local witnesses.  
- Record a short report documenting outcome and basic audits required by the seed pack.

### Description

- Add `GlobalAsymptoticDAGWitness` structure capturing a global family `family : ∀ N, DagCircuit N` together with a single `(coeff, exponent)` polynomial bound and a `decides_global` field that ties the family to `gapPartialMCSP_AsymptoticLanguage`.  
- Define `globalPolyDAGSizeBound` with signature `Nat → Rat → Rat → Nat → Prop` that derives slice size-bounds from a `GlobalAsymptoticDAGWitness` and intentionally ignores the `_ε` parameter to match route signatures.  
- Introduce `AsymptoticPromiseYesWeakRouteEventually_global` mirroring the existing eventual weak-route predicate but quantifying over `W : GlobalAsymptoticDAGWitness` and using `globalPolyDAGSizeBound`.  
- Implement `globalWitness_to_hInDag` which projects a global witness `W` to an `InPpolyDAG` for a concrete slice `(n, β)` by selecting the global family at the active encoded length and using a `constFalseDag` off-slice; the definition supplies `polyBound`, `polyBound_poly`, `family`, `family_size_le`, and `correct` proofs using `W.decides_global` and `hAsym.sliceEq`.  
- Add the report file `seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md` summarizing classification and verdict.

### Testing

- Ran `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/GlobalHInDagContractProbe.lean` and confirmed no matches.  
- Checked file size with `wc -l pnp3/Tests/GlobalHInDagContractProbe.lean` and verified it is within the ≤250 LOC budget.  
- Ran the project build via `./scripts/check.sh`; the Lean build completed successfully in this environment and the new staging file kernel-checks, with unrelated pre-existing warnings in other files reported but no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0be545d420832bbd410ecb1883a487)