### PR TITLE
Add L1 iso-strong conclusion report with corrected trace-diagonalisation

### DIFF
--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md
@@ -1,0 +1,49 @@
+# L1 iso-strong conclusion probe (codex)
+
+## 1. Executive verdict
+
+INCONCLUSIVE_NEEDS_L2
+
+## 2. What landed
+
+No new Lean theorem landed in this session.
+
+I confirmed the existing L0 extraction in `pnp3/Tests/IsoStrongConclusionProbe.lean` is intact:
+- `F_Mof`
+- `canonical_isoStrong_implies_eventual_strict_slack`
+
+## 3. Corrected pigeonhole argument
+
+I explicitly did **not** use the false global claim
+
+> "the YES set has cardinality ≤ m+2".
+
+Reason: there are only `m+2` size-1 circuits, but each fixed size-1 circuit can be consistent with many partial tables, so this does **not** bound the count of YES partial tables.
+
+The correct route is trace-diagonalisation over free value coordinates outside `D`:
+
+1. Let `free := Finset.univ \ D` and `r := free.card`.
+2. A size-1 candidate induces a single Boolean trace `free → Bool` on these free coordinates.
+3. Number of size-1 candidates is `m+2`; hence number of candidate traces is at most `m+2`.
+4. Number of all labels on `free` is exactly `2^r`.
+5. Under slack `m+2 < 2^r`, choose a label not equal to any candidate trace.
+6. Build `z` by copying `yYes` on `D` and setting free coordinates to that label (with mask true on free coordinates).
+7. Then `z` is valid, agrees on `D`, and cannot be YES; otherwise a size-1 circuit would match the free trace, contradiction.
+
+## 4. Remaining blockers
+
+The immediate blocker for landing code in one pass is proof-engineering complexity around:
+
+- clean finite-type packaging for traces over `(Finset.univ \ D).attach`;
+- bridging the route-level slack shape to a reusable cardinality lemma without introducing brittle coercion chains;
+- efficient proof of the `¬ z ∈ Yes` step through current `decideYesAt1_iff`/candidate-consistency interfaces.
+
+A robust L2 should first isolate a small helper API for:
+
+- candidate trace extraction,
+- image-cardinality upper bound,
+- existence of non-image label under strict cardinality inequality.
+
+## 5. Next action
+
+open_isoStrong_conclusion_L2_design


### PR DESCRIPTION
### Motivation
- Record the L1 probe progress for the iso-strong canonical track and document the corrected pigeonhole argument (trace-diagonalisation over free value coordinates) while explicitly rejecting the incorrect global claim that `|YES| ≤ m + 2`.

### Description
- Add the session report file `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md` containing the executive verdict `INCONCLUSIVE_NEEDS_L2`, the corrected trace-diagonalisation argument, listed blockers, and the next action `open_isoStrong_conclusion_L2_design`, and do not modify any Lean sources (no changes to `pnp3/Tests/IsoStrongConclusionProbe.lean`).

### Testing
- Ran `lake build PnP3 Pnp4` and `./scripts/check.sh` (build streamed successfully with existing linter warnings but no new repo-local errors observed), and ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/IsoStrongConclusionProbe.lean` which reported no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4f2b86b0832bab459e5c51a00561)