### PR TITLE
tests: add L1 iso-strong size1 candidate cardinality scaffold

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -33,6 +33,40 @@ open Magnification
 open LowerBounds
 open GlobalHInDagContractProbe
 
+/-- Finite canonical index type for size-1 candidate circuits over `n` variables. -/
+inductive Size1Candidate (n : Nat)
+  | const : Bool → Size1Candidate n
+  | input : Fin n → Size1Candidate n
+
+namespace Size1Candidate
+
+instance (n : Nat) : Fintype (Size1Candidate n) :=
+  Fintype.ofFinite _
+
+@[simp] lemma card_size1Candidate (n : Nat) :
+    Fintype.card (Size1Candidate n) = n + 2 := by
+  classical
+  -- `Bool ⊕ Fin n` has cardinality `2 + n`, and `Size1Candidate n` is equivalent to it.
+  let e : Size1Candidate n ≃ (Bool ⊕ Fin n) :=
+    { toFun := fun c =>
+        match c with
+        | .const b => Sum.inl b
+        | .input i => Sum.inr i
+      invFun := fun s =>
+        match s with
+        | Sum.inl b => .const b
+        | Sum.inr i => .input i
+      left_inv := by intro c; cases c <;> rfl
+      right_inv := by intro s; cases s <;> rfl }
+  calc
+    Fintype.card (Size1Candidate n)
+        = Fintype.card (Bool ⊕ Fin n) := Fintype.card_congr e
+    _ = Fintype.card Bool + Fintype.card (Fin n) := Fintype.card_sum
+    _ = 2 + n := by simp
+    _ = n + 2 := by omega
+
+end Size1Candidate
+
 /-- Shorthand for the canonical eventual gap-slice family. -/
 private def F : GapSliceFamilyEventually :=
   eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_l1a.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_l1a.md
@@ -1,0 +1,45 @@
+## 1. Executive verdict
+
+YELLOW_ONE_OF_THREE_LANDED
+
+## 2. What landed
+
+Landed theorem:
+
+- `Size1Candidate.card_size1Candidate (n : Nat) : Fintype.card (Size1Candidate n) = n + 2`
+
+and supporting finite index type:
+
+- `inductive Size1Candidate (n : Nat) | const : Bool → ... | input : Fin n → ...`
+
+This provides the exact canonical count of size-1 circuit *candidates* needed by the corrected L1 trace-diagonalisation route.
+
+## 3. Corrected pigeonhole argument
+
+I did **not** use the false shortcut “YES cardinality ≤ m+2”.
+
+Reason: while there are only `m+2` size-1 circuits, each circuit may be consistent with many distinct partial truth tables, so global YES-cardinality is not bounded by `m+2`.
+
+Correct approach (targeted for next session):
+
+- work on free coordinates `free = univ \ D`;
+- each size-1 candidate induces one trace `free → Bool`;
+- traces realizable by candidates are at most `m+2`;
+- all labels `free → Bool` are `2^|free|`;
+- from strict slack `m+2 < 2^|free|`, choose a label outside candidate traces;
+- encode a valid `z` that copies `yYes` on `D` and realizes this label on `free` (with mask=true on free coordinates);
+- conclude `z` is valid, agrees on `D`, and cannot be YES.
+
+## 4. Remaining blockers
+
+1. Formalize `traceSize1CandidateOnFree` and prove image cardinality bound on traces.
+2. Build `exists_trace_not_size1` from slack and finite function-space cardinality.
+3. Construct `z` via `encodePartial` and discharge:
+   - `ValidEncoding p z`
+   - `AgreeOnValues D yYes z`
+   - `¬ z ∈ (gapSliceOfParams p).Yes`
+4. Compose into `exists_valid_agreeing_not_yes_under_slack`, then main theorem.
+
+## 5. Next action
+
+open_isoStrong_conclusion_L1_session_2


### PR DESCRIPTION
### Motivation

- Provide the corrected combinatorial foundation for the L1 trace-diagonalisation route (avoid the invalid global “YES ≤ m+2” shortcut) by exposing an explicit finite index for size-1 candidate circuits. 
- Make explicit the canonical count `m + 2` as a Fintype cardinality so follow-up L1 work can formalize traces on free coordinates and build the constructive `z` counterexample.

### Description

- Added `Size1Candidate` (inductive `const` / `input`) and proved `card_size1Candidate : Fintype.card (Size1Candidate n) = n + 2` inside `pnp3/Tests/IsoStrongConclusionProbe.lean` to expose a concrete finite index type for size-1 circuit candidates. 
- Added an L1 progress report `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_l1a.md` documenting the corrected pigeonhole strategy, remaining sub-lemmas, and the next-session handoff.

### Testing

- Ran `lake build PnP3 Pnp4` and observed a deep, successful incremental build in the captured logs with no kernel errors reported in the recorded output segment. 
- Ran `./scripts/check.sh` (build/check initiated) and observed no immediate failures in the captured output segment. 
- Ran repository grep audits: `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and the forbidden-pattern grep on the staging file; no `sorry`/`admit` or forbidden patterns were found in the staging file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4f3030e4832bb26dc5461015d530)