### PR TITLE
pnp3: assemble iso-strong canonical contradiction theorem (L1 session 4)

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -331,6 +331,75 @@ theorem exists_valid_agreeing_not_yes_under_slack
   · exact diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact diagonal_z_not_yes_of_label_not_trace p hsYES yYes D label hLabel
 
+
+lemma correctOnPromiseSlice_of_InPpolyDAG_family
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  constructor
+  · intro x hx
+    have hCorr := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+  · intro x hx
+    have hCorr := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+
+lemma slack_for_D_of_isoStrong_slack
+    (p : GapPartialMCSPParams)
+    (κv : Nat)
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (hDcard : D.card ≤ κv)
+    (hRawSlack : p.n + 2 < 2 ^ (Partial.tableLen p.n - κv)) :
+    p.n + 2 < 2 ^ (Partial.tableLen p.n - D.card) := by
+  have hExpLe : Partial.tableLen p.n - κv ≤ Partial.tableLen p.n - D.card := by
+    exact Nat.sub_le_sub_left hDcard (Partial.tableLen p.n)
+  have hPowLe : 2 ^ (Partial.tableLen p.n - κv) ≤ 2 ^ (Partial.tableLen p.n - D.card) := by
+    exact Nat.pow_le_pow_right (by decide : 0 < 2) hExpLe
+  exact lt_of_lt_of_le hRawSlack hPowLe
+
+@[simp] lemma F_params_sYES (n : Nat) (β : Rat) :
+    (F.paramsOf n β).sYES = 1 := by
+  simp [F, eventualGapSliceFamily_of_asymptotic]
+
+theorem isoStrong_conclusion_negative_for_canonical :
+    ∀ W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym,
+      ¬ IsoStrongFamilyEventually
+          (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+          (globalWitness_to_hInDag W) := by
+  intro W hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by linarith
+  have hβLt : β < β0 := by linarith
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := by
+    exact le_rfl
+  let p := F.paramsOf n β
+  let hInDag := globalWitness_to_hInDag W
+  let C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize : ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) := by
+    simpa [C, ppolyDAGSizeBoundOnSlicesEventually] using
+      (hInDag n β).family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  have hCorrect : CorrectOnPromiseSlice C (gapSliceOfParams p) := by
+    simpa [C, p] using correctOnPromiseSlice_of_InPpolyDAG_family F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hCanonSlack : p.n + 2 < 2 ^ (Partial.tableLen p.n - κ n β) := by
+    simpa [p, F, eventualGapSliceFamily_of_asymptotic] using hRawSlack
+  have hSlackForD : p.n + 2 < 2 ^ (Partial.tableLen p.n - D.card) :=
+    slack_for_D_of_isoStrong_slack p (κ n β) D hDcard hCanonSlack
+  have hsYES : p.sYES = 1 := by
+    simpa [p] using F_params_sYES n β
+  rcases exists_valid_agreeing_not_yes_under_slack p hsYES yYes hValidYes D hSlackForD with
+    ⟨z, hzValid, hzAgree, hzNotYes⟩
+  exact hzNotYes (hAllYes z hzValid hzAgree)
+
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by
   trivial

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
@@ -1,0 +1,28 @@
+# L1 iso-strong conclusion session 4 report (codex)
+
+## 1. Executive verdict
+
+RED_CONCLUSION_REFUTED
+
+## 2. What landed
+
+- `correctOnPromiseSlice_of_InPpolyDAG_family`
+- `slack_for_D_of_isoStrong_slack`
+- `F_params_sYES`
+- `isoStrong_conclusion_negative_for_canonical`
+
+## 3. Main theorem status
+
+The target theorem landed:
+
+- `isoStrong_conclusion_negative_for_canonical`
+
+The proof is a composition-only assembly using the existing forcing/slack decomposition of `IsoStrongFamilyEventually`, the global-to-slice `InPpolyDAG` witness, and the session-3 diagonal theorem `exists_valid_agreeing_not_yes_under_slack`.
+
+## 4. Remaining blockers
+
+No blocker remains for the L1 session-4 target theorem.
+
+## 5. Next action
+
+close_canonical_track_record_conclusion_inconsistent


### PR DESCRIPTION
### Motivation
- Close L1 session 4 by composing previously-landed diagonalisation and forcing/slack extraction lemmas to refute `IsoStrongFamilyEventually` on the canonical eventual gap-slice family. 
- Produce a composition-only proof that uses the global DAG witness projection to per-slice `InPpolyDAG` and the session-3 diagonal contradiction lemma to obtain a direct contradiction. 

### Description
- Added `correctOnPromiseSlice_of_InPpolyDAG_family` which extracts `CorrectOnPromiseSlice` from an `InPpolyDAG` family at the encoded length. 
- Added `slack_for_D_of_isoStrong_slack` which converts the iso-strong slack inequality framed with `κ` into a slack inequality framed with `D.card` via monotonicity of subtraction and powers. 
- Added `[simp] lemma F_params_sYES` proving `(F.paramsOf n β).sYES = 1` for the canonical family `F`. 
- Assembled the main theorem `isoStrong_conclusion_negative_for_canonical` which shows `¬ IsoStrongFamilyEventually (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym) (globalWitness_to_hInDag W)` for any global witness `W` by composing the forcing and slack clauses with `exists_valid_agreeing_not_yes_under_slack`. 
- Added the session report file `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md`. 
- All edits are confined to `pnp3/Tests/IsoStrongConclusionProbe.lean` and the report path. 

### Testing
- Ran `lake build PnP3 Pnp4` which completed successfully with warnings and no build errors in the captured output. 
- Ran `./scripts/check.sh` which executed the full checks and produced only lint/build warnings in the captured output and no errors. 
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and found no matches. 
- Ran the forbidden-pattern check on the modified test file and found no matches for the listed forbidden identifiers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9e7b0c18832b8574771d0a4cd197)