### PR TITLE
Add L1 session 3 structured failure report for general iso-strong no-go probe

### DIFF
--- a/seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md
+++ b/seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md
@@ -1,0 +1,25 @@
+# L1 session 3 structured failure (codex53)
+
+## Executive verdict
+INCONCLUSIVE_NEEDS_L2
+
+## Attempted targets
+- is_consistent_general_diagonal_table_implies_trace_in_image
+- general_diagonal_z_not_yes_of_label_not_in_trace_image
+- exists_valid_agreeing_not_yes_under_general_slack
+
+## Blocking details
+1. Elaboration/heartbeat timeout in `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` while proving the general trace bridge over `(Finset.univ \ D).attach` (`whnf` timeout at theorem block), before kernel acceptance.
+2. The guessed bridge from `z ∈ (gapSliceOfParams p).Yes` to language-level YES required exact local rewriting discipline; intermediate attempt using direct `simpa [gapSliceOfParams]` worked partially but depended on the unresolved trace theorem.
+3. Membership transport to `circuitsOfSizeAtMost` and attached-row coercions are straightforward individually, but composition still blocked by (1).
+
+## Precise blocker statements
+- Need a kernel-accepted proof of:
+  `is_consistent_general_diagonal_table_implies_trace_in_image`.
+- Then complete:
+  `general_diagonal_z_not_yes_of_label_not_in_trace_image`.
+- Then compose:
+  `exists_valid_agreeing_not_yes_under_general_slack`.
+
+## Next action
+open_general_isoStrong_no_go_L2_design


### PR DESCRIPTION
### Motivation
- Record a structured failure for L1 session 3 after attempts to land the general not-YES bridge and slack composition timed out / hit elaboration blockers, while keeping the tree compiling and actionable next steps clear.

### Description
- Add a structured failure report `seed_packs/general_isoStrong_no_go_L1/failures/L1_session3_codex53.md` documenting the executive verdict `INCONCLUSIVE_NEEDS_L2`, attempted theorem targets, precise blockers, and the recommended next action `open_general_isoStrong_no_go_L2_design`.
- Restore the working theorem file state so there is no net change to `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` in this PR and the repo remains buildable.

### Testing
- Ran `lake build Tests.GeneralIsoStrongNoGoProbe`, which completed successfully after restoring the working state.
- Ran `lake build PnP3 Pnp4` and `./scripts/check.sh`; the repository build and checks were executed over the large build graph during the session (build progress observed to completion in the interactive run).
- Ran repository scans `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and the forbidden-pattern `rg` for restricted imports against `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`, both returned no violations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d9ab4d498832bb30627a96287a867)