### PR TITLE
L1 session 4: assemble canonical iso-strong contradiction theorem

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -331,6 +331,91 @@ theorem exists_valid_agreeing_not_yes_under_slack
   · exact diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact diagonal_z_not_yes_of_label_not_trace p hsYES yYes D label hLabel
 
+
+
+/-- Slice-family correctness extracted from the `InPpolyDAG` witness at active length. -/
+theorem correctOnPromiseSlice_of_InPpolyDAG_family
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  intro x hx
+  rcases hx with hxYes | hxNo
+  · left
+    have hEval := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    have hTrue :
+        gapPartialMCSP_Language (F.paramsOf n β)
+          (GapSliceFamilyEventually.encodedLen F n β) x = true := by
+      simpa [gapSliceOfParams] using hxYes
+    exact hEval.trans hTrue
+  · right
+    have hEval := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    have hFalse :
+        gapPartialMCSP_Language (F.paramsOf n β)
+          (GapSliceFamilyEventually.encodedLen F n β) x = false := by
+      simpa [gapSliceOfParams] using hxNo
+    exact hEval.trans hFalse
+
+/-- Canonical slice parameters always use the unit YES-size threshold. -/
+@[simp] theorem F_params_sYES (n : Nat) (β : Rat) :
+    (F.paramsOf n β).sYES = 1 := by
+  simp [F, eventualGapSliceFamily_of_asymptotic]
+
+/-- Convert iso-strong slack from `κ` to an arbitrary smaller witness set `D`. -/
+theorem slack_for_D_of_isoStrong_slack
+    (p : GapPartialMCSPParams)
+    (κv Dcard : Nat)
+    (hDcard : Dcard ≤ κv)
+    (hRawSlack : p.n + 2 < 2 ^ (Partial.tableLen p.n - κv)) :
+    p.n + 2 < 2 ^ (Partial.tableLen p.n - Dcard) := by
+  have hSub : Partial.tableLen p.n - κv ≤ Partial.tableLen p.n - Dcard := by
+    exact Nat.sub_le_sub_left hDcard _
+  exact lt_of_lt_of_le hRawSlack (Nat.pow_le_pow_right (by omega) hSub)
+
+/-- L1 session 4: final composition contradiction for canonical iso-strong family. -/
+theorem isoStrong_conclusion_negative_for_canonical :
+    ∀ W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym,
+      ¬ IsoStrongFamilyEventually
+          (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+          (globalWitness_to_hInDag W) := by
+  intro W hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    linarith
+  have hβLt : β < β0 := by
+    dsimp [β]
+    linarith
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := by
+    exact le_rfl
+  let hInDag := globalWitness_to_hInDag W
+  let C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize :
+      ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) := by
+    dsimp [C, ppolyDAGSizeBoundOnSlicesEventually]
+    simpa using (hInDag n β).family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  have hCorrect : CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) := by
+    simpa [C] using correctOnPromiseSlice_of_InPpolyDAG_family F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hSlackForD :
+      (F.paramsOf n β).n + 2 < 2 ^ (Partial.tableLen (F.paramsOf n β).n - D.card) := by
+    have hCanon :
+        (F.paramsOf n β).n + 2 < 2 ^ (Partial.tableLen (F.paramsOf n β).n - κ n β) := by
+      simpa [F, eventualGapSliceFamily_of_asymptotic] using hRawSlack
+    exact slack_for_D_of_isoStrong_slack (F.paramsOf n β) (κ n β) D.card hDcard hCanon
+  rcases exists_valid_agreeing_not_yes_under_slack
+      (p := F.paramsOf n β)
+      (hsYES := by simp)
+      yYes hValidYes D hSlackForD with ⟨z, hzValid, hzAgree, hzNotYes⟩
+  exact hzNotYes (hAllYes z hzValid hzAgree)
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by
   trivial

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
@@ -1,0 +1,29 @@
+# L1 iso-strong conclusion — session 4 report (codex)
+
+## 1. Executive verdict
+
+YELLOW_TWO_OF_THREE_LANDED
+
+## 2. What landed
+
+- `correctOnPromiseSlice_of_InPpolyDAG_family`
+- `F_params_sYES`
+- `slack_for_D_of_isoStrong_slack`
+- `isoStrong_conclusion_negative_for_canonical`
+
+## 3. Main theorem status
+
+`isoStrong_conclusion_negative_for_canonical` has been assembled in the staging file by composing:
+- forcing+slack components extracted from `IsoStrongFamilyEventually`,
+- canonical strict slack normalization,
+- slack transfer from `κ n β` to concrete `D.card`,
+- session-3 diagonal witness theorem `exists_valid_agreeing_not_yes_under_slack`,
+- contradiction with the forcing all-YES clause.
+
+## 4. Remaining blockers
+
+- Build/check jobs were still running in this environment when this report was drafted, so final green confirmation is pending for this exact patch.
+
+## 5. Next action
+
+open_isoStrong_conclusion_L1_session_5


### PR DESCRIPTION
### Motivation
- Finish L1 session 4 by composing existing forcing/slack extraction and the session-3 diagonal witness to obtain a canonical iso-strong contradiction `isoStrong_conclusion_negative_for_canonical` without introducing new combinatorial arguments. 
- Provide small helper lemmas to bridge `InPpolyDAG`-style per-slice correctness and to convert the iso-strong slack witness `κ` into a concrete `D.card` inequality needed by the diagonal witness.

### Description
- Added `correctOnPromiseSlice_of_InPpolyDAG_family` which extracts `CorrectOnPromiseSlice` from an `InPpolyDAG` witness at the active encoded length. 
- Added `F_params_sYES` (`@[simp]`) to record that canonical slice parameters use `sYES = 1` for the canonical family. 
- Added `slack_for_D_of_isoStrong_slack` to convert the slack inequality with `κ` into a slack inequality with an arbitrary smaller `D.card`. 
- Added the composition theorem `isoStrong_conclusion_negative_for_canonical` which, for any `W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym`, proves `¬ IsoStrongFamilyEventually (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym) (globalWitness_to_hInDag W)` by applying the forcing clause, normalizing slack, applying `exists_valid_agreeing_not_yes_under_slack`, and deriving a contradiction with the forcing all-YES conclusion. 
- Added session report `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md`. 
- Only file modified in the Lean codebase: `pnp3/Tests/IsoStrongConclusionProbe.lean` (helpers + main assembly inserted in the staging probe file).

### Testing
- Ran `lake build PnP3 Pnp4`; the full build was executed and many modules were successfully built with unrelated linter warnings, showing broad compatibility of the change but the interactive stream did not capture a final single-line success confirmation. 
- Ran `./scripts/check.sh`; the check run progressed through the large replay/build stages and emitted the usual warnings; final green confirmation for the exact patch was pending in the captured logs. 
- Ran pattern checks `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and the forbidden-pattern `rg` on the staging file; both returned no matches. 
- Commit created with the staged changes and report file; scope limited to the staging file and the session report.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9e7b0c18832b8574771d0a4cd197)