### PR TITLE
general iso-strong no-go L1 session 4: assemble final route-level contradiction

### DIFF
--- a/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
+++ b/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
@@ -95,6 +95,7 @@ namespace GeneralIsoStrongNoGoProbe
 open Models
 open LowerBounds
 open Counting
+open ComplexityInterfaces
 
 /--
 Finite-image pigeonhole: any `S : Finset (α → Bool)` of cardinality strictly
@@ -390,6 +391,75 @@ theorem exists_valid_agreeing_not_yes_under_general_slack
   · exact general_diagonal_z_valid p yYes D label
   · exact general_diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact general_diagonal_z_not_yes_of_label_not_in_trace_image p yYes D label hLabel
+
+/--
+Slice-correctness witness extracted directly from an `InPpolyDAG` family
+at the encoded slice length.
+-/
+lemma correctOnPromiseSlice_of_InPpolyDAG_family_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  constructor
+  · intro x hx
+    have hCorr := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+  · intro x hx
+    have hCorr := (hInDag n β).correct (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+
+/--
+General route-level no-go assembly: under per-slice `InPpolyDAG` witnesses,
+the iso-strong forcing/slack package is contradictory.
+-/
+theorem isoStrong_conclusion_negative_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    ¬ IsoStrongFamilyEventually F hInDag := by
+  intro hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    linarith
+  have hβLt : β < β0 := by
+    dsimp [β]
+    linarith
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := le_rfl
+  have hn0 : F.N0 ≤ n := le_max_left _ _
+  let p := F.paramsOf n β
+  let C : DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize :
+      ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (DagCircuit.size C) := by
+    simpa [C, ppolyDAGSizeBoundOnSlicesEventually] using
+      (hInDag n β).family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  have hCorrect : CorrectOnPromiseSlice C (gapSliceOfParams p) := by
+    simpa [C, p] using
+      correctOnPromiseSlice_of_InPpolyDAG_family_general F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hSlackForD :
+      circuitCountBound p.n (p.sNO - 1) < 2 ^ (Partial.tableLen p.n - D.card) := by
+    simpa [p, GapSliceFamilyEventually.tableLen] using
+      slack_for_D_of_isoStrong_slack_general F n β hn0 D (κ n β) hDcard hRawSlack
+  have hSlackForD' :
+      circuitCountBound p.n (p.sNO - 1) < 2 ^ ((Finset.univ \ D).card) := by
+    simpa [Finset.card_sdiff (Finset.subset_univ D)] using hSlackForD
+  rcases exists_valid_agreeing_not_yes_under_general_slack
+      p yYes hValidYes D hSlackForD' with ⟨z, hzValid, hzAgree, hzNotYes⟩
+  exact hzNotYes (hAllYes z hzValid hzAgree)
 
 end GeneralIsoStrongNoGoProbe
 end Tests

--- a/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
+++ b/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
@@ -5,17 +5,21 @@ import LowerBounds.MCSPGapLocality
 import Tests.CircuitCountTraceBoundProbe
 
 /-!
-# General iso-strong no-go probe (L1, sessions 1, 2, and 3)
+# General iso-strong no-go probe (L1, sessions 1–4)
 
 L1 staging probe consuming the counting bricks landed in
 `pnp3/Tests/CircuitCountTraceBoundProbe.lean` and lifting the full
-generalised pigeonhole, slack, diagonal-encoding, and not-YES bridge
-chain towards `isoStrong_conclusion_negative_general`.
+generalised pigeonhole, slack, diagonal-encoding, not-YES bridge,
+and route-level assembly chain.  After session 4 the route-level
+conclusion-side refutation of `IsoStrongFamilyEventually` is closed
+for arbitrary `GapSliceFamilyEventually`:
 
-After session 3 all six canonical L1 ingredients have generic
-replacements, kernel-checked here.  The only remaining work is the
-final route-level assembly into `isoStrong_conclusion_negative_general`
-over an arbitrary `GapSliceFamilyEventually`.
+```lean
+theorem isoStrong_conclusion_negative_general
+    (F : GapSliceFamilyEventually)
+    (hInDag : ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β))) :
+    ¬ IsoStrongFamilyEventually F hInDag
+```
 
 This file is intentionally local to `pnp3/Tests/` and does not modify
 endpoints, specs, or trust-root surfaces.  No `axiom` / `opaque` /
@@ -72,20 +76,31 @@ endpoints, specs, or trust-root surfaces.  No `axiom` / `opaque` /
    `diagonal_z_not_yes_of_label_not_trace`.
 
 8. `exists_valid_agreeing_not_yes_under_general_slack` — the
-   final session-3 composition: under the strict trace-cardinality
-   slack `circuitCountBound p.n (p.sNO - 1) < 2 ^ |Finset.univ \ D|`,
+   session-3 composition: under the strict trace-cardinality slack
+   `circuitCountBound p.n (p.sNO - 1) < 2 ^ |Finset.univ \ D|`,
    there exists `z` that is a `ValidEncoding`, agrees with `yYes`
    on `D`, and is not in the YES promise slice.  Generic replacement
    for canonical `exists_valid_agreeing_not_yes_under_slack`.
 
-## What remains for L1 session 4
+## What session 4 lands
 
-- Final route-level assembly
-  `isoStrong_conclusion_negative_general (F : GapSliceFamilyEventually)
-    (hInDag : ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β))) :
-    ¬ IsoStrongFamilyEventually F hInDag`,
-  composing the per-slice bricks above with `slack_for_D_of_isoStrong_slack_general`
-  to thread the eventual κ-slack through `F.hM` / `F.hT`.
+9. `correctOnPromiseSlice_of_InPpolyDAG_family_general` — lifts an
+   `InPpolyDAG` witness at slice `(n, β)` to the corresponding
+   `CorrectOnPromiseSlice` witness for the family circuit at encoded
+   length.  Direct general counterpart of the canonical helper
+   `correctOnPromiseSlice_of_InPpolyDAG_family` in
+   `Tests/IsoStrongConclusionProbe.lean`.
+
+10. `isoStrong_conclusion_negative_general` — the route-level
+    no-go assembly: for any `F : GapSliceFamilyEventually` and any
+    per-slice `InPpolyDAG` family, the iso-strong forcing/slack
+    package is contradictory.  The forcing clause requires all
+    valid encodings agreeing on `D` to be YES; the session-3
+    constructive diagonal produces a valid/agreeing counterexample
+    under the same strict slack.
+
+After session 4 the entire canonical iso-strong L1 chain has a
+parameter-agnostic generic counterpart in this file.
 -/
 
 namespace Pnp3
@@ -393,8 +408,12 @@ theorem exists_valid_agreeing_not_yes_under_general_slack
   · exact general_diagonal_z_not_yes_of_label_not_in_trace_image p yYes D label hLabel
 
 /--
-Slice-correctness witness extracted directly from an `InPpolyDAG` family
-at the encoded slice length.
+Lift an `InPpolyDAG` witness at slice `(n, β)` to the corresponding
+`CorrectOnPromiseSlice` witness for the family circuit at encoded
+length.
+
+Direct general counterpart of `correctOnPromiseSlice_of_InPpolyDAG_family`
+from `pnp3/Tests/IsoStrongConclusionProbe.lean`.
 -/
 lemma correctOnPromiseSlice_of_InPpolyDAG_family_general
     (F : GapSliceFamilyEventually)
@@ -415,8 +434,20 @@ lemma correctOnPromiseSlice_of_InPpolyDAG_family_general
     exact hx ▸ hCorr
 
 /--
-General route-level no-go assembly: under per-slice `InPpolyDAG` witnesses,
-the iso-strong forcing/slack package is contradictory.
+Route-level no-go assembly for the general iso-strong route.
+
+Given an eventual family `F : GapSliceFamilyEventually` and any
+per-slice `InPpolyDAG` witness family `hInDag`,
+`IsoStrongFamilyEventually F hInDag` is inconsistent: the forcing
+clause would require all valid encodings agreeing on `D` to be in
+YES, but the session-3 constructive diagonal
+(`exists_valid_agreeing_not_yes_under_general_slack`) produces a
+valid/agreeing counterexample under the same strict trace-cardinality
+slack derived via `slack_for_D_of_isoStrong_slack_general`.
+
+Generic counterpart of the canonical `isoStrong_conclusion_negative_for_canonical`,
+covering arbitrary eventual families rather than just the canonical
+`sYES = 1, sNO = 2` instantiation.
 -/
 theorem isoStrong_conclusion_negative_general
     (F : GapSliceFamilyEventually)
@@ -448,7 +479,7 @@ theorem isoStrong_conclusion_negative_general
     simpa [C, p] using
       correctOnPromiseSlice_of_InPpolyDAG_family_general F hInDag n β
   rcases hForce n β hβPos hβLt hn C hSize hCorrect with
-    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+    ⟨yYes, _hyYes, hValidYes, D, hDcard, hAllYes⟩
   have hRawSlack := hSlack n β hβPos hβLt hn
   have hSlackForD :
       circuitCountBound p.n (p.sNO - 1) < 2 ^ (Partial.tableLen p.n - D.card) := by

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
@@ -1,36 +1,113 @@
-# L1 general iso-strong no-go — session 4 (codex53)
+# L1 general iso-strong no-go — session 4
+
+Task: general iso-strong no-go L1 session 4
+Handle: codex53 (with opus47 enrichment on merge)
+Branch: main
 
 ## 1. Executive verdict
 
-RED_GENERAL_ISOSTRONG_REFUTED
+**RED_GENERAL_ISOSTRONG_REFUTED**
 
-## 2. What landed
+The final L1 route-level assembly landed.  Two new theorems were added
+to `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`, both kernel-checked
+with clean axiom dependencies (no `axiom` / `opaque` / `sorry` /
+`admit` / `native_decide` / `sorryAx`).
 
-- `correctOnPromiseSlice_of_InPpolyDAG_family_general`
-- `isoStrong_conclusion_negative_general`
+After this session **the entire canonical iso-strong L1 chain has a
+parameter-agnostic generic counterpart**, and the route-level
+conclusion-side refutation of `IsoStrongFamilyEventually` is closed
+for arbitrary `GapSliceFamilyEventually`.
 
-## 3. General route-level assembly status
+## 2. What landed in session 4
 
-The final route-level assembly landed. For arbitrary
-`F : GapSliceFamilyEventually` and per-slice witnesses
-`hInDag : ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β))`, the
-new theorem
+In `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`:
 
-`isoStrong_conclusion_negative_general : ¬ IsoStrongFamilyEventually F hInDag`
+1. `correctOnPromiseSlice_of_InPpolyDAG_family_general` — lifts an
+   `InPpolyDAG` witness at slice `(n, β)` to the corresponding
+   `CorrectOnPromiseSlice` witness for the family circuit at encoded
+   length.  Direct general counterpart of the canonical helper
+   `correctOnPromiseSlice_of_InPpolyDAG_family` in
+   `pnp3/Tests/IsoStrongConclusionProbe.lean`.
+   Axiom deps: `[propext, Classical.choice, Quot.sound]`.
 
-is proved by contradiction via:
-- forcing witness extraction (`hForce`),
-- eventual slack extraction (`hSlack`),
-- conversion to `D.card` slack (`slack_for_D_of_isoStrong_slack_general`), and
-- session-3 diagonal witness (`exists_valid_agreeing_not_yes_under_general_slack`).
+2. `isoStrong_conclusion_negative_general` — the route-level
+   no-go assembly:
+   ```
+   ∀ F : GapSliceFamilyEventually,
+   ∀ hInDag : ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β)),
+     ¬ IsoStrongFamilyEventually F hInDag
+   ```
+   Closed by composing all prior L1 bricks via the canonical
+   assembly template:
+   - Destructure `IsoStrongFamilyEventually` to obtain
+     `(β0, hβ0, κ, nIso, hForce, hSlack)`.
+   - Choose `β := β0 / 2` and `n := max F.N0 (nIso β)`.
+   - Lift the per-slice `InPpolyDAG` witness `C` via
+     `correctOnPromiseSlice_of_InPpolyDAG_family_general`.
+   - Invoke `hForce` at the chosen `(n, β, C)` to obtain a
+     YES witness `yYes`, a coordinate set `D`, and the
+     "all valid agreeing on `D` are YES" clause `hAllYes`.
+   - Invoke `hSlack` and convert raw slack to `D.card` form via
+     `slack_for_D_of_isoStrong_slack_general` and a
+     `Finset.card_sdiff` normalisation.
+   - Apply `exists_valid_agreeing_not_yes_under_general_slack` to
+     produce a `z` that is `ValidEncoding`, agrees with `yYes` on `D`,
+     and is not in the YES promise slice.
+   - Contradict `hAllYes z hzValid hzAgree` against `hzNotYes`.
+   Axiom deps: `[propext, Classical.choice, Quot.sound]`.
 
-Therefore the general L1 iso-strong package is refuted at route level under the
-existing assumptions.
+## 3. Ten-of-ten generic L1 ingredient table
 
-## 4. Remaining blockers
+| # | Canonical L1 ingredient | Generic equivalent | Session |
+|---|---|---|---|
+| 1 | `exists_trace_not_size1_of_card_lt` | `exists_label_not_in_trace_image_of_card_lt` | 1 |
+| 2 | `slack_for_D_of_isoStrong_slack` | `slack_for_D_of_isoStrong_slack_general` | 1 |
+| 3 | `diagonalPartialTable` | `generalDiagonalPartialTable` | 2 |
+| 4 | `diagonal_z_valid` | `general_diagonal_z_valid` | 2 |
+| 5 | `diagonal_z_agrees_on_D` | `general_diagonal_z_agrees_on_D` | 2 |
+| 6 | `is_consistent_diagonal_table_implies_label_trace` | `is_consistent_general_diagonal_table_implies_trace_in_image` | 3 |
+| 7 | `diagonal_z_not_yes_of_label_not_trace` | `general_diagonal_z_not_yes_of_label_not_in_trace_image` | 3 |
+| 8 | `exists_valid_agreeing_not_yes_under_slack` | `exists_valid_agreeing_not_yes_under_general_slack` | 3 |
+| 9 | `correctOnPromiseSlice_of_InPpolyDAG_family` | `correctOnPromiseSlice_of_InPpolyDAG_family_general` | **4** |
+| 10 | `isoStrong_conclusion_negative_for_canonical` | `isoStrong_conclusion_negative_general` | **4** |
 
-None for the stated L1 session-4 target.
+## 4. Build verification (local, lean4 v4.22.0-rc2)
 
-## 5. Next action
+- `lake build Tests.GeneralIsoStrongNoGoProbe` → success.
+- `lake build PnP3 Pnp4` → success.
+- `#print axioms` for both new theorems → standard kernel axioms only.
 
-close_isoStrong_route_pattern_refuted
+## 5. Strategic significance
+
+The canonical iso-strong refutation was previously formalised only at
+the canonical `sYES = 1, sNO = 2` instantiation
+(`isoStrong_conclusion_negative_for_canonical`).  After session 4 the
+**entire iso-strong route class** is provably empty for arbitrary
+`GapSliceFamilyEventually` — not just the canonical point.
+
+This means:
+
+- The iso-strong route class is **mathematically dead** as a route
+  family in this formalisation, not merely at one parametrisation.
+- Future attacks on the canonical lower-bound chain via the
+  iso-strong shape are precluded — the obstruction is generic and
+  structural, not specific to the chosen `(sYES, sNO)` parameters.
+- Future work must pivot to a different route family (promise-YES
+  weak / certificate, pnp4 frontier `SearchMCSPWeakLowerBound`,
+  AC0 milestone, or genuinely new research-level mathematics).
+
+## 6. Scope violations
+
+none.  Markdown report + one Lean test-local file; no endpoint, spec,
+JSONL, NoGoLog, known_guards, or trust-root edits; no
+`ResearchGapWitness`, `SourceTheorem`, `gap_from`, endpoint, or
+`P ≠ NP` claim.
+
+## 7. Next action
+
+**close_isoStrong_route_pattern_refuted**
+
+(Optional follow-ups: update STATUS.md to record the general iso-strong
+route closure; consider lifting the promise-YES routes via the
+existing pointwise contrapositive implications now that all generic
+iso-strong machinery is in place.)

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
@@ -1,0 +1,36 @@
+# L1 general iso-strong no-go — session 4 (codex53)
+
+## 1. Executive verdict
+
+RED_GENERAL_ISOSTRONG_REFUTED
+
+## 2. What landed
+
+- `correctOnPromiseSlice_of_InPpolyDAG_family_general`
+- `isoStrong_conclusion_negative_general`
+
+## 3. General route-level assembly status
+
+The final route-level assembly landed. For arbitrary
+`F : GapSliceFamilyEventually` and per-slice witnesses
+`hInDag : ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β))`, the
+new theorem
+
+`isoStrong_conclusion_negative_general : ¬ IsoStrongFamilyEventually F hInDag`
+
+is proved by contradiction via:
+- forcing witness extraction (`hForce`),
+- eventual slack extraction (`hSlack`),
+- conversion to `D.card` slack (`slack_for_D_of_isoStrong_slack_general`), and
+- session-3 diagonal witness (`exists_valid_agreeing_not_yes_under_general_slack`).
+
+Therefore the general L1 iso-strong package is refuted at route level under the
+existing assumptions.
+
+## 4. Remaining blockers
+
+None for the stated L1 session-4 target.
+
+## 5. Next action
+
+close_isoStrong_route_pattern_refuted


### PR DESCRIPTION
### Motivation
- Complete the L1 route-level assembly by composing the six generic L1 ingredients into the final contradiction for arbitrary `GapSliceFamilyEventually` instances. 
- Provide a direct bridge from per-slice `InPpolyDAG` witnesses to a slice-correctness witness usable by the forcing/slack package. 
- Record the session-4 outcome and next action in the seed-pack report for the general iso-strong no-go route. 

### Description
- Add `correctOnPromiseSlice_of_InPpolyDAG_family_general :` a helper lemma that extracts `CorrectOnPromiseSlice` from a per-slice `InPpolyDAG` witness at the encoded slice length. 
- Add `isoStrong_conclusion_negative_general :` the route-level theorem proving `¬ IsoStrongFamilyEventually F hInDag` by instantiating `hForce` and `hSlack`, converting slack to the `D.card` form, invoking the session-3 diagonal witness, and deriving the contradiction. 
- Reuse existing session-1/2/3 bricks (`slack_for_D_of_isoStrong_slack_general`, `exists_valid_agreeing_not_yes_under_general_slack`, `general_diagonal_*`) without changing endpoints or trust-root surfaces. 
- Add session-4 report at `seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md` with verdict `RED_GENERAL_ISOSTRONG_REFUTED` and next action `close_isoStrong_route_pattern_refuted`. 

### Testing
- Ran `lake build Tests.GeneralIsoStrongNoGoProbe` and it completed successfully. 
- Ran `lake build PnP3 Pnp4` and the multi-package build completed successfully. 
- Ran `./scripts/check.sh` and it succeeded (no new `axiom`/`sorry`/`admit`/`native_decide` introduced in proofs). 
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` which reported matches only inside comments/docstrings (no proof holes), and ran the forbidden-pattern `rg` scan on the modified test file which returned no restricted imports.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dacb77664832ba86cc91575c3c8f3)