### PR TITLE
[isoStrong D0] Add iso-strong conclusion audit report (codex53)

### DIFF
--- a/seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
+++ b/seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
@@ -1,0 +1,250 @@
+# 1. Executive verdict
+
+**INCONCLUSIVE_NEEDS_LEAN_PROBE**
+
+# 2. Required-reading inventory
+
+## Files read
+- `RESEARCH_CONSTITUTION.md` (Rule 0 / 1 / 6 focus).
+- `STATUS.md`.
+- `seed_packs/isoStrong_conclusion_audit_D0/README.md`.
+- `seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md`.
+- `seed_packs/global_hInDag_contract_repair_D0/reports/D0_global_hInDag_contract_repair_codex53.md`.
+- `pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean` (requested vicinity including eventual weak route payload and `IsoStrongFamilyEventually`).
+- `pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean` (carrier defs, `encodedLen`, `tableLen`).
+- `pnp3/Magnification/CanonicalAsymptoticTrackData.lean` (canonical `sYES=1, sNO=2`, canonical params/hypothesis).
+- `pnp3/Tests/GlobalHInDagContractProbe.lean` (global witness contract and projection).
+- `pnp3/Models/Model_PartialMCSP.lean` (language/promise/encoding surfaces).
+- `pnp3/LowerBounds/DAGStableRestrictionProducer.lean` (agreement-coordinate infrastructure).
+- `pnp3/Magnification/FinalResultMainline.lean` (route wiring and conversions).
+
+## Files missing
+- None among required paths.
+
+# 3. Conclusion statement under audit
+
+Audit target (globalized route body):
+
+- `AsymptoticPromiseYesWeakRouteEventually_global canonicalAsymptoticHAsym` asks that for every
+  `W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym`, there exist `ε>0`, `β0>0`, and
+  eventual threshold `n0` such that for all large enough `n` and small enough `β`,
+  `SmallDAGImpliesPromiseYesSubcubeAtEventually F (globalPolyDAGSizeBound W) n β ε` holds.
+
+Equivalent projected form under PR #1404 bridge:
+
+- via `globalWitness_to_hInDag W`, this is the same structural conclusion family as
+  `IsoStrongFamilyEventually F (globalWitness_to_hInDag W)` plus route-conversion wrappers.
+
+Unfolded core obligation (at each sufficiently-large canonical slice):
+
+- For every DAG `C : DagCircuit (encodedLen F n β)` with
+  `size C ≤ W.coeff * encodedLen^W.exponent + W.coeff` and
+  `CorrectOnPromiseSlice C (gapSliceOfParams (paramsOf n β))`, produce:
+  1. `yYes ∈ Yes` with `ValidEncoding yYes`;
+  2. `D : Finset (Fin (tableLen F n β))` (cardinality bounded by chosen budget);
+  3. forcing clause: every valid `z` agreeing with `yYes` on `D` is in `Yes`;
+  4. counting slack clause (canonical specialization):
+     `m + 2 < 2^(2^m - |D|)` where `m` is slice index after coherence rewrite.
+
+# 4. Triviality test (GREEN)
+
+Attempted trivial constructions were evaluated at the canonical track (`sYES=1, sNO=2`):
+
+## Attempt A: constant-false YES center with tiny `D`
+- Candidate: choose `yYes` as an encoding of all-false total table (a size-1 YES witness), and
+  `D = ∅` (or tiny fixed set).
+- Slack: easy (`|D|` tiny implies huge RHS), so counting inequality is satisfied.
+- Failure point: forcing clause becomes global (`AgreeOnValues ∅` is vacuous), so it requires **all**
+  valid encodings to be YES, false for canonical promise where NO points exist.
+- Verdict for Attempt A: fails on forcing clause.
+
+## Attempt B: constant-false YES center with large `D`
+- Candidate: same `yYes`, but choose `D` almost full table so agreement class shrinks.
+- Forcing plausibility improves (fewer extensions), but one still needs a proof that every agreeing
+  valid encoding remains YES. For canonical partial-table encoding, agreement on many coordinates
+  does not obviously force consistency with a size-1 function for all extensions.
+- Failure point: in markdown we cannot certify the exact structural threshold at which agreement on
+  chosen `D` forces YES-membership.
+- Verdict for Attempt B: unresolved without formal combinatorial lemma.
+
+## Attempt C: input-projection YES center (`x_i`) and structured `D`
+- Candidate: choose `yYes` from size-1 projection function and bind coordinates corresponding to the
+  observed partial table entries.
+- Challenge: coordinate geometry of `tableLen=2^m` and partial encoding validity constraints may let
+  adversarial completions remain valid yet exit YES unless `D` encodes near-complete information.
+- Failure point: not enough to derive trivial discharge; also not enough to produce explicit failure.
+
+**GREEN status:** not established in markdown.
+
+# 5. Refutability test (RED)
+
+## Candidate adversary 1: compiled `decideAsymptotic` family
+- Natural first adversary is the polynomial-size DAG family expected from global witness `W`.
+- But route quantifies over all bounded-correct DAGs; to refute, need one explicit `C` where **no**
+  suitable `(yYes,D)` (with route budget) exists.
+- In markdown we can motivate risk (YES set extremely sparse among valid encodings), but cannot prove
+  universal nonexistence of all valid isolation pairs.
+
+## Candidate adversary 2: alternate correct DAGs with same language behavior
+- Extensional correctness on promise leaves large implementation freedom.
+- A RED proof would require proving for at least one correct `C` that every candidate YES center and
+  every allowed `D` admits a valid agreeing `z` outside YES.
+- This is a quantified combinatorial negation over encoding-valid domain; no existing already-landed
+  theorem in read set directly discharges it.
+
+**RED status:** not established in markdown.
+
+# 6. Combinatorial structure analysis
+
+At canonical `sYES=1, sNO=2`:
+
+- Number of size-1 Boolean functions on `m` variables is exactly `m+2` (`const false`, `const true`,
+  and each projection `x_i`).
+- YES instances correspond to valid encodings of partial tables consistent with one of these `m+2`
+  functions.
+- NO instances are a complement slice (as defined by promise): not consistent with any size-≤2 circuit.
+
+Qualitative geometry:
+
+- Ambient table coordinate space has size `2^m`; encoded inputs length `2·2^m` (mask/value halves).
+- Counting slack inequality is weak/easy: can be met with very large `|D|` close to `2^m`.
+- Real burden is forcing clause: agreement class must be YES-pure, i.e., no valid agreeing NO point.
+
+Bias assessment:
+
+- Structure does **not** look trivially GREEN (forcing is strong).
+- Structure also not plainly RED from high-level counting alone, because route allows prover-chosen
+  `D` depending on `C`, and potentially large.
+- Therefore combinatorics suggest nontrivial content but do not settle truth value.
+
+# 7. Conclusion vacuity vs research-open classification
+
+Given Sections 4–6:
+
+- Trivial discharge (GREEN) is not derivable from obvious constructions.
+- Explicit counterexample family (RED) is not derivable with parameter-complete rigor.
+- Current markdown evidence supports “nontrivial combinatorial core,” but not a decisive theorem-level
+  YELLOW claim because satisfiable/unsatisfiable status is still unresolved.
+
+Hence final classification for this D0 audit is:
+
+**INCONCLUSIVE_NEEDS_LEAN_PROBE**.
+
+# 8. Lean probe target (only if INCONCLUSIVE)
+
+## Exact theorem target (positive-or-negative disjunction strategy)
+
+Staging path: `pnp3/Tests/IsoStrongConclusionProbe.lean`.
+
+Suggested settle-by-contradiction pair:
+
+1. Positive probe:
+
+```lean
+ theorem canonical_isoStrong_conclusion_holds_for_globalWitness
+   (W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym) :
+   IsoStrongFamilyEventually
+     (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+     (globalWitness_to_hInDag W)
+```
+
+2. Negative probe:
+
+```lean
+ theorem canonical_isoStrong_conclusion_refutable_for_globalWitness :
+   ∃ W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym,
+     ¬ IsoStrongFamilyEventually
+       (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+       (globalWitness_to_hInDag W)
+```
+
+Either theorem (with kernel proof) settles D0.
+
+## Estimated LOC
+- ~120–220 LOC for a first decisive probe (depending on helper lemmas needed about canonical YES
+  geometry under `AgreeOnValues` and `ValidEncoding`).
+
+## Key lemmas/helpers to invoke
+- `IsoStrongFamilyEventually`, `SmallDAGImpliesPromiseYesSubcubeAtEventually`,
+  `ppolyDAGSizeBoundOnSlicesEventually` (`AsymptoticDAGBarrierTheorems`).
+- `globalPolyDAGSizeBound`, `globalWitness_to_hInDag` (`GlobalHInDagContractProbe`).
+- canonical coherence/params (`CanonicalAsymptoticTrackData`).
+- `AgreeOnValues` / certificate structures (`DAGStableRestrictionProducer`).
+- promise shape + encoding lemmas (`Model_PartialMCSP`).
+
+# 9. Implications for the canonical track
+
+For this verdict (`INCONCLUSIVE`):
+
+- Canonical track is **not closed** at conclusion level by markdown argument alone.
+- Next step must be L0 Lean probe resolving whether conclusion is trivially true, false, or genuinely
+  open.
+- Canonical-track implication label: **needs_L0_to_decide**.
+
+# 10. NoGo cross-check
+
+This verdict does not conflict with existing refutations:
+
+- `FormulaCertificateProviderPartial → False`.
+- `FormulaSupportRestrictionBoundsPartial → False`.
+- `FormulaSupportBoundsFromMultiSwitchingContract → False`.
+- `MagnificationAssumptions → False` and `_fromPipeline` variant.
+- `FormulaSupportBoundsPartial_fromPipeline → False`.
+
+Reason: present audit concerns a different surface (global-hInDag-repaired conclusion side of
+iso-strong/eventual-weak DAG route) and does not reassert any refuted predicate.
+
+# 11. Scope statement
+
+Confirmed:
+
+- No Lean/spec/JSONL/NoGoLog/known_guards/trust-root edits.
+- No `ResearchGapWitness` / `SourceTheorem` / `gap_from` / endpoint / `P ≠ NP` claim introduced.
+- Only one markdown report added under allowed seed-pack path.
+
+# 12. Commands run
+
+```bash
+git rev-parse --short HEAD
+sed -n '1,220p' RESEARCH_CONSTITUTION.md
+sed -n '1,220p' STATUS.md
+sed -n '1,260p' seed_packs/isoStrong_conclusion_audit_D0/README.md
+sed -n '1,260p' seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
+sed -n '1,260p' seed_packs/global_hInDag_contract_repair_D0/reports/D0_global_hInDag_contract_repair_codex53.md
+sed -n '940,1135p' pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
+sed -n '1,180p' pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean
+sed -n '1,260p' pnp3/Magnification/CanonicalAsymptoticTrackData.lean
+sed -n '1,260p' pnp3/Tests/GlobalHInDagContractProbe.lean
+sed -n '1,260p' pnp3/Models/Model_PartialMCSP.lean
+sed -n '1,260p' pnp3/LowerBounds/DAGStableRestrictionProducer.lean
+sed -n '218,500p' pnp3/Magnification/FinalResultMainline.lean
+./scripts/check.sh
+```
+
+---
+
+Task: iso-strong conclusion audit D0
+Handle: codex53
+Branch: main
+Commit before: c31e59b
+Commit after: c31e59b
+Changed files:
+  seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
+
+Outcome:
+  REPORT_LANDED
+
+If report landed:
+  executive verdict: INCONCLUSIVE_NEEDS_LEAN_PROBE
+  L0 probe target (if INCONCLUSIVE):
+    `canonical_isoStrong_conclusion_holds_for_globalWitness` OR
+    `canonical_isoStrong_conclusion_refutable_for_globalWitness` in
+    `pnp3/Tests/IsoStrongConclusionProbe.lean`
+  canonical-track implication: needs_L0_to_decide
+  next action:
+    open_isoStrong_conclusion_L0_probe
+  commands run:
+    (listed in section 12)
+
+Scope violations:
+  none


### PR DESCRIPTION
### Motivation
- Add the required markdown-only D0 audit report for the iso-strong conclusion-side analysis under the global hInDag contract to record the audit verdict and probe targets without changing any Lean sources.

### Description
- Create `seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md` containing the 12-section worker-prompt-compliant audit (executive verdict `INCONCLUSIVE_NEEDS_LEAN_PROBE`, required-reading inventory, unfolded conclusion, triviality/refutability tests, combinatorial analysis, and concrete L0 probe targets).

### Testing
- Ran the repository build check via `./scripts/check.sh`, which progressed to completion of the large Lean build with non-blocking linter warnings and no task-local blocking errors; the new report is a markdown-only file and does not affect compilation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfef00468832b887fc7e758d83f46)