### PR TITLE
Clarify STATUS canonical-route closure after post-RED audit

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -203,10 +203,20 @@ theorem isoStrong_conclusion_negative_for_canonical :
 
 **Consequence.** The canonical asymptotic track via
 `canonicalAsymptoticHAsym` is **formally closed** at conclusion
-level.  The iso-strong route, the promise-YES weak route, and the
-promise-YES certificate route at the canonical spec are all
-inconsistent at the conclusion side under the (now Lean-witnessed)
-`GlobalAsymptoticDAGWitness` contract.
+level for the iso-strong route: the standalone Lean negation theorem is
+`isoStrong_conclusion_negative_for_canonical`.
+
+For the promise-YES weak and promise-YES certificate routes, the
+post-RED closure at `globalWitness_to_hInDag W` is currently obtained by
+pointwise contrapositive propagation along existing route-level
+implications,
+`asymptoticPromiseYesCertificateRoute_of_asymptoticPromiseYesWeakRouteEventually`
+and
+`asymptoticIsoStrongRoute_of_asymptoticPromiseYesCertificateRoute`,
+composed with `isoStrong_conclusion_negative_for_canonical`.
+These two companion promise negations are not yet exposed as standalone
+Lean negation theorems; adding them is optional packaging and is not
+required for the present status correction.
 
 This does **NOT** prove `P ≠ NP` or even `NP ⊄ P/poly`.  It rules
 out the canonical asymptotic track at the canonical `sYES = 1,


### PR DESCRIPTION
### Motivation
- Remove an overclaim in the canonical asymptotic track wording that implied all three canonical conclusion routes already had standalone Lean negation theorems. 
- Accurately record the post-RED audit landing `ISO_RED_PROMISE_OVERCLAIM` findings so the repo status reflects which negations are theorem-backed and which are derived by implication. 
- Keep the change markdown-only and avoid touching any Lean source or introducing theorem claims.

### Description
- Edited `STATUS.md` to state that the iso-strong canonical conclusion is formally refuted by the standalone theorem `isoStrong_conclusion_negative_for_canonical`. 
- Clarified that the promise-YES weak and promise-YES certificate routes are not yet exposed as standalone negation theorems and that their closure at `globalWitness_to_hInDag W` is obtained by pointwise contrapositive propagation along `asymptoticPromiseYesCertificateRoute_of_asymptoticPromiseYesWeakRouteEventually` and `asymptoticIsoStrongRoute_of_asymptoticPromiseYesCertificateRoute`, composed with `isoStrong_conclusion_negative_for_canonical`. 
- Explicitly noted that adding companion promise-negation theorems would be optional packaging and is not required for this status correction. 
- Change scope: markdown-only modification limited to `STATUS.md` and no Lean/source claims were added.

### Testing
- Ran `./scripts/check.sh` to validate the tree and build pipeline; the script completed with a full Lean build and emitted only unrelated linter/warning messages. 
- The `check.sh` run did not report any STATUS.md-specific failures. 
- No additional automated tests or Lean source changes were performed because this is a documentation-only patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cbbf752b8832b93ec7ff2375fa6fb)