### PR TITLE
general iso-strong no-go L1 session 3: structured failure + report

### DIFF
--- a/seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md
+++ b/seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md
@@ -1,0 +1,26 @@
+# L1 session 3 failure report (codex53)
+
+## Executive verdict
+INCONCLUSIVE_NEEDS_L2
+
+## What was attempted
+- Implement `is_consistent_general_diagonal_table_implies_trace_in_image`.
+- Attempt bridge theorem from `z ∈ Yes` to trace-image membership.
+- Attempt composition theorem under general slack.
+
+## General not-YES bridge status
+Not closed in this session. The blocking point is extracting the exact yes-witness elimination path in this module with currently available names/rewrites while keeping the generalized `(Finset.univ \ D).attach` trace domain and avoiding endpoint/trust-root edits.
+
+## Remaining blockers (precise)
+1. `is_consistent_general_diagonal_table_implies_trace_in_image`:
+   - Subtype coercion mismatch between row index expected by `assignmentIndex_vecOfNat_eq` and the attached-row domain used by `generalDiagonalPartialTable`.
+2. `general_diagonal_z_not_yes_of_label_not_in_trace_image`:
+   - Need stable in-scope bridge lemma(s) from
+     `encodePartial (...) ∈ (gapSliceOfParams p).Yes`
+     to `∃ C, C.size ≤ p.sYES ∧ is_consistent C (...)`
+     in this module context.
+3. `exists_valid_agreeing_not_yes_under_general_slack`:
+   - Depends on (2); assembly blocked until not-YES bridge is fully closed.
+
+## Next action
+open_general_isoStrong_no_go_L1_session_4

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session3.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session3.md
@@ -1,0 +1,28 @@
+# general iso-strong no-go L1 session 3 (codex53)
+
+## 1. Executive verdict
+INCONCLUSIVE_NEEDS_L2
+
+## 2. What landed
+- No new Lean theorem landed in `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` in this session.
+- Produced structured blocker analysis and failure log.
+
+## 3. General not-YES bridge status
+The conversion from
+`z ∈ (gapSliceOfParams p).Yes`
+to trace-image membership was **not closed** in this session.
+
+Main technical friction encountered was the combination of:
+- attached-index coercions over `(Finset.univ \ D).attach` in the generalized diagonal table,
+- and locating/using the exact yes-membership elimination lemmas in this module context without broadening imports/scope.
+
+## 4. Remaining blockers
+1. A stable proof of:
+   `is_consistent_general_diagonal_table_implies_trace_in_image`.
+2. Then a bridge theorem:
+   `general_diagonal_z_not_yes_of_label_not_in_trace_image`.
+3. Then composition:
+   `exists_valid_agreeing_not_yes_under_general_slack`.
+
+## 5. Next action
+open_general_isoStrong_no_go_L1_session_4


### PR DESCRIPTION
### Motivation
- Record the outcome of L1 session 3 for the general iso-strong no-go probe as a structured failure and actionable next step when the full not-YES bridge/composition did not land.

### Description
- Add a session report file `seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session3.md` summarising verdict, what landed, blockers, and next action. 
- Add a structured failure log `seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md` describing the attempted proof steps, precise blockers, and recommendation to open a follow-up session; no endpoint, trust-root, or public theorem surfaces were changed.

### Testing
- Ran `lake build Tests.GeneralIsoStrongNoGoProbe` which completed successfully on the working tree. 
- Ran the full `lake build PnP3 Pnp4` / repository build and invoked `./scripts/check.sh` as part of the session workflow, with no repository-level regressions observed in this run. 
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and checks for forbidden-pattern imports against `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`, with no matches introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d9ab4d498832bb30627a96287a867)