### PR TITLE
tests: general iso-strong no-go L1 s3 — land general not-YES bridge (partial)

### DIFF
--- a/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
+++ b/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
@@ -71,6 +71,8 @@ namespace GeneralIsoStrongNoGoProbe
 
 open Models
 open LowerBounds
+open Counting
+open CircuitCountTraceBoundProbe
 
 /--
 Finite-image pigeonhole: any `S : Finset (α → Bool)` of cardinality strictly
@@ -213,6 +215,81 @@ theorem general_diagonal_z_agrees_on_D
         (encodePartial (generalDiagonalPartialTable p yYes D label)) i := by
       symm
       simp [Partial.valPart, encodePartial, Partial.valIndex]
+
+theorem is_consistent_general_diagonal_table_implies_trace_in_image
+    (p : GapPartialMCSPParams)
+    (yYes : Core.BitVec (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \ D).attach → Bool)
+    (C : Circuit p.n)
+    (hSize : C.size ≤ p.sYES)
+    (hCons :
+      is_consistent C
+        (generalDiagonalPartialTable p yYes D label)) :
+    traceCircuitOnRows
+      (n := p.n)
+      ((Finset.univ \ D).attach)
+      (fun a => a.1)
+      C
+    =
+    label := by
+  funext a
+  have hNotInD : a.1.1 ∉ D := by
+    exact (Finset.mem_sdiff.mp a.1.2).2
+  have hdiag : generalDiagonalPartialTable p yYes D label a.1.1 = some (label a) := by
+    simp [generalDiagonalPartialTable, hNotInD]
+  have hAt := hCons (Core.vecOfNat p.n a.1.1.val)
+  have hIdx : assignmentIndex (Core.vecOfNat p.n a.1.1.val) = a.1.1 := by
+    exact assignmentIndex_vecOfNat_eq a.1.1
+  rw [hIdx, hdiag] at hAt
+  simpa [traceCircuitOnRows] using hAt
+
+theorem general_diagonal_z_not_yes_of_label_not_in_trace_image
+    (p : GapPartialMCSPParams)
+    (yYes : Core.BitVec (partialInputLen p))
+    (D : Finset (Fin (Partial.tableLen p.n)))
+    (label : (Finset.univ \ D).attach → Bool)
+    (hLabel :
+      label ∉
+        (circuitsOfSizeAtMost p.n p.sYES).image
+          (traceCircuitOnRows
+            (n := p.n)
+            ((Finset.univ \ D).attach)
+            (fun a => a.1))) :
+    ¬ encodePartial (generalDiagonalPartialTable p yYes D label)
+        ∈ (gapSliceOfParams p).Yes := by
+  intro hzYes
+  have hLang : PartialMCSP_YES p (decodePartial (encodePartial (generalDiagonalPartialTable p yYes D label))) :=
+    (gapPartialMCSP_language_true_iff_yes p
+      (encodePartial (generalDiagonalPartialTable p yYes D label))).1 hzYes
+  rcases hLang with ⟨C, hSize, hCons⟩
+  have hTable :
+      is_consistent C (generalDiagonalPartialTable p yYes D label) := by
+    simpa [decodePartial_encodePartial] using hCons
+  have hTrace :
+      traceCircuitOnRows
+        (n := p.n)
+        ((Finset.univ \ D).attach)
+        (fun a => a.1)
+        C = label :=
+    is_consistent_general_diagonal_table_implies_trace_in_image
+      p yYes D label C hSize hTable
+  have hMemC : C ∈ circuitsOfSizeAtMost p.n p.sYES :=
+    Counting.mem_circuitsOfSizeAtMost C p.sYES hSize
+  have hInImage :
+      label ∈
+        (circuitsOfSizeAtMost p.n p.sYES).image
+          (traceCircuitOnRows
+            (n := p.n)
+            ((Finset.univ \ D).attach)
+            (fun a => a.1)) := by
+    refine Finset.mem_image.mpr ?_
+    exact ⟨C, hMemC, hTrace⟩
+  exact hLabel hInImage
+
+
+
+
 
 end GeneralIsoStrongNoGoProbe
 end Tests

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session3.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session3.md
@@ -1,0 +1,41 @@
+# L1 general iso-strong no-go — session 3
+
+## 1. Executive verdict
+
+**YELLOW_PARTIAL_GENERAL_L1**
+
+## 2. What landed
+
+- `is_consistent_general_diagonal_table_implies_trace_in_image`
+- `general_diagonal_z_not_yes_of_label_not_in_trace_image`
+
+## 3. General not-YES bridge status
+
+Closed for the partial target: from
+`encodePartial (generalDiagonalPartialTable ...) ∈ (gapSliceOfParams p).Yes`,
+we derive a bounded-size consistent circuit witness, convert consistency on the
+general diagonal table into exact trace equality on free rows, and contradict
+`label ∉ image(traceCircuitOnRows ...)`.
+
+## 4. Remaining blockers
+
+- `exists_valid_agreeing_not_yes_under_general_slack` currently triggers a deterministic elaboration timeout (`whnf`, heartbeat limit) in this file context.
+- Precise remaining statement:
+  ```lean
+  theorem exists_valid_agreeing_not_yes_under_general_slack
+      (p : GapPartialMCSPParams)
+      (yYes : Core.BitVec (partialInputLen p))
+      (hValidYes : ValidEncoding p yYes)
+      (D : Finset (Fin (Partial.tableLen p.n)))
+      (hSlack :
+        circuitCountBound p.n (p.sNO - 1) <
+          2 ^ ((Finset.univ \ D).card)) :
+      ∃ z : Core.BitVec (partialInputLen p),
+        ValidEncoding p z ∧
+        AgreeOnValues D yYes z ∧
+        ¬ z ∈ (gapSliceOfParams p).Yes
+  ```
+
+## 5. Next action
+
+**open_general_isoStrong_no_go_L1_session_4**


### PR DESCRIPTION
### Motivation
- Complete the remaining L1 session-3 groundwork for the general iso-strong no-go chain by lifting the canonical size-1 consistency→trace bridge to bounded-size circuits and closing the not-YES bridge for the generalized diagonal encoding. 
- Prepare for the final composition `exists_valid_agreeing_not_yes_under_general_slack` by providing the trace-equality and not-YES lemmas needed to reduce YES-membership to a trace-image contradiction.

### Description
- Added `is_consistent_general_diagonal_table_implies_trace_in_image` in `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`, which proves that any bounded-size circuit `C` consistent with `generalDiagonalPartialTable` has `traceCircuitOnRows ... C = label` on the free rows. 
- Added `general_diagonal_z_not_yes_of_label_not_in_trace_image` in `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`, which shows that if `label` is not in the image of bounded-size traces then the encoded general diagonal cannot be in the YES promise slice. 
- Composed a session report `seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session3.md` documenting the landing, the blocker, and the next action. 
- Left the full general composition theorem `exists_valid_agreeing_not_yes_under_general_slack` staged as a blocker because attempting to add the full composition in this file context triggered deterministic elaboration/`whnf` timeouts; that precise statement is recorded in the report for the next session.

### Testing
- `lake build Tests.GeneralIsoStrongNoGoProbe` ran and completed successfully. 
- `lake build PnP3 Pnp4` was executed and completed successfully with standard linter warnings only. 
- `./scripts/check.sh` was run as part of the validation pipeline and the repo-level build/check progressed to completion (no regressions introduced by the changed files). 
- Repository grep checks for accidental kernel traps (`rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4`) found no `sorry`/`admit` in the active code, and forbidden-pattern checks against `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d9ab1c978832b9564170104be1680)