### PR TITLE
Add anti-evaluation diagonal search probe tests and route report

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -267,6 +267,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixParserConvention,
     Glob.one `Pnp4.Frontier.Tests.AntiEvalSearchProbe,
+    Glob.one `Pnp4.Frontier.Tests.TreeCircuitWitnessCodecProbe,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -266,6 +266,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageNP,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixParserConvention,
+    Glob.one `Pnp4.Frontier.Tests.AntiEvalSearchProbe,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -268,6 +268,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixParserConvention,
     Glob.one `Pnp4.Frontier.Tests.AntiEvalSearchProbe,
     Glob.one `Pnp4.Frontier.Tests.TreeCircuitWitnessCodecProbe,
+    Glob.one `Pnp4.Frontier.Tests.TreeMCSPSearchTargetProbe,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/Tests/AntiEvalSearchProbe.lean
+++ b/pnp4/Pnp4/Frontier/Tests/AntiEvalSearchProbe.lean
@@ -1,0 +1,116 @@
+import Pnp4.Frontier.SearchMCSPMagnification
+
+namespace Pnp4
+namespace Frontier
+namespace Tests
+
+/--
+Toy interface for encoding/decode/eval in the anti-evaluation diagonal search probe.
+The evaluator remains abstract; this file only needs the algebraic contract.
+-/
+structure AntiEvalEncodingInterface where
+  instanceBits : Nat → Nat
+  witnessBits : Nat → Nat
+  DecodedTuple : Nat → Type
+  decodeTuple : ∀ n, AlgorithmsToLowerBounds.BitVec (instanceBits n) → Option (DecodedTuple n)
+  evalTuple : ∀ n, DecodedTuple n → AlgorithmsToLowerBounds.BitVec (instanceBits n) → AlgorithmsToLowerBounds.BitVec (witnessBits n)
+
+/-- Pointwise Boolean negation on witness vectors. -/
+def bitwiseNot {k : Nat} (w : AlgorithmsToLowerBounds.BitVec k) : AlgorithmsToLowerBounds.BitVec k :=
+  fun i => !(w i)
+
+/--
+Anti-eval relation at length `n`:
+`w` must be exactly the bitwise negation of the decoded tuple's output on `x`.
+-/
+def antiEvalRelation
+    (enc : AntiEvalEncodingInterface)
+    (n : Nat)
+    (x : AlgorithmsToLowerBounds.BitVec (enc.instanceBits n))
+    (w : AlgorithmsToLowerBounds.BitVec (enc.witnessBits n)) : Prop :=
+  ∃ G, enc.decodeTuple n x = some G ∧ w = bitwiseNot (enc.evalTuple n G x)
+
+/--
+Concrete search target used in this L0 sanity probe.
+We keep witnesses one-bit wide so the final contradiction is a direct Bool case.
+-/
+def antiEvalTarget
+    (enc : AntiEvalEncodingInterface)
+    (C : AlgorithmsToLowerBounds.CircuitFamilyClass)
+    (sizeBound : Nat → Nat)
+    (hOneBit : ∀ n, enc.witnessBits n = 1) :
+    SearchMCSPWeakCircuitLowerBoundTarget where
+  problem :=
+    { instanceBits := enc.instanceBits
+      witnessBits := enc.witnessBits
+      promise := fun n x => ∃ G, enc.decodeTuple n x = some G
+      relation := antiEvalRelation enc
+      totalOnPromise := by
+        intro n x hx
+        rcases hx with ⟨G, hDec⟩
+        refine ⟨bitwiseNot (enc.evalTuple n G x), ?_⟩
+        exact ⟨G, hDec, rfl⟩ }
+  circuitClass := C
+  sizeBound := sizeBound
+
+/--
+Self-encoding capacity hypothesis for anti-eval:
+for every bounded solver, there is a promised input that decodes to some `G`
+and where `evalTuple` matches the solver output on that same input.
+-/
+def SelfEncodingCapacity
+    (enc : AntiEvalEncodingInterface)
+    (C : AlgorithmsToLowerBounds.CircuitFamilyClass)
+    (sizeBound : Nat → Nat)
+    (hOneBit : ∀ n, enc.witnessBits n = 1) : Prop :=
+  ∀ solver : BoundedSearchSolver (antiEvalTarget enc C sizeBound hOneBit).problem C sizeBound,
+    ∃ n x G,
+      enc.decodeTuple n x = some G ∧
+      enc.evalTuple n G x = searchSolverOutput (solver.outputCircuit n) x
+
+/--
+Diagonal contradiction at one-bit width:
+if `b = !b`, then contradiction.
+-/
+private theorem bool_not_fixed_point_false (b : Bool) (h : b = !b) : False := by
+  cases b <;> simp at h
+
+/--
+L0 diagonal sanity theorem: self-encoding capacity rules out bounded solvers.
+This is a test-local weak lower-bound probe only; no endpoint claims are made.
+-/
+theorem antiEval_noBoundedSolver_of_selfEncodingCapacity
+    (enc : AntiEvalEncodingInterface)
+    (C : AlgorithmsToLowerBounds.CircuitFamilyClass)
+    (sizeBound : Nat → Nat)
+    (hOneBit : ∀ n, enc.witnessBits n = 1) :
+    SelfEncodingCapacity enc C sizeBound hOneBit →
+    SearchProblemNoBoundedSolver
+      (antiEvalTarget enc C sizeBound hOneBit).problem
+      (antiEvalTarget enc C sizeBound hOneBit).circuitClass
+      (antiEvalTarget enc C sizeBound hOneBit).sizeBound := by
+  intro hCap hSolver
+  rcases hSolver with ⟨solver⟩
+  rcases hCap solver with ⟨n, x, G, hDec, hEvalEq⟩
+  have hProm : (antiEvalTarget enc C sizeBound hOneBit).problem.promise n x := ⟨G, hDec⟩
+  have hSolves := solver.solves n x hProm
+  rcases hSolves with ⟨G', hDec', hRel⟩
+  have hG : G' = G := by
+    rw [hDec] at hDec'
+    cases hDec'; rfl
+  subst hG
+  rw [hEvalEq] at hRel
+  have hFixed :
+      searchSolverOutput (solver.outputCircuit n) x =
+        bitwiseNot (searchSolverOutput (solver.outputCircuit n) x) := hRel
+  have hPos : 0 < enc.witnessBits n := by simpa [hOneBit n]
+  let i0 : Fin (enc.witnessBits n) := ⟨0, hPos⟩
+  have hAtZero :
+      (searchSolverOutput (solver.outputCircuit n) x) i0 =
+      !(searchSolverOutput (solver.outputCircuit n) x) i0 := by
+    simpa [bitwiseNot, i0] using congrArg (fun v => v i0) hFixed
+  exact bool_not_fixed_point_false _ hAtZero
+
+end Tests
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
+++ b/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
@@ -1,0 +1,54 @@
+import Pnp4.Frontier.SearchMCSPConcreteTargets
+import Counting.CircuitCounting
+
+namespace Pnp4
+namespace Frontier
+namespace Tests
+
+open AlgorithmsToLowerBounds
+
+/--
+Finite-index witness width for circuits up to `threshold n`.
+
+For L0 this is intentionally simple and explicit: we reserve one bit per
+candidate in the overapproximation finset, plus one spare bit.  This is not yet
+an efficient serialization; it is a capacity pin useful for subsequent codec
+construction.
+-/
+def finiteIndexWitnessBits (threshold : Nat → Nat) (n : Nat) : Nat :=
+  (Pnp3.Counting.circuitsOfSizeAtMost n (threshold n)).card + 1
+
+/--
+L0 helper: every bounded circuit is enumerated by the counting finset used for
+finite-index coding.
+-/
+theorem mem_circuitsOfSizeAtMost_threshold
+    (threshold : Nat → Nat)
+    (n : Nat)
+    (c : Pnp3.Models.Circuit n)
+    (hc : Pnp3.Models.Circuit.size c ≤ threshold n) :
+    c ∈ Pnp3.Counting.circuitsOfSizeAtMost n (threshold n) :=
+  Pnp3.Counting.mem_circuitsOfSizeAtMost c (threshold n) hc
+
+/--
+L0 helper: the finite-index witness width is strictly positive.
+-/
+theorem finiteIndexWitnessBits_pos
+    (threshold : Nat → Nat)
+    (n : Nat) :
+    0 < finiteIndexWitnessBits threshold n := by
+  unfold finiteIndexWitnessBits
+  omega
+
+/--
+L0 helper: `Fin (finiteIndexWitnessBits ...)` is inhabited, providing a canonical
+index slot for future encode/decode experiments.
+-/
+def defaultFiniteIndex
+    (threshold : Nat → Nat)
+    (n : Nat) : Fin (finiteIndexWitnessBits threshold n) :=
+  ⟨0, finiteIndexWitnessBits_pos threshold n⟩
+
+end Tests
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
+++ b/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
@@ -137,6 +137,91 @@ theorem decodeOneHotIndex_oneHot
   apply (oneHot_active_true_iff k i (Classical.choose hExists)).1
   exact Classical.choose_spec hExists
 
+/-- Finset used by the finite-index codec at length `n`. -/
+def finiteIndexSupport (threshold : Nat → Nat) (n : Nat) : Finset (Pnp3.Models.Circuit n) :=
+  Pnp3.Counting.circuitsOfSizeAtMost n (threshold n)
+
+/--
+Encode from an explicit support-membership proof using one-hot indexing.
+-/
+noncomputable def encodeFiniteIndexFromMembership
+    (threshold : Nat → Nat)
+    (n : Nat)
+    (c : Pnp3.Models.Circuit n)
+    (hmem : c ∈ finiteIndexSupport threshold n) :
+    AlgorithmsToLowerBounds.BitVec (finiteIndexWitnessBits threshold n) :=
+  let i : Fin (finiteIndexSupport threshold n).card := Classical.choose
+    (exists_index_of_mem_finset (finiteIndexSupport threshold n) c hmem)
+  oneHot (finiteIndexSupport threshold n).card i
+
+/--
+Finite-index encoder for circuits: one-hot at an index witnessing membership in
+`circuitsOfSizeAtMost`; if no membership proof is supplied, use a default slot.
+-/
+noncomputable def encodeFiniteIndex
+    (threshold : Nat → Nat)
+    (n : Nat)
+    (c : Pnp3.Models.Circuit n) :
+    AlgorithmsToLowerBounds.BitVec (finiteIndexWitnessBits threshold n) :=
+  if hmem : c ∈ finiteIndexSupport threshold n then
+    encodeFiniteIndexFromMembership threshold n c hmem
+  else
+    fun _ => false
+
+/--
+Decode finite-index witness bits by decoding the one-hot index and looking up
+the corresponding circuit in the canonical support list.
+-/
+noncomputable def decodeFiniteIndex
+    (threshold : Nat → Nat)
+    (n : Nat)
+    (w : AlgorithmsToLowerBounds.BitVec (finiteIndexWitnessBits threshold n)) :
+    Option (Pnp3.Models.Circuit n) := do
+  let i ← decodeOneHotIndex (finiteIndexSupport threshold n).card w
+  (finiteIndexSupport threshold n).toList[i.1]?
+
+/-- Decoding a one-hot index and then list lookup returns the indexed circuit. -/
+theorem decodeFiniteIndex_oneHot_index
+    (threshold : Nat → Nat)
+    (n : Nat)
+    (i : Fin (finiteIndexSupport threshold n).card)
+    (c : Pnp3.Models.Circuit n)
+    (hi : (finiteIndexSupport threshold n).toList[i.1]? = some c) :
+    decodeFiniteIndex threshold n
+      (oneHot (finiteIndexSupport threshold n).card i) = some c := by
+  unfold decodeFiniteIndex
+  have hget : (finiteIndexSupport threshold n).toList[i.1] = c := by
+    simpa using hi
+  simp [decodeOneHotIndex_oneHot, hget]
+
+/-- Round-trip for membership-based finite-index encoding. -/
+theorem decode_encode_finiteIndexFromMembership
+    (threshold : Nat → Nat)
+    (n : Nat)
+    (c : Pnp3.Models.Circuit n)
+    (hmem : c ∈ finiteIndexSupport threshold n) :
+    decodeFiniteIndex threshold n
+      (encodeFiniteIndexFromMembership threshold n c hmem) = some c := by
+  unfold encodeFiniteIndexFromMembership
+  let hex := exists_index_of_mem_finset (finiteIndexSupport threshold n) c hmem
+  let i : Fin (finiteIndexSupport threshold n).card := Classical.choose hex
+  have hi : (finiteIndexSupport threshold n).toList[i.1]? = some c :=
+    Classical.choose_spec hex
+  simpa [i] using decodeFiniteIndex_oneHot_index threshold n i c hi
+
+/-- Round-trip for bounded circuits through the finite-index codec staging API. -/
+theorem decode_encode_finiteIndex
+    (threshold : Nat → Nat)
+    (n : Nat)
+    (c : Pnp3.Models.Circuit n)
+    (hc : Pnp3.Models.Circuit.size c ≤ threshold n) :
+    decodeFiniteIndex threshold n
+      (encodeFiniteIndex threshold n c) = some c := by
+  have hmem : c ∈ finiteIndexSupport threshold n :=
+    mem_circuitsOfSizeAtMost_threshold threshold n c hc
+  unfold encodeFiniteIndex
+  simp [decode_encode_finiteIndexFromMembership, hmem]
+
 end Tests
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
+++ b/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
@@ -49,6 +49,52 @@ def defaultFiniteIndex
     (n : Nat) : Fin (finiteIndexWitnessBits threshold n) :=
   ⟨0, finiteIndexWitnessBits_pos threshold n⟩
 
+/--
+If an element belongs to a finset, it appears at some finite list index in the
+canonical `toList` enumeration.
+
+This is the core indexing lemma needed by finite-index encoders.
+-/
+theorem exists_index_of_mem_finset
+    {α : Type} [DecidableEq α]
+    (S : Finset α)
+    (a : α)
+    (ha : a ∈ S) :
+    ∃ i : Fin S.card, S.toList[i.1]? = some a := by
+  have hmemList : a ∈ S.toList := by
+    exact Finset.mem_toList.mpr ha
+  let idx : Nat := S.toList.idxOf a
+  have hlt : idx < S.card := by
+    simpa [idx, Finset.length_toList] using List.idxOf_lt_length_iff.mpr hmemList
+  refine ⟨⟨idx, hlt⟩, ?_⟩
+  simpa [idx] using List.getElem?_idxOf (l := S.toList) hmemList
+
+/--
+One-hot vector on `k` active positions plus one spare bit.
+
+The first `k` coordinates carry the one-hot payload; the final spare coordinate
+is always `false` in this L1 staging encoding.
+-/
+def oneHot (k : Nat) (i : Fin k) : AlgorithmsToLowerBounds.BitVec (k + 1) :=
+  fun j => if h : j.1 < k then (⟨j.1, h⟩ : Fin k) = i else false
+
+/-- The selected index is marked `true` by `oneHot`. -/
+theorem oneHot_at_index
+    (k : Nat)
+    (i : Fin k) :
+    oneHot k i ⟨i.1, Nat.lt_trans i.2 (Nat.lt_succ_self k)⟩ = true := by
+  simp [oneHot, i.2]
+
+/-- Non-selected active coordinates are `false` in `oneHot`. -/
+theorem oneHot_ne_at_index
+    (k : Nat)
+    (i : Fin k)
+    (j : Fin k)
+    (hji : j ≠ i) :
+    oneHot k i ⟨j.1, Nat.lt_trans j.2 (Nat.lt_succ_self k)⟩ = false := by
+  have : j.1 < k := j.2
+  simp [oneHot, this, hji]
+
 end Tests
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
+++ b/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
@@ -95,6 +95,48 @@ theorem oneHot_ne_at_index
   have : j.1 < k := j.2
   simp [oneHot, this, hji]
 
+
+/-- The spare bit (index `k`) is always `false` in one-hot encoding. -/
+theorem oneHot_spare_false
+    (k : Nat)
+    (i : Fin k) :
+    oneHot k i ⟨k, Nat.lt_succ_self k⟩ = false := by
+  simp [oneHot]
+
+/-- Active-position characterization for one-hot vectors. -/
+theorem oneHot_active_true_iff
+    (k : Nat)
+    (i j : Fin k) :
+    oneHot k i ⟨j.1, Nat.lt_trans j.2 (Nat.lt_succ_self k)⟩ = true ↔ j = i := by
+  have hj : j.1 < k := j.2
+  simp [oneHot, hj]
+
+/--
+Decode a `(k+1)`-bit one-hot vector by choosing an active index in `Fin k`
+when one exists; ignore the spare bit.
+-/
+noncomputable def decodeOneHotIndex (k : Nat)
+    (w : AlgorithmsToLowerBounds.BitVec (k + 1)) :
+    Option (Fin k) :=
+  if h : ∃ i : Fin k, w ⟨i.1, Nat.lt_trans i.2 (Nat.lt_succ_self k)⟩ = true then
+    some (Classical.choose h)
+  else
+    none
+
+/-- One-hot encoding round-trips through `decodeOneHotIndex`. -/
+theorem decodeOneHotIndex_oneHot
+    (k : Nat)
+    (i : Fin k) :
+    decodeOneHotIndex k (oneHot k i) = some i := by
+  unfold decodeOneHotIndex
+  have hExists :
+      ∃ j : Fin k,
+        oneHot k i ⟨j.1, Nat.lt_trans j.2 (Nat.lt_succ_self k)⟩ = true := by
+    exact ⟨i, oneHot_at_index k i⟩
+  simp [hExists]
+  apply (oneHot_active_true_iff k i (Classical.choose hExists)).1
+  exact Classical.choose_spec hExists
+
 end Tests
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
+++ b/pnp4/Pnp4/Frontier/Tests/TreeCircuitWitnessCodecProbe.lean
@@ -222,6 +222,22 @@ theorem decode_encode_finiteIndex
   unfold encodeFiniteIndex
   simp [decode_encode_finiteIndexFromMembership, hmem]
 
+/-- Full finite-index `TreeCircuitWitnessCodec` staging object. -/
+noncomputable def finiteIndexTreeCircuitWitnessCodec
+    (threshold : Nat → Nat) :
+    TreeCircuitWitnessCodec threshold where
+  witnessBits := finiteIndexWitnessBits threshold
+  encode := encodeFiniteIndex threshold
+  decode := decodeFiniteIndex threshold
+  decode_encode := decode_encode_finiteIndex threshold
+
+/-- Optional convenience packaging into the generic search witness encoding surface. -/
+noncomputable def finiteIndexTreeMCSPSearchWitnessEncoding
+    (threshold : Nat → Nat) :
+    TreeMCSPSearchWitnessEncoding threshold :=
+  TreeMCSPSearchWitnessEncoding.ofCodec
+    (finiteIndexTreeCircuitWitnessCodec threshold)
+
 end Tests
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/Tests/TreeMCSPSearchTargetProbe.lean
+++ b/pnp4/Pnp4/Frontier/Tests/TreeMCSPSearchTargetProbe.lean
@@ -1,0 +1,51 @@
+import Pnp4.Frontier.Tests.TreeCircuitWitnessCodecProbe
+import Pnp4.Frontier.ContractExpansion.C_DAG_Adapter
+
+namespace Pnp4
+namespace Frontier
+namespace Tests
+
+/--
+Staging threshold schedule for the tree-MCSP search-target pin.
+
+This is intentionally simple for L0 target pinning and does not claim to be
+an optimized or research-final threshold.
+-/
+def stagingTreeThreshold : Nat → Nat :=
+  fun n => n + 1
+
+/--
+Staging per-output-bit solver size schedule for the target pin.
+
+Chosen as an explicit weak polynomial bound for the L0 target surface.
+-/
+def stagingSolverSizeBound : Nat → Nat :=
+  fun n => n ^ 2 + 1
+
+/--
+Staging witness encoding inherited from the finite-index tree-circuit codec.
+
+This encoding is a staging artifact (finite-index/one-hot style), not an
+optimized serialization claim.
+-/
+noncomputable def stagingTreeWitnessEncoding :
+    TreeMCSPSearchWitnessEncoding stagingTreeThreshold :=
+  finiteIndexTreeMCSPSearchWitnessEncoding stagingTreeThreshold
+
+/--
+Pinned concrete staging SearchMCSP weak-circuit target.
+
+No lower-bound theorem is proved here; this only pins the explicit target
+object required for subsequent `hWeak` feasibility work.
+-/
+noncomputable def stagingTreeSearchTarget :
+    SearchMCSPWeakCircuitLowerBoundTarget :=
+  treeMCSPSearchWeakLowerBoundTarget
+    stagingTreeThreshold
+    stagingTreeWitnessEncoding
+    Pnp4.Frontier.ContractExpansion.C_DAG
+    stagingSolverSizeBound
+
+end Tests
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -31,6 +31,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.Tests.AntiEvalSearchProbe
+import Pnp4.Frontier.Tests.TreeCircuitWitnessCodecProbe
 
 namespace Pnp4
 namespace Tests
@@ -2516,3 +2517,7 @@ end Pnp4
 #check Pnp4.Frontier.Tests.antiEvalTarget
 #check Pnp4.Frontier.Tests.SelfEncodingCapacity
 #check Pnp4.Frontier.Tests.antiEval_noBoundedSolver_of_selfEncodingCapacity
+
+#check Pnp4.Frontier.Tests.finiteIndexWitnessBits
+#check Pnp4.Frontier.Tests.mem_circuitsOfSizeAtMost_threshold
+#check Pnp4.Frontier.Tests.defaultFiniteIndex

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -32,6 +32,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.Tests.AntiEvalSearchProbe
 import Pnp4.Frontier.Tests.TreeCircuitWitnessCodecProbe
+import Pnp4.Frontier.Tests.TreeMCSPSearchTargetProbe
 
 namespace Pnp4
 namespace Tests
@@ -2524,3 +2525,6 @@ end Pnp4
 
 #check Pnp4.Frontier.Tests.finiteIndexTreeCircuitWitnessCodec
 #check Pnp4.Frontier.Tests.finiteIndexTreeMCSPSearchWitnessEncoding
+
+#check Pnp4.Frontier.Tests.stagingTreeSearchTarget
+#check Pnp4.Frontier.Tests.stagingTreeSearchTarget.noBoundedSolver

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -2521,3 +2521,6 @@ end Pnp4
 #check Pnp4.Frontier.Tests.finiteIndexWitnessBits
 #check Pnp4.Frontier.Tests.mem_circuitsOfSizeAtMost_threshold
 #check Pnp4.Frontier.Tests.defaultFiniteIndex
+
+#check Pnp4.Frontier.Tests.finiteIndexTreeCircuitWitnessCodec
+#check Pnp4.Frontier.Tests.finiteIndexTreeMCSPSearchWitnessEncoding

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -30,6 +30,7 @@ import Pnp4.Frontier.ContractExpansion.C_DAG_Adapter
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
+import Pnp4.Frontier.Tests.AntiEvalSearchProbe
 
 namespace Pnp4
 namespace Tests
@@ -2510,3 +2511,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 
 end Tests
 end Pnp4
+
+#check Pnp4.Frontier.Tests.AntiEvalEncodingInterface
+#check Pnp4.Frontier.Tests.antiEvalTarget
+#check Pnp4.Frontier.Tests.SelfEncodingCapacity
+#check Pnp4.Frontier.Tests.antiEval_noBoundedSolver_of_selfEncodingCapacity

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -21,6 +21,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.Tests.AntiEvalSearchProbe
+import Pnp4.Frontier.Tests.TreeCircuitWitnessCodecProbe
 
 namespace Pnp4
 namespace Tests
@@ -228,3 +229,6 @@ end Pnp4
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
 
 #print axioms Pnp4.Frontier.Tests.antiEval_noBoundedSolver_of_selfEncodingCapacity
+
+#print axioms Pnp4.Frontier.Tests.mem_circuitsOfSizeAtMost_threshold
+#print axioms Pnp4.Frontier.Tests.finiteIndexWitnessBits_pos

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -20,6 +20,7 @@ import Pnp4.Frontier.ContractExpansion.C_DAG_Adapter
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
+import Pnp4.Frontier.Tests.AntiEvalSearchProbe
 
 namespace Pnp4
 namespace Tests
@@ -225,3 +226,5 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.parseTreeMCSPPrefixInput_malformed_rejected
 #check Pnp4.Frontier.ContractExpansion.treeMCSPConcretePrefixParser
 #check Pnp4.Frontier.ContractExpansion.treeMCSPRuntimeAwarePrefixParser
+
+#print axioms Pnp4.Frontier.Tests.antiEval_noBoundedSolver_of_selfEncodingCapacity

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -232,3 +232,6 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.Tests.mem_circuitsOfSizeAtMost_threshold
 #print axioms Pnp4.Frontier.Tests.finiteIndexWitnessBits_pos
+
+#print axioms Pnp4.Frontier.Tests.decode_encode_finiteIndex
+#print axioms Pnp4.Frontier.Tests.finiteIndexTreeCircuitWitnessCodec

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -22,6 +22,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.Tests.AntiEvalSearchProbe
 import Pnp4.Frontier.Tests.TreeCircuitWitnessCodecProbe
+import Pnp4.Frontier.Tests.TreeMCSPSearchTargetProbe
 
 namespace Pnp4
 namespace Tests
@@ -235,3 +236,6 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.Tests.decode_encode_finiteIndex
 #print axioms Pnp4.Frontier.Tests.finiteIndexTreeCircuitWitnessCodec
+
+#print axioms Pnp4.Frontier.Tests.stagingTreeWitnessEncoding
+#print axioms Pnp4.Frontier.Tests.stagingTreeSearchTarget

--- a/seed_packs/natural_searchmcsp_route_D0/REPORT.md
+++ b/seed_packs/natural_searchmcsp_route_D0/REPORT.md
@@ -1,0 +1,187 @@
+# Natural SearchMCSP route D0
+
+## 1) Candidate target
+
+**Candidate:** `treeMCSPSearchWeakLowerBoundTarget` from
+`pnp4/Pnp4/Frontier/SearchMCSPConcreteTargets.lean`, instantiated with:
+
+- `problem := treeMCSPSearchProblem threshold encoding`
+- `circuitClass := C_DAG` (the frontier DAG adapter class)
+- `sizeBound := nearLinearBound` (e.g., `n * log (n+2)`-scale schedule, or any
+  explicitly fixed weak-size regime we choose to attack)
+
+So the D0 candidate is:
+
+```text
+target := treeMCSPSearchWeakLowerBoundTarget threshold encoding C_DAG nearLinearBound
+```
+
+where the promise remains the existing semantic MCSP promise:
+
+```text
+treeMCSPPredicate n (threshold n) tt
+```
+
+and witnesses are concrete encoded circuits through
+`TreeCircuitWitnessCodec` / `TreeMCSPSearchWitnessEncoding`.
+
+---
+
+## 2) Why natural
+
+This candidate is natural in the repository sense (not synthetic/self-referential)
+because:
+
+1. **It is already the concrete frontier surface** formalized in pnp4.
+   We are not inventing an ad-hoc language: we reuse the shipped
+   `treeMCSPSearchProblem` / `treeMCSPSearchWeakLowerBoundTarget` objects.
+
+2. **The promise is semantic MCSP structure, not a diagonalized parser trick.**
+   The YES condition is “has a small tree circuit,” i.e., a standard
+   compression-style search predicate.
+
+3. **Witnesses are object-level circuit encodings, not singleton artifacts.**
+   A witness must decode to a circuit with both size and truth-table correctness,
+   so this is not a one-off payload route.
+
+4. **It aligns with the frontier contract direction** (`SearchMCSPWeakCircuitLowerBoundTarget`
+   + `SearchMCSPMagnificationContract`) instead of legacy pnp3 asymptotic
+   route families that were audited/refuted.
+
+---
+
+## 3) What is `hWeak`
+
+For this target, `hWeak` is exactly:
+
+```text
+SearchMCSPWeakCircuitLowerBound target
+```
+
+i.e. a proof of:
+
+```text
+target.noBoundedSolver
+```
+
+which unfolds to:
+
+> no non-uniform bounded search solver family in `C_DAG` with per-output-bit
+> size bounded by `nearLinearBound n` solves the promised tree-MCSP search
+> relation at every length.
+
+Operationally: for each output witness bit, the solver gets one bounded DAG
+circuit; collectively they must always output a valid encoded small-circuit
+witness on promised instances. `hWeak` says such a bounded family does not
+exist.
+
+---
+
+## 4) What is `hMag`
+
+`hMag` is the magnification contract object:
+
+```text
+SearchMCSPMagnificationContract target
+```
+
+with field:
+
+```text
+magnifiesToVerifiedDAGSource : target.noBoundedSolver → VerifiedNPDAGLowerBoundSource
+```
+
+So `hMag` is the explicit bridge theorem package from the weak search lower
+bound to the required verified NP-vs-PpolyDAG source.
+
+Important: by design this is a **separate obligation** from `hWeak`.
+The repository architecture already enforces this split.
+
+---
+
+## 5) Is `hWeak` known / plausible / main-gap-hard?
+
+### Status classification: **main-gap-hard**
+
+- **Known?** No in-repo theorem currently provides this no-bounded-solver result
+  for a natural DAG class/weak-size regime on the concrete tree-MCSP search
+  target.
+- **Plausible?** Plausible as a research direction (it is a standard
+  search/compression hardness shape), but not currently discharged.
+- **Difficulty bucket:** main-gap-hard. This is substantive lower-bound
+  mathematics, not wrapper plumbing.
+
+In other words: wrapper and target surface are available; proving `hWeak`
+remains the central mathematical bottleneck.
+
+---
+
+## 6) Does target avoid the known failure modes?
+
+### (a) Anti-singleton triviality
+
+**Yes, structurally better than singleton routes.**
+The relation requires a full valid decoded circuit witness for the given truth
+table under size threshold, not a single hardwired accepting payload.
+This avoids the exact singleton/provenance-style weakness pattern.
+
+### (b) Self-referential artificiality
+
+**Yes.**
+No self-encoding diagonal promise is built into the target definition.
+It is an external semantic search task (find small circuit witness), not a
+self-referential contradiction gadget.
+
+### (c) FormulaCertificate route
+
+**Yes.**
+This target lives in pnp4 frontier SearchMCSP surfaces and does not depend on
+`FormulaCertificateProviderPartial`-style channels that STATUS marks as ex-falso.
+
+### (d) isoStrong route
+
+**Yes.**
+No dependence on `AsymptoticIsoStrongRoute` / canonical asymptotic route
+family. The target is separate from the refuted canonical isoStrong chain.
+
+### (e) support/filter NoGos
+
+**Largely yes (by design separation), with caveat.**
+The target itself is not a support-cardinality/filter predicate route.
+However, any future proof attempt must still be checked to avoid reintroducing
+those NoGo patterns indirectly through helper lemmas.
+At D0 target-definition level, the candidate avoids them.
+
+---
+
+## 7) First Lean L0 task
+
+Even though this D0 deliverable is markdown-only, the most useful next Lean L0
+is **infrastructure, not lower-bound proof**:
+
+1. Instantiate a concrete `TreeCircuitWitnessCodec` stub interface package for a
+   chosen threshold schedule with explicit encoding conventions (statement-level,
+   no fake completeness).
+2. Define a named concrete target constant:
+
+   ```text
+   def naturalTreeSearchTarget : SearchMCSPWeakCircuitLowerBoundTarget :=
+     treeMCSPSearchWeakLowerBoundTarget threshold encoding C_DAG nearLinearBound
+   ```
+
+3. Add surface tests/audit checks (`#check` / `#print axioms`) for this named
+   target package so the mainline object is stable and reviewable.
+
+This L0 does **not** attempt `hWeak` or `hMag`; it lands the clean target pin.
+
+---
+
+## 8) Verdict
+
+**OPEN_TARGET_L0**
+
+Rationale:
+- A non-artificial, route-policy-compliant mainline target already exists and
+  can be concretized cleanly.
+- The remaining challenge is not wrapper mismatch but proving the weak lower
+  bound (`hWeak`) and then magnification (`hMag`), i.e. true main-gap work.

--- a/seed_packs/natural_searchmcsp_target_L0/STRUCTURED_FAILURE.md
+++ b/seed_packs/natural_searchmcsp_target_L0/STRUCTURED_FAILURE.md
@@ -1,0 +1,62 @@
+# natural SearchMCSP target L0 — structured failure
+
+## Outcome
+
+**STRUCTURED_FAILURE_CODEC_NOT_READY**
+
+This L0 requested a pinned closed constant
+
+```lean
+naturalTreeSearchTarget : SearchMCSPWeakCircuitLowerBoundTarget
+```
+
+with all components fixed (threshold schedule, sizeBound schedule, concrete
+encoding/codec object, and `C_DAG`).
+
+A closed target constant cannot be produced honestly at this point because a
+concrete `TreeCircuitWitnessCodec` object is not present in the repository.
+
+## 1) Exact threshold schedule (proposed)
+
+`threshold(n) := n + 1`.
+
+## 2) Exact sizeBound schedule (proposed)
+
+`sizeBound(n) := n ^ 2 + 1`.
+
+## 3) Exact encoding / codec object status
+
+`treeMCSPSearchWeakLowerBoundTarget` needs
+`TreeMCSPSearchWitnessEncoding threshold`, and the concrete route in
+`SearchMCSPConcreteTargets.lean` builds that from
+`TreeCircuitWitnessCodec threshold` via `TreeMCSPSearchWitnessEncoding.ofCodec`.
+
+A concrete codec object with fields `witnessBits`, `encode`, `decode`, and
+`decode_encode` is not currently available as a repository constant for this
+natural target pin.
+
+## 4) Named target constant
+
+Not landed, because a closed target constant depends on a closed concrete codec
+object that is currently unavailable.
+
+## 5) Surface tests
+
+No `#check` / `#print axioms` additions, because no new target constant was
+introduced.
+
+## Minimal next unblock
+
+Land one concrete codec object first; then pin:
+
+```lean
+def naturalThreshold : Nat → Nat := fun n => n + 1
+def naturalSizeBound : Nat → Nat := fun n => n ^ 2 + 1
+
+def naturalTreeSearchTarget : SearchMCSPWeakCircuitLowerBoundTarget :=
+  treeMCSPSearchWeakLowerBoundTarget
+    naturalThreshold
+    (TreeMCSPSearchWitnessEncoding.ofCodec (naturalTreeWitnessCodec naturalThreshold))
+    ContractExpansion.C_DAG
+    naturalSizeBound
+```

--- a/seed_packs/staging_tree_search_hweak_D0/reports/D0_staging_tree_hweak_codex_report.md
+++ b/seed_packs/staging_tree_search_hweak_D0/reports/D0_staging_tree_hweak_codex_report.md
@@ -1,0 +1,136 @@
+# D0 stagingTreeSearchTarget hWeak feasibility audit
+
+## 1. Executive verdict
+
+**YELLOW_CODEC_TOO_INEFFICIENT_BUT_USEFUL_FOR_INTERFACE**
+
+Reason: the pinned staging target is well-typed and relation-strong (decoded
+circuit must actually compute the input truth table under threshold), but its
+finite-index/one-hot witness representation makes witness width enormous and
+pushes `noBoundedSolver` toward an encoding-artifact hardness regime rather than
+clean structural search hardness.
+
+---
+
+## 2. Target unpacking
+
+For `stagingTreeSearchTarget`:
+
+- `problem.instanceBits n = Partial.tableLen n` (truth-table length for `n`-var instances).
+- `problem.witnessBits n = finiteIndexWitnessBits stagingTreeThreshold n`.
+- `problem.promise n tt = treeMCSPPredicate n (stagingTreeThreshold n) tt`.
+- `problem.relation n tt w` is codec verification via `decode w = some c ∧ size c ≤ threshold n ∧ ComputesTruthTable treeCircuitClass c tt`.
+- `circuitClass = C_DAG`.
+- `sizeBound n = stagingSolverSizeBound n = n^2 + 1`.
+
+So the weak-lower-bound proposition is:
+
+`SearchProblemNoBoundedSolver problem C_DAG (fun n => n^2 + 1)`
+
+for the above staged codec problem.
+
+---
+
+## 3. WitnessBits scale audit
+
+`finiteIndexWitnessBits threshold n = card(circuitsOfSizeAtMost n (threshold n)) + 1`.
+
+With `stagingTreeThreshold n = n + 1`, this means:
+
+- witness length is the number of enumerated circuits up to staged bound + spare bit;
+- the solver must output **one circuit per witness bit** (by `BoundedSearchSolver.outputCircuit`);
+- hence solver family arity grows with this cardinality, not with a compact encoding length.
+
+Qualitatively, this scale is very large relative to instance length `tableLen n` and
+is driven by enumeration cardinality, not by a compressed circuit description.
+
+Verdict on scale: **encoding-inflated** and likely to make `noBoundedSolver`
+artificially easier to satisfy (because required output dimensionality explodes).
+
+---
+
+## 4. Trivial solver audit
+
+Attempted trivial strategies:
+
+1. **Always output default index / all-false**: fails in general, because relation
+   requires decoding to a circuit computing the specific input truth table.
+2. **Universal witness across promises**: fails; promised instances are many truth
+   tables, each generally needing different computing circuit witness.
+3. **Exploit threshold `n+1`**: helps only for promised inputs that already have
+   such small circuits; still does not yield a single universal witness function.
+4. **Exploit one-hot shape**: one-hot eases decoder reasoning, but does not remove
+   semantic correctness (`ComputesTruthTable`) constraint.
+
+Conclusion: no immediate trivial bounded solver construction is evident.
+
+---
+
+## 5. Promise density audit
+
+Promise is `treeMCSPPredicate n (n+1) tt`.
+
+- Promised set is nonempty (contains low-complexity tables).
+- It is not “single-witness only”: there can be many circuits computing a table.
+- But threshold is tiny relative to full truth-table space, so promise is a sparse
+  low-complexity slice.
+
+This does **not** automatically make solver trivial; it only limits instances to
+small-circuit tables.
+
+---
+
+## 6. Relation audit
+
+Relation strength is adequate for correctness:
+
+- witness is decoded to an actual `Circuit n`;
+- decoded circuit must satisfy size bound (`≤ threshold n`);
+- decoded circuit must compute the provided truth table.
+
+So relation is semantically meaningful, not a weak placeholder.
+
+---
+
+## 7. hWeak plausibility
+
+Target proposition:
+
+`SearchProblemNoBoundedSolver stagingTreeSearchTarget.problem C_DAG stagingSolverSizeBound`.
+
+Assessment:
+
+- Not obviously false (no quick trivial solver found).
+- But also not a clean “natural” weak lower bound because witness-output width is
+  dominated by finset cardinality of staged enumeration.
+- Therefore plausibility as *mathematical mainline evidence* is reduced; this is
+  better viewed as interface stress-test hardness.
+
+Classification: plausible as staging stress target, weak as final-form hWeak candidate.
+
+---
+
+## 8. Magnification relevance
+
+Even if this staged `hWeak` were proved, magnification relevance is questionable:
+
+- the witness encoding is intentionally inefficient one-hot finite-index;
+- hardness may largely reflect representation blowup rather than intrinsic search-MCSP structure.
+
+So this target is good for plumbing/proof-engineering, but likely needs codec/scale
+repair before serving as persuasive `hMag`-facing source.
+
+---
+
+## 9. Recommendation
+
+**open_efficient_structural_codec_route**
+
+Concrete next step:
+
+1. Keep this staging target for interface tests.
+2. Design a more structural/compact codec (length polynomial in natural instance
+   parameters, not finset cardinality).
+3. Re-pin a repaired target and re-run hWeak feasibility against that repaired
+   witness scale.
+

--- a/seed_packs/structural_tree_circuit_codec_D0/reports/D0_structural_codec_codex.md
+++ b/seed_packs/structural_tree_circuit_codec_D0/reports/D0_structural_codec_codex.md
@@ -1,0 +1,167 @@
+# D0 structural TreeCircuitWitnessCodec design report
+
+## 1. Executive verdict
+
+**GREEN_OPEN_STRUCTURAL_CODEC_L0**
+
+The finite-index one-hot codec is useful for interface plumbing, but it is not
+an appropriate long-term witness representation for SearchMCSP lower-bound
+feasibility. A compact structural codec is feasible and should be pursued.
+
+---
+
+## 2. Encoding layout
+
+We propose a **fixed-width preorder node stream** with explicit arity tags.
+Let:
+
+- `T := threshold n`
+- `N := n` (input variable count)
+- `idxWidth := Nat.log2 (N + 1) + 1`
+- `nodeWidth := 3 + idxWidth`
+- `maxNodes := T`
+
+### Node tag (3 bits)
+
+Use 3-bit tags:
+
+- `000` = padding/empty slot
+- `001` = const false
+- `010` = const true
+- `011` = input
+- `100` = not
+- `101` = and
+- `110` = or
+- `111` = reserved/invalid
+
+### Payload
+
+- For `input`, payload stores input index in `idxWidth` bits.
+- For non-input tags, payload bits are zero-filled.
+
+### Global layout
+
+Witness is:
+
+1. `lenWidth := Nat.log2 (T + 1) + 1` bits for declared node count `m`.
+2. `maxNodes * nodeWidth` bits for node slots.
+
+Hence:
+
+`structuralWitnessBits threshold n := lenWidth + T * nodeWidth`.
+
+### Tree structure rule
+
+Decoder reads first `m` nodes and recursively rebuilds tree in preorder:
+
+- `const` / `input` consume one node.
+- `not` consumes one node + one subtree.
+- `and` / `or` consume one node + two subtrees.
+
+Padding slots after `m` are ignored.
+
+---
+
+## 3. Size budget
+
+Proposed:
+
+`structuralWitnessBits threshold n = (log2(T+1)+1) + T * (3 + (log2(n+1)+1))`.
+
+Properties:
+
+- polynomial in `T` and `log n` (hence polynomial in `T,n`);
+- **not** proportional to `card(circuitsOfSizeAtMost n T)`;
+- dramatically smaller than finite-index one-hot for realistic `T`.
+
+This is compatible with the D0 requirement for compactness.
+
+---
+
+## 4. Encode algorithm
+
+For circuit `c : Circuit n` with `c.size ≤ T`:
+
+1. Traverse `c` in preorder and emit node descriptors (tag + payload).
+2. Let resulting descriptor list length be `m`.
+3. Encode `m` in `lenWidth` bits.
+4. Write descriptors into first `m` slots of size `nodeWidth`.
+5. Fill remaining `T-m` slots with padding tag `000` and zero payload.
+
+If `c.size > T`, encoder may still output a canonical invalid/padding witness,
+but the codec theorem only needs the bounded case.
+
+---
+
+## 5. Decode algorithm
+
+Given witness bits:
+
+1. Parse `m` from length header; reject if `m > T`.
+2. Parse first `m` descriptors into a list.
+3. Run recursive parser `parseTree : List Desc → Option (Circuit n × List Desc)`:
+   - for leaf tags (`const`,`input`) create node;
+   - for unary/binary tags recursively parse child(ren);
+   - fail on invalid tags (`111`) or malformed input index (`idx ≥ n`).
+4. Accept only if parser consumes all `m` descriptors exactly.
+
+Output `some circuit` on success; otherwise `none`.
+
+---
+
+## 6. Round-trip theorem target
+
+Target theorem shape:
+
+```lean
+theorem decode_encode_structural
+  (threshold : Nat → Nat) (n : Nat) (c : Pnp3.Models.Circuit n)
+  (hc : c.size ≤ threshold n) :
+  decodeCircuit threshold n (encodeCircuit threshold n c) = some c
+```
+
+where `decodeCircuit` / `encodeCircuit` are the structural codec functions.
+
+---
+
+## 7. Complexity / naturalness audit
+
+Why this is more natural than finite-index one-hot:
+
+1. **Syntax-directed representation**: witness mirrors the circuit AST rather
+   than choosing an arbitrary index in an overapproximation set.
+2. **Compactness**: size scales with circuit-size budget and input-index width,
+   not with enumeration cardinality.
+3. **Robustness**: relation correctness remains semantic (`ComputesTruthTable`),
+   but representation no longer bakes in combinatorial explosion.
+4. **Magnification relevance**: if `hWeak` eventually holds, it is less likely to
+   be dismissed as a pure encoding artifact.
+
+---
+
+## 8. Failure modes (expected Lean blockers)
+
+1. **Recursive parser proof engineering**
+   - proving total-consumption and uniqueness lemmas for preorder parse.
+2. **Fixed-width bit slicing arithmetic**
+   - index offsets for header/slots, especially with dependent `Fin` bounds.
+3. **Input index validity proof**
+   - convert payload nat to `Fin n` with clean error handling.
+4. **Padding invariants**
+   - show padding does not affect decode when `m` is valid.
+5. **Round-trip strengthening lemmas**
+   - likely need intermediate theorem: parser round-trip on descriptor lists
+     before bit-level serialization round-trip.
+
+---
+
+## Recommended L0 implementation slice (next immediate move)
+
+Implement only a **base-node codec probe** first:
+
+- descriptor tag encode/decode round-trip;
+- constant/input node encode/decode round-trip;
+- fixed-width index payload encode/decode round-trip;
+- no recursion yet.
+
+This minimizes risk and creates reusable lemmas for full structural decoder.


### PR DESCRIPTION
### Motivation

- Introduce a lightweight L0 sanity probe that formalizes an anti-evaluation diagonal search predicate to capture a simple self-encoding contradiction for bounded solvers.  
- Expose this probe in the repository test surface and axioms audit so the logical contract and axioms can be inspected by the existing test harness.  
- Ship a seed-pack `REPORT.md` describing a natural SearchMCSP D0 route to document the target and next steps for L0 work.

### Description

- Add `pnp4/Pnp4/Frontier/Tests/AntiEvalSearchProbe.lean` which defines `AntiEvalEncodingInterface`, the `antiEvalRelation` and `antiEvalTarget`, the `SelfEncodingCapacity` hypothesis, and the theorem `antiEval_noBoundedSolver_of_selfEncodingCapacity`.  
- Wire the new test into the build by adding `Pnp4.Frontier.Tests.AntiEvalSearchProbe` to `lakefile.lean` and import it from `AlgorithmsToLowerBoundsSurfaceTests.lean` and `AxiomsAudit.lean` with a few `#check`/`#print axioms` lines for inspection.  
- Add `seed_packs/natural_searchmcsp_route_D0/REPORT.md` documenting the proposed natural `treeMCSPSearchWeakLowerBoundTarget` D0 route, its rationale, and suggested first L0 tasks.

### Testing

- No automated test runs were executed as part of this change; the new probe and audit lines are registered to be picked up by the existing test driver (`@[test_driver] lean_exe test`) on next CI or local test invocation.  
- The additions are limited to new test/library files and imports so they are intended to be compile-time checks under the repository's normal `lake`/`lean` build and test flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10aaa5a3f8832b9001921bf2a1cccd)