### PR TITLE
Start DAG query composition for decision-to-search extraction

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -268,6 +268,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.SearchMCSPMagnification,
     Glob.one `Pnp4.Frontier.SearchMCSPConcreteTargets,
     Glob.one `Pnp4.Frontier.ContractExpansion.C_DAG_Adapter,
+    Glob.one `Pnp4.Frontier.ContractExpansion.QueryComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageNP,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/QueryComposition.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/QueryComposition.lean
@@ -1,0 +1,84 @@
+import Pnp4.Frontier.ContractExpansion.C_DAG_Adapter
+import Complexity.DagCompose
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# DAG query composition for the decision→search extraction
+
+First reusable brick of the downstream *decision→search extraction*: composing a
+DAG-decider for a query language with DAG-circuits that compute each query bit
+from the original input.
+
+The frozen `pnp3` composition layer (`Complexity.DagCompose`) already provides
+the workhorse `DagCircuit.substInputs` together with its `eval` and `size`
+correctness lemmas.  Here we phrase the single composition step the extraction
+needs *in `pnp4`'s own `C_DAG` circuit-family view*, so that downstream
+extraction modules never have to reach across into the raw `pnp3` `DagCircuit`
+API.
+
+`C_DAG` is only an adapter: `C_DAG.Family n` is definitionally
+`Pnp3.ComplexityInterfaces.DagCircuit n`, and `C_DAG.eval`/`C_DAG.size` are the
+frozen `DagCircuit` evaluator and size measure.  So this file introduces **no**
+new circuit semantics.
+
+Scope discipline — this is a *reusable primitive*, not an endpoint:
+
+* **no** `PrefixExtensionLanguage` parser/serialization logic;
+* **no** `BoundedSearchSolver` assembly;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge or endpoint wrapper;
+* **no** `P ≠ NP` / `NP ⊄ P/poly` consequence.
+
+It proves exactly one thing: *a DAG-decider composed with DAG query-builders is
+again a `C_DAG` circuit, with the expected `eval` and a `size` bound.*
+-/
+
+/-- **DAG query composition.**
+
+Given a `C_DAG` decider over `queryBits` query bits and, for each query bit, a
+`C_DAG` circuit computing that bit from the original `inputBits`-bit input,
+produce the `C_DAG` circuit over the original input that first computes every
+query bit and then runs the decider.
+
+This is exactly the frozen `pnp3` input-substitution `DagCircuit.substInputs`,
+re-exposed through the `C_DAG` family view (`C_DAG.Family _` is definitionally
+`DagCircuit _`). -/
+def composeDeciderWithQuery
+    {inputBits queryBits : Nat}
+    (decider : C_DAG.Family queryBits)
+    (queryBit : Fin queryBits → C_DAG.Family inputBits) :
+    C_DAG.Family inputBits :=
+  Pnp3.ComplexityInterfaces.DagCircuit.substInputs decider queryBit
+
+/-- Evaluating the composed circuit on `x` runs the decider on the bit-vector
+whose `j`-th coordinate is the `j`-th query circuit evaluated on `x`.
+
+Direct re-export of `DagCircuit.eval_substInputs` through the `C_DAG` view. -/
+@[simp] theorem eval_composeDeciderWithQuery
+    {inputBits queryBits : Nat}
+    (decider : C_DAG.Family queryBits)
+    (queryBit : Fin queryBits → C_DAG.Family inputBits)
+    (x : AlgorithmsToLowerBounds.BitVec inputBits) :
+    C_DAG.eval (composeDeciderWithQuery decider queryBit) x =
+      C_DAG.eval decider (fun j => C_DAG.eval (queryBit j) x) :=
+  Pnp3.ComplexityInterfaces.DagCircuit.eval_substInputs decider queryBit x
+
+/-- The composed circuit is no larger than the decider plus the total size of
+the query-bit circuits.
+
+Direct re-export of `DagCircuit.size_substInputs_le` through the `C_DAG` view. -/
+theorem size_composeDeciderWithQuery_le
+    {inputBits queryBits : Nat}
+    (decider : C_DAG.Family queryBits)
+    (queryBit : Fin queryBits → C_DAG.Family inputBits) :
+    C_DAG.size (composeDeciderWithQuery decider queryBit) ≤
+      C_DAG.size decider + ∑ j, C_DAG.size (queryBit j) :=
+  Pnp3.ComplexityInterfaces.DagCircuit.size_substInputs_le decider queryBit
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -27,6 +27,7 @@ import Pnp4.Frontier.CompressionMagnification
 import Pnp4.Frontier.SearchMCSPMagnification
 import Pnp4.Frontier.SearchMCSPConcreteTargets
 import Pnp4.Frontier.ContractExpansion.C_DAG_Adapter
+import Pnp4.Frontier.ContractExpansion.QueryComposition
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
@@ -85,6 +86,36 @@ theorem check_PpolyDAG_decider_as_C_DAG_decider
         ∀ x : AlgorithmsToLowerBounds.BitVec n,
           Pnp4.Frontier.ContractExpansion.C_DAG.eval C x = L n x :=
   Pnp4.Frontier.ContractExpansion.PpolyDAG_decider_as_C_DAG_decider h
+
+section QueryCompositionSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+def check_composeDeciderWithQuery
+    {inputBits queryBits : Nat}
+    (decider : C_DAG.Family queryBits)
+    (queryBit : Fin queryBits → C_DAG.Family inputBits) :
+    C_DAG.Family inputBits :=
+  composeDeciderWithQuery decider queryBit
+
+theorem check_eval_composeDeciderWithQuery
+    {inputBits queryBits : Nat}
+    (decider : C_DAG.Family queryBits)
+    (queryBit : Fin queryBits → C_DAG.Family inputBits)
+    (x : AlgorithmsToLowerBounds.BitVec inputBits) :
+    C_DAG.eval (composeDeciderWithQuery decider queryBit) x =
+      C_DAG.eval decider (fun j => C_DAG.eval (queryBit j) x) :=
+  eval_composeDeciderWithQuery decider queryBit x
+
+theorem check_size_composeDeciderWithQuery_le
+    {inputBits queryBits : Nat}
+    (decider : C_DAG.Family queryBits)
+    (queryBit : Fin queryBits → C_DAG.Family inputBits) :
+    C_DAG.size (composeDeciderWithQuery decider queryBit) ≤
+      C_DAG.size decider + ∑ j, C_DAG.size (queryBit j) :=
+  size_composeDeciderWithQuery_le decider queryBit
+
+end QueryCompositionSurface
 
 section PrefixExtensionLanguageSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -17,6 +17,7 @@ import Pnp4.Frontier.CompressionMagnification
 import Pnp4.Frontier.SearchMCSPMagnification
 import Pnp4.Frontier.SearchMCSPConcreteTargets
 import Pnp4.Frontier.ContractExpansion.C_DAG_Adapter
+import Pnp4.Frontier.ContractExpansion.QueryComposition
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
@@ -187,6 +188,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.InPpolyDAG_to_C_DAG_family
 #print axioms Pnp4.Frontier.ContractExpansion.C_DAG_family_to_InPpolyDAG
 #print axioms Pnp4.Frontier.ContractExpansion.PpolyDAG_decider_as_C_DAG_decider
+
+#print axioms Pnp4.Frontier.ContractExpansion.eval_composeDeciderWithQuery
+#print axioms Pnp4.Frontier.ContractExpansion.size_composeDeciderWithQuery_le
 
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_accepts_iff
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_rejects_malformed


### PR DESCRIPTION
## Summary

This PR adds the first small downstream extraction brick after the verified
DAG composition layer merged in #1493.

It introduces `QueryComposition.lean`, a pnp4-facing adapter for composing a
`C_DAG` query decider with one `C_DAG` circuit per query bit.

## What is proved

- `composeDeciderWithQuery`
- `eval_composeDeciderWithQuery`
- `size_composeDeciderWithQuery_le`

These are direct, thin re-exports of the verified pnp3 `DagCircuit.substInputs`
eval and size lemmas through the pnp4 `C_DAG` view.

## Scope discipline

This PR intentionally does not introduce:

- `PrefixExtensionLanguage` parser / serialization logic
- `BoundedSearchSolver` assembly
- `PpolyDAG` / `InPpolyDAG` bridge
- endpoint wrappers
- `P ≠ NP` / `NP ⊄ P/poly` consequences

It is only a reusable circuit-composition adapter for the downstream
decision→search extraction work.

## Verification

- `lake build PnP3 Pnp4`
- `lake test`
- axiom audit of the new declarations: standard axioms only, no `sorryAx`

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_