### PR TITLE
iso-strong conclusion L1 session 4: assemble canonical contradiction theorem

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -331,6 +331,72 @@ theorem exists_valid_agreeing_not_yes_under_slack
   · exact diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact diagonal_z_not_yes_of_label_not_trace p hsYES yYes D label hLabel
 
+
+theorem correctOnPromiseSlice_of_InPpolyDAG_family
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  constructor
+  · intro x hx
+    have hcorr := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    simpa [gapSliceOfParams] using hcorr.trans hx
+  · intro x hx
+    have hcorr := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    simpa [gapSliceOfParams] using hcorr.trans hx
+
+lemma F_params_sYES (n : Nat) (β : Rat) :
+    ((eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym).paramsOf n β).sYES = 1 := by
+  simp [eventualGapSliceFamily_of_asymptotic, canonicalAsymptoticHAsym, canonicalAsymptoticSpec]
+
+theorem isoStrong_conclusion_negative_for_canonical :
+    ∀ W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym,
+      ¬ IsoStrongFamilyEventually
+          (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+          (globalWitness_to_hInDag W) := by
+  intro W hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    nlinarith [hβ0]
+  have hβLt : β < β0 := by
+    dsimp [β]
+    nlinarith [hβ0]
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := by
+    exact le_rfl
+  let hInDag := globalWitness_to_hInDag W
+  let C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize :
+      ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) := by
+    dsimp [ppolyDAGSizeBoundOnSlicesEventually, C]
+    exact (hInDag n β).family_size_le _
+  have hCorrect : CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) := by
+    simpa [C] using correctOnPromiseSlice_of_InPpolyDAG_family F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hPowMono :
+      2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β)
+        ≤ 2 ^ (GapSliceFamilyEventually.tableLen F n β - D.card) := by
+    apply Nat.pow_le_pow_right
+    exact Nat.sub_le_sub_left hDcard _
+  have hSlackForD :
+      F.Mof n (F.Tof n β) < 2 ^ (GapSliceFamilyEventually.tableLen F n β - D.card) :=
+    lt_of_lt_of_le hRawSlack hPowMono
+  have hsYES : (F.paramsOf n β).sYES = 1 := by
+    simpa [F] using F_params_sYES n β
+  obtain ⟨z, hzValid, hzAgree, hzNotYes⟩ :=
+    exists_valid_agreeing_not_yes_under_slack
+      (p := F.paramsOf n β)
+      hsYES yYes hValidYes D (by simpa [GapSliceFamilyEventually.tableLen] using hSlackForD)
+  exact hzNotYes (hAllYes z hzValid hzAgree)
+
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by
   trivial

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
@@ -1,0 +1,30 @@
+## 1. Executive verdict
+
+RED_CONCLUSION_REFUTED
+
+## 2. What landed
+
+- `correctOnPromiseSlice_of_InPpolyDAG_family`
+- `F_params_sYES`
+- `isoStrong_conclusion_negative_for_canonical`
+
+## 3. Main theorem status
+
+Landed. The theorem
+`isoStrong_conclusion_negative_for_canonical` is now proved in
+`pnp3/Tests/IsoStrongConclusionProbe.lean` by composing:
+
+1. iso-strong forcing/slack extraction,
+2. canonical-family witness circuit (`globalWitness_to_hInDag`),
+3. session-3 diagonal theorem `exists_valid_agreeing_not_yes_under_slack`,
+4. contradiction with the forcing clause's universal YES conclusion.
+
+No new combinatorial route was introduced.
+
+## 4. Remaining blockers
+
+None for the L1 session-4 target theorem.
+
+## 5. Next action
+
+close_canonical_track_record_conclusion_inconsistent


### PR DESCRIPTION
### Motivation
- Finish L1 session-4 by composing the previously developed diagonalisation and under-slack pieces into the canonical iso-strong contradiction for the eventual canonical family. 
- Provide small local helpers to bridge the `InPpolyDAG` family API to the `CorrectOnPromiseSlice` obligations used by the iso-strong forcing clause.

### Description
- Added `correctOnPromiseSlice_of_InPpolyDAG_family` which converts an `InPpolyDAG` family `correct` field into `CorrectOnPromiseSlice` at the encoded length. 
- Added `F_params_sYES` to simplify the canonical family `sYES` bookkeeping. 
- Added `isoStrong_conclusion_negative_for_canonical` which destructures an `IsoStrongFamilyEventually` witness at the canonical family, instantiates the canonical per-slice circuit via `globalWitness_to_hInDag`, extracts forcing and slack, converts slack from `κ` to `D.card`, applies `exists_valid_agreeing_not_yes_under_slack`, and derives a contradiction with the forcing clause. 
- Added the session report `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md` summarizing the landing and verdict. 

### Testing
- Ran `lake build PnP3 Pnp4`, which completed the Lean build for the repository in this environment. 
- Executed `./scripts/check.sh`, which produced an extensive build/check log with pre-existing warnings; the run produced large output in this environment and the full check log was captured but its terminal exit was not fully determinable here. 
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no `sorry`/`admit` occurrences in the touched areas. 
- Ran the forbidden-pattern search for `FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline` in `pnp3/Tests/IsoStrongConclusionProbe.lean` and found no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9e782114832b8ed6b054d162610e)