### PR TITLE
L0 probe: IsoStrong conclusion — canonical slack extraction (partial)

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -1,0 +1,80 @@
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Magnification.FinalResultMainline
+import LowerBounds.AsymptoticDAGBarrierTheorems
+import LowerBounds.AsymptoticDAGBarrierInterfaces
+import LowerBounds.MCSPGapLocality
+import «pnp3».Tests.GlobalHInDagContractProbe
+
+/-!
+# Iso-strong conclusion L0 probe (canonical track)
+
+This file is intentionally local to `pnp3/Tests/` and does **not** alter any
+mainline endpoint.  We attempt the recommended Direction N first; in this L0
+session we land a structured **partial** result that cleanly exposes the exact
+canonical arithmetic obligations produced by `IsoStrongFamilyEventually`.
+
+The key extraction is: from `IsoStrongFamilyEventually` at the canonical family,
+we can derive (for sufficiently large slices) the strict slack inequality
+`m + 2 < 2^(2^m - κ m β)`.
+
+This is the precise bridge needed by the proposed pigeonhole contradiction
+(`m+2` YES-side cap vs. subcube cardinality above `m+2`).
+-/
+
+namespace Pnp3
+namespace Tests
+namespace IsoStrongConclusionProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+open LowerBounds
+open GlobalHInDagContractProbe
+
+/-- Shorthand for the canonical eventual gap-slice family. -/
+private def F : GapSliceFamilyEventually :=
+  eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym
+
+@[simp] lemma F_Mof (n : Nat) : F.Mof n (F.Tof n (0 : Rat)) = n + 2 := by
+  simp [F, eventualGapSliceFamily_of_asymptotic]
+
+/--
+From iso-strong on the canonical family, extract the eventual strict slack shape
+for any admissible `β`: `m + 2 < 2^(2^m - κ m β)`.
+
+This is the arithmetic target required by the Direction N pigeonhole plan.
+-/
+theorem canonical_isoStrong_implies_eventual_strict_slack
+    (W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym)
+    (hIso :
+      IsoStrongFamilyEventually
+        (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+        (globalWitness_to_hInDag W)) :
+    ∃ β0 : Rat, 0 < β0 ∧
+      ∃ κ : Nat → Rat → Nat,
+        ∃ nIso : Rat → Nat,
+          ∀ m : Nat, ∀ β : Rat,
+            0 < β → β < β0 →
+            m ≥ max F.N0 (nIso β) →
+              m + 2 < 2 ^ (2 ^ m - κ m β) := by
+  rcases hIso with ⟨β0, hβ0, κ, nIso, _hForce, hSlack⟩
+  refine ⟨β0, hβ0, κ, nIso, ?_⟩
+  intro m β hβPos hβLt hm
+  -- Canonical `Mof` is exactly `m+2`, canonical `tableLen` is exactly `2^m`.
+  have hRaw := hSlack m β hβPos hβLt hm
+  simpa [F, eventualGapSliceFamily_of_asymptotic] using hRaw
+
+/--
+L0 status lemma:
+we have not (in this bounded session) completed a full Direction N contradiction.
+The missing ingredient is a kernel-level pigeonhole lemma converting the strict
+slack inequality into an explicit counterexample `z` to the forcing clause.
+-/
+theorem isoStrong_conclusion_L0_status : True := by
+  trivial
+
+end IsoStrongConclusionProbe
+end Tests
+end Pnp3

--- a/seed_packs/isoStrong_conclusion_L0/reports/L0_isoStrong_conclusion_codex.md
+++ b/seed_packs/isoStrong_conclusion_L0/reports/L0_isoStrong_conclusion_codex.md
@@ -1,0 +1,52 @@
+# L0 iso-strong conclusion probe report (handle: codex)
+
+## Scope and objective
+
+- Staging Lean file: `pnp3/Tests/IsoStrongConclusionProbe.lean`.
+- Attempted direction: **N** (structural negation) first, per worker prompt.
+- Constraint: keep Lean file ≤300 LOC and avoid hidden payload / forbidden imports.
+
+## What landed
+
+A kernel-checked partial theorem was landed:
+
+- `canonical_isoStrong_implies_eventual_strict_slack`
+
+Statement (informal): if canonical `IsoStrongFamilyEventually` holds for a global DAG witness `W`, then for sufficiently large slices and admissible `β`, one gets:
+
+`m + 2 < 2^(2^m - κ m β)`.
+
+This is the exact arithmetic side needed for the proposed Direction-N pigeonhole contradiction.
+
+## Why full Direction N did not land in this L0
+
+The full negative theorem needs a constructive finite combinatorics bridge inside Lean:
+
+1. Convert strict slack into a lower bound on the number of valid agreement extensions under `AgreeOnValues`.
+2. Bound YES-side representable extensions by `m+2` (from canonical `sYES = 1` counting envelope).
+3. Build explicit `z` (valid encoding, agrees on `D`, but not in YES) to contradict forcing.
+
+Step (1)+(3) require a nontrivial glue lemma over:
+
+- `ValidEncoding`, `encodePartial`, `decodePartial`,
+- coordinate-set semantics in `MCSPGapLocality`,
+- and subcube cardinality counting in the encoded bitstring representation.
+
+That combinatorial bridge did not fit safely into this ≤300 LOC L0 while preserving audit hygiene.
+
+## Audits and policy checks
+
+- Forbidden-pattern grep on staging file: no matches.
+- No forbidden imports used.
+- No `axiom` / `sorry` / `admit` / `opaque` / `native_decide` introduced.
+
+## L1 handoff (precise missing theorem)
+
+A targeted L1 theorem is needed:
+
+- Given `ValidEncoding p yYes`, `D : Finset (Fin (Partial.tableLen p.n))`, and strict slack bound,
+  construct a valid `z` with `AgreeOnValues D yYes z` and `z ∉ Yes`.
+
+This is the minimal theorem that should unlock full Direction N refutation.
+
+YELLOW_PARTIAL_LANDING


### PR DESCRIPTION
### Motivation

- Attempt a Direction N L0 probe to decide the iso-strong conclusion for the canonical track by formalizing the pigeonhole-style slack arithmetic needed for a contradiction.
- Keep the probe local and audit-safe (≤300 LOC, no forbidden imports or proof holes) and expose the precise L1 gap that blocks a full refutation.

### Description

- Added `pnp3/Tests/IsoStrongConclusionProbe.lean` which defines `F := eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym` and proves `canonical_isoStrong_implies_eventual_strict_slack`, extracting the canonical slack inequality `m + 2 < 2 ^ (2 ^ m - κ m β)` from `IsoStrongFamilyEventually` instantiated via `globalWitness_to_hInDag`.
- Added the report `seed_packs/isoStrong_conclusion_L0/reports/L0_isoStrong_conclusion_codex.md` recording the outcome `YELLOW_PARTIAL_LANDING` and identifying the exact L1 blocker: a constructive pigeonhole lemma that, from `ValidEncoding`, `D`, and the strict slack, builds a valid `z` with `AgreeOnValues D yYes z` and `z ∉ Yes`.
- No other files changed; no `axiom`/`sorry`/`admit`/`opaque`/`native_decide` introduced and forbidden-pattern imports were avoided.

### Testing

- Ran `lake build PnP3 Pnp4`, which completed successfully and compiled the new probe as part of the tree.
- Ran `./scripts/check.sh`, which passed the repository hygiene, governance and audit checks.
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/IsoStrongConclusionProbe.lean` and observed no matches.
- Result classification: `YELLOW_PARTIAL_LANDING` with the L1 theorem target described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c23bae534832b94a04d9c6506664a)