### PR TITLE
pnp3: L1 session 2 diagonal trace-to-encoding scaffolding

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -155,6 +155,90 @@ theorem exists_trace_not_size1
   exact exists_trace_not_size1_of_card_lt ((Finset.univ \\ D).attach)
     (fun i => ⟨i.1.1, i.1.2.1⟩) hSlack'
 
+/--
+Trace of a size-1 candidate on an arbitrary finite family of truth-table rows.
+
+Unlike `traceSize1CandidateOnFree`, this trace is expressed directly in terms of
+row indices `Fin (Partial.tableLen n)` and therefore aligns with partial-table
+semantics (value coordinates), not variable-index coordinates `Fin n`.
+-/
+def traceSize1CandidateOnRows
+    {n : Nat}
+    (α : Type) [Fintype α]
+    (row : α → Fin (Partial.tableLen n))
+    (c : Size1Candidate n) : α → Bool :=
+  match c with
+  | .const b => fun _ => b
+  | .input i => fun a => Nat.testBit (row a).val i.val
+
+/--
+Generic finite-family diagonalization: any family `γ` of traces over `α` with
+strictly fewer members than `2^|α|` misses at least one Boolean label.
+-/
+theorem exists_label_not_in_finite_trace_family
+    {α γ : Type} [Fintype α] [Fintype γ]
+    (trace : γ → α → Bool)
+    (h : Fintype.card γ < 2 ^ Fintype.card α) :
+    ∃ label : α → Bool,
+      ∀ g : γ, label ≠ trace g := by
+  classical
+  have hNotSurj : ¬ Function.Surjective trace := by
+    intro hsurj
+    have hCardLe : Fintype.card (α → Bool) ≤ Fintype.card γ :=
+      Fintype.card_le_of_surjective _ hsurj
+    have hCardLt : Fintype.card γ < Fintype.card (α → Bool) := by
+      simpa [Fintype.card_fun, Fintype.card_bool] using h
+    exact (Nat.not_lt.mpr hCardLe) hCardLt
+  rcases not_forall.mp hNotSurj with ⟨label, hLabel⟩
+  refine ⟨label, ?_⟩
+  intro g hg
+  exact hLabel ⟨g, hg⟩
+
+/--
+Diagonal partial table: keep `yYes` values on `D`, and force the complement by
+the diagonal label.
+-/
+def diagonalPartialTable
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    PartialTruthTable p.n :=
+  fun j =>
+    if hD : j ∈ D then
+      decodePartial yYes j
+    else
+      some (label ⟨j, by
+        refine Finset.mem_sdiff.mpr ?_
+        exact ⟨Finset.mem_univ j, hD⟩⟩)
+
+theorem diagonal_z_valid
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    ValidEncoding p (encodePartial (diagonalPartialTable p yYes D label)) := by
+  simpa using validEncoding_encodePartial p (diagonalPartialTable p yYes D label)
+
+theorem diagonal_z_agrees_on_D
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (hValidYes : ValidEncoding p yYes)
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool) :
+    AgreeOnValues D yYes (encodePartial (diagonalPartialTable p yYes D label)) := by
+  intro i hiD
+  have hDecodeEq : decodePartial yYes i = decodePartial (encodePartial (decodePartial yYes)) i := by
+    simp
+  rw [← hValidYes] at hDecodeEq
+  rw [Partial.decodePartial_valPart] at hDecodeEq
+  have hDiag : diagonalPartialTable p yYes D label i = decodePartial yYes i := by
+    simp [diagonalPartialTable, hiD]
+  have hValZ : Partial.valPart (encodePartial (diagonalPartialTable p yYes D label)) i =
+      Option.getD (diagonalPartialTable p yYes D label i) false := by
+    simp [Partial.valPart]
+  rw [hValZ, hDiag, hDecodeEq]
+
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by
   trivial

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md
@@ -1,57 +1,34 @@
-# L1 iso-strong conclusion report (codex)
-
-## 1. Executive verdict
+# 1. Executive verdict
 
 YELLOW_ONE_OF_THREE_LANDED
 
-## 2. What landed
+# 2. What landed
 
-Landed (kernel-checked) sub-lemma family for the corrected combinatorial core:
+- `traceSize1CandidateOnRows`
+- `exists_label_not_in_finite_trace_family`
+- `diagonalPartialTable`
+- `diagonal_z_valid`
+- `diagonal_z_agrees_on_D`
 
-- `card_Size1Candidate`:
-  `Fintype.card (Size1Candidate n) = n + 2`.
-- `exists_trace_not_size1_of_card_lt`:
-  for any finite free-coordinate type `α` and embedding `α → Fin n`, if
-  `n + 2 < 2 ^ Fintype.card α`, then there exists a Boolean labeling
-  `label : α → Bool` that is different from every size-1 candidate trace.
-- `exists_trace_not_size1`:
-  instantiated to `α = (Finset.univ \ D).attach` with slack
-  `p.n + 2 < 2 ^ ((Finset.univ \ D).card`.
+# 3. Corrected trace argument
 
-Not landed in this session:
+The corrected route must trace size-1 candidates on **truth-table rows** (`Fin (Partial.tableLen n)`), not on variable indices (`Fin n`).
 
-- construction of a valid encoding `z` from the non-candidate trace,
-- the full bridge `exists_valid_agreeing_not_yes_under_slack`,
-- the main theorem `isoStrong_conclusion_negative_for_canonical`.
+- The older helper `traceSize1CandidateOnFree` is indexed by an embedding into `Fin n`, so it captures projections against variable coordinates.
+- For diagonalization over a partial table subcube `(Finset.univ \ D).attach`, we need labels on row IDs (assignments), and candidate evaluations must read assignment bits via `Nat.testBit row i`.
+- `traceSize1CandidateOnRows` implements exactly that row-level semantics:
+  - constants map to constant traces,
+  - input projection `i` maps row `r` to the `i`-th bit of `r.val`.
 
-## 3. Corrected pigeonhole argument
+This aligns the finite pigeonhole step with the MCSP value-coordinate layer.
 
-I explicitly did **not** use the false shortcut “YES cardinality ≤ m+2”.
-That statement is not correct globally over partial tables, since one size-1
-circuit may be consistent with many partial truth tables.
+# 4. Remaining blockers
 
-Instead, this session formalizes the correct diagonalization nucleus:
+- Missing conversion lemma from `z ∈ (gapSliceOfParams p).Yes` with `p.sYES = 1` to an explicit `Size1Candidate p.n` whose row-trace matches all defined rows of `decodePartial z`.
+- Missing/unfinished bridge lemma from consistency of that witness with `decodePartial (encodePartial (diagonalPartialTable ...))` to equality with `label` on `(Finset.univ \ D).attach`.
+- End-to-end theorem still pending:
+  - `exists_valid_agreeing_not_yes_under_slack`
 
-- size-1 candidate family has cardinality exactly `m+2`;
-- each candidate induces one trace on the chosen free-coordinate domain;
-- if `m+2 < 2^r`, then not all `2^r` labelings can be covered by those traces;
-- therefore there exists a free-coordinate labeling not equal to any size-1 trace.
+# 5. Next action
 
-This is the precise trace-level pigeonhole step needed before constructing `z`.
-
-## 4. Remaining blockers
-
-1. Define the concrete free-coordinate trace map directly from consistency of
-   `decodePartial z` with size-1 circuits, so the abstract diagonal label can be
-   turned into an explicit `z` contradiction.
-2. Build `z` by patching `decodePartial yYes` on `D` and setting free coordinates
-   from the diagonal label, then prove:
-   - `ValidEncoding p z`,
-   - `AgreeOnValues D yYes z`,
-   - `z ∉ (gapSliceOfParams p).Yes`.
-3. Compose with the forcing clause from iso-strong and then finish the canonical
-   contradiction theorem.
-
-## 5. Next action
-
-open_isoStrong_conclusion_L1_session_2
+open_isoStrong_conclusion_L1_session_3


### PR DESCRIPTION
### Motivation
- Continue L1 work by connecting the abstract trace-diagonalisation nucleus to the MCSP encoding layer so we can build a concrete encoded partial truth table `z` that witnesses the pigeonhole contradiction. 
- Fix the earlier incorrect shortcut reasoning about YES-cardinality by moving from variable-index traces to real truth-table row traces and diagonalizing over value coordinates.

### Description
- Added a row-semantic trace and generic diagonalization utilities: `traceSize1CandidateOnRows` and `exists_label_not_in_finite_trace_family` to express candidate traces over truth-table rows (assignments) and to find a missing label. 
- Added the diagonal partial-table constructor `diagonalPartialTable` and two helper lemmas `diagonal_z_valid` and `diagonal_z_agrees_on_D` to produce a canonical `encodePartial` witness that preserves `yYes` on `D` and enforces the diagonal label on the complement. 
- Left the end-to-end existential lemma `exists_valid_agreeing_not_yes_under_slack` unlanded and documented the remaining precise blockers in the updated L1 report. 
- Updated the L1 session report at `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex.md` to record landed lemmas, the corrected trace argument, remaining blockers, and next action.

### Testing
- Ran `lake build PnP3 Pnp4` which completed successfully (repository warnings were reported but pre-existing). 
- Ran `./scripts/check.sh` (full replay/build) which completed with the normal repository warnings and no new check failures. 
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no matches in the modified code paths. 
- Ran the forbidden-pattern audit grep on the modified test file and found no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c710889f0832b9390860df43e33cc)