### PR TITLE
Record structured failure for general iso-strong no-go (L1 session 2)

### DIFF
--- a/seed_packs/general_isoStrong_no_go_L1/failures/L1_session2_codex53.md
+++ b/seed_packs/general_isoStrong_no_go_L1/failures/L1_session2_codex53.md
@@ -1,0 +1,45 @@
+# L1 session 2 structured failure (codex53)
+
+## Scope and intent
+Attempted to land the session-2 general not-YES bridge in:
+- `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`
+
+Target theorem:
+- `exists_valid_agreeing_not_yes_under_general_slack`
+
+## What was attempted
+Implemented (then reverted) the planned general-diagonal stack:
+1. `generalDiagonalPartialTable`
+2. `general_diagonal_z_valid`
+3. `general_diagonal_z_agrees_on_D`
+4. `is_consistent_general_diagonal_table_implies_trace_in_image`
+5. `general_diagonal_z_not_yes_of_label_not_in_trace_image`
+6. final composition theorem
+
+## Precise blockers (Lean elaboration)
+When compiling `Tests.GeneralIsoStrongNoGoProbe`, Lean reported stable elaboration/typeclass failures in this file:
+
+1. **`Bitstring`/`circuitsOfSizeAtMost` not resolved in local context**
+   - Errors of form `Function expected at Bitstring` and `Function expected at circuitsOfSizeAtMost`.
+   - This indicates missing namespace openings/import alignment for these constants in this file’s current import/open profile.
+
+2. **Subtype level mismatch around free-row index type**
+   - Error form:
+     - `Subtype.mk j` expected `{x // x ∈ Finset.univ \ D}` but received `Fin (...)`.
+   - And later a goal with doubly-subtyped free-row index:
+     - `a : {x // x ∈ (Finset.univ \ D).attach}`.
+   - This indicates coercion/attachment mismatch between expected free-row domain and the concrete `label`/trace domain in the attempted statements.
+
+3. **Bridge extraction mismatch for Yes-membership path**
+   - Attempted direct route via `gapSlice` membership to `PartialMCSP_YES` did not fully elaborate under the file’s current local setup; unresolved goals persisted after extracting witness circuit.
+
+## Why reverted
+To keep repository green and avoid landing a broken probe file, the attempted edits to
+`pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` were reverted.
+
+## Suggested next unblock sequence (session 2b)
+1. First land a tiny local helper lemma in this file fixing the free-row type alias:
+   - e.g. `abbrev FreeRows (p D) := (Finset.univ \ D).attach`.
+2. Rebuild only the trace-equality lemma using that alias to avoid attach/subtype drift.
+3. Add explicit namespace opens (`ComplexityInterfaces`, `Counting`) used by constants before introducing theorem statements with `Bitstring`/`circuitsOfSizeAtMost`.
+4. Reuse the exact `gapSlice_yes_iff` pipeline from `IsoStrongConclusionProbe` with identical unfolding order, then generalize.

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session2.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session2.md
@@ -1,0 +1,30 @@
+Task: general iso-strong no-go L1 session 2
+Handle: codex53
+Branch: main
+Commit before: 75c5ae0a6d69c778f4e27404a0bdaedcb9b2ff50
+Commit after: (set by git history; see final assistant message)
+Changed files:
+  seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session2.md
+  seed_packs/general_isoStrong_no_go_L1/failures/L1_session2_codex53.md
+
+Outcome:
+  STRUCTURED_FAILURE
+
+Executive verdict:
+  INCONCLUSIVE_NEEDS_L2
+
+Theorems landed:
+  - none (probe file changes reverted due elaboration blockers)
+
+Main session-2 theorem landed:
+  no
+
+Commands run:
+  - lake build Tests.GeneralIsoStrongNoGoProbe → fail (elaboration/type-resolution blockers in attempted session-2 additions; reverted)
+  - lake build PnP3 Pnp4 → not re-run after revert in this session
+  - ./scripts/check.sh → not run in this structured-failure pass
+  - rg sorry/admit → not run in this structured-failure pass
+  - forbidden-pattern rg → not run in this structured-failure pass
+
+Scope violations:
+  none


### PR DESCRIPTION
### Motivation
- Attempted to land the general diagonal / not-YES bridge (`exists_valid_agreeing_not_yes_under_general_slack`) for L1 session 2 but encountered Lean elaboration/type-resolution blockers, so record a structured failure and next-step unblock plan.

### Description
- Add a failure artifact `seed_packs/general_isoStrong_no_go_L1/failures/L1_session2_codex53.md` with precise diagnostics and suggested unblock steps. 
- Add the session report `seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session2.md` and revert the non-compiling edits to `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` to keep the repository in a clean state.

### Testing
- Ran `lake build Tests.GeneralIsoStrongNoGoProbe` during the attempt and it failed with elaboration/type-resolution errors (details captured in the failure report). 
- `lake build PnP3 Pnp4` was invoked during investigation and produced a partial build with warnings, but the session-2 edits were reverted and `./scripts/check.sh` was not run after the revert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7754e748832bb4e4a2bc81652a4b)