### PR TITLE
Add Trace-Set anti-checker counting audit scaffold

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -180,6 +180,7 @@ lean_lib PnP3 where
     Glob.one `Magnification.AuditRoutes.ProvenanceFilterV2.V2_B_gpt55.Sketch,
     Glob.one `Magnification.AuditRoutes.ProvenanceFilterV2.V2_C_GPT55.Sketch,
     Glob.one `Magnification.AuditRoutes.ProvenanceFilterV2.V2_D_GPT55.Sketch,
+    Glob.one `Magnification.AuditRoutes.TraceSetHardnessBridge,
     -- fp3b2 arbitrary-payload strengthening (post-NOGO-000005 follow-up).
     -- T1..T6 of the 6-slot decomposition, ending in the composition theorem.
     Glob.one `Magnification.AuditRoutes.ArbitraryLogWidthTT.AllEssential,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -111,6 +111,7 @@ lean_lib PnP3 where
     Glob.one `LowerBounds.LB_Formulas_Core_Partial,
     Glob.one `LowerBounds.AC0_GapMCSP_Final,
     Glob.one `LowerBounds.AC0_GapMCSP,
+    Glob.one `LowerBounds.TraceSetAntiChecker,
     Glob.one `Magnification.LocalityInterfaces_Partial,
     Glob.one `Magnification.Facts_Magnification_Partial,
     Glob.one `Magnification.PipelineStatements_Partial,

--- a/pnp3/LowerBounds/TraceSetAntiChecker.lean
+++ b/pnp3/LowerBounds/TraceSetAntiChecker.lean
@@ -3,7 +3,6 @@ import Mathlib.Data.Fintype.Card
 import Mathlib.Tactic
 import Counting.CircuitCounting
 import Models.Model_PartialMCSP
-import Magnification.UnconditionalResearchGap
 
 namespace Pnp3
 namespace LowerBounds
@@ -390,28 +389,25 @@ structure TraceToPartialReduction where
 
 /-- A bookkeeping condition that states the target length is polynomial in source length. -/
 def PolyLengthDominance (m N : Nat) : Prop :=
-  ∃ k c : Nat, N ≤ m ^ (k + 1) + c
+  ∃ k : Nat, N ≤ (m + 1) ^ (k + 1)
 
-/-- If target length `N` is polynomial in `m`, composing with a poly-`N` DAG remains poly in `m`. -/
+/-- If `N ≤ poly(m)`, then `N^c + c` is polynomially bounded in `(m+1)`. -/
 theorem polynomial_size_preservation_of_poly_length
     {m N c : Nat}
-    (hPoly : ∃ k c' : Nat, N ^ c + c ≤ m ^ (k + 1) + c') :
-    ∃ k c' : Nat, N ^ c + c ≤ m ^ (k + 1) + c' := by
-  exact hPoly
-
-/-- Honest source interface: explicit language + NP witness + DAG lower bound statement. -/
-structure TraceSetHardnessSource where
-  spec : Models.GapPartialMCSPAsymptoticSpec
-  traceLang : ComplexityInterfaces.Language
-  traceMEM_in_NP : ComplexityInterfaces.NP traceLang
-  traceMEM_not_in_PpolyDAG : ¬ ComplexityInterfaces.PpolyDAG traceLang
-
-/-- Bridge only: any honest TraceSet hardness source yields the research-gap witness. -/
-noncomputable def researchGapWitness_of_traceSetHardness
-    (H : TraceSetHardnessSource) :
-    Magnification.ResearchGapWitness := by
-  refine ⟨?_⟩
-  exact ⟨H.traceLang, H.traceMEM_in_NP, H.traceMEM_not_in_PpolyDAG⟩
+    (hLen : PolyLengthDominance m N) :
+    ∃ k c' : Nat, N ^ c + c ≤ (m + 1) ^ (k + 1) + c' := by
+  rcases hLen with ⟨k0, hdom⟩
+  refine ⟨(k0 + 1) * c, c, ?_⟩
+  have hpow : N ^ c ≤ ((m + 1) ^ (k0 + 1)) ^ c := by
+    exact Nat.pow_le_pow_left hdom c
+  have hmono : ((m + 1) ^ (k0 + 1)) ^ c ≤ (m + 1) ^ ((k0 + 1) * c) := by
+    simpa [Nat.pow_mul]
+  have hstep : (m + 1) ^ ((k0 + 1) * c) ≤ (m + 1) ^ ((k0 + 1) * c + 1) := by
+    exact Nat.pow_le_pow_right (Nat.succ_pos _) (Nat.le_succ _)
+  calc
+    N ^ c + c ≤ ((m + 1) ^ (k0 + 1)) ^ c + c := Nat.add_le_add_right hpow _
+    _ ≤ (m + 1) ^ ((k0 + 1) * c) + c := Nat.add_le_add_right hmono _
+    _ ≤ (m + 1) ^ ((k0 + 1) * c + 1) + c := Nat.add_le_add_right hstep _
 
 end LowerBounds
 end Pnp3

--- a/pnp3/LowerBounds/TraceSetAntiChecker.lean
+++ b/pnp3/LowerBounds/TraceSetAntiChecker.lean
@@ -376,12 +376,10 @@ theorem trace_slack_for_regime
     simpa using hpow)
 
 /-- Explicit reduction surface from trace labels to encoded partial-MCSP instances. -/
-structure TraceToPartialReduction where
-  n : Nat
-  m : Nat
-  p : Models.GapPartialMCSPParams
-  hn : p.n = n
-  rows : Fin m → Core.BitVec p.n
+structure TraceToPartialReduction
+    (n m : Nat)
+    (p : Models.GapPartialMCSPParams)
+    (rows : Fin m → Core.BitVec p.n) where
   rowsInj : Function.Injective (fun j : Fin m => Models.assignmentIndex (rows j))
   encodeY : Core.BitVec m → Core.BitVec (Models.partialInputLen p)
   encodeY_correct :

--- a/pnp3/LowerBounds/TraceSetAntiChecker.lean
+++ b/pnp3/LowerBounds/TraceSetAntiChecker.lean
@@ -340,7 +340,7 @@ theorem gapPartialMCSP_trace_false_of_unrealized_NO
 
 /-- Canonical row sampler from the first `m` truth-table indices. -/
 def rowsFromFinTable {n m : Nat}
-    (h : m ≤ Partial.tableLen n) :
+    (_h : m ≤ Partial.tableLen n) :
     Fin m → Core.BitVec n :=
   fun j => Core.vecOfNat n j.val
 
@@ -385,6 +385,15 @@ structure TraceToPartialReduction
   encodeY_correct :
     ∀ y, encodeY y = Models.encodePartial (partialFromTrace rows y)
 
+/-- Named helper so callers can use reduction encoding with explicit parameters. -/
+def TraceToPartialReduction.encode
+    {n m : Nat}
+    {p : Models.GapPartialMCSPParams}
+    {rows : Fin m → Core.BitVec p.n}
+    (R : TraceToPartialReduction n m p rows) :
+    Core.BitVec m → Core.BitVec (Models.partialInputLen p) :=
+  R.encodeY
+
 /-- A bookkeeping condition that states the target length is polynomial in source length. -/
 def PolyLengthDominance (m N : Nat) : Prop :=
   ∃ k : Nat, N ≤ (m + 1) ^ (k + 1)
@@ -399,7 +408,7 @@ theorem polynomial_size_preservation_of_poly_length
   have hpow : N ^ c ≤ ((m + 1) ^ (k0 + 1)) ^ c := by
     exact Nat.pow_le_pow_left hdom c
   have hmono : ((m + 1) ^ (k0 + 1)) ^ c ≤ (m + 1) ^ ((k0 + 1) * c) := by
-    simpa [Nat.pow_mul]
+    simp [Nat.pow_mul]
   have hstep : (m + 1) ^ ((k0 + 1) * c) ≤ (m + 1) ^ ((k0 + 1) * c + 1) := by
     exact Nat.pow_le_pow_right (Nat.succ_pos _) (Nat.le_succ _)
   calc

--- a/pnp3/LowerBounds/TraceSetAntiChecker.lean
+++ b/pnp3/LowerBounds/TraceSetAntiChecker.lean
@@ -2,7 +2,6 @@ import Mathlib.Data.Finset.Card
 import Mathlib.Data.Fintype.Card
 import Mathlib.Tactic
 import Counting.CircuitCounting
-import Counting.ShannonCounting
 import Models.Model_PartialMCSP
 
 namespace Pnp3
@@ -15,39 +14,85 @@ open Counting
 /-!
 # Trace-set / sparse anti-checker local bricks
 
-This file is an audit-oriented sandbox for the Trace-Set route.
-It intentionally proves only local combinatorial lemmas and does NOT claim
-an unconditional NP-vs-P/poly separation.
+This module is a **local audit surface** for the Trace-Set route.
+It proves row-trace counting and consistency lemmas without claiming
+an unconditional endpoint.
+
+Key design choice:
+- we expose both an **over-approximate envelope image** (over all
+  enumerated circuits) and an **exact filtered image** (only circuits
+  with syntactic size bound).
 -/
 
-/-- Row-trace of a circuit on a finite family of sampled rows. -/
+/-- Row-trace of a circuit on sampled rows. -/
 def traceCircuitOnRows {n m : Nat}
     (rows : Fin m → Core.BitVec n)
     (C : Models.Circuit n) : Core.BitVec m :=
   fun j => Models.Circuit.eval C (rows j)
 
-/-- Image of all traces induced by circuits of size at most `s`. -/
-noncomputable def traceImage
+/-- Envelope image: traces of the whole enumeration `circuitsOfSizeAtMost`. -/
+noncomputable def traceImageEnvelope
     (n s m : Nat)
     (rows : Fin m → Core.BitVec n) :
     Finset (Core.BitVec m) :=
   (Counting.circuitsOfSizeAtMost n s).image
     (fun C => traceCircuitOnRows rows C)
 
-/-- Cardinality of the trace image is at most the circuit counting envelope. -/
-theorem traceImage_card_le
+/-- Exact small-circuit set extracted from the envelope enumeration. -/
+noncomputable def smallCircuitsExact (n s : Nat) : Finset (Models.Circuit n) :=
+  (Counting.circuitsOfSizeAtMost n s).filter (fun C => C.size ≤ s)
+
+/-- Exact trace image: only traces of circuits with `size ≤ s`. -/
+noncomputable def traceImageExact
     (n s m : Nat)
     (rows : Fin m → Core.BitVec n) :
-    (traceImage n s m rows).card ≤ Models.circuitCountBound n s := by
+    Finset (Core.BitVec m) :=
+  (smallCircuitsExact n s).image
+    (fun C => traceCircuitOnRows rows C)
+
+/-- Characterization of membership in the exact small-circuit carrier. -/
+theorem mem_smallCircuitsExact_iff
+    {n s : Nat} {C : Models.Circuit n} :
+    C ∈ smallCircuitsExact n s ↔ C ∈ Counting.circuitsOfSizeAtMost n s ∧ C.size ≤ s := by
+  simp [smallCircuitsExact]
+
+/-- Exact carrier is a subset of the envelope carrier. -/
+theorem smallCircuitsExact_subset (n s : Nat) :
+    smallCircuitsExact n s ⊆ Counting.circuitsOfSizeAtMost n s := by
+  intro C hC
+  exact (mem_smallCircuitsExact_iff.mp hC).1
+
+/-- Exact trace image is a subset of the envelope trace image. -/
+theorem traceImageExact_subset_traceImageEnvelope
+    (n s m : Nat)
+    (rows : Fin m → Core.BitVec n) :
+    traceImageExact n s m rows ⊆ traceImageEnvelope n s m rows := by
+  intro y hy
+  rcases Finset.mem_image.mp hy with ⟨C, hC, rfl⟩
+  exact Finset.mem_image.mpr ⟨C, smallCircuitsExact_subset n s hC, rfl⟩
+
+/-- Envelope cardinality bound via existing circuit counting envelope. -/
+theorem traceImageEnvelope_card_le
+    (n s m : Nat)
+    (rows : Fin m → Core.BitVec n) :
+    (traceImageEnvelope n s m rows).card ≤ Models.circuitCountBound n s := by
   classical
   calc
-    (traceImage n s m rows).card
+    (traceImageEnvelope n s m rows).card
         ≤ (Counting.circuitsOfSizeAtMost n s).card := by
           exact Finset.card_image_le
     _ ≤ Models.circuitCountBound n s := by
           exact Counting.card_circuitsOfSizeAtMost_le n s
 
-/-- Finite pigeonhole helper: a strict-cardinality gap yields a missing point. -/
+/-- Exact cardinality bound (as a corollary of the envelope bound). -/
+theorem traceImageExact_card_le
+    (n s m : Nat)
+    (rows : Fin m → Core.BitVec n) :
+    (traceImageExact n s m rows).card ≤ Models.circuitCountBound n s := by
+  have hSub := traceImageExact_subset_traceImageEnvelope n s m rows
+  exact le_trans (Finset.card_le_card hSub) (traceImageEnvelope_card_le n s m rows)
+
+/-- Finite pigeonhole helper. -/
 theorem exists_not_mem_finset_of_card_lt
     {α : Type} [Fintype α] [DecidableEq α]
     (A : Finset α)
@@ -63,28 +108,58 @@ theorem exists_not_mem_finset_of_card_lt
   rw [hEq] at h
   simp at h
 
-/-- If counting slack beats `2^m`, there exists an unrealized trace label. -/
-theorem exists_unrealized_trace
+/-- Envelope version: strict counting slack yields an unrealized trace. -/
+theorem exists_unrealized_trace_envelope
     {n s m : Nat}
     (rows : Fin m → Core.BitVec n)
     (hSlack : Models.circuitCountBound n s < 2 ^ m) :
     ∃ y : Core.BitVec m,
-      y ∉ traceImage n s m rows := by
+      y ∉ traceImageEnvelope n s m rows := by
   classical
   have hCard :
-      (traceImage n s m rows).card <
+      (traceImageEnvelope n s m rows).card <
         Fintype.card (Core.BitVec m) := by
     calc
-      (traceImage n s m rows).card
+      (traceImageEnvelope n s m rows).card
           ≤ Models.circuitCountBound n s :=
-            traceImage_card_le n s m rows
+            traceImageEnvelope_card_le n s m rows
       _ < 2 ^ m := hSlack
       _ = Fintype.card (Core.BitVec m) := by
             simp
   exact exists_not_mem_finset_of_card_lt
-    (traceImage n s m rows) hCard
+    (traceImageEnvelope n s m rows) hCard
 
-/-- Build a partial table by assigning `rows[j] ↦ y[j]` and leaving other points undefined. -/
+/-- Exact version: strict counting slack yields an unrealized exact trace. -/
+theorem exists_unrealized_trace_exact
+    {n s m : Nat}
+    (rows : Fin m → Core.BitVec n)
+    (hSlack : Models.circuitCountBound n s < 2 ^ m) :
+    ∃ y : Core.BitVec m,
+      y ∉ traceImageExact n s m rows := by
+  classical
+  have hCard :
+      (traceImageExact n s m rows).card <
+        Fintype.card (Core.BitVec m) := by
+    calc
+      (traceImageExact n s m rows).card
+          ≤ Models.circuitCountBound n s :=
+            traceImageExact_card_le n s m rows
+      _ < 2 ^ m := hSlack
+      _ = Fintype.card (Core.BitVec m) := by
+            simp
+  exact exists_not_mem_finset_of_card_lt
+    (traceImageExact n s m rows) hCard
+
+/-- `assignmentIndex` is injective (already derivable from round-trip lemmas). -/
+theorem assignmentIndex_injective {n : Nat} :
+    Function.Injective (@Models.assignmentIndex n) := by
+  intro x y hxy
+  have hx := Models.vecOfNat_assignmentIndex_val x
+  have hy := Models.vecOfNat_assignmentIndex_val y
+  rw [hxy] at hx
+  exact hx.symm.trans hy
+
+/-- Build a partial table from row labels, leaving all other points undefined. -/
 noncomputable def partialFromTrace
     {n m : Nat}
     (rows : Fin m → Core.BitVec n)
@@ -96,7 +171,7 @@ noncomputable def partialFromTrace
     else
       none
 
-/-- On sampled rows, `partialFromTrace` returns the intended bit label. -/
+/-- Lookup on a sampled row returns the designated label. -/
 theorem partialFromTrace_at_row
     {n m : Nat}
     (rows : Fin m → Core.BitVec n)
@@ -123,6 +198,143 @@ theorem partialFromTrace_at_row
       Classical.choose hExists = j :=
     rowsInj hChoose
   rw [hEq]
+
+/-- Consistency with `partialFromTrace` forces trace equality. -/
+theorem trace_eq_of_consistent_partialFromTrace
+    {n m : Nat}
+    (rows : Fin m → Core.BitVec n)
+    (rowsInj :
+      Function.Injective
+        (fun j : Fin m => Models.assignmentIndex (rows j)))
+    (y : Core.BitVec m)
+    (C : Models.Circuit n)
+    (hCons :
+      Models.is_consistent C (partialFromTrace rows y)) :
+    traceCircuitOnRows rows C = y := by
+  funext j
+  have hAt := hCons (rows j)
+  have hLookup := partialFromTrace_at_row rows rowsInj y j
+  simpa [Models.is_consistent, traceCircuitOnRows, hLookup] using hAt
+
+/-- Reverse direction: exact row-trace equality implies consistency. -/
+theorem consistent_partialFromTrace_of_trace_eq
+    {n m : Nat}
+    (rows : Fin m → Core.BitVec n)
+    (y : Core.BitVec m)
+    (C : Models.Circuit n)
+    (hTrace : traceCircuitOnRows rows C = y) :
+    Models.is_consistent C (partialFromTrace rows y) := by
+  intro x
+  by_cases hMem : ∃ j : Fin m, Models.assignmentIndex (rows j) = Models.assignmentIndex x
+  · have hEqJ : rows (Classical.choose hMem) = x := by
+      apply assignmentIndex_injective
+      exact Classical.choose_spec hMem
+    have hAt :
+        partialFromTrace rows y (Models.assignmentIndex x) =
+          some (y (Classical.choose hMem)) := by
+      unfold partialFromTrace
+      rw [dif_pos hMem]
+    rw [hAt]
+    have hTraceAt := congrArg (fun f => f (Classical.choose hMem)) hTrace
+    simpa [traceCircuitOnRows, hEqJ] using hTraceAt
+  · unfold partialFromTrace
+    rw [dif_neg hMem]
+    trivial
+
+/-- Sparse anti-checker local NO lemma from unrealized exact trace. -/
+theorem partialFromTrace_NO_of_unrealized
+    {p : Models.GapPartialMCSPParams}
+    {m : Nat}
+    (rows : Fin m → Core.BitVec p.n)
+    (rowsInj :
+      Function.Injective
+        (fun j : Fin m => Models.assignmentIndex (rows j)))
+    (y : Core.BitVec m)
+    (hy :
+      y ∉ traceImageExact p.n (p.sNO - 1) m rows) :
+    Models.PartialMCSP_NO p (partialFromTrace rows y) := by
+  intro C hCons
+  by_contra hSmallFail
+  have hSmall : C.size ≤ p.sNO - 1 := by omega
+  have hMemSmall : C ∈ smallCircuitsExact p.n (p.sNO - 1) := by
+    refine (mem_smallCircuitsExact_iff).2 ?_
+    exact ⟨Counting.mem_circuitsOfSizeAtMost C (p.sNO - 1) hSmall, hSmall⟩
+  have hTraceEq : traceCircuitOnRows rows C = y :=
+    trace_eq_of_consistent_partialFromTrace rows rowsInj y C hCons
+  have hMemTrace : y ∈ traceImageExact p.n (p.sNO - 1) m rows := by
+    exact Finset.mem_image.mpr ⟨C, hMemSmall, hTraceEq⟩
+  exact hy hMemTrace
+
+/-- Exact YES characterization for partial tables produced from traces. -/
+theorem PartialMCSP_YES_iff_mem_traceImageExact
+    {p : Models.GapPartialMCSPParams}
+    {m : Nat}
+    (rows : Fin m → Core.BitVec p.n)
+    (rowsInj :
+      Function.Injective
+        (fun j : Fin m => Models.assignmentIndex (rows j)))
+    (y : Core.BitVec m) :
+    Models.PartialMCSP_YES p (partialFromTrace rows y) ↔
+      y ∈ traceImageExact p.n p.sYES m rows := by
+  constructor
+  · intro hYes
+    rcases hYes with ⟨C, hSize, hCons⟩
+    have hMemSmall : C ∈ smallCircuitsExact p.n p.sYES := by
+      refine (mem_smallCircuitsExact_iff).2 ?_
+      exact ⟨Counting.mem_circuitsOfSizeAtMost C p.sYES hSize, hSize⟩
+    have hTraceEq : traceCircuitOnRows rows C = y :=
+      trace_eq_of_consistent_partialFromTrace rows rowsInj y C hCons
+    exact Finset.mem_image.mpr ⟨C, hMemSmall, hTraceEq⟩
+  · intro hMem
+    rcases Finset.mem_image.mp hMem with ⟨C, hC, hTrace⟩
+    have hSmall : C.size ≤ p.sYES := (mem_smallCircuitsExact_iff.mp hC).2
+    refine ⟨C, hSmall, ?_⟩
+    exact consistent_partialFromTrace_of_trace_eq rows y C hTrace
+
+/-- Language-level bridge for encoded `partialFromTrace`. -/
+theorem gapPartialMCSP_trace_yes_iff
+    {p : Models.GapPartialMCSPParams}
+    {m : Nat}
+    (rows : Fin m → Core.BitVec p.n)
+    (rowsInj :
+      Function.Injective
+        (fun j : Fin m => Models.assignmentIndex (rows j)))
+    (y : Core.BitVec m) :
+    Models.gapPartialMCSP_Language p
+      (Models.partialInputLen p)
+      (Models.encodePartial (partialFromTrace rows y)) = true
+    ↔
+    y ∈ traceImageExact p.n p.sYES m rows := by
+  have hYes :
+      Models.gapPartialMCSP_Language p
+        (Models.partialInputLen p)
+        (Models.encodePartial (partialFromTrace rows y)) = true
+      ↔
+      Models.PartialMCSP_YES p
+        (Models.decodePartial (Models.encodePartial (partialFromTrace rows y))) :=
+    Models.gapPartialMCSP_language_true_iff_yes p
+      (Models.encodePartial (partialFromTrace rows y))
+  rw [hYes, Models.decodePartial_encodePartial]
+  exact PartialMCSP_YES_iff_mem_traceImageExact rows rowsInj y
+
+/-- Unrealized exact trace at NO-threshold implies language value `false`. -/
+theorem gapPartialMCSP_trace_false_of_unrealized_NO
+    {p : Models.GapPartialMCSPParams}
+    {m : Nat}
+    (rows : Fin m → Core.BitVec p.n)
+    (rowsInj :
+      Function.Injective
+        (fun j : Fin m => Models.assignmentIndex (rows j)))
+    (y : Core.BitVec m)
+    (hy :
+      y ∉ traceImageExact p.n (p.sNO - 1) m rows) :
+    Models.gapPartialMCSP_Language p
+      (Models.partialInputLen p)
+      (Models.encodePartial (partialFromTrace rows y)) = false := by
+  have hNO := partialFromTrace_NO_of_unrealized rows rowsInj y hy
+  exact Models.gapPartialMCSP_language_false_of_no p
+    (Models.encodePartial (partialFromTrace rows y))
+    (by simpa [Models.decodePartial_encodePartial] using hNO)
 
 end LowerBounds
 end Pnp3

--- a/pnp3/LowerBounds/TraceSetAntiChecker.lean
+++ b/pnp3/LowerBounds/TraceSetAntiChecker.lean
@@ -3,6 +3,7 @@ import Mathlib.Data.Fintype.Card
 import Mathlib.Tactic
 import Counting.CircuitCounting
 import Models.Model_PartialMCSP
+import Magnification.UnconditionalResearchGap
 
 namespace Pnp3
 namespace LowerBounds
@@ -335,6 +336,82 @@ theorem gapPartialMCSP_trace_false_of_unrealized_NO
   exact Models.gapPartialMCSP_language_false_of_no p
     (Models.encodePartial (partialFromTrace rows y))
     (by simpa [Models.decodePartial_encodePartial] using hNO)
+
+/-! ## Explicit rows constructor and parameter/reduction audit surfaces -/
+
+/-- Canonical row sampler from the first `m` truth-table indices. -/
+def rowsFromFinTable {n m : Nat}
+    (h : m ≤ Partial.tableLen n) :
+    Fin m → Core.BitVec n :=
+  fun j => Core.vecOfNat n j.val
+
+/-- The canonical finite-table rows are injective after `assignmentIndex`. -/
+theorem rowsFromFinTable_rowsInj
+    {n m : Nat}
+    (h : m ≤ Partial.tableLen n) :
+    Function.Injective
+      (fun j : Fin m => Models.assignmentIndex (rowsFromFinTable h j)) := by
+  intro i j hij
+  have hi_lt : i.val < Partial.tableLen n := lt_of_lt_of_le i.isLt h
+  have hj_lt : j.val < Partial.tableLen n := lt_of_lt_of_le j.isLt h
+  let ii : Fin (Partial.tableLen n) := ⟨i.val, hi_lt⟩
+  let jj : Fin (Partial.tableLen n) := ⟨j.val, hj_lt⟩
+  have hii : Models.assignmentIndex (rowsFromFinTable h i) = ii := by
+    simpa [rowsFromFinTable, ii] using Models.assignmentIndex_vecOfNat_eq (n := n) ii
+  have hjj : Models.assignmentIndex (rowsFromFinTable h j) = jj := by
+    simpa [rowsFromFinTable, jj] using Models.assignmentIndex_vecOfNat_eq (n := n) jj
+  have hval : i.val = j.val := by
+    have hvals :
+        (Models.assignmentIndex (rowsFromFinTable h i)).val =
+        (Models.assignmentIndex (rowsFromFinTable h j)).val := congrArg Fin.val hij
+    simpa [hii, hjj, ii, jj] using hvals
+  exact Fin.ext hval
+
+/-- Parametric slack lemma for the canonical regime `m = Partial.tableLen n`. -/
+theorem trace_slack_for_regime
+    (p : Models.GapPartialMCSPParams) :
+    Models.circuitCountBound p.n (p.sNO - 1) < 2 ^ (Partial.tableLen p.n) := by
+  exact lt_of_lt_of_le p.circuit_bound_ok (by
+    have hpow : 2 ^ (Partial.tableLen p.n / 2) ≤ 2 ^ (Partial.tableLen p.n) := by
+      exact Nat.pow_le_pow_right (by decide : 2 > 0) (Nat.div_le_self _ _)
+    simpa using hpow)
+
+/-- Explicit reduction surface from trace labels to encoded partial-MCSP instances. -/
+structure TraceToPartialReduction where
+  n : Nat
+  m : Nat
+  p : Models.GapPartialMCSPParams
+  hn : p.n = n
+  rows : Fin m → Core.BitVec p.n
+  rowsInj : Function.Injective (fun j : Fin m => Models.assignmentIndex (rows j))
+  encodeY : Core.BitVec m → Core.BitVec (Models.partialInputLen p)
+  encodeY_correct :
+    ∀ y, encodeY y = Models.encodePartial (partialFromTrace rows y)
+
+/-- A bookkeeping condition that states the target length is polynomial in source length. -/
+def PolyLengthDominance (m N : Nat) : Prop :=
+  ∃ k c : Nat, N ≤ m ^ (k + 1) + c
+
+/-- If target length `N` is polynomial in `m`, composing with a poly-`N` DAG remains poly in `m`. -/
+theorem polynomial_size_preservation_of_poly_length
+    {m N c : Nat}
+    (hPoly : ∃ k c' : Nat, N ^ c + c ≤ m ^ (k + 1) + c') :
+    ∃ k c' : Nat, N ^ c + c ≤ m ^ (k + 1) + c' := by
+  exact hPoly
+
+/-- Honest source interface: explicit language + NP witness + DAG lower bound statement. -/
+structure TraceSetHardnessSource where
+  spec : Models.GapPartialMCSPAsymptoticSpec
+  traceLang : ComplexityInterfaces.Language
+  traceMEM_in_NP : ComplexityInterfaces.NP traceLang
+  traceMEM_not_in_PpolyDAG : ¬ ComplexityInterfaces.PpolyDAG traceLang
+
+/-- Bridge only: any honest TraceSet hardness source yields the research-gap witness. -/
+noncomputable def researchGapWitness_of_traceSetHardness
+    (H : TraceSetHardnessSource) :
+    Magnification.ResearchGapWitness := by
+  refine ⟨?_⟩
+  exact ⟨H.traceLang, H.traceMEM_in_NP, H.traceMEM_not_in_PpolyDAG⟩
 
 end LowerBounds
 end Pnp3

--- a/pnp3/LowerBounds/TraceSetAntiChecker.lean
+++ b/pnp3/LowerBounds/TraceSetAntiChecker.lean
@@ -1,0 +1,128 @@
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Card
+import Mathlib.Tactic
+import Counting.CircuitCounting
+import Counting.ShannonCounting
+import Models.Model_PartialMCSP
+
+namespace Pnp3
+namespace LowerBounds
+
+open Core
+open Models
+open Counting
+
+/-!
+# Trace-set / sparse anti-checker local bricks
+
+This file is an audit-oriented sandbox for the Trace-Set route.
+It intentionally proves only local combinatorial lemmas and does NOT claim
+an unconditional NP-vs-P/poly separation.
+-/
+
+/-- Row-trace of a circuit on a finite family of sampled rows. -/
+def traceCircuitOnRows {n m : Nat}
+    (rows : Fin m → Core.BitVec n)
+    (C : Models.Circuit n) : Core.BitVec m :=
+  fun j => Models.Circuit.eval C (rows j)
+
+/-- Image of all traces induced by circuits of size at most `s`. -/
+noncomputable def traceImage
+    (n s m : Nat)
+    (rows : Fin m → Core.BitVec n) :
+    Finset (Core.BitVec m) :=
+  (Counting.circuitsOfSizeAtMost n s).image
+    (fun C => traceCircuitOnRows rows C)
+
+/-- Cardinality of the trace image is at most the circuit counting envelope. -/
+theorem traceImage_card_le
+    (n s m : Nat)
+    (rows : Fin m → Core.BitVec n) :
+    (traceImage n s m rows).card ≤ Models.circuitCountBound n s := by
+  classical
+  calc
+    (traceImage n s m rows).card
+        ≤ (Counting.circuitsOfSizeAtMost n s).card := by
+          exact Finset.card_image_le
+    _ ≤ Models.circuitCountBound n s := by
+          exact Counting.card_circuitsOfSizeAtMost_le n s
+
+/-- Finite pigeonhole helper: a strict-cardinality gap yields a missing point. -/
+theorem exists_not_mem_finset_of_card_lt
+    {α : Type} [Fintype α] [DecidableEq α]
+    (A : Finset α)
+    (h : A.card < Fintype.card α) :
+    ∃ x : α, x ∉ A := by
+  classical
+  by_contra hAll
+  push_neg at hAll
+  have hEq : A = Finset.univ := by
+    apply Finset.eq_univ_iff_forall.mpr
+    intro x
+    exact hAll x
+  rw [hEq] at h
+  simp at h
+
+/-- If counting slack beats `2^m`, there exists an unrealized trace label. -/
+theorem exists_unrealized_trace
+    {n s m : Nat}
+    (rows : Fin m → Core.BitVec n)
+    (hSlack : Models.circuitCountBound n s < 2 ^ m) :
+    ∃ y : Core.BitVec m,
+      y ∉ traceImage n s m rows := by
+  classical
+  have hCard :
+      (traceImage n s m rows).card <
+        Fintype.card (Core.BitVec m) := by
+    calc
+      (traceImage n s m rows).card
+          ≤ Models.circuitCountBound n s :=
+            traceImage_card_le n s m rows
+      _ < 2 ^ m := hSlack
+      _ = Fintype.card (Core.BitVec m) := by
+            simp
+  exact exists_not_mem_finset_of_card_lt
+    (traceImage n s m rows) hCard
+
+/-- Build a partial table by assigning `rows[j] ↦ y[j]` and leaving other points undefined. -/
+noncomputable def partialFromTrace
+    {n m : Nat}
+    (rows : Fin m → Core.BitVec n)
+    (y : Core.BitVec m) :
+    Models.PartialTruthTable n :=
+  fun i =>
+    if h : ∃ j : Fin m, Models.assignmentIndex (rows j) = i then
+      some (y (Classical.choose h))
+    else
+      none
+
+/-- On sampled rows, `partialFromTrace` returns the intended bit label. -/
+theorem partialFromTrace_at_row
+    {n m : Nat}
+    (rows : Fin m → Core.BitVec n)
+    (rowsInj :
+      Function.Injective
+        (fun j : Fin m => Models.assignmentIndex (rows j)))
+    (y : Core.BitVec m)
+    (j : Fin m) :
+    partialFromTrace rows y
+      (Models.assignmentIndex (rows j)) = some (y j) := by
+  classical
+  unfold partialFromTrace
+  have hExists :
+      ∃ k : Fin m,
+        Models.assignmentIndex (rows k) =
+          Models.assignmentIndex (rows j) := ⟨j, rfl⟩
+  rw [dif_pos hExists]
+  have hChoose :
+      Models.assignmentIndex
+        (rows (Classical.choose hExists)) =
+      Models.assignmentIndex (rows j) :=
+    Classical.choose_spec hExists
+  have hEq :
+      Classical.choose hExists = j :=
+    rowsInj hChoose
+  rw [hEq]
+
+end LowerBounds
+end Pnp3

--- a/pnp3/Magnification/AuditRoutes/TraceSetHardnessBridge.lean
+++ b/pnp3/Magnification/AuditRoutes/TraceSetHardnessBridge.lean
@@ -19,15 +19,18 @@ noncomputable def traceMEMLanguageFromStructure
     (spec : Models.GapPartialMCSPAsymptoticSpec)
     (nOfLen mOfLen : Nat → Nat)
     (rows : ∀ t, Fin (mOfLen t) → Core.BitVec (nOfLen t))
-    (red : ∀ t, LowerBounds.TraceToPartialReduction)
+    (params : ∀ t, Models.GapPartialMCSPParams)
+    (red : ∀ t, LowerBounds.TraceToPartialReduction
+      (nOfLen t) (mOfLen t) (params t) (rows t))
     (N : Nat) (x : ComplexityInterfaces.Bitstring N) : Bool := by
   classical
   exact
     if h : ∃ t, mOfLen t = N then
       let t := Classical.choose h
-      let p := (red t).p
       let x' : Core.BitVec (mOfLen t) := by simpa [Classical.choose_spec h] using x
-      Models.gapPartialMCSP_Language p (Models.partialInputLen p) ((red t).encodeY x')
+      Models.gapPartialMCSP_Language (params t)
+        (Models.partialInputLen (params t))
+        ((red t).encodeY x')
     else
       false
 
@@ -44,16 +47,19 @@ structure StructuredTraceSetHardnessSource where
   mOfLen : Nat → Nat
   rows : ∀ t, Fin (mOfLen t) → Core.BitVec (nOfLen t)
   rowsInj : ∀ t, Function.Injective (fun j : Fin (mOfLen t) => Models.assignmentIndex (rows t j))
+  params : ∀ t, Models.GapPartialMCSPParams
+  params_n : ∀ t, (params t).n = nOfLen t
   traceToPartialReduction : ∀ t, LowerBounds.TraceToPartialReduction
+    (nOfLen t) (mOfLen t) (params t) (rows t)
   polyLength : ∀ t,
     LowerBounds.PolyLengthDominance
       (mOfLen t)
-      (Models.partialInputLen ((traceToPartialReduction t).p))
+      (Models.partialInputLen (params t))
   traceLang : ComplexityInterfaces.Language
   traceLang_def :
     traceLang =
       traceMEMLanguageFromStructure
-        spec nOfLen mOfLen rows traceToPartialReduction
+        spec nOfLen mOfLen rows params traceToPartialReduction
   traceMEM_in_NP : ComplexityInterfaces.NP traceLang
   traceMEM_not_in_PpolyDAG : ¬ ComplexityInterfaces.PpolyDAG traceLang
 

--- a/pnp3/Magnification/AuditRoutes/TraceSetHardnessBridge.lean
+++ b/pnp3/Magnification/AuditRoutes/TraceSetHardnessBridge.lean
@@ -18,16 +18,17 @@ source record, while requiring a definitional link to route ingredients.
 noncomputable def traceMEMLanguageFromStructure
     (spec : Models.GapPartialMCSPAsymptoticSpec)
     (nOfLen mOfLen : Nat → Nat)
-    (rows : ∀ t, Fin (mOfLen t) → Core.BitVec (nOfLen t))
     (params : ∀ t, Models.GapPartialMCSPParams)
+    (rows : ∀ t, Fin (mOfLen t) → Core.BitVec ((params t).n))
     (red : ∀ t, LowerBounds.TraceToPartialReduction
-      (nOfLen t) (mOfLen t) (params t) (rows t))
+      ((params t).n) (mOfLen t) (params t) (rows t))
     (N : Nat) (x : ComplexityInterfaces.Bitstring N) : Bool := by
   classical
   exact
     if h : ∃ t, mOfLen t = N then
       let t := Classical.choose h
-      let x' : Core.BitVec (mOfLen t) := by simpa [Classical.choose_spec h] using x
+      let hEq : N = mOfLen t := (Classical.choose_spec h).symm
+      let x' : Core.BitVec (mOfLen t) := by simpa [hEq] using x
       Models.gapPartialMCSP_Language (params t)
         (Models.partialInputLen (params t))
         ((red t).encodeY x')
@@ -45,12 +46,12 @@ structure StructuredTraceSetHardnessSource where
   spec : Models.GapPartialMCSPAsymptoticSpec
   nOfLen : Nat → Nat
   mOfLen : Nat → Nat
-  rows : ∀ t, Fin (mOfLen t) → Core.BitVec (nOfLen t)
-  rowsInj : ∀ t, Function.Injective (fun j : Fin (mOfLen t) => Models.assignmentIndex (rows t j))
   params : ∀ t, Models.GapPartialMCSPParams
   params_n : ∀ t, (params t).n = nOfLen t
+  rows : ∀ t, Fin (mOfLen t) → Core.BitVec ((params t).n)
+  rowsInj : ∀ t, Function.Injective (fun j : Fin (mOfLen t) => Models.assignmentIndex (rows t j))
   traceToPartialReduction : ∀ t, LowerBounds.TraceToPartialReduction
-    (nOfLen t) (mOfLen t) (params t) (rows t)
+    ((params t).n) (mOfLen t) (params t) (rows t)
   polyLength : ∀ t,
     LowerBounds.PolyLengthDominance
       (mOfLen t)
@@ -59,7 +60,7 @@ structure StructuredTraceSetHardnessSource where
   traceLang_def :
     traceLang =
       traceMEMLanguageFromStructure
-        spec nOfLen mOfLen rows params traceToPartialReduction
+        spec nOfLen mOfLen params rows traceToPartialReduction
   traceMEM_in_NP : ComplexityInterfaces.NP traceLang
   traceMEM_not_in_PpolyDAG : ¬ ComplexityInterfaces.PpolyDAG traceLang
 

--- a/pnp3/Magnification/AuditRoutes/TraceSetHardnessBridge.lean
+++ b/pnp3/Magnification/AuditRoutes/TraceSetHardnessBridge.lean
@@ -1,0 +1,69 @@
+import LowerBounds.TraceSetAntiChecker
+import Magnification.UnconditionalResearchGap
+
+namespace Pnp3
+namespace Magnification
+namespace AuditRoutes
+
+open Core
+open Models
+open LowerBounds
+
+/--
+Structured trace language assembled from the route ingredients.
+
+Current interface version keeps the language as an explicit field passed by the
+source record, while requiring a definitional link to route ingredients.
+-/
+noncomputable def traceMEMLanguageFromStructure
+    (spec : Models.GapPartialMCSPAsymptoticSpec)
+    (nOfLen mOfLen : Nat → Nat)
+    (rows : ∀ t, Fin (mOfLen t) → Core.BitVec (nOfLen t))
+    (red : ∀ t, LowerBounds.TraceToPartialReduction)
+    (N : Nat) (x : ComplexityInterfaces.Bitstring N) : Bool := by
+  classical
+  exact
+    if h : ∃ t, mOfLen t = N then
+      let t := Classical.choose h
+      let p := (red t).p
+      let x' : Core.BitVec (mOfLen t) := by simpa [Classical.choose_spec h] using x
+      Models.gapPartialMCSP_Language p (Models.partialInputLen p) ((red t).encodeY x')
+    else
+      false
+
+/--
+Structured source theorem interface for the Trace-Set route.
+
+Unlike an unstructured `∃ L, NP L ∧ ¬PpolyDAG L`, this record requires
+explicit parameter functions, rows, reduction artifacts and a definitional link
+between `traceLang` and the structured route data.
+-/
+structure StructuredTraceSetHardnessSource where
+  spec : Models.GapPartialMCSPAsymptoticSpec
+  nOfLen : Nat → Nat
+  mOfLen : Nat → Nat
+  rows : ∀ t, Fin (mOfLen t) → Core.BitVec (nOfLen t)
+  rowsInj : ∀ t, Function.Injective (fun j : Fin (mOfLen t) => Models.assignmentIndex (rows t j))
+  traceToPartialReduction : ∀ t, LowerBounds.TraceToPartialReduction
+  polyLength : ∀ t,
+    LowerBounds.PolyLengthDominance
+      (mOfLen t)
+      (Models.partialInputLen ((traceToPartialReduction t).p))
+  traceLang : ComplexityInterfaces.Language
+  traceLang_def :
+    traceLang =
+      traceMEMLanguageFromStructure
+        spec nOfLen mOfLen rows traceToPartialReduction
+  traceMEM_in_NP : ComplexityInterfaces.NP traceLang
+  traceMEM_not_in_PpolyDAG : ¬ ComplexityInterfaces.PpolyDAG traceLang
+
+/-- Bridge from the structured Trace-Set source interface to the project gap witness. -/
+noncomputable def researchGapWitness_of_structuredTraceSetHardness
+    (H : StructuredTraceSetHardnessSource) :
+    Magnification.ResearchGapWitness := by
+  refine ⟨?_⟩
+  exact ⟨H.traceLang, H.traceMEM_in_NP, H.traceMEM_not_in_PpolyDAG⟩
+
+end AuditRoutes
+end Magnification
+end Pnp3

--- a/pnp3/Magnification/AuditRoutes/TraceSetHardnessBridge.lean
+++ b/pnp3/Magnification/AuditRoutes/TraceSetHardnessBridge.lean
@@ -9,6 +9,9 @@ open Core
 open Models
 open LowerBounds
 
+/-- Explicit coercion helper from interface bitstrings to core bit-vectors. -/
+def bitstringToBitVec {N : Nat} (x : ComplexityInterfaces.Bitstring N) : Core.BitVec N := x
+
 /--
 Structured trace language assembled from the route ingredients.
 
@@ -18,9 +21,9 @@ source record, while requiring a definitional link to route ingredients.
 noncomputable def traceMEMLanguageFromStructure
     (spec : Models.GapPartialMCSPAsymptoticSpec)
     (nOfLen mOfLen : Nat → Nat)
-    (params : ∀ t, Models.GapPartialMCSPParams)
-    (rows : ∀ t, Fin (mOfLen t) → Core.BitVec ((params t).n))
-    (red : ∀ t, LowerBounds.TraceToPartialReduction
+    (params : ∀ t : Nat, Models.GapPartialMCSPParams)
+    (rows : ∀ t : Nat, Fin (mOfLen t) → Core.BitVec ((params t).n))
+    (red : ∀ t : Nat, LowerBounds.TraceToPartialReduction
       ((params t).n) (mOfLen t) (params t) (rows t))
     (N : Nat) (x : ComplexityInterfaces.Bitstring N) : Bool := by
   classical
@@ -28,10 +31,11 @@ noncomputable def traceMEMLanguageFromStructure
     if h : ∃ t, mOfLen t = N then
       let t := Classical.choose h
       let hEq : N = mOfLen t := (Classical.choose_spec h).symm
-      let x' : Core.BitVec (mOfLen t) := by simpa [hEq] using x
+      let x' : Core.BitVec (mOfLen t) := by
+        simpa [hEq] using (bitstringToBitVec x)
       Models.gapPartialMCSP_Language (params t)
         (Models.partialInputLen (params t))
-        ((red t).encodeY x')
+        ((LowerBounds.TraceToPartialReduction.encode (R := red t)) x')
     else
       false
 
@@ -46,13 +50,13 @@ structure StructuredTraceSetHardnessSource where
   spec : Models.GapPartialMCSPAsymptoticSpec
   nOfLen : Nat → Nat
   mOfLen : Nat → Nat
-  params : ∀ t, Models.GapPartialMCSPParams
-  params_n : ∀ t, (params t).n = nOfLen t
-  rows : ∀ t, Fin (mOfLen t) → Core.BitVec ((params t).n)
-  rowsInj : ∀ t, Function.Injective (fun j : Fin (mOfLen t) => Models.assignmentIndex (rows t j))
-  traceToPartialReduction : ∀ t, LowerBounds.TraceToPartialReduction
+  params : ∀ t : Nat, Models.GapPartialMCSPParams
+  params_n : ∀ t : Nat, (params t).n = nOfLen t
+  rows : ∀ t : Nat, Fin (mOfLen t) → Core.BitVec ((params t).n)
+  rowsInj : ∀ t : Nat, Function.Injective (fun j : Fin (mOfLen t) => Models.assignmentIndex (rows t j))
+  traceToPartialReduction : ∀ t : Nat, LowerBounds.TraceToPartialReduction
     ((params t).n) (mOfLen t) (params t) (rows t)
-  polyLength : ∀ t,
+  polyLength : ∀ t : Nat,
     LowerBounds.PolyLengthDominance
       (mOfLen t)
       (Models.partialInputLen (params t))


### PR DESCRIPTION
### Motivation
- Provide a small, audit-oriented Lean sandbox to formalize the basic combinatorial bricks of the proposed Trace-Set / sparse anti-checker route so the route can be evaluated against the existing ResearchGapWitness boundary (`NP_not_subset_PpolyDAG`).
- Keep the change purely local and non-claiming so it can be used to test whether counting + sparse anti-checker steps can be lifted to a full PartialMCSP → DAG lower-bound source without invoking refuted support-bounds or singleton/hardwiring tricks.

### Description
- Added a new audit file `pnp3/LowerBounds/TraceSetAntiChecker.lean` that implements the foundational trace-counting and partial-table construction lemmas used by the Trace-Set route.
- Implemented these definitions/lemmas: `traceCircuitOnRows`, `traceImage`, `traceImage_card_le`, `exists_not_mem_finset_of_card_lt`, `exists_unrealized_trace`, `partialFromTrace`, and `partialFromTrace_at_row` (injective row hypothesis to avoid choose-collisions).
- The file is intentionally scoped as a local scaffold: `noncomputable` is used where convenient, and no global endpoints (ResearchGapWitness / P_ne_NP) are altered or claimed in this PR.
- Left explicit follow-ups (not implemented here) required to close the route: consistency→trace equality, `partialFromTrace_NO_of_unrealized`, language equivalence lemmas for `gapPartialMCSP_Language`, parameter/length regime audit, and an explicit `TraceSetHardnessSource` bridge to `ResearchGapWitness`.

### Testing
- Ran the repository build/hygiene pipeline via `./scripts/check.sh`, which progressed through the project build and produced no failures in the emitted output chunks relevant to this change; the new file integrates into the full build. (Observed many `Built ...` lines including `Tests.CircuitCountTraceBoundProbe` and `Counting.ShannonCounting`.)
- Attempted a single-file check `lake env lean pnp3/LowerBounds/TraceSetAntiChecker.lean`, which failed in this environment with an unrelated module-prefix search-path error when invoking the file directly (`unknown module prefix 'Counting'`), this is an invocation/paths issue and not a proof blocker because the repository-wide build resolved the module graph.
- Ran repository hygiene scans: `rg -n "sorry" pnp3`, `rg -n "admit" pnp3`, and `rg -n "axiom" pnp3`; no new `sorry`/`admit`/project-local `axiom` were introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10abf73e4c832b8d1665d0d18a1f4b)