### PR TITLE
Add D0 iso-strong conclusion audit report (codex53)

### DIFF
--- a/seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
+++ b/seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
@@ -1,0 +1,212 @@
+# 1. Executive verdict
+
+**INCONCLUSIVE_NEEDS_LEAN_PROBE**
+
+# 2. Required-reading inventory
+
+Files read:
+- `RESEARCH_CONSTITUTION.md` (with focus on Rules 0/1/6).
+- `STATUS.md`.
+- `seed_packs/isoStrong_conclusion_audit_D0/README.md`.
+- `seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md`.
+- `seed_packs/global_hInDag_contract_repair_D0/reports/D0_global_hInDag_contract_repair_codex53.md`.
+- `pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean` (requested ranges, incl. eventual definitions and `IsoStrongFamilyEventually`).
+- `pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean`.
+- `pnp3/Magnification/CanonicalAsymptoticTrackData.lean`.
+- `pnp3/Tests/GlobalHInDagContractProbe.lean`.
+- `pnp3/Models/Model_PartialMCSP.lean`.
+- `pnp3/LowerBounds/DAGStableRestrictionProducer.lean`.
+- `pnp3/Magnification/FinalResultMainline.lean` (routes and route-conversion lemmas).
+
+Files missing:
+- None (all required paths were present in the checkout).
+
+# 3. Conclusion statement under audit
+
+Under the global contract introduced in `GlobalHInDagContractProbe`, the audited conclusion is:
+
+```lean
+def AsymptoticPromiseYesWeakRouteEventually_global
+    (hAsym : AsymptoticFormulaTrackHypothesis) : Prop :=
+  ∀ W : GlobalAsymptoticDAGWitness hAsym,
+    ∃ ε : Rat, 0 < ε ∧
+      ∃ β0 : Rat, 0 < β0 ∧
+        ∀ β : Rat, 0 < β → β < β0 →
+          ∃ n0 : Nat,
+            (eventualGapSliceFamily_of_asymptotic hAsym).N0 ≤ n0 ∧
+              ∀ n ≥ n0,
+                SmallDAGImpliesPromiseYesSubcubeAtEventually
+                  (eventualGapSliceFamily_of_asymptotic hAsym)
+                  (globalPolyDAGSizeBound W)
+                  n β ε
+```
+
+Equivalent reformulation used here: `IsoStrongFamilyEventually F (globalWitness_to_hInDag W)` at canonical `hAsym`, where the size side means “for all DAGs `C` below one shared polynomial in encoded length, if `C` is correct-on-promise, then there exists a YES center with bounded agreement set and slack.”
+
+# 4. Triviality test (GREEN)
+
+Attempt A (constant-false YES center):
+- Candidate `yYes`: encoding of a partial table consistent with the size-1 function `const false`.
+- Natural trivial `D`: empty set or tiny fixed set.
+- Obstruction: with `D = ∅`, agreement imposes no coordinate constraints, so valid encodings include both YES and NO promise points; requirement
+  `∀ z, ValidEncoding z → AgreeOnValues D yYes z → z ∈ Yes`
+  fails immediately.
+
+Attempt B (constant-true YES center):
+- Same failure mode as A for small `D`: agreement class is huge and crosses YES/NO boundary.
+
+Attempt C (dictator input bit center):
+- `yYes` from a size-1 input function.
+- With any low-information `D`, agreement class still includes many valid NO points.
+
+Attempt D (maximally informative `D`):
+- If one takes `D` close to full table coordinates, isolation may become possible, but then one must preserve strict counting slack
+  `m+2 < 2^(2^m - |D|)`.
+- Slack still allows very large `|D|` (up to `2^m - O(log m)`), so this does **not** trivially kill the construction; but neither does it produce an obvious “always works” template in markdown.
+
+GREEN decision:
+- No structurally trivial, `C`-independent recipe was found that provably discharges the universal isolation condition.
+- Therefore GREEN is **not** established.
+
+# 5. Refutability test (RED)
+
+Candidate adversarial `C` family:
+- The most natural adversary is the compiled decider family from the global witness itself (`W.family activeLen`) restricted to canonical slices.
+- This `C` is by definition polynomial-size and correct-on-promise, thus admissible.
+
+Potential obstruction modes checked:
+1. “No valid YES center exists in acceptance geometry.”
+   - Not immediate: the conclusion quantifies YES from language semantics, not only from syntactic accepting set characterization.
+2. “Every allowed `D` has an agreement extension outside YES.”
+   - Plausible for some `C`, but not derivable cleanly in markdown without formal combinatorial lemmas about canonical YES cylinders vs valid encodings.
+
+RED decision:
+- I cannot produce a parameter-complete counterexample DAG family with a rigorous obstruction argument at D0 markdown level.
+- Therefore RED is **not** established.
+
+# 6. Combinatorial structure analysis
+
+Canonical spec (`sYES=1`, `sNO=2`) gives:
+- YES functions at slice `m`: exactly `m+2` size-1 total functions (false/true/dictators).
+- Table domain size: `2^m` entries; encoding length is `2·2^m` bits.
+- YES set consists of valid partial encodings consistent with one of those `m+2` functions; NO is complement inside promise.
+
+Qualitative geometry:
+- YES is highly structured but sparse relative to ambient valid encodings.
+- Agreement classes `AgreeOnValues D yYes` are subcubes/cylinders over unfixed coordinates.
+- For small/moderate `|D|`, cylinders are enormous and typically intersect both YES and NO.
+- For very large `|D|`, cylinders can become narrow enough to isolate YES behavior, and slack still permits almost-full `D`.
+
+Net effect:
+- Structure is neither obviously trivially isolating (GREEN) nor obviously impossible (RED).
+- This is a genuine combinatorial threshold question depending on exact interaction among valid-encoding constraints, promise partition, and the `m+2` low-complexity families.
+
+# 7. Conclusion vacuity vs research-open classification
+
+Classification: **INCONCLUSIVE_NEEDS_LEAN_PROBE**.
+
+Reason:
+- The markdown analysis narrows the space: trivial constructions fail in obvious low-`D` forms; universal refutation is plausible but unproven.
+- Deciding between true research-open YELLOW vs outright RED requires formalized combinatorial lemmas (or a constructive witness theorem) at canonical slices.
+
+# 8. Lean probe target (only if INCONCLUSIVE)
+
+Precise probe theorem target (negative form preferred):
+
+```lean
+theorem isoStrong_conclusion_counterexample_or_witness_canonical
+  : (∃ (W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym),
+      ¬ IsoStrongFamilyEventually
+        (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+        (globalWitness_to_hInDag W))
+    ∨
+    (∀ (W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym),
+      IsoStrongFamilyEventually
+        (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+        (globalWitness_to_hInDag W))
+```
+
+Practical staging target:
+- `pnp3/Tests/IsoStrongConclusionProbe.lean`
+- Estimated size: ~180–260 LOC (definition unfolding, canonical arithmetic/slack lemmas reuse, one focused combinatorial core lemma).
+
+Likely helper lemmas/import leverage:
+- `SmallDAGImpliesPromiseYesSubcubeAtEventually` and `IsoStrongFamilyEventually` surfaces.
+- `canonicalAsymptoticSpec` / `canonicalAsymptoticParams` coherence and `Mof`/`Tof` facts.
+- `AgreeOnValues` and promise-YES certificate structures from `DAGStableRestrictionProducer`.
+- `countingSlack_at_requiredComplementBudget`-style counting lemmas from asymptotic barrier theorems.
+
+# 9. Implications for the canonical track
+
+With current verdict (`INCONCLUSIVE_NEEDS_LEAN_PROBE`):
+- canonical-track implication: **needs_L0_to_decide**.
+- No closure at conclusion level yet.
+- Next actionable step: implement the targeted L0 probe theorem above.
+
+# 10. NoGo cross-check
+
+This verdict does not conflict with existing refutations:
+- `FormulaCertificateProviderPartial → False`.
+- `FormulaSupportRestrictionBoundsPartial → False`.
+- `FormulaSupportBoundsFromMultiSwitchingContract → False`.
+- `MagnificationAssumptions[_fromPipeline] → False`.
+- `FormulaSupportBoundsPartial_fromPipeline → False`.
+
+Rationale: current audit is conclusion-side analysis under the *new global DAG witness contract* and does not revive any refuted formula-provider/support-bounds channels.
+
+# 11. Scope statement
+
+Confirmed:
+- No Lean/spec/JSONL/NoGoLog/known_guards/trust-root edits introduced.
+- No `ResearchGapWitness` / `SourceTheorem` / `gap_from` / endpoint / `P ≠ NP` claims introduced.
+- Only one markdown report file added in the permitted seed-pack scope.
+
+# 12. Commands run
+
+```sh
+git rev-parse HEAD
+rg --files -g 'AGENTS.md'
+cat AGENTS.md
+cat seed_packs/isoStrong_conclusion_audit_D0/WORKER_PROMPT_D0.md
+rg --files seed_packs/isoStrong_conclusion_audit_D0 seed_packs/global_hInDag_contract_L0/reports seed_packs/global_hInDag_contract_repair_D0/reports RESEARCH_CONSTITUTION.md STATUS.md pnp3/Tests/GlobalHInDagContractProbe.lean pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean pnp3/Magnification/CanonicalAsymptoticTrackData.lean pnp3/Models/Model_PartialMCSP.lean pnp3/LowerBounds/DAGStableRestrictionProducer.lean pnp3/Magnification/FinalResultMainline.lean
+sed -n '1,220p' seed_packs/isoStrong_conclusion_audit_D0/README.md
+sed -n '1,220p' seed_packs/global_hInDag_contract_L0/reports/L0_global_contract_codex53.md
+sed -n '1,220p' seed_packs/global_hInDag_contract_repair_D0/reports/D0_global_hInDag_contract_repair_codex53.md
+sed -n '1,160p' RESEARCH_CONSTITUTION.md
+sed -n '1,220p' STATUS.md
+sed -n '930,1125p' pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean
+sed -n '60,140p' pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean
+sed -n '1,220p' pnp3/Magnification/CanonicalAsymptoticTrackData.lean
+sed -n '1,240p' pnp3/Tests/GlobalHInDagContractProbe.lean
+sed -n '1,260p' pnp3/Models/Model_PartialMCSP.lean
+sed -n '1,260p' pnp3/LowerBounds/DAGStableRestrictionProducer.lean
+sed -n '218,470p' pnp3/Magnification/FinalResultMainline.lean
+./scripts/check.sh
+```
+
+---
+
+Task: iso-strong conclusion audit D0
+Handle: codex53
+Branch: main
+Commit before: c31e59b00a3ce7c71662d3695d95121065f165f3
+Commit after: e85773927da09575437a5e4ad38f0521998c1298
+Changed files:
+  seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md
+
+Outcome:
+  REPORT_LANDED
+
+If report landed:
+  executive verdict: INCONCLUSIVE_NEEDS_LEAN_PROBE
+  L0 probe target (if INCONCLUSIVE):
+    theorem isoStrong_conclusion_counterexample_or_witness_canonical
+    staging path pnp3/Tests/IsoStrongConclusionProbe.lean
+  canonical-track implication: needs_L0_to_decide
+  next action:
+    if INCONCLUSIVE: open_isoStrong_conclusion_L0_probe
+  commands run:
+    (see section 12)
+
+Scope violations:
+  none


### PR DESCRIPTION
### Motivation
- Produce the required D0 markdown-only audit of the iso-strong conclusion under the global `hInDag` contract and record a precise verdict and L0 probe target per the worker prompt.

### Description
- Add `seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md` containing the 12 mandated sections and the executive verdict `INCONCLUSIVE_NEEDS_LEAN_PROBE` together with a concrete Lean probe theorem target and staging path `pnp3/Tests/IsoStrongConclusionProbe.lean`.
- The report records the required-reading inventory, the unfolded conclusion (`AsymptoticPromiseYesWeakRouteEventually_global` / `IsoStrongFamilyEventually` at canonical `sYES = 1, sNO = 2`), the triviality/refutation attempts, combinatorial analysis, and the recommended L0 probe statement.
- No Lean/source edits were made outside the seed pack; this is a markdown-only change that follows the seed-pack's forbidden/scope rules.

### Testing
- Ran `./scripts/check.sh` (full repository build/check); the build completed successfully and no task-local compile errors were introduced, though unrelated linter warnings were reported in other files.
- No additional automated tests were required for this markdown-only addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfef36510832bb3338c1de1a0561b)