### PR TITLE
[D0] Add iso-strong conclusion audit report (codex53)

### DIFF
--- a/seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
+++ b/seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
@@ -1,0 +1,237 @@
+# 1. Executive verdict
+
+INCONCLUSIVE_NEEDS_LEAN_PROBE
+
+# 2. Required-reading inventory
+
+## Files read
+
+- `RESEARCH_CONSTITUTION.md` (Rules 0/1/6 reviewed).
+- `STATUS.md` (head section reviewed).
+- `seed_packs/isoStrong_conclusion_audit_D0/README.md`.
+- `seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md`.
+- `seed_packs/global_hInDag_contract_repair_D0/reports/D0_global_hInDag_contract_repair_codex53.md`.
+- `pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean` (requested ranges including 966–1104).
+- `pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean` (requested range).
+- `pnp3/Magnification/CanonicalAsymptoticTrackData.lean`.
+- `pnp3/Tests/GlobalHInDagContractProbe.lean`.
+- `pnp3/Models/Model_PartialMCSP.lean` (top section plus requested symbols context).
+- `pnp3/LowerBounds/DAGStableRestrictionProducer.lean` (top section plus requested symbols context).
+- `pnp3/Magnification/FinalResultMainline.lean` (requested range 218–460).
+
+## Files missing
+
+- None among required paths.
+
+# 3. Conclusion statement under audit
+
+Under
+`AsymptoticPromiseYesWeakRouteEventually_global canonicalAsymptoticHAsym`,
+and equivalently through the projection provided in
+`GlobalHInDagContractProbe.lean`, the audited conclusion is the eventual
+iso-strong condition:
+
+```lean
+IsoStrongFamilyEventually F (globalWitness_to_hInDag W)
+```
+
+with `IsoStrongFamilyEventually` unfolding to an eventual statement over slice
+index `n` and slack parameter `β`, requiring
+`SmallDAGImpliesPromiseYesSubcubeAtEventually F ...` for every small DAG
+solver `C` correct on the canonical promise slice, and producing a YES center,
+a bounded coordinate set `D`, agreement-closure inside YES, and the canonical
+counting-slack inequality.
+
+# 4. Triviality test (GREEN)
+
+Attempted trivial constructions in markdown (no Lean proof):
+
+1. **Constant-false-style YES center candidate**
+   - Candidate: pick `yYes` as an encoding of a very sparse/degenerate partial
+     object (intended to mimic “constant-false table style”).
+   - Failure mode (informal): to use this in the conclusion, `yYes` must already
+     be in `Yes` and satisfy `ValidEncoding`; this is nontrivial for canonical
+     slice semantics. The README/context indicates this cannot be asserted by
+     pure shape alone.
+
+2. **Take `D = ∅`**
+   - Then `AgreeOnValues D yYes z` is vacuous (modulo validity).
+   - This forces essentially “all valid encodings are YES”, which clearly fails
+     for the canonical gap promise (`sYES = 1`, `sNO = 2`) where NO instances are
+     abundant.
+
+3. **Take `D` very large**
+   - Could isolate a single point, but must satisfy the size bound
+     `|D| ≤ κ m β` and the strict slack inequality
+     `m + 2 < 2^(2^m - κ m β)` simultaneously.
+   - For small enough `β`, this may permit moderate `|D|`, but markdown-only
+     analysis cannot certify that one can always choose `D` so every valid
+     agreement extension stays in YES for every admissible correct `C`.
+
+Result of GREEN test: **no structurally trivial proof path is established in
+markdown**.
+
+# 5. Refutability test (RED)
+
+Tried adversarial-family sketches:
+
+1. **Compiled `decideAsymptotic` DAG family (natural witness route)**
+   - This family is the intended “natural” source and is polynomial-size by
+     construction in the contract discussion.
+   - Not enough in markdown to derive that its accepting set necessarily blocks
+     all admissible YES-isolation certificates with required slack.
+
+2. **Other promise-correct polynomial DAGs**
+   - A possible obstruction would be: for every candidate `D` in size budget,
+     there exists a valid extension agreeing on `D` but outside YES.
+   - This is plausible in dense-complement settings, but converting plausibility
+     into a fully parameter-complete counterexample family needs Lean-level
+     cardinality/encoding lemmas and exact interaction with
+     `PromiseYesSubcubeAt` definitions.
+
+Result of RED test: **no formal-enough counterexample family is certified in
+markdown**.
+
+# 6. Combinatorial structure analysis
+
+For canonical `sYES = 1`, `sNO = 2`:
+
+- YES side is constrained (small-support / low-complexity style predicate), and
+  in the seed-pack framing is bounded by a quantity of order `(m+2)` times the
+  number of admissible partial encodings per function family bucket.
+- NO side is the promise complement and is therefore combinatorially dominant on
+  raw encoding space.
+- Agreement cylinders induced by small `D` are huge; forcing an entire cylinder
+  into YES is therefore a strong geometric demand unless the center/coordinates
+  are selected with very specific canonical structure.
+- The slack inequality `m + 2 < 2^(2^m - κ m β)` is extremely permissive on the
+  RHS for moderate `m`, so the likely bottleneck is **not** counting slack alone
+  but the semantic closure condition “all valid agreement extensions are YES”.
+
+Net structural signal: neither immediate vacuity (GREEN) nor immediate
+obstruction (RED) is decisively established from markdown-only inspection.
+
+# 7. Conclusion vacuity vs research-open classification
+
+Given sections 4–6:
+
+- GREEN not established (no trivial constructor proven to always work).
+- RED not established (no complete adversarial family proof sketch at required
+  parameter precision).
+- The remaining options are YELLOW vs INCONCLUSIVE. Because this D0 task asks
+  for an audit at theorem-body precision and the decisive step depends on exact
+  Lean definitions (`ValidEncoding`, `AgreeOnValues`,
+  `PromiseYesSubcubeAt`, quantified eventual bounds), markdown-only inspection is
+  insufficient to certify YELLOW rigorously.
+
+Therefore verdict is:
+
+**INCONCLUSIVE_NEEDS_LEAN_PROBE**.
+
+# 8. Lean probe target (only if INCONCLUSIVE)
+
+## Exact theorem targets that would settle the audit
+
+Either of the following would settle the conclusion-side audit.
+
+### Positive (GREEN-style) probe theorem
+
+```lean
+theorem isoStrong_conclusion_trivial_for_canonical_global
+  (F : ComplexityInterfaces.AsymptoticLanguage)
+  (hRoute : AsymptoticPromiseYesWeakRouteEventually_global canonicalAsymptoticHAsym F) :
+  ∀ W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym,
+    IsoStrongFamilyEventually F (globalWitness_to_hInDag W)
+```
+
+(If provable by a construction that ignores substantive circuit behavior, this
+would support GREEN.)
+
+### Negative (RED-style) probe theorem
+
+```lean
+theorem isoStrong_conclusion_refutable_for_canonical_global
+  (F : ComplexityInterfaces.AsymptoticLanguage) :
+  ∃ W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym,
+    ¬ IsoStrongFamilyEventually F (globalWitness_to_hInDag W)
+```
+
+(If provable with a concrete polynomial-size promise-correct DAG family, this
+would support RED.)
+
+## Estimated staging LOC
+
+- Path: `pnp3/Tests/IsoStrongConclusionProbe.lean`
+- Estimated LOC: **180–320 LOC** (definition unfolding, helper lemmas,
+  arithmetic/cardinality side lemmas, and either positive or negative witness
+  construction).
+
+## Key helpers likely needed
+
+- `IsoStrongFamilyEventually` and immediate unfold chain from
+  `AsymptoticDAGBarrierTheorems.lean`.
+- `SmallDAGImpliesPromiseYesSubcubeAtEventually` and associated solver/correct-on-promise
+  wrappers.
+- `canonicalAsymptoticSpec`, `canonicalAsymptoticParams`,
+  `canonicalAsymptoticHAsym` from canonical track data.
+- `ValidEncoding`, promise YES/NO predicates, and partial-table encoding lemmas
+  from `Model_PartialMCSP.lean`.
+- `ValueCoordinateSet`, `AgreeOnValues`, and `PromiseYesSubcubeAt` structures
+  from `DAGStableRestrictionProducer.lean`.
+
+# 9. Implications for the canonical track
+
+For this verdict (`INCONCLUSIVE_NEEDS_LEAN_PROBE`):
+
+- Canonical track status: **needs L0 probe to decide** conclusion-side
+  consistency/vacuity.
+- Immediate planning implication: open a dedicated Lean probe to settle whether
+  the global-contract conclusion is trivially true, refutable, or genuinely
+  research-open.
+
+# 10. NoGo cross-check
+
+This verdict does **not** conflict with existing refutations:
+
+- `FormulaCertificateProviderPartial` chain.
+- `FormulaSupportRestrictionBoundsPartial` chain.
+- `FormulaSupportBoundsFromMultiSwitchingContract` chain.
+- `MagnificationAssumptions` / `MagnificationAssumptions_fromPipeline` chain.
+- `FormulaSupportBoundsPartial_fromPipeline` chain.
+
+Reason: this report does not claim restored validity of any refuted route; it
+isolates an unresolved conclusion-side audit question under the repaired global
+contract.
+
+# 11. Scope statement
+
+Confirmed:
+
+- No Lean code added.
+- No mainline `pnp3`/`pnp4` theorem or spec changes.
+- No JSONL / NoGoLog / known_guards / trust-root edits.
+- No `ResearchGapWitness`/`SourceTheorem`/`gap_from`/endpoint/`P ≠ NP` claim.
+- Only one markdown report file added under the seed pack report path.
+
+# 12. Commands run
+
+```sh
+git rev-parse --short HEAD
+./scripts/check.sh
+sed -n '1,220p' RESEARCH_CONSTITUTION.md
+sed -n '1,220p' STATUS.md
+sed -n '1,260p' seed_packs/isoStrong_conclusion_audit_D0/README.md
+sed -n '1,260p' seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
+sed -n '1,260p' seed_packs/global_hInDag_contract_repair_D0/reports/D0_global_hInDag_contract_repair_codex53.md
+sed -n '966,1108p' pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
+sed -n '70,140p' pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean
+sed -n '1,260p' pnp3/Magnification/CanonicalAsymptoticTrackData.lean
+sed -n '1,260p' pnp3/Tests/GlobalHInDagContractProbe.lean
+sed -n '1,260p' pnp3/Models/Model_PartialMCSP.lean
+sed -n '1,260p' pnp3/LowerBounds/DAGStableRestrictionProducer.lean
+sed -n '218,460p' pnp3/Magnification/FinalResultMainline.lean
+```
+
+---
+
+INCONCLUSIVE_NEEDS_LEAN_PROBE


### PR DESCRIPTION
### Motivation

- Add the required D0 markdown-only audit for the iso-strong conclusion under the repaired global `hInDag` contract, following the worker prompt and repository audit checklist.

### Description

- Create `seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md` containing the 12 required sections and recording the verdict `INCONCLUSIVE_NEEDS_LEAN_PROBE` with an explicit Lean probe target and estimated staging path.

### Testing

- Ran `./scripts/check.sh` on `main` and the build/checks completed successfully (Lean build passed with repository warnings/info only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfef36510832bb3338c1de1a0561b)