### PR TITLE
docs: correct canonical asymptotic closure wording in STATUS.md

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -202,11 +202,20 @@ theorem isoStrong_conclusion_negative_for_canonical :
    contradiction.
 
 **Consequence.** The canonical asymptotic track via
-`canonicalAsymptoticHAsym` is **formally closed** at conclusion
-level.  The iso-strong route, the promise-YES weak route, and the
-promise-YES certificate route at the canonical spec are all
-inconsistent at the conclusion side under the (now Lean-witnessed)
-`GlobalAsymptoticDAGWitness` contract.
+`canonicalAsymptoticHAsym` is closed at conclusion level in the
+following precise sense:
+
+- The iso-strong route is formally refuted by the standalone theorem
+  `isoStrong_conclusion_negative_for_canonical`.
+- The promise-YES weak and promise-YES certificate routes are not yet
+  exposed as standalone Lean negation theorems.
+- Their closure at `globalWitness_to_hInDag W` follows by pointwise
+  contrapositive of existing route-level implications:
+  `asymptoticPromiseYesCertificateRoute_of_asymptoticPromiseYesWeakRouteEventually`
+  and
+  `asymptoticIsoStrongRoute_of_asymptoticPromiseYesCertificateRoute`.
+- Companion promise-route negation theorems are optional packaging for
+  attribution clarity, not required for the current status correction.
 
 This does **NOT** prove `P ≠ NP` or even `NP ⊄ P/poly`.  It rules
 out the canonical asymptotic track at the canonical `sYES = 1,
@@ -313,9 +322,13 @@ hypothesis parameter throughout the magnification mainline.  See
   `W : Models.GapPartialMCSP_Asymptotic_TMWitness canonicalAsymptoticSpec`.
 
 `pnp3/Tests/CanonicalIntegrationTests.lean` validates end-to-end
-integration with `i4_final_wiring_of_formulaCertificate`,
-`NP_not_subset_PpolyDAG_final_of_asymptotic_isoStrongRoute_withAntiChecker`,
-the promise-YES certificate route, and their `P ≠ NP` companions.
+integration wiring surfaces, including
+`i4_final_wiring_of_formulaCertificate` and
+`NP_not_subset_PpolyDAG_final_of_asymptotic_isoStrongRoute_withAntiChecker`.
+For the canonical conclusion-side closure statement, only
+`isoStrong_conclusion_negative_for_canonical` is currently a standalone
+negation theorem; promise-route closure is presently tracked via the
+route-implication contrapositive chain above.
 
 The single remaining typed-deliverable for the canonical track is the TM
 verifier: see "What Is Still Open" below.

--- a/STATUS.md
+++ b/STATUS.md
@@ -206,16 +206,28 @@ theorem isoStrong_conclusion_negative_for_canonical :
 following precise sense:
 
 - The iso-strong route is formally refuted by the standalone theorem
-  `isoStrong_conclusion_negative_for_canonical`.
+  `isoStrong_conclusion_negative_for_canonical`
+  (`pnp3/Tests/IsoStrongConclusionProbe.lean:368`).
 - The promise-YES weak and promise-YES certificate routes are not yet
   exposed as standalone Lean negation theorems.
 - Their closure at `globalWitness_to_hInDag W` follows by pointwise
   contrapositive of existing route-level implications:
   `asymptoticPromiseYesCertificateRoute_of_asymptoticPromiseYesWeakRouteEventually`
+  (`pnp3/Magnification/FinalResultMainline.lean:348`)
   and
-  `asymptoticIsoStrongRoute_of_asymptoticPromiseYesCertificateRoute`.
+  `asymptoticIsoStrongRoute_of_asymptoticPromiseYesCertificateRoute`
+  (`pnp3/Magnification/FinalResultMainline.lean:400`).
+  Both implication theorems open with `intro hInDag` and operate on the
+  body at that specific `hInDag`, so contrapositive at
+  `hInDag = globalWitness_to_hInDag W` propagates the iso-strong negation
+  to negations of the promise-route bodies.
 - Companion promise-route negation theorems are optional packaging for
   attribution clarity, not required for the current status correction.
+- Inhabitancy caveat: `GlobalAsymptoticDAGWitness canonicalAsymptoticHAsym`
+  is referenced only as a universal hypothesis (`∀ W : ...`) in the
+  inspected files; no explicit inhabitant is constructed in the current
+  codebase.  This is recorded as context; the `∀ W, ¬P(W)` theorem is
+  logically meaningful as-is.
 
 This does **NOT** prove `P ≠ NP` or even `NP ⊄ P/poly`.  It rules
 out the canonical asymptotic track at the canonical `sYES = 1,
@@ -248,8 +260,11 @@ either:
 | 10. isoStrong_conclusion_L1 sessions 1-3 (#1416, #1423, #1427) | YELLOW_PARTIAL chain | extends to 340 LOC |
 | 11. isoStrong_conclusion_L1 session 4 (#1433) | **RED_CONCLUSION_REFUTED** | extends to 409 LOC; `isoStrong_conclusion_negative_for_canonical` formally proved |
 
-The canonical asymptotic track is now formally closed.  The four
-major refutations in the post-PR13 chain:
+The canonical asymptotic track is now closed at conclusion side under
+the attribution above (iso-strong via standalone theorem; promise-YES
+weak and certificate routes via pointwise contrapositive of existing
+route-level implications composed with the iso-strong negation).  The
+four major refutations in the post-PR13 chain:
 
 1. `FormulaCertificateProviderPartial → False` (PR 13, formula-side
    truth-table hardwiring).


### PR DESCRIPTION
### Motivation
- Fix an overclaim in the canonical-asymptotic section of `STATUS.md` so that only the iso-strong conclusion is attributed to a standalone theorem while promise-route closures are described as derivable via existing implication lemmas.

### Description
- Update `STATUS.md` canonical-asymptotic paragraph to state that the iso-strong route is formally refuted by `isoStrong_conclusion_negative_for_canonical`, that the promise-YES weak and promise-YES certificate routes are not yet exposed as standalone negation theorems, and that their closure at `globalWitness_to_hInDag W` follows by pointwise contrapositive of `asymptoticPromiseYesCertificateRoute_of_asymptoticPromiseYesWeakRouteEventually` and `asymptoticIsoStrongRoute_of_asymptoticPromiseYesCertificateRoute`, with companion promise-route negation theorems noted as optional packaging.

### Testing
- Ran `./scripts/check.sh` on the modified tree, which completed successfully (build/check passed; only pre-existing linter/warning messages were emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbbf752b8832b93ec7ff2375fa6fb)