### PR TITLE
general iso-strong no-go L1 session 4: finalize route-level assembly

### DIFF
--- a/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
+++ b/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
@@ -391,6 +391,88 @@ theorem exists_valid_agreeing_not_yes_under_general_slack
   · exact general_diagonal_z_agrees_on_D p yYes hValidYes D label
   · exact general_diagonal_z_not_yes_of_label_not_in_trace_image p yYes D label hLabel
 
+lemma correctOnPromiseSlice_of_InPpolyDAG_family_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β)))
+    (n : Nat) (β : Rat) :
+    CorrectOnPromiseSlice
+      ((hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β))
+      (gapSliceOfParams (F.paramsOf n β)) := by
+  constructor
+  · intro x hx
+    have hCorr := (hInDag n β).correct
+      (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+  · intro x hx
+    have hCorr := (hInDag n β).correct
+      (GapSliceFamilyEventually.encodedLen F n β) x
+    exact hx ▸ hCorr
+
+/--
+General route-level assembly (L1 session 4): `IsoStrongFamilyEventually` is
+inconsistent with the always-available per-slice `InPpolyDAG` witness for the
+same family.
+
+This is the generic analogue of
+`IsoStrongConclusionProbe.isoStrong_conclusion_negative_for_canonical`,
+obtained by instantiating the iso-strong forcing/slack package at
+`β = β0 / 2` and `n = max F.N0 (nIso β)`, then composing:
+
+1. size/correctness witnesses from `hInDag`;
+2. forced YES-pivot and agreement set `D` from `hForce`;
+3. slack conversion `slack_for_D_of_isoStrong_slack_general`;
+4. session-3 diagonal witness
+   `exists_valid_agreeing_not_yes_under_general_slack`;
+5. contradiction with the universal YES-forcing clause `hAllYes`.
+-/
+theorem isoStrong_conclusion_negative_general
+    (F : GapSliceFamilyEventually)
+    (hInDag :
+      ∀ n β,
+        ComplexityInterfaces.InPpolyDAG
+          (gapPartialMCSP_Language (F.paramsOf n β))) :
+    ¬ IsoStrongFamilyEventually F hInDag := by
+  intro hIso
+  rcases hIso with ⟨β0, hβ0, κ, nIso, hForce, hSlack⟩
+  let β : Rat := β0 / 2
+  have hβPos : 0 < β := by
+    dsimp [β]
+    linarith
+  have hβLt : β < β0 := by
+    dsimp [β]
+    linarith
+  let n : Nat := max F.N0 (nIso β)
+  have hn : n ≥ max F.N0 (nIso β) := le_rfl
+  have hn0 : F.N0 ≤ n := le_max_left _ _
+  let p := F.paramsOf n β
+  let C : ComplexityInterfaces.DagCircuit (GapSliceFamilyEventually.encodedLen F n β) :=
+    (hInDag n β).family (GapSliceFamilyEventually.encodedLen F n β)
+  have hSize :
+      ppolyDAGSizeBoundOnSlicesEventually F hInDag n β 1 (ComplexityInterfaces.DagCircuit.size C) := by
+    simpa [C, ppolyDAGSizeBoundOnSlicesEventually] using
+      (hInDag n β).family_size_le (GapSliceFamilyEventually.encodedLen F n β)
+  have hCorrect : CorrectOnPromiseSlice C (gapSliceOfParams p) := by
+    simpa [C, p] using
+      correctOnPromiseSlice_of_InPpolyDAG_family_general F hInDag n β
+  rcases hForce n β hβPos hβLt hn C hSize hCorrect with
+    ⟨yYes, hyYes, hValidYes, D, hDcard, hAllYes⟩
+  have hRawSlack := hSlack n β hβPos hβLt hn
+  have hSlackForD :
+      circuitCountBound (F.paramsOf n β).n ((F.paramsOf n β).sNO - 1) <
+        2 ^ (Partial.tableLen (F.paramsOf n β).n - D.card) := by
+    exact slack_for_D_of_isoStrong_slack_general
+      F n β hn0 D (κ n β) hDcard hRawSlack
+  have hSlackForD' :
+      circuitCountBound p.n (p.sNO - 1) < 2 ^ ((Finset.univ \ D).card) := by
+    simpa [p, Finset.card_sdiff (Finset.subset_univ D)] using hSlackForD
+  rcases exists_valid_agreeing_not_yes_under_general_slack
+      p yYes hValidYes D hSlackForD' with
+    ⟨z, hzValid, hzAgree, hzNotYes⟩
+  exact hzNotYes (hAllYes z hzValid hzAgree)
+
 end GeneralIsoStrongNoGoProbe
 end Tests
 end Pnp3

--- a/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
+++ b/seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md
@@ -1,0 +1,35 @@
+# L1 general iso-strong no-go — session 4 (codex53)
+
+## 1. Executive verdict
+
+RED_GENERAL_ISOSTRONG_REFUTED
+
+## 2. What landed
+
+- `Pnp3.Tests.GeneralIsoStrongNoGoProbe.isoStrong_conclusion_negative_general`
+
+## 3. General route-level assembly status
+
+The final general L1 route-level assembly is now landed: for any
+`F : GapSliceFamilyEventually` and any per-slice DAG witness family
+`hInDag : ∀ n β, InPpolyDAG (gapPartialMCSP_Language (F.paramsOf n β))`,
+we have a formal contradiction with `IsoStrongFamilyEventually F hInDag`.
+
+Concretely, the theorem
+
+- `isoStrong_conclusion_negative_general`
+
+proves
+
+- `¬ IsoStrongFamilyEventually F hInDag`.
+
+So the general iso-strong route pattern is refuted at this probe layer.
+
+## 4. Remaining blockers
+
+None at L1 for this route-level theorem. The requested final assembly theorem
+is present and kernel-checked.
+
+## 5. Next action
+
+close_isoStrong_route_pattern_refuted


### PR DESCRIPTION
### Motivation

- Complete the L1 route-level assembly for the general iso-strong no-go chain by composing the six generic L1 ingredients (counting pigeonhole, diagonal encoding, not-YES bridge, slack conversion, and the forcing package) into the final contradiction theorem for arbitrary `GapSliceFamilyEventually` and per-slice `InPpolyDAG` witnesses.

### Description

- Added `correctOnPromiseSlice_of_InPpolyDAG_family_general` to lift a per-slice `InPpolyDAG` witness into a `CorrectOnPromiseSlice` instance for the corresponding gap slice.  (Edited `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`.)
- Implemented `isoStrong_conclusion_negative_general` which instantiates the iso-strong forcing/slack package at `β = β0 / 2` and `n = max F.N0 (nIso β)` then composes `hInDag`, `hForce`, `slack_for_D_of_isoStrong_slack_general`, and `exists_valid_agreeing_not_yes_under_general_slack` to derive a contradiction with `hAllYes`.  (Edited `pnp3/Tests/GeneralIsoStrongNoGoProbe.lean`.)
- Kept all work local to the test probe and reused the L0–L3 bricks already present in the repository without adding `axiom`/`sorry`/`admit`/`native_decide` proof holes.
- Added the session report `seed_packs/general_isoStrong_no_go_L1/reports/L1_general_isoStrong_no_go_codex53_session4.md` documenting the verdict `RED_GENERAL_ISOSTRONG_REFUTED` and next action `close_isoStrong_route_pattern_refuted`.

### Testing

- Ran `lake build Tests.GeneralIsoStrongNoGoProbe` which completed successfully and produced a kernel-checked `Tests.GeneralIsoStrongNoGoProbe` build. 
- Ran `lake build PnP3 Pnp4` (full repo build) which completed in-stream with only linter warnings and no theorem-local failures observable in the build output. 
- Ran `./scripts/check.sh` over the tree; the script-driven build completed its run with repository warnings only and no new proof holes introduced. 
- Ran `rg -n "\bsorry\b|\badmit\b" -g"*.lean" pnp3 pnp4` and `rg "FormulaCertificateProviderPartial|FormulaSupportRestrictionBoundsPartial|MagnificationAssumptions|FormulaCertificateProviderPartial_fromPipeline" pnp3/Tests/GeneralIsoStrongNoGoProbe.lean` which reported only comment/docstring occurrences for `sorry`/`admit` and no forbidden-pattern matches in the probe file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dacb2bea8832bb88f30dd531c254c)