### PR TITLE
L1 iso-strong probe: add structured failure report (codex2)

### DIFF
--- a/seed_packs/isoStrong_conclusion_L1/failures/L1_isoStrong_conclusion_codex2.md
+++ b/seed_packs/isoStrong_conclusion_L1/failures/L1_isoStrong_conclusion_codex2.md
@@ -1,0 +1,36 @@
+# L1 iso-strong conclusion probe failure note (handle: codex2)
+
+## Executive verdict
+INCONCLUSIVE_NEEDS_L2
+
+## What was attempted
+- Loaded required context files and inspected the existing L0 probe.
+- Inspected `CanonicalAsymptoticDecider` primitives for `size1Candidates`, `decideYesAt1_iff`, and size-1 membership lemmas.
+- Inspected the forcing/iso-strong shape in `AsymptoticDAGBarrierTheorems` and encoding locality primitives in `MCSPGapLocality`.
+
+## Why no kernel-checked L1 lemma was landed in this session
+The blocker in this session is not the arithmetic pigeonhole idea itself; it is the amount of glue required to bridge all of the following simultaneously in a robust Lean proof without introducing brittle ad-hoc coercion lemmas:
+
+1. A finite-domain function-space counting argument over `(Finset.univ \ D).attach → Bool` at exactly the needed cardinality form.
+2. A compatibility bridge from size-1 *circuit syntax* (`Circuit p.n`) to free-coordinate *trace functions* on table indices (with decoding semantics and consistency obligations).
+3. A constructive `z` build that preserves `ValidEncoding` and proves `AgreeOnValues` on value coordinates while fixing free coordinates as fully-masked labels.
+4. A contradiction route from `z ∈ Yes` to a trace equality against one of the size-1 candidates via `decideYesAt1_iff` + consistency semantics.
+
+The current codebase has the ingredients, but this composition requires a dedicated intermediate API layer (trace extraction, class indexing, and reusable cardinality wrappers). That layer is larger than what could be landed safely in this single pass without risking regressions or fragile proof scripts.
+
+## Corrected pigeonhole argument (explicitly used, but not yet formalized)
+I did **not** use the false shortcut “`|YES| ≤ m+2` globally.”
+
+Correct plan remains:
+- Only `m+2` size-1 candidates exist.
+- Each candidate induces exactly one Boolean trace on free coordinates outside `D`.
+- Free-coordinate labelings are `2^r` where `r = |free|`.
+- If `m+2 < 2^r`, choose a labeling not equal to any candidate trace.
+- Encode that labeling into a valid `z` agreeing with `yYes` on `D`, forcing `z ∉ YES`.
+
+## L2 request
+A focused L2 design should first land a small reusable trace API in this test probe file (or explicitly approved shared test helper), then prove:
+- candidate-trace image card bound,
+- existence of a non-candidate trace,
+- constructive `z` contradiction lemma.
+

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex2.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex2.md
@@ -1,0 +1,25 @@
+# L1 iso-strong conclusion report (handle: codex2)
+
+## 1. Executive verdict
+INCONCLUSIVE_NEEDS_L2
+
+## 2. What landed
+No new kernel-checked Lean theorem was landed in this session.
+
+## 3. Corrected pigeonhole argument
+This session explicitly follows the correction: we do **not** claim a global cardinality bound `|YES| ≤ m+2` on partial tables.
+
+Instead, the correct argument is trace-diagonalisation on free value coordinates:
+- index free coordinates by `free := Finset.univ \ D`,
+- consider trace functions `free.attach → Bool` induced by each size-1 candidate circuit,
+- use strict slack `m+2 < 2^|free|` to pick a free-labeling outside candidate traces,
+- encode that labeling into a valid partial table agreeing on `D`,
+- derive contradiction with iso-strong forcing if that encoding were in YES.
+
+## 4. Remaining blockers
+- Missing dedicated in-file API for candidate-trace extraction at free coordinates.
+- Nontrivial coercion/cardinality plumbing for function-space and image-card bounds.
+- Constructive `z`-builder proof linking `ValidEncoding`, `AgreeOnValues`, and `decideYesAt1_iff` consistency semantics.
+
+## 5. Next action
+open_isoStrong_conclusion_L2_design


### PR DESCRIPTION
### Motivation
- Record a structured L1 session failure and exact corrected pigeonhole (trace-diagonalisation) plan because the constructive pigeonhole z-construction could not be kernel-checked in this session and requires an L2 design pass.

### Description
- Added two seed-pack artifacts documenting the session: `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex2.md` with an `INCONCLUSIVE_NEEDS_L2` verdict and the corrected trace-diagonalisation argument, and `seed_packs/isoStrong_conclusion_L1/failures/L1_isoStrong_conclusion_codex2.md` with a precise failure note and L2 handoff; no Lean source files were modified.

### Testing
- Ran `lake build PnP3 Pnp4` (completed with linter warnings but no hard build failure observed in captured output), ran `./scripts/check.sh` (advanced through the Lean build with warnings and no hard failure captured), and verified `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and the forbidden-pattern `rg` against `pnp3/Tests/IsoStrongConclusionProbe.lean` produced no matches; no new kernel-checked theorems landed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4f3030e4832bb26dc5461015d530)