### PR TITLE
pnp3: assemble L1 session 4 iso-strong canonical contradiction

### DIFF
--- a/pnp3/Tests/IsoStrongConclusionProbe.lean
+++ b/pnp3/Tests/IsoStrongConclusionProbe.lean
@@ -331,6 +331,99 @@ theorem exists_valid_agreeing_not_yes_under_slack
   · exact diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact diagonal_z_not_yes_of_label_not_trace p hsYES yYes D label hLabel
 
+/-- Extract promise-slice correctness of the active family from `InPpolyDAG`. -/
+theorem correctOnPromiseSlice_of_InPpolyDAG_family
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  intro x hxYes hxNo
+  constructor
+  · have hCorr := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    simpa [gapSliceOfParams] using hCorr.trans hxYes
+  · have hCorr := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    simpa [gapSliceOfParams] using hCorr.trans hxNo
+
+/-- Canonical `sYES` parameter on every eventual slice. -/
+@[simp] lemma F_params_sYES (n : Nat) (β : Rat) :
+    (F.paramsOf n β).sYES = 1 := by
+  simp [F, eventualGapSliceFamily_of_asymptotic]
+
+/--
+Convert the iso-strong slack bound at exponent `κ n β` into the slack bound
+needed by session-3 diagonalisation at exponent `D.card`.
+-/
+theorem slack_for_D_of_isoStrong_slack
+    (n : Nat) (β : Rat)
+    (κ : Nat → Rat → Nat)
+    (D : Finset (Fin (GapSliceFamilyEventually.tableLen F n β)))
+    (hDcard : D.card ≤ κ n β)
+    (hRawSlack :
+      F.Mof n (F.Tof n β) <
+        2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β)) :
+    (F.paramsOf n β).n + 2 <
+      2 ^ (Partial.tableLen (F.paramsOf n β).n - D.card) := by
+  have hSub :
+      GapSliceFamilyEventually.tableLen F n β - κ n β ≤
+        GapSliceFamilyEventually.tableLen F n β - D.card :=
+    Nat.sub_le_sub_left hDcard (GapSliceFamilyEventually.tableLen F n β)
+  have hPow :
+      (2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β) : Nat) ≤
+        (2 ^ (GapSliceFamilyEventually.tableLen F n β - D.card) : Nat) :=
+    Nat.pow_le_pow_right (by decide : 0 < 2) hSub
+  calc
+    (F.paramsOf n β).n + 2
+        = F.Mof n (F.Tof n β) := by
+            simp [F, eventualGapSliceFamily_of_asymptotic]
+    _ < 2 ^ (GapSliceFamilyEventually.tableLen F n β - κ n β) := hRawSlack
+    _ ≤ 2 ^ (GapSliceFamilyEventually.tableLen F n β - D.card) := hPow
+    _ = 2 ^ (Partial.tableLen (F.paramsOf n β).n - D.card) := by
+          simp [GapSliceFamilyEventually.tableLen]
+
+/-- L1 session 4: final composition contradiction for the canonical iso-strong source. -/
+theorem isoStrong_conclusion_negative_for_canonical :
+    ∀ W : GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym,
+      ¬ IsoStrongFamilyEventually
+          (eventualGapSliceFamily_of_asymptotic canonicalAsymptoticHAsym)
+          (globalWitness_to_hInDag W) := by
+  intro W hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    nlinarith [hβ0]
+  have hβLt : β < β0 := by
+    dsimp [β]
+    nlinarith [hβ0]
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := by
+    exact le_rfl
+  let hInDag := globalWitness_to_hInDag W
+  let C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize :
+      ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) := by
+    simpa [ppolyDAGSizeBoundOnSlicesEventually, C] using
+      (hInDag n β).family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  have hCorrect :
+      CorrectOnPromiseSlice C (gapSliceOfParams (F.paramsOf n β)) := by
+    simpa [C] using correctOnPromiseSlice_of_InPpolyDAG_family F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hSlackForD :
+      (F.paramsOf n β).n + 2 <
+        2 ^ (Partial.tableLen (F.paramsOf n β).n - D.card) :=
+    slack_for_D_of_isoStrong_slack n β κ D hDcard hRawSlack
+  have hsYES : (F.paramsOf n β).sYES = 1 := by simp
+  rcases exists_valid_agreeing_not_yes_under_slack
+      (F.paramsOf n β) hsYES yYes hValidYes D hSlackForD with
+    ⟨z, hzValid, hzAgree, hzNotYes⟩
+  exact hzNotYes (hAllYes z hzValid hzAgree)
+
 /-- L1 session status: one kernel-checked sub-lemma family landed. -/
 theorem isoStrong_conclusion_L1_status : True := by
   trivial

--- a/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
+++ b/seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md
@@ -1,0 +1,33 @@
+# L1 iso-strong conclusion — session 4 (codex)
+
+## 1. Executive verdict
+
+RED_CONCLUSION_REFUTED
+
+## 2. What landed
+
+- `correctOnPromiseSlice_of_InPpolyDAG_family`
+- `F_params_sYES`
+- `slack_for_D_of_isoStrong_slack`
+- `isoStrong_conclusion_negative_for_canonical`
+
+## 3. Main theorem status
+
+`isoStrong_conclusion_negative_for_canonical` landed in `pnp3/Tests/IsoStrongConclusionProbe.lean`.
+
+The proof follows the planned composition route:
+- destructure `IsoStrongFamilyEventually` into forcing/slack components;
+- pick `β = β0 / 2`, `n = max F.N0 (nIso β)`;
+- instantiate the forcing clause with the active family circuit from `globalWitness_to_hInDag`;
+- derive correctness and size hypotheses from `InPpolyDAG`;
+- convert the slack bound from `κ n β` to `D.card` via monotonicity of subtraction and powers;
+- invoke `exists_valid_agreeing_not_yes_under_slack`;
+- contradict the forcing all-YES clause.
+
+## 4. Remaining blockers
+
+None for L1 session 4 target theorem.
+
+## 5. Next action
+
+close_canonical_track_record_conclusion_inconsistent


### PR DESCRIPTION
### Motivation

- Complete the L1 composition step by assembling the forcing/slack extraction from the previous sessions into a final contradiction for the canonical eventual gap-slice family, so the iso-strong source contract can be refuted at canonical lengths.

### Description

- Add `correctOnPromiseSlice_of_InPpolyDAG_family` which extracts `CorrectOnPromiseSlice` for the active circuit from an `InPpolyDAG` witness at the slice encoded length.
- Add `F_params_sYES` (a `@[simp]` lemma) asserting the canonical slice parameter `sYES = 1` for every eventual slice.
- Add `slack_for_D_of_isoStrong_slack` which converts the iso-strong slack bound indexed by `κ n β` into the slack inequality in terms of `D.card` used by the session-3 diagonalisation lemma.
- Add the main composition theorem `isoStrong_conclusion_negative_for_canonical` which, for any `GlobalAsymptoticDAGWitness` on the canonical asymptotic track, shows `¬ IsoStrongFamilyEventually` for the canonical eventual family by instantiating the forcing clause with `globalWitness_to_hInDag`, deriving size and correctness from `InPpolyDAG`, applying the iso-strong slack conversion, and invoking `exists_valid_agreeing_not_yes_under_slack` to reach a contradiction.
- Add the session report `seed_packs/isoStrong_conclusion_L1/reports/L1_isoStrong_conclusion_codex_session4.md` documenting the verdict and landed lemmas; all edits are limited to `pnp3/Tests/IsoStrongConclusionProbe.lean` and the report file.

### Testing

- Ran `lake build PnP3 Pnp4`, which completed successfully (Lean build succeeded with only linter warnings).
- Ran `./scripts/check.sh`, which completed successfully (no check failures reported).
- Ran source checks `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and the forbidden-pattern scan for the listed patterns against the modified test file, with no matches found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9e7b0c18832b8574771d0a4cd197)