### PR TITLE
Concrete prefix query value / serializer round-trip

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -275,6 +275,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageNP,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixParserConvention,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPrefixSerializer.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPrefixSerializer.lean
@@ -1,0 +1,99 @@
+import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Concrete zero-prefix tree-MCSP serializer round-trip (downstream extraction)
+
+Fourth reusable brick.  The previous bricks were generic/contract-level
+(`QueryCircuitBuilder`, `PrefixQueryBuilder`).  This file supplies the *concrete
+semantic serializer* half of a future `PrefixQueryBuilder` instance for the
+tree-MCSP prefix convention, **without any circuits yet**.
+
+It defines the *zero-prefix* query string for an instance `x` (the serialized
+prefix-input whose active prefix length is `i = 0`, i.e. no witness bits fixed)
+and shows it round-trips through the concrete parser: it parses back to a genuine
+`PrefixInput` whose target length is `n` and whose instance is `x`.  This is
+exactly the `PrefixQueryBuilder.parses_back` contract shape, instantiated for the
+tree-MCSP parser via the already-proved encoder/parser inverse
+`parse_encodeTreeMCSPPrefixFields`.
+
+Scope discipline — semantic serializer round-trip only:
+
+* **no** `queryBitCircuit` / per-bit `C_DAG` circuits (next brick);
+* **no** `QueryCircuitBuilder` / `PrefixQueryBuilder` instance (later brick);
+* **no** greedy witness-bit construction;
+* **no** `BoundedSearchSolver` assembly;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
+  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/--
+The canonical raw fields for the *zero-prefix* tree-MCSP query at instance `x`:
+target length `n`, truth table `x`, and an empty active prefix (`i = 0`, so the
+prefix payload `p : PrefixBitVec 0` is the empty function).
+-/
+def zeroPrefixFields
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    CanonicalRawTreeMCSPPrefixFields codec where
+  n := n
+  x := x
+  i := 0
+  prefixLength_le := Nat.zero_le _
+  p := fun i => i.elim0
+
+/--
+The serialized zero-prefix query string for instance `x`, of the parser's
+ambient length `treeMCSPPrefixM codec n`.
+-/
+def zeroPrefixQueryValue
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    PrefixBitVec (treeMCSPPrefixM codec n) :=
+  encodeTreeMCSPPrefixFields codec (zeroPrefixFields codec n x)
+
+/--
+The concrete parser round-trips the zero-prefix query string back to its
+canonical parsed input.  Direct instance of `parse_encodeTreeMCSPPrefixFields`.
+-/
+theorem parse_zeroPrefixQueryValue
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    parseTreeMCSPPrefixInput threshold codec (zeroPrefixQueryValue codec n x) =
+      some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec
+        (zeroPrefixFields codec n x)) :=
+  parse_encodeTreeMCSPPrefixFields codec (zeroPrefixFields codec n x)
+
+/--
+Round-trip in the `PrefixQueryBuilder.parses_back` contract shape: the zero-prefix
+query string parses to a prefix-input about `x` at target length `n`.
+
+`input.n = n` and `HEq input.x x` hold definitionally because the parsed input is
+the canonical `toPrefixInput`, whose `n`/`x` fields are exactly the raw `n`/`x`.
+-/
+theorem zeroPrefixQueryValue_parses
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    ∃ input : PrefixInput
+        (treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec))
+        (treeMCSPPrefixM codec n),
+      parseTreeMCSPPrefixInput threshold codec (zeroPrefixQueryValue codec n x) = some input
+        ∧ input.n = n
+        ∧ HEq input.x x :=
+  ⟨CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec (zeroPrefixFields codec n x),
+    parse_zeroPrefixQueryValue codec n x, rfl, HEq.rfl⟩
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -33,6 +33,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixQueryBuilder
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 
 namespace Pnp4
 namespace Tests
@@ -217,6 +218,44 @@ theorem check_PrefixQueryBuilder_queryValue_parses
   pqb.queryValue_parses n x
 
 end PrefixQueryBuilderSurface
+
+section TreeMCSPPrefixSerializerSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+def check_zeroPrefixQueryValue
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    PrefixBitVec (treeMCSPPrefixM codec n) :=
+  zeroPrefixQueryValue codec n x
+
+theorem check_parse_zeroPrefixQueryValue
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    parseTreeMCSPPrefixInput threshold codec (zeroPrefixQueryValue codec n x) =
+      some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec
+        (zeroPrefixFields codec n x)) :=
+  parse_zeroPrefixQueryValue codec n x
+
+theorem check_zeroPrefixQueryValue_parses
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    ∃ input : PrefixInput
+        (Frontier.treeMCSPSearchProblem threshold
+          (Frontier.TreeMCSPSearchWitnessEncoding.ofCodec codec))
+        (treeMCSPPrefixM codec n),
+      parseTreeMCSPPrefixInput threshold codec (zeroPrefixQueryValue codec n x) = some input
+        ∧ input.n = n
+        ∧ HEq input.x x :=
+  zeroPrefixQueryValue_parses codec n x
+
+end TreeMCSPPrefixSerializerSurface
 
 section PrefixExtensionLanguageSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -23,6 +23,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
 import Pnp4.Frontier.ContractExpansion.PrefixQueryBuilder
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 
 namespace Pnp4
 namespace Tests
@@ -201,6 +202,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixQueryBuilder.eval_compose
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixQueryBuilder.size_compose_le
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixQueryBuilder.queryValue_parses
+
+#print axioms Pnp4.Frontier.ContractExpansion.parse_zeroPrefixQueryValue
+#print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryValue_parses
 
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_accepts_iff
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_rejects_malformed


### PR DESCRIPTION
## Summary

Fourth small downstream extraction brick: the concrete **semantic serializer**
half of a future `PrefixQueryBuilder` instance for the tree-MCSP prefix
convention — **without any circuits yet**.

It introduces `TreeMCSPPrefixSerializer.lean`, defining the *zero-prefix* query
string for an instance `x` (the serialized prefix-input whose active prefix
length is `i = 0`) and proving it round-trips through the concrete parser to a
genuine `PrefixInput` about `x` at target length `n`.

## What is added

- `zeroPrefixFields` — canonical raw fields with empty active prefix (`i = 0`)
- `zeroPrefixQueryValue` — the serialized zero-prefix query string for `x`, via
  `encodeTreeMCSPPrefixFields`
- `parse_zeroPrefixQueryValue` — round-trip (direct instance of the existing
  `parse_encodeTreeMCSPPrefixFields`)
- `zeroPrefixQueryValue_parses` — the `PrefixQueryBuilder.parses_back` contract
  shape: `∃ input, parse … = some input ∧ input.n = n ∧ HEq input.x x`

`input.n = n` and `HEq input.x x` hold definitionally because the parsed input
is the canonical `toPrefixInput`, whose `n`/`x` fields are exactly the raw `n`/`x`.

## Scope discipline

Semantic serializer round-trip only. It intentionally does not introduce:

- `queryBitCircuit` / per-bit `C_DAG` circuits (next brick)
- a `QueryCircuitBuilder` / `PrefixQueryBuilder` instance (later brick)
- greedy witness-bit construction
- `BoundedSearchSolver` assembly
- `PpolyDAG` / `InPpolyDAG` bridge
- endpoint wrappers
- `P ≠ NP` / `NP ⊄ P/poly` consequences

## Verification

- `lake build PnP3 Pnp4`
- `lake test`
- `./scripts/check.sh`
- module registered in `lakefile.lean`; pnp4 surface tests
  (`TreeMCSPPrefixSerializerSurface`) and axioms audit extended; new theorem
  surfaces depend only on `propext` / `Classical.choice` / `Quot.sound`.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_