### PR TITLE
general iso-strong no-go L1 session 3: structured failure report and status

### DIFF
--- a/seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md
+++ b/seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md
@@ -1,0 +1,32 @@
+# L1 session 3 structured failure (codex53)
+
+## Executive verdict
+INCONCLUSIVE_NEEDS_L2
+
+## Attempted targets
+- is_consistent_general_diagonal_table_implies_trace_in_image
+- general_diagonal_z_not_yes_of_label_not_in_trace_image
+- exists_valid_agreeing_not_yes_under_general_slack
+
+## Why blocked
+1. **Bridge from `z ∈ (gapSliceOfParams p).Yes` to language witness in this module context**
+   - In `GeneralIsoStrongNoGoProbe`, helper lemmas used by the canonical probe (`gapSlice_yes_iff`, `gapPartialMCSP_Language_eq_true_iff_yes`) were not directly available under current imports/namespace assumptions.
+   - A direct `simpa [gapSliceOfParams]` gave shape mismatches around the expected domain of `gapPartialMCSP_Language` in this file, indicating additional coercion/arity plumbing is required before extracting `∃ C, C.size ≤ p.sYES ∧ is_consistent C ...`.
+
+2. **Trace-family qualification and coercion friction**
+   - `traceCircuitOnRows`/`boundedSizeTrace_image_card_lt_of_slack` are in `Pnp3.Tests.CircuitCountTraceBoundProbe`; unqualified use caused elaboration failures.
+   - Even with qualification, final cardinality goal expected exponent in one normal form while the derived bound arrived in another, requiring an explicit normalisation bridge.
+
+3. **Subtype-indexed row extraction mismatch**
+   - In the consistency-to-trace lemma, the row index from `((Finset.univ \ D).attach)` produced coercion mismatches when feeding `assignmentIndex_vecOfNat_eq`; additional local coercion lemmas are needed to avoid fragile `simp` failures.
+
+## Precise blockers
+- A stable local theorem in this file equivalent to:
+  `x ∈ (gapSliceOfParams p).Yes → ∃ C : Circuit p.n, C.size ≤ p.sYES ∧ is_consistent C (decodePartial x)`
+  with the exact `x` type used in this probe.
+- A coercion-normalisation lemma for indices from `((Finset.univ \ D).attach)` to `Fin (Partial.tableLen p.n)` compatible with `assignmentIndex_vecOfNat_eq`.
+- A normalisation step connecting
+  `2 ^ ((Finset.univ \ D).card)` and the expected local exponent form in the final composition goal.
+
+## Next action
+open_general_isoStrong_no_go_L2_design

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session3.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session3.md
@@ -1,0 +1,24 @@
+# general iso-strong no-go L1 — session 3 (codex53)
+
+## 1. Executive verdict
+INCONCLUSIVE_NEEDS_L2
+
+## 2. What landed
+- No new theorem landed in `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` during this session.
+
+## 3. General not-YES bridge status
+- Not closed in this session.
+- The attempted conversion from
+  `encodePartial (generalDiagonalPartialTable ...) ∈ (gapSliceOfParams p).Yes`
+  to an explicit bounded-size witness
+  `∃ C, C.size ≤ p.sYES ∧ is_consistent C (...)`
+  encountered local elaboration/normalization mismatches (details in failure note).
+
+## 4. Remaining blockers
+1. Need a robust local bridge theorem with exact term shapes used in this file:
+   `x ∈ (gapSliceOfParams p).Yes → ∃ C : Circuit p.n, C.size ≤ p.sYES ∧ is_consistent C (decodePartial x)`.
+2. Coercion-normalization for indices from `((Finset.univ \\ D).attach)` to rows used by `assignmentIndex_vecOfNat_eq`.
+3. Final cardinality-normalization bridge in the composition step (exponent form alignment).
+
+## 5. Next action
+open_general_isoStrong_no_go_L2_design


### PR DESCRIPTION
### Motivation
- Attempt to advance L1 session 3 of the general iso-strong no-go probe by proving the general not-YES bridge and the slack composition, and to capture blockers when the proof attempt could not be completed.

### Description
- Add a session-3 report `seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session3.md` and a structured failure note `seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md` documenting the attempted targets, concrete type/elaboration/coercion blockers, and the recommended next action; no Lean theorem surfaces or endpoint/trust-root files were changed.

### Testing
- Ran `lake build Tests.GeneralIsoStrongNoGoProbe` which completed successfully, `lake build PnP3 Pnp4` and `./scripts/check.sh` which were launched and progressed substantially but are large and did not finish within the interactive session window, and ran `rg` checks for forbidden patterns (the `rg "\bsorry\b|\badmit\b"` hits were in explanatory comments, not introduced proof placeholders).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d9ab4d498832bb30627a96287a867)