### PR TITLE
tests: assemble general iso-strong no-go session 4

### DIFF
--- a/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
+++ b/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
@@ -391,6 +391,82 @@ theorem exists_valid_agreeing_not_yes_under_general_slack
   · exact general_diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact general_diagonal_z_not_yes_of_label_not_in_trace_image p yYes D label hLabel
 
+/--
+Per-slice correctness extraction from an `InPpolyDAG` witness for the
+general eventual family.  This is the direct generalisation of the
+canonical helper from `IsoStrongConclusionProbe`.
+-/
+lemma correctOnPromiseSlice_of_InPpolyDAG_family_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  constructor
+  · intro x hx
+    have hCorr := (hInDag n β).correct
+      (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+  · intro x hx
+    have hCorr := (hInDag n β).correct
+      (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+
+/--
+Route-level assembly (general family): iso-strong forcing plus eventual
+slack contradict the session-3 diagonal no-go witness on a large enough
+slice, so `IsoStrongFamilyEventually F hInDag` is impossible.
+-/
+theorem isoStrong_conclusion_negative_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    ¬ IsoStrongFamilyEventually F hInDag := by
+  intro hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    nlinarith [hβ0]
+  have hβLt : β < β0 := by
+    dsimp [β]
+    nlinarith [hβ0]
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := le_rfl
+  have hn0 : F.N0 ≤ n := le_max_left _ _
+  let p := F.paramsOf n β
+  let C : ComplexityInterfaces.DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize :
+      ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (ComplexityInterfaces.DagCircuit.size C) := by
+    simpa [C, ppolyDAGSizeBoundOnSlicesEventually] using
+      (hInDag n β).family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  have hCorrect : CorrectOnPromiseSlice C (gapSliceOfParams p) := by
+    simpa [C, p] using
+      correctOnPromiseSlice_of_InPpolyDAG_family_general F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hSlackForD :
+      circuitCountBound (F.paramsOf n β).n ((F.paramsOf n β).sNO - 1) <
+        2 ^ (Partial.tableLen (F.paramsOf n β).n - D.card) := by
+    exact slack_for_D_of_isoStrong_slack_general
+      F n β hn0 D (κ n β) hDcard hRawSlack
+  have hSlackForD' :
+      circuitCountBound p.n (p.sNO - 1) <
+        2 ^ ((Finset.univ \ D).card) := by
+    simpa [p, Finset.card_sdiff (Finset.subset_univ D)] using hSlackForD
+  rcases exists_valid_agreeing_not_yes_under_general_slack
+      p yYes hValidYes D hSlackForD' with
+    ⟨z, hzValid, hzAgree, hzNotYes⟩
+  exact hzNotYes (hAllYes z hzValid hzAgree)
+
 end GeneralIsoStrongNoGoProbe
 end Tests
 end Pnp3

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
@@ -1,0 +1,20 @@
+# L1 general iso-strong no-go (session 4) — codex53
+
+## 1. Executive verdict
+RED_GENERAL_ISOSTRONG_REFUTED
+
+## 2. What landed
+- `correctOnPromiseSlice_of_InPpolyDAG_family_general`
+- `isoStrong_conclusion_negative_general`
+
+## 3. General route-level assembly status
+The final route-level assembly is complete in `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`.
+For arbitrary `F : GapSliceFamilyEventually` and arbitrary per-slice DAG witness
+`hInDag : ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β))`, the theorem
+`isoStrong_conclusion_negative_general` now proves `¬ IsoStrongFamilyEventually F hInDag`.
+
+## 4. Remaining blockers
+None at L1 session-4 scope. The route-level contradiction assembly landed.
+
+## 5. Next action
+close_isoStrong_route_pattern_refuted


### PR DESCRIPTION
### Motivation
- Finish the L1 route-level assembly by proving the general iso-strong contradiction for arbitrary eventual gap-slice families, reusing the six session-1/2/3 bricks already landed. 
- Provide a small helper to extract per-slice correctness from `InPpolyDAG` witnesses at the encoded length used by the forcing clause. 

### Description
- Add `correctOnPromiseSlice_of_InPpolyDAG_family_general` which extracts `CorrectOnPromiseSlice` from a per-slice `InPpolyDAG` witness at `GapSliceFamilyEventually.encodedLen`. 
- Add `isoStrong_conclusion_negative_general` which assembles forcing, the `slack_for_D_of_isoStrong_slack_general` conversion, and the session-3 diagonal no-go lemma to prove `¬ IsoStrongFamilyEventually F hInDag`. 
- Use `ComplexityInterfaces.DagCircuit.size` and `nlinarith`/`dsimp` for the rational-inequality steps to avoid proof failures on the general family template. 
- Add the session report `seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md` summarising the landing and next action. 

### Testing
- `lake build Tests.GeneralIsoStrongNoGoProbe` completed successfully and the modified file type-checks. 
- `lake build PnP3 Pnp4` completed successfully (full repo Lean build passed). 
- `./scripts/check.sh` ran but failed the repository hygiene scan due to `rg` matching the strings `sorry`/`admit` inside documentation/comment text (no new proof placeholders were introduced by these changes). 
- `rg -n "\bsorry\b|\badmit\b"` and the targeted forbidden-pattern scan were executed and reported only comment/doc-string matches and no forbidden imports in the modified test file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dacb77664832ba86cc91575c3c8f3)