### PR TITLE
Assemble canonical iso-strong contradiction (L1 session 4)

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -331,6 +331,68 @@ theorem exists_valid_agreeing_not_yes_under_slack
   · exact diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact diagonal_z_not_yes_of_label_not_trace p hsYES yYes D label hLabel
 
+theorem correctOnPromiseSlice_of_InPpolyDAG_family
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  refine ⟨?_, ?_⟩
+  · intro x hxYes
+    have hCorrect := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    simpa [GapSliceFamilyEventually.encodedLen, gapSliceOfParams] using hCorrect.trans hxYes
+  · intro x hxNo
+    have hCorrect := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    simpa [GapSliceFamilyEventually.encodedLen, gapSliceOfParams] using hCorrect.trans hxNo
+
+@[simp] lemma F_params_sYES (n : Nat) (β : Rat) : (F.paramsOf n β).sYES = 1 := by
+  simp [F, eventualGapSliceFamily_of_asymptotic]
+
+theorem isoStrong_conclusion_negative_for_canonical :
+    ∀ W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym,
+      ¬ IsoStrongFamilyEventually
+          (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+          (globalWitness_to_hInDag W) := by
+  intro W hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    nlinarith
+  have hβLt : β < β0 := by
+    dsimp [β]
+    nlinarith
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := by
+    exact le_rfl
+  let p : GapPartialMCSPParams := F.paramsOf n β
+  let hInDag := globalWitness_to_hInDag W
+  let C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize :
+      ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) := by
+    simpa [C] using (hInDag n β).family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  have hCorrect : CorrectOnPromiseSlice C (gapSliceOfParams p) := by
+    simpa [p, C] using correctOnPromiseSlice_of_InPpolyDAG_family F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hSlackForD :
+      p.n + 2 < 2 ^ (Partial.tableLen p.n - D.card) := by
+    have hSub : Partial.tableLen p.n - κ n β ≤ Partial.tableLen p.n - D.card := by
+      exact Nat.sub_le_sub_left hDcard (Partial.tableLen p.n)
+    have hPow : 2 ^ (Partial.tableLen p.n - κ n β) ≤ 2 ^ (Partial.tableLen p.n - D.card) := by
+      exact Nat.pow_le_pow_right (by decide : 0 ≤ 2) hSub
+    have hRaw' : p.n + 2 < 2 ^ (Partial.tableLen p.n - κ n β) := by
+      simpa [p, F, eventualGapSliceFamily_of_asymptotic] using hRawSlack
+    exact lt_of_lt_of_le hRaw' hPow
+  have hsYES : p.sYES = 1 := by simpa [p] using F_params_sYES n β
+  rcases exists_valid_agreeing_not_yes_under_slack p hsYES yYes hValidYes D hSlackForD with
+    ⟨z, hzValid, hzAgree, hzNotYes⟩
+  exact hzNotYes (hAllYes z hzValid hzAgree)
+
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by
   trivial

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
@@ -1,0 +1,25 @@
+# L1 iso-strong conclusion — session 4 (codex)
+
+## 1. Executive verdict
+RED_CONCLUSION_REFUTED
+
+## 2. What landed
+- `correctOnPromiseSlice_of_InPpolyDAG_family`
+- `F_params_sYES`
+- `isoStrong_conclusion_negative_for_canonical`
+
+## 3. Main theorem status
+`isoStrong_conclusion_negative_for_canonical` landed in
+`pnp3/Tests/IsoStrongConclusionProbe.lean` as a composition proof:
+- destructures `IsoStrongFamilyEventually`;
+- instantiates forcing with the canonical witness family circuit at encoded length;
+- derives correctness from `InPpolyDAG.correct`;
+- converts slack from `κ n β` to `D.card` via monotonicity of subtraction/powers;
+- applies `exists_valid_agreeing_not_yes_under_slack`;
+- contradicts the forcing all-YES conclusion.
+
+## 4. Remaining blockers
+No theorem-level blocker remains for the session 4 target theorem.
+
+## 5. Next action
+close_canonical_track_record_conclusion_inconsistent


### PR DESCRIPTION
### Motivation
- Close the L1 canonical track by composing the session-1/2/3 components into a single contradiction theorem that rules out `IsoStrongFamilyEventually` for the canonical family via the existing diagonal / under-slack kernel lemma.

### Description
- Add `correctOnPromiseSlice_of_InPpolyDAG_family` which lifts an `InPpolyDAG` instance into `CorrectOnPromiseSlice` at the slice encoded length using the family `correct` field.
- Add `F_params_sYES` (`@[simp]`) to record the canonical simplification `(F.paramsOf n β).sYES = 1` for the canonical family `F`.
- Add the composition theorem `isoStrong_conclusion_negative_for_canonical` which, given a global polynomial DAG witness `W`, instantiates the forcing clause at a chosen `β` and `n`, converts the slack bound from `κ n β` to `D.card`, applies `exists_valid_agreeing_not_yes_under_slack`, and derives a contradiction with the forcing `∀`-clause.
- Add the session report `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md` summarizing the landing and next action.

### Testing
- Built the project with `lake build PnP3 Pnp4` and the build completed successfully (with unrelated linter warnings only). 
- Ran `./scripts/check.sh` and it completed successfully (warnings present in other files but no failures). 
- Ran the grep checks `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and the forbidden-pattern grep for `FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline` on the modified file; both returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9e782114832b8ed6b054d162610e)