### PR TITLE
tests: extend iso-strong L1 session 2 diagonal scaffolding

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -113,6 +113,40 @@ def traceSize1CandidateOnFree {n : Nat} (α : Type) [Fintype α]
   fun a => evalSize1Candidate c (fun i => decide (i = embed a))
 
 /--
+Trace a size-1 candidate on an explicit family of truth-table rows.
+
+Unlike `traceSize1CandidateOnFree`, this uses real table-row indices
+`Fin (Partial.tableLen n)` (semantic assignments encoded as row numbers),
+not variable indices in `Fin n`.
+-/
+def traceSize1CandidateOnRows
+    {n : Nat}
+    (α : Type) [Fintype α]
+    (row : α → Fin (Partial.tableLen n))
+    (c : Size1Candidate n) : α → Bool :=
+  match c with
+  | .const b => fun _ => b
+  | .input i => fun a => Nat.testBit (row a).val i.val
+
+/-- Generic finite pigeonhole diagonalisation over a trace family. -/
+theorem exists_label_not_in_finite_trace_family
+    {α γ : Type} [Fintype α] [Fintype γ]
+    (trace : γ → α → Bool)
+    (h : Fintype.card γ < 2 ^ Fintype.card α) :
+    ∃ label : α → Bool,
+      ∀ g : γ, label ≠ trace g := by
+  classical
+  have hNotSurj : ¬ Function.Surjective trace := by
+    intro hsurj
+    have hCardLe : Fintype.card (α → Bool) ≤ Fintype.card γ :=
+      Fintype.card_le_of_surjective _ hsurj
+    have hCardLt : Fintype.card γ < Fintype.card (α → Bool) := by
+      simpa [Fintype.card_fun, Fintype.card_bool] using h
+    exact (Nat.not_lt.mpr hCardLe) hCardLt
+  rcases not_forall.mp hNotSurj with ⟨label, hlabel⟩
+  exact ⟨label, fun g hg => hlabel ⟨g, hg⟩⟩
+
+/--
 Finite-pigeonhole core: if the candidate family has size `< 2^|α|`, there exists
 a Boolean labeling of `α` outside all candidate traces.
 -/
@@ -154,6 +188,56 @@ theorem exists_trace_not_size1
     simpa using hSlack
   exact exists_trace_not_size1_of_card_lt ((Finset.univ \\ D).attach)
     (fun i => ⟨i.1.1, i.1.2.1⟩) hSlack'
+
+/--
+Diagonal partial table: keep `yYes` on fixed coordinates `D`, and set free rows
+to the chosen diagonal `label`.
+-/
+def diagonalPartialTable
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    PartialTruthTable p.n :=
+  fun j =>
+    if hD : j ∈ D then
+      decodePartial yYes j
+    else
+      some (label ⟨j, by
+        refine Finset.mem_sdiff.mpr ?_
+        exact ⟨Finset.mem_univ j, hD⟩⟩)
+
+theorem diagonal_z_valid
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    ValidEncoding p (encodePartial (diagonalPartialTable p yYes D label)) := by
+  exact validEncoding_encodePartial p _
+
+theorem diagonal_z_agrees_on_D
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (hValidYes : ValidEncoding p yYes)
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    AgreeOnValues D yYes (encodePartial (diagonalPartialTable p yYes D label)) := by
+  intro i hi
+  -- Use canonicality of `yYes` on valid encodings.
+  have hy : yYes = encodePartial (decodePartial yYes) := hValidYes
+  -- The diagonal table copies `decodePartial yYes` on all points of `D`.
+  have hdiag : diagonalPartialTable p yYes D label i = decodePartial yYes i := by
+    simp [diagonalPartialTable, hi]
+  -- Compare value-bits through the canonical encoding.
+  calc
+    Partial.valPart yYes i
+        = Partial.valPart (encodePartial (decodePartial yYes)) i := by simpa [hy]
+    _ = (decodePartial yYes i).getD false := by
+      simp [Partial.valPart, encodePartial, Partial.valIndex]
+    _ = (diagonalPartialTable p yYes D label i).getD false := by simpa [hdiag]
+    _ = Partial.valPart (encodePartial (diagonalPartialTable p yYes D label)) i := by
+      symm
+      simp [Partial.valPart, encodePartial, Partial.valIndex]
 
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session2.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session2.md
@@ -1,0 +1,44 @@
+# L1 iso-strong conclusion — session 2 (codex)
+
+## 1. Executive verdict
+
+YELLOW_ONE_OF_THREE_LANDED
+
+## 2. What landed
+
+- `traceSize1CandidateOnRows`
+- `exists_label_not_in_finite_trace_family`
+- `diagonalPartialTable`
+- `diagonal_z_valid`
+- `diagonal_z_agrees_on_D`
+
+## 3. Corrected trace argument
+
+The session now separates two notions of trace:
+
+- **Variable-index trace** (`Fin n` coordinates), suitable for one-hot assignment embeddings.
+- **Row-trace on truth-table rows** (`Fin (Partial.tableLen n)` coordinates), which is the correct object for partial truth-table diagonalisation.
+
+`traceSize1CandidateOnRows` evaluates size-1 candidates directly on row indices:
+
+- constants map to constant labels;
+- projection `input i` maps row `r` to `Nat.testBit r.val i.val`.
+
+This fixes the prior mismatch where embedding free coordinates into `Fin n` could accidentally treat truth-table rows as variable indices.
+
+## 4. Remaining blockers
+
+Main blocker to full session goal:
+
+- Missing bridge lemma from YES-witness circuits (`Circuit n`) with `size ≤ 1` to `Size1Candidate n`, plus consistency transport to row-trace equality on `(Finset.univ \ D).attach`.
+
+Concretely still unlanded:
+
+- `diagonal_z_not_yes_of_label_not_trace`
+- `exists_valid_agreeing_not_yes_under_slack`
+
+The current file has valid/agreeing construction pieces, but not the final `¬ z ∈ Yes` contradiction.
+
+## 5. Next action
+
+open_isoStrong_conclusion_L1_session_3


### PR DESCRIPTION
### Motivation

- Connect the L1 abstract trace-diagonalisation scaffold to the MCSP encoding layer by defining row-based traces and building a diagonal partial truth table that can be encoded as a canonical input `z`.
- Fix the previous trace mismatch by separating variable-index traces from real truth-table row traces so diagonalisation uses semantic row coordinates.
- Provide the small canonical lemmas needed to show `z` is a valid encoding and that it agrees with the YES witness on the fixed coordinates `D` as a step toward the pigeonhole contradiction.

### Description

- Added `traceSize1CandidateOnRows` to evaluate `Size1Candidate n` on actual truth-table rows (`Fin (Partial.tableLen n)`) so projections read bits via `Nat.testBit` on row indices.
- Added a generic pigeonhole/diagonal lemma `exists_label_not_in_finite_trace_family` usable for arbitrary trace families (cardinality → non-surjectivity → label outside family).
- Added `diagonalPartialTable` which keeps `decodePartial yYes` on coordinates `D` and uses the diagonal `label` on free rows, and two helper lemmas: `diagonal_z_valid` and `diagonal_z_agrees_on_D` proving `encodePartial (diagonalPartialTable ...)` is a `ValidEncoding` and agrees with `yYes` on `D` respectively.
- Documented session outcome and remaining work in `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session2.md` and left the main target lemma `exists_valid_agreeing_not_yes_under_slack` unlanded due to a missing bridge from a size-≤1 circuit YES witness to `Size1Candidate` plus the consistency→trace-equality transport on free rows.

### Testing

- Ran `lake build PnP3 Pnp4` which completed successfully (build finished; only linter/warning messages were emitted).
- Ran `./scripts/check.sh` which completed successfully (replayed/checked the project; only warnings reported, no errors).
- Searched for disallowed placeholders and patterns: `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` returned no matches, and forbidden-pattern `rg` on `IsoStrongConclusionProbe.lean` returned no matches.
- All automated checks passed (no failures), and the remaining proof obligations are recorded in the report for follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c70fff868832bb1090e66a43524e6)