### PR TITLE
Add L1 trace-diagonalisation lemmas for isoStrong probe

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -32,6 +32,7 @@ open Models
 open Magnification
 open LowerBounds
 open GlobalHInDagContractProbe
+open scoped BigOperators
 
 /-- Shorthand for the canonical eventual gap-slice family. -/
 private def F : GapSliceFamilyEventually :=
@@ -73,6 +74,89 @@ The missing ingredient is a kernel-level pigeonhole lemma converting the strict
 slack inequality into an explicit counterexample `z` to the forcing clause.
 -/
 theorem isoStrong_conclusion_L0_status : True := by
+  trivial
+
+/-! ## L1: trace-diagonalisation scaffolding (partial landing) -/
+
+/-- Finite code for size-1 candidate functions: two constants and all projections. -/
+inductive Size1Candidate (n : Nat)
+  | const : Bool → Size1Candidate n
+  | input : Fin n → Size1Candidate n
+  deriving DecidableEq
+
+instance (n : Nat) : Fintype (Size1Candidate n) where
+  elems :=
+    ({Size1Candidate.const false, Size1Candidate.const true} : Finset (Size1Candidate n)) ∪
+      Finset.univ.image Size1Candidate.input
+  complete := by
+    intro c
+    cases c with
+    | const b =>
+      cases b <;> simp
+    | input i =>
+      apply Finset.mem_union_right
+      exact Finset.mem_image.mpr ⟨i, Finset.mem_univ i, rfl⟩
+
+@[simp] theorem card_Size1Candidate (n : Nat) : Fintype.card (Size1Candidate n) = n + 2 := by
+  classical
+  simp [Fintype.card_ofFinset, Finset.card_union, Finset.card_image]
+
+/-- Value of a size-1 candidate on an input assignment. -/
+def evalSize1Candidate {n : Nat} (c : Size1Candidate n) (x : Fin n → Bool) : Bool :=
+  match c with
+  | .const b => b
+  | .input i => x i
+
+/-- Restrict a size-1 candidate to a finite coordinate set `α` via an embedding into `Fin n`. -/
+def traceSize1CandidateOnFree {n : Nat} (α : Type) [Fintype α]
+    (embed : α → Fin n) (c : Size1Candidate n) : α → Bool :=
+  fun a => evalSize1Candidate c (fun i => decide (i = embed a))
+
+/--
+Finite-pigeonhole core: if the candidate family has size `< 2^|α|`, there exists
+a Boolean labeling of `α` outside all candidate traces.
+-/
+theorem exists_trace_not_size1_of_card_lt {n : Nat} (α : Type) [Fintype α]
+    (embed : α → Fin n)
+    (hSlack : n + 2 < 2 ^ Fintype.card α) :
+    ∃ label : α → Bool,
+      ∀ c : Size1Candidate n,
+        label ≠ traceSize1CandidateOnFree α embed c := by
+  classical
+  have hCand : Fintype.card (Size1Candidate n) < Fintype.card (α → Bool) := by
+    simpa [Fintype.card_fun, Fintype.card_bool, card_Size1Candidate] using hSlack
+  -- Convert strict inequality of cardinals into existence outside the image.
+  have hNotSurj : ¬ Function.Surjective (traceSize1CandidateOnFree α embed) := by
+    intro hsurj
+    have hCardLe : Fintype.card (α → Bool) ≤ Fintype.card (Size1Candidate n) :=
+      Fintype.card_le_of_surjective _ hsurj
+    exact (Nat.not_lt.mpr hCardLe) hCand
+  rcases not_forall.mp hNotSurj with ⟨label, hLabel⟩
+  refine ⟨label, ?_⟩
+  intro c hc
+  exact hLabel ⟨c, hc⟩
+
+/--
+L1 partial landing: free-coordinate trace diagonalisation in abstract form.
+This is the corrected (non-naive) pigeonhole ingredient.
+-/
+theorem exists_trace_not_size1
+    (p : GapPartialMCSPParams)
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (hSlack : p.n + 2 < 2 ^ ((Finset.univ \\ D).card)) :
+    ∃ label : (Finset.univ \\ D).attach → Bool,
+      ∀ c : Size1Candidate p.n,
+        label ≠ traceSize1CandidateOnFree ((Finset.univ \\ D).attach)
+          (fun i => ⟨i.1.1, i.1.2.1⟩) c := by
+  classical
+  -- Rewrite slack into the cardinality form expected by `exists_trace_not_size1_of_card_lt`.
+  have hSlack' : p.n + 2 < 2 ^ Fintype.card ((Finset.univ \\ D).attach) := by
+    simpa using hSlack
+  exact exists_trace_not_size1_of_card_lt ((Finset.univ \\ D).attach)
+    (fun i => ⟨i.1.1, i.1.2.1⟩) hSlack'
+
+/-- L1 session status: one kernel-checked sub-lemma family landed. -/
+theorem isoStrong_conclusion_L1_status : True := by
   trivial
 
 end IsoStrongConclusionProbe

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md
@@ -1,0 +1,57 @@
+# L1 iso-strong conclusion report (codex)
+
+## 1. Executive verdict
+
+YELLOW_ONE_OF_THREE_LANDED
+
+## 2. What landed
+
+Landed (kernel-checked) sub-lemma family for the corrected combinatorial core:
+
+- `card_Size1Candidate`:
+  `Fintype.card (Size1Candidate n) = n + 2`.
+- `exists_trace_not_size1_of_card_lt`:
+  for any finite free-coordinate type `α` and embedding `α → Fin n`, if
+  `n + 2 < 2 ^ Fintype.card α`, then there exists a Boolean labeling
+  `label : α → Bool` that is different from every size-1 candidate trace.
+- `exists_trace_not_size1`:
+  instantiated to `α = (Finset.univ \ D).attach` with slack
+  `p.n + 2 < 2 ^ ((Finset.univ \ D).card`.
+
+Not landed in this session:
+
+- construction of a valid encoding `z` from the non-candidate trace,
+- the full bridge `exists_valid_agreeing_not_yes_under_slack`,
+- the main theorem `isoStrong_conclusion_negative_for_canonical`.
+
+## 3. Corrected pigeonhole argument
+
+I explicitly did **not** use the false shortcut “YES cardinality ≤ m+2”.
+That statement is not correct globally over partial tables, since one size-1
+circuit may be consistent with many partial truth tables.
+
+Instead, this session formalizes the correct diagonalization nucleus:
+
+- size-1 candidate family has cardinality exactly `m+2`;
+- each candidate induces one trace on the chosen free-coordinate domain;
+- if `m+2 < 2^r`, then not all `2^r` labelings can be covered by those traces;
+- therefore there exists a free-coordinate labeling not equal to any size-1 trace.
+
+This is the precise trace-level pigeonhole step needed before constructing `z`.
+
+## 4. Remaining blockers
+
+1. Define the concrete free-coordinate trace map directly from consistency of
+   `decodePartial z` with size-1 circuits, so the abstract diagonal label can be
+   turned into an explicit `z` contradiction.
+2. Build `z` by patching `decodePartial yYes` on `D` and setting free coordinates
+   from the diagonal label, then prove:
+   - `ValidEncoding p z`,
+   - `AgreeOnValues D yYes z`,
+   - `z ∉ (gapSliceOfParams p).Yes`.
+3. Compose with the forcing clause from iso-strong and then finish the canonical
+   contradiction theorem.
+
+## 5. Next action
+
+open_isoStrong_conclusion_L1_session_2


### PR DESCRIPTION
### Motivation

- Complete the missing constructive pigeonhole step for Direction N by replacing the incorrect global ‘|YES| ≤ m+2’ shortcut with a trace-diagonalisation argument over free value coordinates. 
- Provide the kernel-level combinatorial nucleus needed to turn the L0 slack inequality into an explicit non-YES encoding `z` in a follow-up session.

### Description

- Added a small finite encoding of size-1 candidate functions `Size1Candidate` and a `Fintype` instance to enumerate them. 
- Proved the exact cardinality lemma `card_Size1Candidate : Fintype.card (Size1Candidate n) = n + 2`.
- Implemented `evalSize1Candidate` and `traceSize1CandidateOnFree` to view size-1 candidates as traces on an arbitrary finite free-coordinate domain. 
- Proved the core finite-pigeonhole diagonalisation `exists_trace_not_size1_of_card_lt` and instantiated it for the free-coordinate finset as `exists_trace_not_size1` (the corrected L1 combinatorial lemma). 
- Added `isoStrong_conclusion_L1_status` (session status) and the required report `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md` summarizing progress and next actions. 
- All edits confined to the allowed probe scope: `pnp3/Tests/IsoStrongConclusionProbe.lean` and the seed-pack report file.

### Testing

- Ran `lake build PnP3 Pnp4` and the build completed successfully (project modules rebuilt; only preexisting linter warnings were emitted). 
- Ran `./scripts/check.sh` and the repository check completed without introducing new hard errors; the build output included warnings but no check-stage failures were observed in the captured run. 
- Ran repository scans `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and the forbidden-pattern scan on `pnp3/Tests/IsoStrongConclusionProbe.lean`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4f2b86b0832bab459e5c51a00561)