### PR TITLE
pnp3: add row-trace and diagonal encoding scaffolding for iso-strong L1 s2

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -113,6 +113,22 @@ def traceSize1CandidateOnFree {n : Nat} (α : Type) [Fintype α]
   fun a => evalSize1Candidate c (fun i => decide (i = embed a))
 
 /--
+Row-trace of a size-1 candidate on an arbitrary finite family of truth-table rows.
+
+Unlike `traceSize1CandidateOnFree`, this trace is over *table row indices*
+`Fin (Partial.tableLen n)` (assignment indices), not variable indices `Fin n`.
+This is the semantically correct object for diagonalisation on free rows.
+-/
+def traceSize1CandidateOnRows
+    {n : Nat}
+    (α : Type) [Fintype α]
+    (row : α → Fin (Partial.tableLen n))
+    (c : Size1Candidate n) : α → Bool :=
+  match c with
+  | .const b => fun _ => b
+  | .input i => fun a => Nat.testBit (row a).val i.val
+
+/--
 Finite-pigeonhole core: if the candidate family has size `< 2^|α|`, there exists
 a Boolean labeling of `α` outside all candidate traces.
 -/
@@ -154,6 +170,60 @@ theorem exists_trace_not_size1
     simpa using hSlack
   exact exists_trace_not_size1_of_card_lt ((Finset.univ \\ D).attach)
     (fun i => ⟨i.1.1, i.1.2.1⟩) hSlack'
+
+/--
+Diagonal partial table:
+* on constrained coordinates `D`, reuse values of `decodePartial yYes`;
+* on free coordinates, set values to `label`.
+-/
+def diagonalPartialTable
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    PartialTruthTable p.n :=
+  fun j =>
+    if hD : j ∈ D then
+      decodePartial yYes j
+    else
+      some (label ⟨j, by simp [hD]⟩)
+
+/-- The encoded diagonal table is always a valid canonical encoding. -/
+theorem diagonal_z_valid
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    ValidEncoding p (encodePartial (diagonalPartialTable p yYes D label)) := by
+  simpa using validEncoding_encodePartial p (diagonalPartialTable p yYes D label)
+
+/--
+On coordinates from `D`, diagonal encoding agrees with `yYes` at value bits.
+
+The proof uses that `yYes` is canonical (`ValidEncoding`) and that decoding an
+encoding returns the underlying partial table.
+-/
+theorem diagonal_z_agrees_on_D
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool)
+    (hValidYes : ValidEncoding p yYes) :
+    AgreeOnValues D yYes (encodePartial (diagonalPartialTable p yYes D label)) := by
+  intro i hiD
+  have hyCanon : yYes = encodePartial (decodePartial yYes) := hValidYes
+  have hLeft : Partial.valPart yYes i = Partial.valPart (encodePartial (decodePartial yYes)) i := by
+    simpa [hyCanon]
+  have hDiag :
+      decodePartial (encodePartial (diagonalPartialTable p yYes D label)) i =
+      decodePartial yYes i := by
+    simp [diagonalPartialTable, hiD]
+  have hRight :
+      Partial.valPart (encodePartial (diagonalPartialTable p yYes D label)) i =
+      Partial.valPart (encodePartial (decodePartial yYes)) i := by
+    -- Convert through decoded tables; both sides encode equal values at `i`.
+    cases hdy : decodePartial yYes i <;> simp [Partial.valPart, encodePartial, hDiag, hdy]
+  exact hLeft.trans hRight.symm
 
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md
@@ -1,57 +1,24 @@
-# L1 iso-strong conclusion report (codex)
-
-## 1. Executive verdict
-
+# Executive verdict
 YELLOW_ONE_OF_THREE_LANDED
 
-## 2. What landed
+# What landed
+- `traceSize1CandidateOnRows`
+- `diagonalPartialTable`
+- `diagonal_z_valid`
+- `diagonal_z_agrees_on_D`
 
-Landed (kernel-checked) sub-lemma family for the corrected combinatorial core:
+# Corrected trace argument
+The session adds the row-based trace object needed for the corrected diagonal argument.
+The old helper `traceSize1CandidateOnFree` uses an embedding into `Fin n`, i.e. variable-coordinate encoding.
+For the L1 diagonal step, free coordinates are truth-table rows (`Fin (2^n)`), so the relevant trace must evaluate projections via
+`Nat.testBit (row a).val i.val` where `row a : Fin (Partial.tableLen n)`.
+This is exactly what `traceSize1CandidateOnRows` encodes.
 
-- `card_Size1Candidate`:
-  `Fintype.card (Size1Candidate n) = n + 2`.
-- `exists_trace_not_size1_of_card_lt`:
-  for any finite free-coordinate type `α` and embedding `α → Fin n`, if
-  `n + 2 < 2 ^ Fintype.card α`, then there exists a Boolean labeling
-  `label : α → Bool` that is different from every size-1 candidate trace.
-- `exists_trace_not_size1`:
-  instantiated to `α = (Finset.univ \ D).attach` with slack
-  `p.n + 2 < 2 ^ ((Finset.univ \ D).card`.
+# Remaining blockers
+- `diagonal_z_not_yes_of_label_not_trace`: missing bridge from YES-witness circuits of size `≤ 1` to `Size1Candidate` plus consistency→row-trace equality.
+- `exists_valid_agreeing_not_yes_under_slack`: depends on the previous missing bridge and final contradiction assembly.
+- Potential helper needed for cleaner arithmetic transport:
+  `Partial.tableLen p.n - D.card = (Finset.univ \ D).card`.
 
-Not landed in this session:
-
-- construction of a valid encoding `z` from the non-candidate trace,
-- the full bridge `exists_valid_agreeing_not_yes_under_slack`,
-- the main theorem `isoStrong_conclusion_negative_for_canonical`.
-
-## 3. Corrected pigeonhole argument
-
-I explicitly did **not** use the false shortcut “YES cardinality ≤ m+2”.
-That statement is not correct globally over partial tables, since one size-1
-circuit may be consistent with many partial truth tables.
-
-Instead, this session formalizes the correct diagonalization nucleus:
-
-- size-1 candidate family has cardinality exactly `m+2`;
-- each candidate induces one trace on the chosen free-coordinate domain;
-- if `m+2 < 2^r`, then not all `2^r` labelings can be covered by those traces;
-- therefore there exists a free-coordinate labeling not equal to any size-1 trace.
-
-This is the precise trace-level pigeonhole step needed before constructing `z`.
-
-## 4. Remaining blockers
-
-1. Define the concrete free-coordinate trace map directly from consistency of
-   `decodePartial z` with size-1 circuits, so the abstract diagonal label can be
-   turned into an explicit `z` contradiction.
-2. Build `z` by patching `decodePartial yYes` on `D` and setting free coordinates
-   from the diagonal label, then prove:
-   - `ValidEncoding p z`,
-   - `AgreeOnValues D yYes z`,
-   - `z ∉ (gapSliceOfParams p).Yes`.
-3. Compose with the forcing clause from iso-strong and then finish the canonical
-   contradiction theorem.
-
-## 5. Next action
-
-open_isoStrong_conclusion_L1_session_2
+# Next action
+open_isoStrong_conclusion_L1_session_3


### PR DESCRIPTION
### Motivation
- Connect the abstract trace-diagonalisation kernel from L1 to the MCSP encoding layer so we can build a concrete encoded partial truth-table `z` that witnesses the pigeonhole diagonalisation step. 
- Fix the semantic mismatch between variable-index traces and truth-table row traces so the diagonal label can be instantiated on actual table rows instead of projection indices. 

### Description
- Added `traceSize1CandidateOnRows` to evaluate `Size1Candidate` on truth-table row coordinates (`Fin (Partial.tableLen n)`) rather than variable indices. 
- Added `diagonalPartialTable` that patches `decodePartial yYes` on constrained coordinates `D` and uses a diagonal `label` on free rows to produce a `PartialTruthTable`. 
- Added `diagonal_z_valid` showing `encodePartial (diagonalPartialTable ...)` is a `ValidEncoding` via `validEncoding_encodePartial`. 
- Added `diagonal_z_agrees_on_D` proving agreement of value-coordinates on `D` between `yYes` and the encoded diagonal table under `ValidEncoding p yYes`. 
- Updated L1 session report `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md` describing landed lemmas, corrected trace argument, remaining blockers, and next action. 
- Changed files: `pnp3/Tests/IsoStrongConclusionProbe.lean` and `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md`. 

### Testing
- Ran `lake build PnP3 Pnp4` which completed successfully for the affected modules though the build produced pre-existing linter warnings (no new errors introduced). 
- Ran the repository check script `./scripts/check.sh` and observed a full build/replay flow with no new failures from the modified files in the captured output. 
- Searched for disallowed placeholders with `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no matches. 
- Checked for forbidden import patterns in the modified probe with `rg` and found no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c70fff868832bb1090e66a43524e6)