### PR TITLE
Add D0 iso-strong conclusion audit report (codex53)

### DIFF
--- a/seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
+++ b/seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
@@ -1,0 +1,207 @@
+# 1. Executive verdict
+
+**INCONCLUSIVE_NEEDS_LEAN_PROBE**
+
+# 2. Required-reading inventory
+
+## Files read
+- `RESEARCH_CONSTITUTION.md` (Rules 0/1/6 reviewed).
+- `STATUS.md`.
+- `seed_packs/isoStrong_conclusion_audit_D0/README.md`.
+- `seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md`.
+- `seed_packs/global_hInDag_contract_repair_D0/reports/D0_global_hInDag_contract_repair_codex53.md`.
+- `pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean` (requested definition region read).
+- `pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean` (requested definition region read).
+- `pnp3/Magnification/CanonicalAsymptoticTrackData.lean` (canonical `sYES=1`, `sNO=2`, `N0=8`).
+- `pnp3/Tests/GlobalHInDagContractProbe.lean` (global witness contract and projection).
+- `pnp3/Models/Model_PartialMCSP.lean` (encoding/promise primitives and counts).
+- `pnp3/LowerBounds/DAGStableRestrictionProducer.lean` (YES-subcube vocabulary context).
+- `pnp3/Magnification/FinalResultMainline.lean` (route composition context).
+
+## Files missing
+- None observed.
+
+# 3. Conclusion statement under audit
+
+Unfolded target (equivalent route-side form):
+
+- `AsymptoticPromiseYesWeakRouteEventually_global canonicalAsymptoticHAsym` means:
+  for every `W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym`, there exist `ε, β0 > 0` such that for each `0 < β < β0`, eventually in `n`,
+  `SmallDAGImpliesPromiseYesSubcubeAtEventually` holds with size predicate
+  `globalPolyDAGSizeBound W`.
+
+The source-level strong form used for audit:
+
+- `IsoStrongFamilyEventually F (globalWitness_to_hInDag W)` where
+  `F := eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym`, i.e.
+  there are `β0`, `κ`, `nIso` with two obligations eventually in `(n,β)`:
+  1) For every small correct DAG `C`, one can find `yYes ∈ Yes`, valid encoding,
+     and a coordinate set `D` with `|D| ≤ κ n β` so that every valid `z`
+     agreeing with `yYes` on `D` is in `Yes`.
+  2) Counting slack: `F.Mof n (F.Tof n β) < 2^(tableLen - κ n β)`.
+
+At canonical parameters, `N0 = 8`, `sYES = 1`, `sNO = 2`, and hence
+`F.Mof n (F.Tof n β) = circuitCountBound n 1 = n + 2` (for coherent large `n`).
+
+# 4. Triviality test (GREEN)
+
+Attempted trivial pattern family:
+
+1. **Singleton-style center**: pick a fixed YES witness `yYes` (e.g., encoding of a
+   very small consistent partial table accepted by canonical threshold `sYES=1`),
+   and set `D :=` all value coordinates.
+   - This makes agreement class essentially singleton-like among valid encodings,
+     so closure-to-YES can become tautological.
+   - But then `|D|` is huge (`≈ tableLen`), so slack inequality
+     `n+2 < 2^(tableLen-|D|)` fails immediately (RHS near `1`).
+
+2. **Tiny `D` (e.g., `D=∅`)**:
+   - Slack inequality succeeds strongly.
+   - But closure-to-YES fails: there are valid NO encodings agreeing on `∅`.
+
+3. **Intermediate `D`**:
+   - Needs nontrivial combinatorial property: all valid encodings sharing those
+     coordinates with chosen YES center must still be YES.
+   - Not obviously true from pure cardinality/sketch arguments; depends on deep
+     structure of partial-table extension classes and promise geometry.
+
+Result: no clearly trivial construction simultaneously satisfies both
+forcing and slack conditions.
+
+# 5. Refutability test (RED)
+
+Adversarial candidates considered:
+
+1. **Compiled `decideAsymptotic` DAG family** (natural global witness projected to slice).
+2. **Other polynomial-size promise-correct DAGs** (including potentially YES-sparse
+   acceptance boundaries consistent with promise correctness).
+
+Observed obstacle for markdown-only refutation:
+- To prove RED informally, one needs a parameter-complete family `C_n` and a proof
+  that for every allowed `(yYes,D)` under slack bound there exists a valid agreement
+  extension outside YES (or equivalently that no qualifying YES center exists).
+- This requires exact interaction between `ValidEncoding`, `AgreeOnValues`, and the
+  promise partition at canonical slices. Current hand analysis does not isolate a
+  robust counterexample family with full quantifier coverage.
+
+Result: no convincing informal counterexample family completed.
+
+# 6. Combinatorial structure analysis
+
+Canonical slice geometry (`sYES=1`, `sNO=2`):
+
+- YES instances are structurally sparse relative to full encoding space
+  (intuitively controlled by size-1 realizability and consistency constraints).
+- NO is the complement within valid promise universe and should be overwhelmingly
+  dense as `n` grows.
+- High density of NO suggests that a random low-codimension cylinder around a YES
+  point likely intersects NO; this is RED-leaning.
+- However, YES structure is not arbitrary: it is induced by constrained partial
+  truth-table semantics. There may exist carefully chosen coordinates that lock
+  enough semantic content while keeping `|D|` below slack budget. That is exactly
+  the research-content core and is not settled by counting alone.
+
+Net: combinatorics looks genuinely nontrivial, neither obviously vacuous nor
+obviously impossible from quick audit arguments.
+
+# 7. Conclusion vacuity vs research-open classification
+
+Given sections 4–6:
+- GREEN not established (no trivial witness+restriction recipe survives slack).
+- RED not established (no complete adversarial family proof sketch with quantifier
+  closure).
+- The statement appears to carry substantive combinatorial burden.
+
+But because the current task requires a decisive verdict and markdown reasoning alone
+cannot certify either proof or refutation, classification is:
+
+**INCONCLUSIVE_NEEDS_LEAN_PROBE**.
+
+# 8. Lean probe target (only if INCONCLUSIVE)
+
+## Exact theorem targets
+
+Proposed positive probe:
+
+```lean
+theorem isoStrong_conclusion_canonical_positive_probe
+  (W : GlobalHInDagContractProbe.GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym) :
+  IsoStrongFamilyEventually
+    (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+    (GlobalHInDagContractProbe.globalWitness_to_hInDag W)
+```
+
+Proposed negative probe alternative:
+
+```lean
+theorem isoStrong_conclusion_canonical_negative_probe :
+  ¬ (∀ W : GlobalHInDagContractProbe.GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym,
+      IsoStrongFamilyEventually
+        (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+        (GlobalHInDagContractProbe.globalWitness_to_hInDag W))
+```
+
+## Estimated LOC
+- `pnp3/Tests/IsoStrongConclusionProbe.lean`: ~180–320 LOC for first meaningful
+  probe (including helper lemmas on `ValidEncoding` + `AgreeOnValues`).
+
+## Likely helpers
+- `IsoStrongFamilyEventually` and eventual adapters in
+  `AsymptoticDAGBarrierTheorems.lean`.
+- Canonical coherence/counting lemmas from
+  `CanonicalAsymptoticTrackData.lean` (`N0=8`, `sYES=1`, `sNO=2`, Shannon bound).
+- Promise totality helper (`mem_yes_or_no_gapSliceOfParams`) and global projection
+  from `GlobalHInDagContractProbe.lean`.
+
+# 9. Implications for the canonical track
+
+With **INCONCLUSIVE**:
+- Canonical track is **not** closed yet at conclusion level.
+- Immediate implication category: **needs_L0_to_decide**.
+- Next action should be focused L0 Lean probe for conclusion-side only.
+
+# 10. NoGo cross-check
+
+This verdict does **not** conflict with known refutations:
+- `FormulaCertificateProviderPartial`.
+- `FormulaSupportRestrictionBoundsPartial`.
+- `FormulaSupportBoundsFromMultiSwitchingContract`.
+- `MagnificationAssumptions` / `MagnificationAssumptions_fromPipeline`.
+- `FormulaSupportBoundsPartial_fromPipeline`.
+
+Reason: those refutations target different hypothesis channels / formula-route
+payload patterns; current audit is conclusion-side geometry under repaired global
+DAG hypothesis contract.
+
+# 11. Scope statement
+
+Confirmed:
+- No Lean edits introduced.
+- No mainline/spec/JSONL/NoGoLog/known_guards/trust-root edits.
+- No `ResearchGapWitness`/`SourceTheorem`/`gap_from`/endpoint/`P ≠ NP` claims.
+- Only seed-pack markdown report added.
+
+# 12. Commands run
+
+```bash
+rg --files -g 'AGENTS.md'
+cat seed_packs/isoStrong_conclusion_audit_D0/WORKER_PROMPT_D0.md
+git rev-parse --short HEAD
+cat RESEARCH_CONSTITUTION.md
+cat STATUS.md
+cat seed_packs/isoStrong_conclusion_audit_D0/README.md
+cat seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
+cat seed_packs/global_hInDag_contract_repair_D0/reports/D0_global_hInDag_contract_repair_codex53.md
+sed -n '70,140p' pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean
+sed -n '966,1108p' pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
+sed -n '1,240p' pnp3/Tests/GlobalHInDagContractProbe.lean
+sed -n '1,260p' pnp3/Magnification/CanonicalAsymptoticTrackData.lean
+sed -n '1,260p' pnp3/Models/Model_PartialMCSP.lean
+sed -n '1,260p' pnp3/LowerBounds/DAGStableRestrictionProducer.lean
+./scripts/check.sh
+./scripts/check.sh
+```
+
+---
+
+**INCONCLUSIVE_NEEDS_LEAN_PROBE**


### PR DESCRIPTION
### Motivation

- Produce the required markdown-only D0 audit of the iso-strong conclusion side under the repaired global `hInDag` contract at canonical parameters (`sYES = 1, sNO = 2, N0 = 8`).
- The audit must decide whether the route conclusion `IsoStrongFamilyEventually` is vacuous/trivial, refutable, research-open, or needs an L0 Lean probe, and provide a precise probe target if needed.

### Description

- Added the markdown audit report `seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md` containing all required sections (executive verdict, reading inventory, unfolded conclusion, GREEN/RED tests, combinatorial analysis, verdict, and L0 probe targets). 
- The report records the verdict `INCONCLUSIVE_NEEDS_LEAN_PROBE` and includes two precise Lean probe statements (`isoStrong_conclusion_canonical_positive_probe` and the complementary negative probe), an estimated LOC for the probe, and a list of likely helper lemmas.
- The report confirms no Lean/spec/NoGoLog/trust-root edits were made and includes the exact shell commands used during the audit for reproducibility.

### Testing

- Ran `./scripts/check.sh` (full Lean build) to ensure repository integrity after adding the markdown report, and repeated the run for reproducibility; both runs completed the build with existing repository warnings but no errors.
- The change is markdown-only and did not modify any Lean sources; the `check.sh` runs therefore show the report did not introduce new build failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfef00468832b887fc7e758d83f46)