### PR TITLE
General iso-strong no-go L1 session 4 — final route-level assembly

### DIFF
--- a/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
+++ b/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
@@ -391,6 +391,73 @@ theorem exists_valid_agreeing_not_yes_under_general_slack
   · exact general_diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact general_diagonal_z_not_yes_of_label_not_in_trace_image p yYes D label hLabel
 
+lemma correctOnPromiseSlice_of_InPpolyDAG_family_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  constructor
+  · intro x hx
+    have hCorr := (hInDag n β).correct
+      (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+  · intro x hx
+    have hCorr := (hInDag n β).correct
+      (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+
+theorem isoStrong_conclusion_negative_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    ¬ IsoStrongFamilyEventually F hInDag := by
+  intro hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    exact div_pos hβ0 (by norm_num)
+  have hβLt : β < β0 := by
+    dsimp [β]
+    linarith
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := by exact le_rfl
+  have hn0 : F.N0 ≤ n := by exact le_max_left _ _
+  let p := F.paramsOf n β
+  let C : ComplexityInterfaces.DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize :
+      ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1
+        (ComplexityInterfaces.DagCircuit.size C) := by
+    simpa [C, ppolyDAGSizeBoundOnSlicesEventually] using
+      (hInDag n β).family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  have hCorrect : CorrectOnPromiseSlice C (gapSliceOfParams p) := by
+    simpa [C, p] using
+      correctOnPromiseSlice_of_InPpolyDAG_family_general F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hSlackForD :
+      circuitCountBound (F.paramsOf n β).n ((F.paramsOf n β).sNO - 1) <
+        2 ^ (Partial.tableLen (F.paramsOf n β).n - D.card) := by
+    exact slack_for_D_of_isoStrong_slack_general
+      F n β hn0 D (κ n β) hDcard hRawSlack
+  have hSlackForD' :
+      circuitCountBound p.n (p.sNO - 1) <
+        2 ^ ((Finset.univ \ D).card) := by
+    simpa [p, Finset.card_sdiff (Finset.subset_univ D)] using hSlackForD
+  rcases exists_valid_agreeing_not_yes_under_general_slack
+      p yYes hValidYes D hSlackForD' with
+    ⟨z, hzValid, hzAgree, hzNotYes⟩
+  exact hzNotYes (hAllYes z hzValid hzAgree)
+
 end GeneralIsoStrongNoGoProbe
 end Tests
 end Pnp3

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
@@ -1,0 +1,32 @@
+# L1 general iso-strong no-go — session 4 report (codex53)
+
+## 1. Executive verdict
+
+RED_GENERAL_ISOSTRONG_REFUTED
+
+## 2. What landed
+
+- `correctOnPromiseSlice_of_InPpolyDAG_family_general`
+- `isoStrong_conclusion_negative_general`
+
+## 3. General route-level assembly status
+
+The final route-level assembly landed in Lean.
+
+Concretely, for arbitrary `F : GapSliceFamilyEventually` and arbitrary
+`hInDag : ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β))`,
+we now have:
+
+- `isoStrong_conclusion_negative_general`:
+  `¬ IsoStrongFamilyEventually F hInDag`.
+
+So the general iso-strong eventual forcing/slack package is formally
+inconsistent under the current definitions in this probe file.
+
+## 4. Remaining blockers
+
+None for L1 session 4 target theorem assembly in this file.
+
+## 5. Next action
+
+close_isoStrong_route_pattern_refuted


### PR DESCRIPTION
### Motivation

- Finish the L1 session-4 route-level assembly by combining the six L1 ingredients to refute `IsoStrongFamilyEventually` for a general `GapSliceFamilyEventually` witness family. 
- Provide a parameter-agnostic lift of the `InPpolyDAG` family correctness surface so the forcing/slack chain can consume arbitrary `hInDag` witnesses.

### Description

- Added `correctOnPromiseSlice_of_InPpolyDAG_family_general` which lifts `InPpolyDAG` family correctness to `CorrectOnPromiseSlice` at the encoded slice length via `((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))` and `gapSliceOfParams (F.paramsOf n β)`. 
- Implemented `isoStrong_conclusion_negative_general` that follows the canonical assembly template: choose `β := β0/2`, `n := max F.N0 (nIso β)`, extract the DAG family witness `C`, prove the size and correctness conditions, convert iso-strong raw slack into the `D.card` form using `slack_for_D_of_isoStrong_slack_general`, apply the session-3 diagonal lemma `exists_valid_agreeing_not_yes_under_general_slack`, and derive a contradiction to the forcing hypothesis. 
- Kept all work local to `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` and added the session report `seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md` recording the verdict and landed theorems.

### Testing

- Ran `lake build Tests.GeneralIsoStrongNoGoProbe` and the target file built successfully. 
- Ran `lake build PnP3 Pnp4` and the repository builds completed successfully. 
- Ran `./scripts/check.sh` and the check passed with no `sorry`/`admit` introduced. 
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and the scan returned no forbidden patterns in the modified area.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dacb77664832ba86cc91575c3c8f3)