### PR TITLE
Iso-strong L1 session 3: close not-YES bridge and under-slack composition

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -5,6 +5,7 @@ import Magnification.FinalResultMainline
 import LowerBounds.AsymptoticDAGBarrierTheorems
 import LowerBounds.AsymptoticDAGBarrierInterfaces
 import LowerBounds.MCSPGapLocality
+import Magnification.CanonicalAsymptoticDecider
 import «pnp3».Tests.GlobalHInDagContractProbe
 
 /-!
@@ -238,6 +239,105 @@ theorem diagonal_z_agrees_on_D
     _ = Partial.valPart (encodePartial (diagonalPartialTable p yYes D label)) i := by
       symm
       simp [Partial.valPart, encodePartial, Partial.valIndex]
+
+theorem is_consistent_diagonal_table_implies_label_trace
+    (p : GapPartialMCSPParams)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool)
+    (c : Size1Candidate p.n)
+    (hCons :
+      is_consistent (match c with
+        | .const b => Circuit.const b
+        | .input i => Circuit.input i)
+        (diagonalPartialTable p yYes D label)) :
+    label =
+      traceSize1CandidateOnRows ((Finset.univ \\ D).attach)
+        (fun a => a.1) c := by
+  funext a
+  have hRow :
+      diagonalPartialTable p yYes D label a.1 = some (label a) := by
+    simp [diagonalPartialTable, a.1.2.2]
+  cases c with
+  | const b =>
+    have hAt := (is_consistent_const_iff_at b (diagonalPartialTable p yYes D label)).mp hCons a.1
+    have hneq : some (label a) ≠ some (!b) := by
+      exact fun hEq => hAt (hRow.trans hEq)
+    have hEq : label a = b := by
+      cases hb : b <;> cases hl : label a <;> simp_all
+    simp [traceSize1CandidateOnRows, evalSize1Candidate, hEq]
+  | input i =>
+    have hInput := (is_consistent_input_iff_at i (diagonalPartialTable p yYes D label)).mp hCons
+    have hEq := hInput a.1 (label a) hRow
+    simp [traceSize1CandidateOnRows, evalSize1Candidate, hEq]
+
+theorem diagonal_z_not_yes_of_label_not_trace
+    (p : GapPartialMCSPParams)
+    (hsYES : p.sYES = 1)
+    (yYes : Bitstring (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \\ D).attach → Bool)
+    (hLabel : ∀ c : Size1Candidate p.n,
+      label ≠ traceSize1CandidateOnRows ((Finset.univ \\ D).attach)
+        (fun a => a.1) c) :
+    ¬ encodePartial (diagonalPartialTable p yYes D label)
+        ∈ (gapSliceOfParams p).Yes := by
+  intro hzYes
+  have hLang : gapPartialMCSP_Language p (partialInputLen p)
+      (encodePartial (diagonalPartialTable p yYes D label)) = true := hzYes
+  have hYES : PartialMCSP_YES p
+      (decodePartial (encodePartial (diagonalPartialTable p yYes D label))) :=
+    (gapPartialMCSP_language_true_iff_yes p
+      (encodePartial (diagonalPartialTable p yYes D label))).mp hLang
+  have hYES' : PartialMCSP_YES p (diagonalPartialTable p yYes D label) := by
+    simpa [decodePartial_encodePartial] using hYES
+  rcases hYES' with ⟨C, hSize, hCons⟩
+  have hSize1 : C.size ≤ 1 := by simpa [hsYES] using hSize
+  have hDec : decideYesAt1 p.n (diagonalPartialTable p yYes D label) = true :=
+    (decideYesAt1_iff p.n (diagonalPartialTable p yYes D label)).2 ⟨C, hSize1, hCons⟩
+  have hCases := (decideYesAt1_iff_const_or_input p.n (diagonalPartialTable p yYes D label)).1 hDec
+  rcases hCases with hConst | hInput
+  · rcases hConst with ⟨b, hb⟩
+    let c : Size1Candidate p.n := Size1Candidate.const b
+    have hConsC : is_consistent (Circuit.const b) (diagonalPartialTable p yYes D label) :=
+      (is_consistent_const_iff_at b (diagonalPartialTable p yYes D label)).2 hb
+    have hEqTrace :
+        label = traceSize1CandidateOnRows ((Finset.univ \\ D).attach)
+          (fun a => a.1) c :=
+      is_consistent_diagonal_table_implies_label_trace p yYes D label c hConsC
+    exact (hLabel c) hEqTrace
+  · rcases hInput with ⟨k, hk⟩
+    let c : Size1Candidate p.n := Size1Candidate.input k
+    have hConsC : is_consistent (Circuit.input k) (diagonalPartialTable p yYes D label) :=
+      (is_consistent_input_iff_at k (diagonalPartialTable p yYes D label)).2 hk
+    have hEqTrace :
+        label = traceSize1CandidateOnRows ((Finset.univ \\ D).attach)
+          (fun a => a.1) c :=
+      is_consistent_diagonal_table_implies_label_trace p yYes D label c hConsC
+    exact (hLabel c) hEqTrace
+
+theorem exists_valid_agreeing_not_yes_under_slack
+    (p : GapPartialMCSPParams)
+    (hsYES : p.sYES = 1)
+    (yYes : Bitstring (partialInputLen p))
+    (hValidYes : ValidEncoding p yYes)
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (hSlack : p.n + 2 < 2 ^ (Partial.tableLen p.n - D.card)) :
+    ∃ z : Bitstring (partialInputLen p),
+      ValidEncoding p z ∧
+      AgreeOnValues D yYes z ∧
+      ¬ z ∈ (gapSliceOfParams p).Yes := by
+  have hSlack' : p.n + 2 < 2 ^ ((Finset.univ \\ D).card) := by
+    simpa [Finset.card_sdiff (Finset.subset_univ D), Fintype.card_fin] using hSlack
+  rcases exists_label_not_in_finite_trace_family
+      (trace := traceSize1CandidateOnRows ((Finset.univ \\ D).attach) (fun a => a.1))
+      (γ := Size1Candidate p.n)
+      (α := (Finset.univ \\ D).attach) with ⟨label, hLabel⟩
+  · simpa [card_Size1Candidate] using hSlack'
+  refine ⟨encodePartial (diagonalPartialTable p yYes D label), ?_, ?_, ?_⟩
+  · exact diagonal_z_valid p yYes D label
+  · exact diagonal_z_agrees_on_D p yYes hValidYes D label
+  · exact diagonal_z_not_yes_of_label_not_trace p hsYES yYes D label hLabel
 
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session3.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session3.md
@@ -1,0 +1,28 @@
+# L1 iso-strong conclusion — session 3 (codex)
+
+## 1. Executive verdict
+YELLOW_TWO_OF_THREE_LANDED
+
+## 2. What landed
+- `is_consistent_diagonal_table_implies_label_trace`
+- `diagonal_z_not_yes_of_label_not_trace`
+- `exists_valid_agreeing_not_yes_under_slack`
+
+## 3. Not-YES bridge status
+Closed in the staging file.
+
+Bridge established:
+1. Assume `z ∈ (gapSliceOfParams p).Yes` for `z := encodePartial (diagonalPartialTable ...)`.
+2. Convert to language truth (`gapPartialMCSP_Language ... = true`).
+3. Convert to semantic YES via `gapPartialMCSP_language_true_iff_yes` and rewrite with `decodePartial_encodePartial`.
+4. Use `hsYES : p.sYES = 1` to obtain size-1 consistency witness (via `decideYesAt1_iff` and `decideYesAt1_iff_const_or_input`).
+5. Convert consistency into trace equality using `is_consistent_diagonal_table_implies_label_trace`.
+6. Contradict `hLabel`.
+
+## 4. Remaining blockers
+No blocker for the session-3 target theorem in this staging pass.
+
+Optional canonical global negation theorem (the `isoStrong_conclusion_negative_for_canonical` endpoint-style theorem) was not attempted in this pass to keep scope tight to the requested not-YES bridge and under-slack composition.
+
+## 5. Next action
+open_isoStrong_conclusion_L1_session_4


### PR DESCRIPTION
### Motivation
- Complete the L1 session-3 goal by proving the not-YES bridge for the diagonal witness and compose it with the diagonalisation under the slack inequality to produce a valid counterexample `z` outside YES. 
- Reuse the canonical size-1 decider characterisations so the semantic YES → size‑1 consistency reduction applies cleanly at the canonical input length.

### Description
- Added `import Magnification.CanonicalAsymptoticDecider` to reuse closed-form size‑1 consistency/decider lemmas. 
- Implemented `is_consistent_diagonal_table_implies_label_trace` which shows any size‑1 consistent circuit on the diagonal table induces the same free-row labeling trace. 
- Implemented `diagonal_z_not_yes_of_label_not_trace` which converts `z ∈ (gapSliceOfParams p).Yes` into a size‑1 consistency witness via the language/YES lemmas and derives a contradiction with the anti-trace hypothesis. 
- Implemented `exists_valid_agreeing_not_yes_under_slack` which composes the diagonal witness with validity and agreement lemmas and the finite-trace diagonalisation to produce `z` that is valid, agrees on `D`, and is not in YES. 
- Added the session report `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session3.md` and kept all mainline edits restricted to the allowed staging file `pnp3/Tests/IsoStrongConclusionProbe.lean`.

### Testing
- Ran `lake build PnP3 Pnp4`, which completed successfully (repository warnings/linter messages present but non-blocking). 
- Ran `./scripts/check.sh`, which completed successfully with no new blocking failures. 
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no matches. 
- Ran the forbidden-pattern grep on `pnp3/Tests/IsoStrongConclusionProbe.lean` and it returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c858fd100832baf498b6b2cd5bcff)