### PR TITLE
Add row-trace and diagonal-partial-table scaffolding for L1 iso-strong probe

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -155,6 +155,75 @@ theorem exists_trace_not_size1
   exact exists_trace_not_size1_of_card_lt ((Finset.univ \\ D).attach)
     (fun i => ⟨i.1.1, i.1.2.1⟩) hSlack'
 
+/--
+Trace a size-1 candidate along a finite family of **truth-table rows**.
+
+This is the row-correct variant needed for the L1 diagonal step:
+`row : α → Fin (Partial.tableLen n)` selects concrete truth-table indices,
+and projection candidates read the corresponding input bit from that row index.
+-/
+def traceSize1CandidateOnRows
+    {n : Nat}
+    (α : Type) [Fintype α]
+    (row : α → Fin (Partial.tableLen n))
+    (c : Size1Candidate n) : α → Bool :=
+  match c with
+  | .const b => fun _ => b
+  | .input i => fun a => Nat.testBit (row a).val i.val
+
+/--
+Diagonal partial table: keep the `D`-coordinates from `yYes`, assign free
+coordinates by `label`.
+-/
+def diagonalPartialTable
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    PartialTruthTable p.n :=
+  fun j =>
+    if hD : j ∈ D then
+      decodePartial yYes j
+    else
+      some (label ⟨j, by
+        exact Finset.mem_sdiff.mpr ⟨Finset.mem_univ j, hD⟩⟩)
+
+/-- The encoded diagonal table is always a valid canonical encoding. -/
+theorem diagonal_z_valid
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    ValidEncoding p (encodePartial (diagonalPartialTable p yYes D label)) := by
+  exact validEncoding_encodePartial p (diagonalPartialTable p yYes D label)
+
+/--
+The diagonal construction agrees with `yYes` on the value coordinates indexed by
+`D`.
+-/
+theorem diagonal_z_agrees_on_D
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (hValidYes : ValidEncoding p yYes)
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    AgreeOnValues D yYes (encodePartial (diagonalPartialTable p yYes D label)) := by
+  intro i hiD
+  -- Canonicalization of `yYes` from validity.
+  have hCanonical : yYes = encodePartial (decodePartial yYes) := hValidYes
+  -- On coordinates in `D`, the diagonal table reuses `decodePartial yYes`.
+  have hDiagAt : diagonalPartialTable p yYes D label i = decodePartial yYes i := by
+    simp [diagonalPartialTable, hiD]
+  -- Reduce both sides to value components of canonical `encodePartial` forms.
+  calc
+    Partial.valPart (encodePartial (diagonalPartialTable p yYes D label)) i
+        = Option.getD (diagonalPartialTable p yYes D label i) false := by
+            simp [Partial.valPart, encodePartial]
+    _ = Option.getD (decodePartial yYes i) false := by rw [hDiagAt]
+    _ = Partial.valPart (encodePartial (decodePartial yYes)) i := by
+          simp [Partial.valPart, encodePartial]
+    _ = Partial.valPart yYes i := by rw [hCanonical]
+
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by
   trivial

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session2.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session2.md
@@ -1,0 +1,36 @@
+## 1. Executive verdict
+
+YELLOW_ONE_OF_THREE_LANDED
+
+## 2. What landed
+
+- `traceSize1CandidateOnRows`
+- `diagonalPartialTable`
+- `diagonal_z_valid`
+- `diagonal_z_agrees_on_D`
+
+## 3. Corrected trace argument
+
+This session adds the row-correct trace interface:
+
+- old abstract trace (`traceSize1CandidateOnFree`) was indexed by an embedding into `Fin n` (variable coordinates);
+- new `traceSize1CandidateOnRows` is indexed by explicit truth-table rows `row : α → Fin (Partial.tableLen n)`;
+- for projection candidate `input i`, trace value is `Nat.testBit (row a).val i.val`, i.e. the `i`-th input bit of the concrete row index.
+
+This is exactly the correction needed to avoid conflating variable indices with truth-table row coordinates.
+
+## 4. Remaining blockers
+
+1. `diagonal_z_not_yes_of_label_not_trace`:
+   convert YES witness (`∃ C, C.size ≤ p.sYES ∧ is_consistent C (decodePartial z)`) at `p.sYES = 1`
+   into a `Size1Candidate`, then derive free-row trace equality and contradict diagonal label inequality.
+
+2. `exists_valid_agreeing_not_yes_under_slack`:
+   compose the existing trace pigeonhole lemma with the concrete diagonal table and the not-YES bridge above.
+
+3. Optional canonical endpoint:
+   `isoStrong_conclusion_negative_for_canonical` after the previous theorem is landed.
+
+## 5. Next action
+
+open_isoStrong_conclusion_L1_session_3


### PR DESCRIPTION
### Motivation

- Connect the abstract trace-diagonalisation core from L1 to the MCSP encoding layer by providing a row-correct trace interface and a concrete diagonal partial table constructor.
- Avoid the false global shortcut about YES cardinality and instead implement the correct diagonal/pigeonhole nucleus at the level of truth-table rows and encoded partial tables.
- Land the concrete building blocks needed to patch free rows with a diagonal label while preserving `D`-coordinates from a canonical `yYes` so later sessions can finish the NOT-YES contradiction.

### Description

- Add `traceSize1CandidateOnRows` to evaluate Size1Candidate functions on explicit truth-table row indices (so projection candidates read bits via `Nat.testBit (row a).val i.val`).
- Add `diagonalPartialTable` which keeps `decodePartial yYes` on coordinates in `D` and fills remaining rows with a diagonal `label` on `(Finset.univ \ D).attach`.
- Add `diagonal_z_valid` proving `ValidEncoding p (encodePartial (diagonalPartialTable ...))` via `validEncoding_encodePartial`.
- Add `diagonal_z_agrees_on_D` proving `AgreeOnValues D yYes (encodePartial (diagonalPartialTable ...))` using `hValidYes : ValidEncoding p yYes` and the definition of `encodePartial`/`decodePartial` value components.
- Add the session report `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session2.md` documenting verdict, landed lemmas, corrected trace argument, blockers, and next action; leave the final `exists_valid_agreeing_not_yes_under_slack` / NOT-YES bridge to the next session because converting YES witnesses to Size1Candidate trace equality remains to be completed.

### Testing

- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no `sorry`/`admit` usages in the modified code. (passed)
- Ran the forbidden-pattern `rg` against the modified test file and confirmed no matches for the restricted imports/patterns. (passed)
- Started `lake build PnP3 Pnp4` and compiled many dependencies in this environment; the build progressed and produced only linter warnings for unrelated files, but a full `./scripts/check.sh` run was not completed inside this session window (partial / in-progress build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c710889f0832b9390860df43e33cc)