### PR TITLE
General iso-strong no-go L1 session 4 — final route-level assembly

### DIFF
--- a/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
+++ b/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
@@ -391,6 +391,77 @@ theorem exists_valid_agreeing_not_yes_under_general_slack
   · exact general_diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact general_diagonal_z_not_yes_of_label_not_in_trace_image p yYes D label hLabel
 
+/-- Extract correctness on the encoded slice from an `InPpolyDAG` witness family. -/
+lemma correctOnPromiseSlice_of_InPpolyDAG_family_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  constructor
+  · intro x hx
+    have hCorr := (hInDag n β).correct
+      (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+  · intro x hx
+    have hCorr := (hInDag n β).correct
+      (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+
+/--
+Final route-level assembly: the generic L1 diagonal chain refutes
+`IsoStrongFamilyEventually` under a per-slice `InPpolyDAG` family.
+-/
+theorem isoStrong_conclusion_negative_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    ¬ IsoStrongFamilyEventually F hInDag := by
+  intro hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    nlinarith [hβ0]
+  have hβLt : β < β0 := by
+    dsimp [β]
+    nlinarith [hβ0]
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := le_rfl
+  have hn0 : F.N0 ≤ n := le_max_left _ _
+  let p := F.paramsOf n β
+  let C : ComplexityInterfaces.DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize :
+      ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (ComplexityInterfaces.DagCircuit.size C) := by
+    simpa [C, ppolyDAGSizeBoundOnSlicesEventually] using
+      (hInDag n β).family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  have hCorrect : CorrectOnPromiseSlice C (gapSliceOfParams p) := by
+    simpa [C, p] using
+      correctOnPromiseSlice_of_InPpolyDAG_family_general F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, _hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hSlackForD :
+      circuitCountBound (F.paramsOf n β).n ((F.paramsOf n β).sNO - 1) <
+        2 ^ (Partial.tableLen (F.paramsOf n β).n - D.card) := by
+    exact slack_for_D_of_isoStrong_slack_general
+      F n β hn0 D (κ n β) hDcard hRawSlack
+  have hSlackForD' :
+      circuitCountBound p.n (p.sNO - 1) <
+        2 ^ ((Finset.univ \ D).card) := by
+    simpa [p, Finset.card_sdiff (Finset.subset_univ D)] using hSlackForD
+  rcases exists_valid_agreeing_not_yes_under_general_slack
+      p yYes hValidYes D hSlackForD' with
+    ⟨z, hzValid, hzAgree, hzNotYes⟩
+  exact hzNotYes (hAllYes z hzValid hzAgree)
+
 end GeneralIsoStrongNoGoProbe
 end Tests
 end Pnp3

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
@@ -1,0 +1,24 @@
+# L1 general iso-strong no-go — session 4 (codex53)
+
+## 1. Executive verdict
+RED_GENERAL_ISOSTRONG_REFUTED
+
+## 2. What landed
+- `correctOnPromiseSlice_of_InPpolyDAG_family_general`
+- `isoStrong_conclusion_negative_general`
+
+## 3. General route-level assembly status
+The final route-level assembly landed. The theorem
+`isoStrong_conclusion_negative_general` now proves that for any
+`F : GapSliceFamilyEventually` and any witness family
+`hInDag : ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β))`,
+we have `¬ IsoStrongFamilyEventually F hInDag`.
+
+So the general L1 iso-strong conclusion route is refuted at the level
+requested in this session.
+
+## 4. Remaining blockers
+None at L1 session-4 scope for this route-level theorem.
+
+## 5. Next action
+close_isoStrong_route_pattern_refuted


### PR DESCRIPTION
### Motivation
- Assemble the final route-level theorem that composes the six L1 ingredients into a general refutation of `IsoStrongFamilyEventually` for arbitrary `GapSliceFamilyEventually` families. 
- Close the L1 chain by converting the per-slice `InPpolyDAG` witnesses, threading the iso-strong slack through `F.hIndex`/`F.hM`/`F.hT`, and applying the session-3 diagonal/pigeonhole composition to obtain a contradiction.

### Description
- Added `correctOnPromiseSlice_of_InPpolyDAG_family_general` which lifts per-length correctness from an `InPpolyDAG` family into `CorrectOnPromiseSlice` for the encoded slice (`GapSliceFamilyEventually.encodedLen`).
- Implemented `isoStrong_conclusion_negative_general : ¬ IsoStrongFamilyEventually F hInDag` which follows the canonical assembly template: destructures the iso-strong witness, sets `β := β0/2` and `n := max F.N0 (nIso β)`, instantiates the DAG family witness, proves the size and correctness obligations, converts slack via `slack_for_D_of_isoStrong_slack_general`, invokes `exists_valid_agreeing_not_yes_under_general_slack`, and contradicts the forcing clause.
- Added the session-4 report `seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md` documenting the landing and verdict `RED_GENERAL_ISOSTRONG_REFUTED`.
- No files outside the allowed scope were modified and no `axiom`/`sorry`/`admit`/`native_decide` were introduced in the new proofs.

### Testing
- Ran `lake build Tests.GeneralIsoStrongNoGoProbe` and it completed successfully.
- Ran `lake build PnP3 Pnp4` and the full project build completed successfully.
- Ran `./scripts/check.sh` which reported a hygiene finding (matches of `sorry`/`admit` in comments/docstrings in existing probe files) causing a non-zero check step, but the new code introduces no `sorry`/`admit` placeholders.
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` and confirmed there are no forbidden API imports or genuine proof placeholders introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dacb58ed0832b84cbd5919a1a91fb)