### PR TITLE
Add L0 iso-strong conclusion probe unpack lemma and report

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -1,0 +1,105 @@
+import Complexity.Interfaces
+import Models.Model_PartialMCSP
+import Magnification.CanonicalAsymptoticTrackData
+import Magnification.FinalResultMainline
+import LowerBounds.AsymptoticDAGBarrierTheorems
+import LowerBounds.AsymptoticDAGBarrierInterfaces
+import LowerBounds.MCSPGapLocality
+import «pnp3».Tests.GlobalHInDagContractProbe
+
+namespace Pnp3
+namespace Tests
+namespace IsoStrongConclusionProbe
+
+open ComplexityInterfaces
+open Models
+open Magnification
+open LowerBounds
+open GlobalHInDagContractProbe
+
+/--
+L0 probe helper: unfold `IsoStrongFamilyEventually` once and package the
+pointwise forcing payload at one concrete `(n, β, C)`.
+
+This lemma is intentionally lightweight and infrastructure-facing:
+it does not settle the canonical conclusion (positive or negative), but it gives
+an explicit reusable elimination form for L1 work.
+-/
+theorem isoStrong_unpack_at
+    (W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym)
+    (hIso :
+      IsoStrongFamilyEventually
+        (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+        (globalWitness_to_hInDag W)) :
+    ∃ β0 : Rat, 0 < β0 ∧
+      ∃ κ : Nat → Rat → Nat,
+        ∃ nIso : Rat → Nat,
+          (∀ n : Nat, ∀ β : Rat,
+            0 < β → β < β0 →
+            n ≥ max
+              (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym).N0
+              (nIso β) →
+            ∀ C : DagCircuit
+              (GapSliceFamilyEventually.encodedLen
+                (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+                n β),
+              ppolyDAGSizeBoundOnSlicesEventually
+                (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+                (globalWitness_to_hInDag W)
+                n β 1 (DagCircuit.size C) →
+              CorrectOnPromiseSlice C
+                (gapSliceOfParams
+                  ((eventualGapSliceFamily_of_asymptotic
+                    canonicalAsymptoticHAsym).paramsOf n β)) →
+                ∃ yYes : Bitstring
+                  (GapSliceFamilyEventually.encodedLen
+                    (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+                    n β),
+                  yYes ∈ (gapSliceOfParams
+                    ((eventualGapSliceFamily_of_asymptotic
+                      canonicalAsymptoticHAsym).paramsOf n β)).Yes ∧
+                  ValidEncoding
+                    ((eventualGapSliceFamily_of_asymptotic
+                      canonicalAsymptoticHAsym).paramsOf n β) yYes ∧
+                  ∃ D : Finset
+                    (Fin
+                      (GapSliceFamilyEventually.tableLen
+                        (eventualGapSliceFamily_of_asymptotic
+                          canonicalAsymptoticHAsym)
+                        n β)),
+                    D.card ≤ κ n β ∧
+                    ∀ z : Bitstring
+                      (GapSliceFamilyEventually.encodedLen
+                        (eventualGapSliceFamily_of_asymptotic
+                          canonicalAsymptoticHAsym)
+                        n β),
+                      ValidEncoding
+                        ((eventualGapSliceFamily_of_asymptotic
+                          canonicalAsymptoticHAsym).paramsOf n β) z →
+                      AgreeOnValues
+                        (p :=
+                          (eventualGapSliceFamily_of_asymptotic
+                            canonicalAsymptoticHAsym).paramsOf n β)
+                        D yYes z →
+                      z ∈ (gapSliceOfParams
+                        ((eventualGapSliceFamily_of_asymptotic
+                          canonicalAsymptoticHAsym).paramsOf n β)).Yes) ∧
+          (∀ n : Nat, ∀ β : Rat,
+            0 < β → β < β0 →
+            n ≥ max
+              (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym).N0
+              (nIso β) →
+              (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym).Mof n
+                  ((eventualGapSliceFamily_of_asymptotic
+                    canonicalAsymptoticHAsym).Tof n β) <
+                2 ^
+                  (GapSliceFamilyEventually.tableLen
+                    (eventualGapSliceFamily_of_asymptotic
+                      canonicalAsymptoticHAsym)
+                    n β -
+                    κ n β)) := by
+  simpa [IsoStrongFamilyEventually] using hIso
+
+end IsoStrongConclusionProbe
+end Tests
+end Pnp3

--- a/seed_packs/isoStrong_conclusion_L0/reports/L0_isoStrong_conclusion_codex.md
+++ b/seed_packs/isoStrong_conclusion_L0/reports/L0_isoStrong_conclusion_codex.md
@@ -1,0 +1,79 @@
+# L0 iso-strong conclusion probe report (codex)
+
+## Scope and reading
+
+Completed required reading set from dispatch and worker prompt:
+- `RESEARCH_CONSTITUTION.md`
+- `STATUS.md`
+- `seed_packs/isoStrong_conclusion_L0/README.md`
+- `seed_packs/isoStrong_conclusion_L0/WORKER_PROMPT_L0.md`
+- `seed_packs/isoStrong_conclusion_audit_D0/reports/D0_isoStrong_conclusion_audit_codex53.md`
+- `pnp3/Tests/GlobalHInDagContractProbe.lean`
+- `pnp3/LowerBounds/AsymptoticDAGBarrierTheorems.lean`
+- `pnp3/LowerBounds/AsymptoticDAGBarrierInterfaces.lean`
+- `pnp3/LowerBounds/MCSPGapLocality.lean`
+- `pnp3/Magnification/CanonicalAsymptoticTrackData.lean`
+- `pnp3/Models/Model_PartialMCSP.lean`
+
+## What was attempted
+
+Direction attempted first: **N**.
+
+I tried to complete the recommended canonical pigeonhole refutation
+(`isoStrong_conclusion_negative_for_canonical`) in ≤300 LOC. The blocker at L0
+is not syntax-level but proof-assembly-level: the argument needs a fully formal
+bridge from slack cardinality (`m + 2 < 2^(tableLen - κ)`) to an explicit valid
+encoding witness outside YES while preserving agreement constraints on `D`.
+
+In this repository shape, that requires a nontrivial L1 lemma bundle over:
+- `ValidEncoding`/`encodePartial`/`decodePartial` image structure,
+- coordinate-level freedom under `AgreeOnValues` on value slots,
+- canonical YES characterization at `sYES = 1` (exactly `m+2` size-1 functions),
+- and a pigeonhole map from agreement subcube points to YES classes.
+
+This exceeded safe L0 completion within one ≤300 LOC probe file without
+introducing brittle wrapper-like artifacts.
+
+## Lean landing
+
+Landed one useful elimination lemma in the staging file:
+- `isoStrong_unpack_at`
+
+This theorem is a clean one-step unpacking of
+`IsoStrongFamilyEventually` specialized to the canonical family and projected
+`globalWitness_to_hInDag W`, exposing both forcing and slack payloads in a
+single reusable shape for L1. It is kernel-checked and keeps imports clean.
+
+## Why this is YELLOW and not RED/GREEN
+
+- **Not GREEN**: no full constructive proof of
+  `IsoStrongFamilyEventually ...` for all global witnesses.
+- **Not RED**: no full structural contradiction proof against all candidate
+  `(yYes, D)` choices under slack.
+- **YELLOW**: a useful partial theorem landed and narrows L1 entry points.
+
+## Required audits and commands
+
+Executed required commands:
+- `lake build PnP3 Pnp4`
+- `./scripts/check.sh`
+- `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4`
+- `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/IsoStrongConclusionProbe.lean`
+
+All passed in this run.
+
+## Exact missing L1 theorem(s)
+
+Primary missing theorem family (informal names):
+1. `agreement_subcube_cardinality_lower_bound`
+2. `canonical_yes_class_count_upper_bound_sYES1`
+3. `exists_valid_agreeing_not_yes_under_slack`
+
+Together they should yield the Direction N theorem directly.
+
+## Next action
+
+Open L1 multi-session probe focused on the three blocking lemmas above and then
+finish Direction N theorem in the same staging surface.
+
+YELLOW_PARTIAL_LANDING


### PR DESCRIPTION
### Motivation
- Provide an L0 Lean probe for the canonical iso-strong conclusion to determine whether the target `IsoStrongFamilyEventually` is provable or refutable at the canonical `sYES = 1, sNO = 2` spec. 
- Capture a small, reusable elimination form that exposes the per-(n,β,C) forcing+slack payload so L1 work can focus on the combinatorial pigeonhole bridge.

### Description
- Added `pnp3/Tests/IsoStrongConclusionProbe.lean` (105 LOC) which defines `theorem isoStrong_unpack_at` that unfolds and packages `IsoStrongFamilyEventually` for `eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym` and any `W : GlobalAsymptoticDAGWitness ...` as a reusable elimination lemma. 
- Added the required report `seed_packs/isoStrong_conclusion_L0/reports/L0_isoStrong_conclusion_codex.md` documenting the required reading, that Direction N was attempted first, the L0 blockers, and the verdict `YELLOW_PARTIAL_LANDING`. 
- The changes are strictly limited to the authorized staging file and the seed-pack report and do not modify any other repository files or mainline theorems. 

### Testing
- Ran `lake build PnP3 Pnp4` and the full build completed (no kernel failures reported in this run). 
- Ran `./scripts/check.sh` and the repository checks completed successfully in this run. 
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no matches. 
- Ran `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/IsoStrongConclusionProbe.lean` and the forbidden-pattern audit passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c23be076c832bbd319b013f8d0d8d)