### PR TITLE
Add structured failure report for general iso-strong no-go L1 session 3

### DIFF
--- a/seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md
+++ b/seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md
@@ -1,0 +1,33 @@
+# L1 session 3 failure report (codex53)
+
+## Executive verdict
+INCONCLUSIVE_NEEDS_L2
+
+## What was attempted
+- Targeted the three requested theorems in `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`:
+  - `is_consistent_general_diagonal_table_implies_trace_in_image`
+  - `general_diagonal_z_not_yes_of_label_not_in_trace_image`
+  - `exists_valid_agreeing_not_yes_under_general_slack`
+
+## Blocking points
+1. **Consistency-at-point shape mismatch** in target 1:
+   - `is_consistent` reduces to a match proposition (`match T i with | some b => ... | none => True`) rather than a direct `Option` equality form, causing a coercion mismatch when trying to pass through `generalDiagonalPartialTable` outside `D`.
+2. **YES-membership bridge normalization mismatch** in target 2:
+   - direct simplification from
+     `encodePartial (...) ∈ (gapSliceOfParams p).Yes`
+     to a usable witness `∃ C, C.size ≤ p.sYES ∧ is_consistent C (...)`
+     did not normalize cleanly under available local lemmas without introducing additional helper lemmas.
+3. **Enumeration membership bridge**:
+   - converting `hSize : C.size ≤ p.sYES` into
+     `C ∈ circuitsOfSizeAtMost p.n p.sYES` needs the exact local lemma shape used by the counting probe namespace; direct simp on `circuitsOfSizeAtMost` was insufficient.
+4. **Heartbeat timeout** on target 3 assembly while elaborating the final existential package with the current proof skeleton.
+
+## Precise missing helper shapes
+- A lemma exposing a pointwise equivalence form for `is_consistent` at a fixed index:
+  `is_consistent C T -> T i = some b -> Circuit.eval C (vecOfNat ...) = b`.
+- A robust bridge theorem for slice YES membership at canonical length in this namespace (analogous to `gapSlice_yes_iff` usage in canonical probe).
+- A lemma turning size bound into finite-enumeration membership for circuits:
+  `C.size ≤ s -> C ∈ circuitsOfSizeAtMost n s`.
+
+## Next action
+open_general_isoStrong_no_go_L2_design


### PR DESCRIPTION
### Motivation
- Record a structured failure for L1 session 3 after attempts to prove the general not-YES bridge and composition were blocked, and capture precise blockers and the next action to move to L2 design.

### Description
- Add `seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md` containing the executive verdict `INCONCLUSIVE_NEEDS_L2`, the attempted theorem targets, concrete blocking points, precise missing helper-lemma shapes, and the prescribed next action, with no endpoint/trust-root edits or landing of the target theorems.

### Testing
- Ran `lake build Tests.GeneralIsoStrongNoGoProbe` which completed successfully; ran `lake build PnP3 Pnp4` which completed (with warnings); ran `./scripts/check.sh` which completed (with warnings); and ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` which reported no forbidden uses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d9ab1c978832b9564170104be1680)