### PR TITLE
Hotfix: paraphrase L0/L1 docstrings to avoid literal sorry/admit words tripping check.sh Step 3/17

### DIFF
--- a/pnp3/Tests/CircuitCountTraceBoundProbe.lean
+++ b/pnp3/Tests/CircuitCountTraceBoundProbe.lean
@@ -26,8 +26,9 @@ An optional strict-slack packaging lemma
 consumption in the future generalised diagonal step.
 
 The file is intentionally local to `pnp3/Tests/` and does not modify
-endpoints or trust-root surfaces.  No `axiom` / `opaque` / `sorry` /
-`admit` / `native_decide` are introduced.
+endpoints or trust-root surfaces.  No kernel-incomplete proof
+placeholders or escape hatches are introduced (the file is checked
+by `./scripts/check.sh` Step 3/17 source-hygiene scan).
 -/
 
 namespace Pnp3

--- a/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
+++ b/pnp3/Tests/GeneralIsoStrongNoGoProbe.lean
@@ -22,8 +22,9 @@ theorem isoStrong_conclusion_negative_general
 ```
 
 This file is intentionally local to `pnp3/Tests/` and does not modify
-endpoints, specs, or trust-root surfaces.  No `axiom` / `opaque` /
-`sorry` / `admit` / `native_decide` are introduced.
+endpoints, specs, or trust-root surfaces.  No kernel-incomplete proof
+placeholders or escape hatches are introduced (the file is checked
+by `./scripts/check.sh` Step 3/17 source-hygiene scan).
 
 ## What session 1 lands
 


### PR DESCRIPTION
## Motivation

`./scripts/check.sh` Step 3/17 (source-hygiene scan) was returning a false-positive non-zero exit, blocking CI on `main`.  The scan uses `rg -n '\bsorry\b|\badmit\b' pnp3 -g'*.lean'` which matches the **literal words** `sorry` / `admit` even inside docstrings / comments.

Three matches were present, all introduced by my own earlier enrichment commits to L0 / L1 probe files (`c436392`, `75c5ae0`, `4002514`, `35fc6f5`, `24d51510`):

```
pnp3/Tests/CircuitCountTraceBoundProbe.lean:29: ...No `axiom` / `opaque` / `sorry` /
pnp3/Tests/CircuitCountTraceBoundProbe.lean:30: `admit` / `native_decide` are introduced.
pnp3/Tests/GeneralIsoStrongNoGoProbe.lean:26:    `sorry` / `admit` / `native_decide` are introduced.
```

The docstrings were saying that the file does **not** introduce `sorry` / `admit` — but the literal words tripped the regex check.

## Fix

Paraphrase the docstrings to convey the same intent without the literal trigger words.  Replace

```
No `axiom` / `opaque` / `sorry` / `admit` / `native_decide` are introduced.
```

with

```
No kernel-incomplete proof placeholders or escape hatches are
introduced (the file is checked by `./scripts/check.sh` Step 3/17
source-hygiene scan).
```

The new wording preserves the original guarantee and additionally points the reader at the precise CI gate that enforces it.

## Scope

- Markdown-comment-only changes in two test-local files.
- No proof code modifications.
- No endpoint, spec, JSONL, NoGoLog, known_guards, or trust-root edits.
- No `ResearchGapWitness`, `SourceTheorem`, `gap_from`, endpoint, or `P ≠ NP` claim.

## Verification (local, lean4 v4.22.0-rc2)

- `rg -n '\bsorry\b|\badmit\b' pnp3 -g'*.lean'` → no matches.
- `lake build PnP3 Pnp4` → success.
- `./scripts/check.sh` → exit 0, **"All checks passed"**, all 17 steps green.

All ten landed theorems across L0 + L1 sessions 1–4 remain kernel-checked with the same axiom footprint (`propext`, `Classical.choice`, `Quot.sound`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiyDeSzJN6LnUfkLynhsV9)_