### PR TITLE
Add query circuit builder interface for downstream extraction

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -269,6 +269,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.SearchMCSPConcreteTargets,
     Glob.one `Pnp4.Frontier.ContractExpansion.C_DAG_Adapter,
     Glob.one `Pnp4.Frontier.ContractExpansion.QueryComposition,
+    Glob.one `Pnp4.Frontier.ContractExpansion.QueryBuilder,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageNP,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/QueryBuilder.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/QueryBuilder.lean
@@ -1,0 +1,134 @@
+import Pnp4.Frontier.ContractExpansion.QueryComposition
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Query circuit builder interface (downstream decision→search extraction)
+
+Second reusable brick of the downstream extraction.  The previous brick
+(`QueryComposition.composeDeciderWithQuery`) composes a `C_DAG` decider with a
+*bare function* `Fin queryBits → C_DAG.Family inputBits` of query-bit circuits.
+This file adds the missing **semantics**: a `QueryCircuitBuilder` packages, at
+every target length `n`, the intended query string `queryValue n x` together
+with one `C_DAG` circuit per query bit *and a proof that those circuits actually
+compute that query string*, plus a uniform per-bit size bound.
+
+This is exactly the data the next layers will need: a concrete prefix-query
+serialization is just a `QueryCircuitBuilder` whose `queryValue` is a serialized
+`PrefixInput`, and the greedy decision steps will read off `queryValue`.
+
+Scope discipline — generic semantic wrapper, not an endpoint:
+
+* **no** `PrefixExtensionLanguage` / `PrefixParser` / `PrefixInput` logic
+  (this layer is deliberately route-agnostic);
+* **no** greedy witness-bit construction;
+* **no** `BoundedSearchSolver` assembly;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
+  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+
+It only lifts `composeDeciderWithQuery` (and its `eval`/`size` lemmas) to act on
+a semantically-specified family of query-bit circuits.
+-/
+
+/--
+A circuit builder for query strings.
+
+At target length `n`, an original input has `inputBits n` bits and the query
+string has `queryBits n` bits.  The builder provides both the semantic query
+value `queryValue n x` and one `C_DAG` circuit `queryBitCircuit n i` computing
+each query bit `i`, with a correctness proof and a uniform per-bit size bound.
+-/
+structure QueryCircuitBuilder
+    (inputBits queryBits : Nat → Nat) where
+  /-- The intended query string computed from the original input. -/
+  queryValue :
+    ∀ n : Nat,
+      AlgorithmsToLowerBounds.BitVec (inputBits n) →
+        AlgorithmsToLowerBounds.BitVec (queryBits n)
+  /-- A `C_DAG` circuit over the original input computing the `i`-th query bit. -/
+  queryBitCircuit :
+    ∀ n : Nat,
+      Fin (queryBits n) →
+        C_DAG.Family (inputBits n)
+  /-- Each query-bit circuit really computes the corresponding query bit. -/
+  queryBit_correct :
+    ∀ n : Nat,
+      ∀ i : Fin (queryBits n),
+      ∀ x : AlgorithmsToLowerBounds.BitVec (inputBits n),
+        C_DAG.eval (queryBitCircuit n i) x = queryValue n x i
+  /-- A uniform per-bit circuit-size bound at each length. -/
+  sizeBound : Nat → Nat
+  /-- Every query-bit circuit respects the per-bit size bound. -/
+  size_le :
+    ∀ n : Nat,
+      ∀ i : Fin (queryBits n),
+        C_DAG.size (queryBitCircuit n i) ≤ sizeBound n
+
+namespace QueryCircuitBuilder
+
+/-- Compose a decider over the query bits with the builder's query-bit circuits,
+yielding a `C_DAG` circuit over the original input. -/
+def compose
+    {inputBits queryBits : Nat → Nat}
+    (builder : QueryCircuitBuilder inputBits queryBits)
+    (n : Nat)
+    (decider : C_DAG.Family (queryBits n)) :
+    C_DAG.Family (inputBits n) :=
+  composeDeciderWithQuery decider (builder.queryBitCircuit n)
+
+/-- Evaluating the composed circuit on `x` runs the decider on the builder's
+intended query string `queryValue n x`. -/
+@[simp] theorem eval_compose
+    {inputBits queryBits : Nat → Nat}
+    (builder : QueryCircuitBuilder inputBits queryBits)
+    (n : Nat)
+    (decider : C_DAG.Family (queryBits n))
+    (x : AlgorithmsToLowerBounds.BitVec (inputBits n)) :
+    C_DAG.eval (builder.compose n decider) x =
+      C_DAG.eval decider (builder.queryValue n x) := by
+  unfold compose
+  rw [eval_composeDeciderWithQuery]
+  congr 1
+  funext i
+  exact builder.queryBit_correct n i x
+
+/-- The composed circuit is no larger than the decider plus the total size of
+the builder's query-bit circuits. -/
+theorem size_compose_le
+    {inputBits queryBits : Nat → Nat}
+    (builder : QueryCircuitBuilder inputBits queryBits)
+    (n : Nat)
+    (decider : C_DAG.Family (queryBits n)) :
+    C_DAG.size (builder.compose n decider) ≤
+      C_DAG.size decider + ∑ i, C_DAG.size (builder.queryBitCircuit n i) := by
+  unfold compose
+  exact size_composeDeciderWithQuery_le decider (builder.queryBitCircuit n)
+
+/-- Closed-form size bound using the uniform per-bit `sizeBound`: the composed
+circuit is no larger than the decider plus `queryBits n * sizeBound n`. -/
+theorem size_compose_le_bound
+    {inputBits queryBits : Nat → Nat}
+    (builder : QueryCircuitBuilder inputBits queryBits)
+    (n : Nat)
+    (decider : C_DAG.Family (queryBits n)) :
+    C_DAG.size (builder.compose n decider) ≤
+      C_DAG.size decider + (queryBits n) * builder.sizeBound n := by
+  calc
+    C_DAG.size (builder.compose n decider)
+        ≤ C_DAG.size decider + ∑ i, C_DAG.size (builder.queryBitCircuit n i) :=
+          builder.size_compose_le n decider
+    _ ≤ C_DAG.size decider + ∑ _i : Fin (queryBits n), builder.sizeBound n :=
+          Nat.add_le_add_left
+            (Finset.sum_le_sum (fun i _hi => builder.size_le n i)) _
+    _ = C_DAG.size decider + (queryBits n) * builder.sizeBound n := by
+          simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+
+end QueryCircuitBuilder
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -28,6 +28,7 @@ import Pnp4.Frontier.SearchMCSPMagnification
 import Pnp4.Frontier.SearchMCSPConcreteTargets
 import Pnp4.Frontier.ContractExpansion.C_DAG_Adapter
 import Pnp4.Frontier.ContractExpansion.QueryComposition
+import Pnp4.Frontier.ContractExpansion.QueryBuilder
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
@@ -116,6 +117,52 @@ theorem check_size_composeDeciderWithQuery_le
   size_composeDeciderWithQuery_le decider queryBit
 
 end QueryCompositionSurface
+
+section QueryBuilderSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+def check_QueryCircuitBuilder
+    (inputBits queryBits : Nat → Nat) : Type :=
+  QueryCircuitBuilder inputBits queryBits
+
+def check_QueryCircuitBuilder_compose
+    {inputBits queryBits : Nat → Nat}
+    (builder : QueryCircuitBuilder inputBits queryBits)
+    (n : Nat)
+    (decider : C_DAG.Family (queryBits n)) :
+    C_DAG.Family (inputBits n) :=
+  builder.compose n decider
+
+theorem check_QueryCircuitBuilder_eval_compose
+    {inputBits queryBits : Nat → Nat}
+    (builder : QueryCircuitBuilder inputBits queryBits)
+    (n : Nat)
+    (decider : C_DAG.Family (queryBits n))
+    (x : AlgorithmsToLowerBounds.BitVec (inputBits n)) :
+    C_DAG.eval (builder.compose n decider) x =
+      C_DAG.eval decider (builder.queryValue n x) :=
+  builder.eval_compose n decider x
+
+theorem check_QueryCircuitBuilder_size_compose_le
+    {inputBits queryBits : Nat → Nat}
+    (builder : QueryCircuitBuilder inputBits queryBits)
+    (n : Nat)
+    (decider : C_DAG.Family (queryBits n)) :
+    C_DAG.size (builder.compose n decider) ≤
+      C_DAG.size decider + ∑ i, C_DAG.size (builder.queryBitCircuit n i) :=
+  builder.size_compose_le n decider
+
+theorem check_QueryCircuitBuilder_size_compose_le_bound
+    {inputBits queryBits : Nat → Nat}
+    (builder : QueryCircuitBuilder inputBits queryBits)
+    (n : Nat)
+    (decider : C_DAG.Family (queryBits n)) :
+    C_DAG.size (builder.compose n decider) ≤
+      C_DAG.size decider + (queryBits n) * builder.sizeBound n :=
+  builder.size_compose_le_bound n decider
+
+end QueryBuilderSurface
 
 section PrefixExtensionLanguageSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -18,6 +18,7 @@ import Pnp4.Frontier.SearchMCSPMagnification
 import Pnp4.Frontier.SearchMCSPConcreteTargets
 import Pnp4.Frontier.ContractExpansion.C_DAG_Adapter
 import Pnp4.Frontier.ContractExpansion.QueryComposition
+import Pnp4.Frontier.ContractExpansion.QueryBuilder
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
@@ -191,6 +192,10 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.eval_composeDeciderWithQuery
 #print axioms Pnp4.Frontier.ContractExpansion.size_composeDeciderWithQuery_le
+
+#print axioms Pnp4.Frontier.ContractExpansion.QueryCircuitBuilder.eval_compose
+#print axioms Pnp4.Frontier.ContractExpansion.QueryCircuitBuilder.size_compose_le
+#print axioms Pnp4.Frontier.ContractExpansion.QueryCircuitBuilder.size_compose_le_bound
 
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_accepts_iff
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_rejects_malformed


### PR DESCRIPTION
## Summary

Second small downstream extraction brick, on top of the `composeDeciderWithQuery`
adapter merged in #1494.

It introduces `QueryBuilder.lean`, adding the missing **semantics** over the
bare query-bit-circuit function: a generic, route-agnostic `QueryCircuitBuilder`
that packages the intended query string together with one `C_DAG` circuit per
query bit, a correctness proof, and a uniform per-bit size bound.

## What is added

`QueryCircuitBuilder inputBits queryBits` with fields:

- `queryValue n x` — the intended query string
- `queryBitCircuit n i` — one `C_DAG` circuit per query bit
- `queryBit_correct` — the circuits compute that query string
- `sizeBound` / `size_le` — a uniform per-bit size bound

and the composition API lifted onto it:

- `QueryCircuitBuilder.compose` (via `composeDeciderWithQuery`)
- `QueryCircuitBuilder.eval_compose` — `eval = decider` on `queryValue n x`
- `QueryCircuitBuilder.size_compose_le` (via `size_composeDeciderWithQuery_le`)
- `QueryCircuitBuilder.size_compose_le_bound` — closed-form `n * sizeBound` bound

## Scope discipline

This PR is a generic semantic wrapper, not an endpoint. It intentionally does
not introduce:

- `PrefixExtensionLanguage` / `PrefixParser` / `PrefixInput` logic
  (this layer is deliberately route-agnostic)
- greedy witness-bit construction
- `BoundedSearchSolver` assembly
- `PpolyDAG` / `InPpolyDAG` bridge
- endpoint wrappers
- `P ≠ NP` / `NP ⊄ P/poly` consequences

## Verification

- `lake build PnP3 Pnp4`
- `lake test`
- `./scripts/check.sh`
- module registered in `lakefile.lean`; pnp4 surface tests (`QueryBuilderSurface`)
  and axioms audit extended; new theorem surfaces depend only on
  `propext` / `Classical.choice` / `Quot.sound`.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_