### PR TITLE
Add zero-prefix query circuits and shared-bundle greedy primitive

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -276,6 +276,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixParserConvention,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -278,6 +278,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder,
+    Glob.one `Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -277,6 +277,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixParserConvention,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp3/Complexity/DagCompose.lean
+++ b/pnp3/Complexity/DagCompose.lean
@@ -20,6 +20,11 @@ Composition layer — micro-step progress (one reusable primitive per commit):
 * step 4c — `substInputs` (input substitution): defs + characterization, full
   eval-preservation (`eval (substInputs D G) x = eval D (fun j => eval (G j) x)`),
   and the size bound (`size (substInputs D G) ≤ size D + ∑ j, size (G j)`);  ✓
+* step 4d — `snocBundleSubst` (shared-bundle greedy step): extend a `DagBundle`
+  by one output computed from the real inputs *and* the existing outputs, with the
+  bundle **shared** (`gates = B.gates + H.gates`, additive not multiplicative), plus
+  eval-preservation for the old and new outputs.  This is the multi-output sharing a
+  *polynomial-size* greedy extraction needs (Option ①, per the size-feasibility gate).  ✓
 
 The composition layer is complete.  Downstream — in separate files, as a
 separate PR/stage — the decision→search *extraction* uses these pieces: greedy
@@ -1159,6 +1164,210 @@ theorem size_substInputs_le {n m : Nat} (D : DagCircuit n) (G : Fin n → DagCir
   simp only [size, Finset.sum_add_distrib, Finset.sum_const, Finset.card_univ,
     Fintype.card_fin, smul_eq_mul, mul_one]
   omega
+
+/-! ### Composition layer, step 4d: `snocBundleSubst` (shared-bundle greedy step)
+
+`snocBundleSubst B H` extends a bundle `B : DagBundle m out` by one new output,
+computed by a head circuit `H : DagCircuit (m + out)` that reads the `m` real
+inputs *and* the `out` existing bundle outputs.  Unlike re-substituting `B` into
+each new bit, the bundle `B` is **shared**: `(snocBundleSubst B H).gates =
+B.gates + H.gates` (additive in `H`, not multiplicative in the prior bits), so
+iterating it keeps circuit size *linear* in the number of outputs.  This is the
+multi-output sharing the size-feasibility spike requires for a polynomial-size
+greedy extraction (Option ①).
+
+It reuses `substInputsWithBundle H (passthroughBundle B)` for the shared gate
+list, where `passthroughBundle B` exposes the `m` real inputs followed by `B`'s
+`out` outputs over a single shared gate list. -/
+
+/-- `eval.evalGateAt` depends only on a circuit's gate list, not its output wire:
+two circuits whose gate at each shared position agrees have the same gate-level
+evaluation.  This congruence lets a shared gate list be reused under a different
+output (the key to multi-output sharing).  Structure mirrors
+`evalGateAt_substInputsWithBundle_left`. -/
+theorem evalGateAt_congr {n : Nat} (C D : DagCircuit n)
+    (hgate : ∀ (i : Nat) (hC : i < C.gates) (hD : i < D.gates),
+        C.gate ⟨i, hC⟩ = D.gate ⟨i, hD⟩) :
+    ∀ {i : Nat} (hC : i < C.gates) (hD : i < D.gates) (x : Bitstring n),
+      DagCircuit.eval.evalGateAt (C := C) (x := x) i hC =
+        DagCircuit.eval.evalGateAt (C := D) (x := x) i hD
+  | i, hC, hD, x => by
+      have hg : C.gate ⟨i, hC⟩ = D.gate ⟨i, hD⟩ := hgate i hC hD
+      cases hOp : D.gate ⟨i, hD⟩ with
+      | const b =>
+          rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+          simp only [hOp]
+      | not w =>
+          cases w with
+          | input j =>
+              rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+              simp only [hOp]
+          | gate g =>
+              rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+              simp only [hOp]
+              rw [evalGateAt_congr C D hgate (Nat.lt_trans g.2 hC) (Nat.lt_trans g.2 hD) x]
+      | and w₁ w₂ =>
+          cases w₁ with
+          | input j₁ =>
+              cases w₂ with
+              | input j₂ =>
+                  rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+                  simp only [hOp]
+              | gate j₂ =>
+                  rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+                  simp only [hOp]
+                  rw [evalGateAt_congr C D hgate (Nat.lt_trans j₂.2 hC) (Nat.lt_trans j₂.2 hD) x]
+          | gate j₁ =>
+              cases w₂ with
+              | input j₂ =>
+                  rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+                  simp only [hOp]
+                  rw [evalGateAt_congr C D hgate (Nat.lt_trans j₁.2 hC) (Nat.lt_trans j₁.2 hD) x]
+              | gate j₂ =>
+                  rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+                  simp only [hOp]
+                  rw [evalGateAt_congr C D hgate (Nat.lt_trans j₁.2 hC) (Nat.lt_trans j₁.2 hD) x,
+                      evalGateAt_congr C D hgate (Nat.lt_trans j₂.2 hC) (Nat.lt_trans j₂.2 hD) x]
+      | or w₁ w₂ =>
+          cases w₁ with
+          | input j₁ =>
+              cases w₂ with
+              | input j₂ =>
+                  rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+                  simp only [hOp]
+              | gate j₂ =>
+                  rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+                  simp only [hOp]
+                  rw [evalGateAt_congr C D hgate (Nat.lt_trans j₂.2 hC) (Nat.lt_trans j₂.2 hD) x]
+          | gate j₁ =>
+              cases w₂ with
+              | input j₂ =>
+                  rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+                  simp only [hOp]
+                  rw [evalGateAt_congr C D hgate (Nat.lt_trans j₁.2 hC) (Nat.lt_trans j₁.2 hD) x]
+              | gate j₂ =>
+                  rw [DagCircuit.eval.evalGateAt, DagCircuit.eval.evalGateAt, hg]
+                  simp only [hOp]
+                  rw [evalGateAt_congr C D hgate (Nat.lt_trans j₁.2 hC) (Nat.lt_trans j₁.2 hD) x,
+                      evalGateAt_congr C D hgate (Nat.lt_trans j₂.2 hC) (Nat.lt_trans j₂.2 hD) x]
+  termination_by i => i
+
+/-- Replace a circuit's output wire, keeping its gate list intact. -/
+def withOutput {n : Nat} (C : DagCircuit n) (w : DagWire n C.gates) : DagCircuit n where
+  gates := C.gates
+  gate := C.gate
+  output := w
+
+@[simp] theorem eval_withOutput_input {n : Nat} (C : DagCircuit n) (j : Fin n)
+    (x : Bitstring n) :
+    eval (withOutput C (DagWire.input j)) x = x j := by
+  unfold eval; rfl
+
+@[simp] theorem eval_withOutput_gate {n : Nat} (C : DagCircuit n) (g : Fin C.gates)
+    (x : Bitstring n) :
+    eval (withOutput C (DagWire.gate g)) x = eval.evalGateAt (C := C) (x := x) g.1 g.2 := by
+  have hstep : eval (withOutput C (DagWire.gate g)) x
+      = eval.evalGateAt (C := withOutput C (DagWire.gate g)) (x := x) g.1 g.2 := by
+    unfold eval; rfl
+  rw [hstep]
+  exact evalGateAt_congr (withOutput C (DagWire.gate g)) C (fun _ _ _ => rfl) g.2 g.2 x
+
+/-- `B` with `m` real-input "passthrough" outputs prepended: a bundle over `m`
+inputs with `m + out` outputs, sharing `B`'s gate list.  Output `i < m` is the
+real input `i`; output `m + k` is `B`'s output `k`. -/
+def passthroughBundle {m out : Nat} (B : DagBundle m out) : DagBundle m (m + out) where
+  gates := B.gates
+  gate := B.gate
+  output := Fin.addCases (fun i : Fin m => DagWire.input i) (fun k : Fin out => B.output k)
+
+@[simp] theorem passthroughBundle_gates {m out : Nat} (B : DagBundle m out) :
+    (passthroughBundle B).gates = B.gates := rfl
+
+@[simp] theorem evalOutput_passthroughBundle_input {m out : Nat} (B : DagBundle m out)
+    (i : Fin m) (x : Bitstring m) :
+    (passthroughBundle B).evalOutput (Fin.castAdd out i) x = x i := by
+  unfold DagBundle.evalOutput
+  unfold eval
+  simp [DagBundle.asCircuit, passthroughBundle, Fin.addCases_left]
+
+@[simp] theorem evalOutput_passthroughBundle_output {m out : Nat} (B : DagBundle m out)
+    (k : Fin out) (x : Bitstring m) :
+    (passthroughBundle B).evalOutput (Fin.natAdd m k) x = B.evalOutput k x := by
+  have hC : (passthroughBundle B).asCircuit (Fin.natAdd m k) = B.asCircuit k := by
+    unfold DagBundle.asCircuit passthroughBundle
+    simp only [Fin.addCases_right]
+  unfold DagBundle.evalOutput
+  rw [hC]
+
+/-- **Shared-bundle greedy step.**  Append to `B` a new output computed by `H`
+from the real inputs and `B`'s outputs, sharing `B`'s gate list. -/
+def snocBundleSubst {m out : Nat} (B : DagBundle m out) (H : DagCircuit (m + out)) :
+    DagBundle m (out + 1) where
+  gates := B.gates + H.gates
+  gate := (substInputsWithBundle H (passthroughBundle B)).gate
+  output := Fin.addCases
+    (fun o : Fin out => weakenWireRight H.gates (B.output o))
+    (fun _ : Fin 1 => (substInputsWithBundle H (passthroughBundle B)).output)
+
+@[simp] theorem snocBundleSubst_gates {m out : Nat} (B : DagBundle m out)
+    (H : DagCircuit (m + out)) :
+    (snocBundleSubst B H).gates = B.gates + H.gates := rfl
+
+theorem snocBundleSubst_output_new {m out : Nat} (B : DagBundle m out)
+    (H : DagCircuit (m + out)) :
+    (snocBundleSubst B H).output (Fin.natAdd out (0 : Fin 1))
+      = (substInputsWithBundle H (passthroughBundle B)).output := by
+  simp only [snocBundleSubst, Fin.addCases_right]
+
+theorem snocBundleSubst_output_old {m out : Nat} (B : DagBundle m out)
+    (H : DagCircuit (m + out)) (o : Fin out) :
+    (snocBundleSubst B H).output (Fin.castAdd 1 o) = weakenWireRight H.gates (B.output o) := by
+  simp only [snocBundleSubst, Fin.addCases_left]
+
+/-- The new (last) output runs `H` on the real inputs together with `B`'s
+outputs. -/
+@[simp] theorem evalOutput_snocBundleSubst_new {m out : Nat} (B : DagBundle m out)
+    (H : DagCircuit (m + out)) (x : Bitstring m) :
+    (snocBundleSubst B H).evalOutput (Fin.natAdd out (0 : Fin 1)) x
+      = eval H (fun j => (passthroughBundle B).evalOutput j x) := by
+  have hC : (snocBundleSubst B H).asCircuit (Fin.natAdd out (0 : Fin 1))
+      = substInputsWithBundle H (passthroughBundle B) := by
+    unfold DagBundle.asCircuit
+    rw [snocBundleSubst_output_new]
+    rfl
+  change eval ((snocBundleSubst B H).asCircuit (Fin.natAdd out (0 : Fin 1))) x = _
+  rw [hC, eval_substInputsWithBundle]
+
+/-- Each old output is preserved (shares `B`'s gate list, untouched by `H`). -/
+@[simp] theorem evalOutput_snocBundleSubst_old {m out : Nat} (B : DagBundle m out)
+    (H : DagCircuit (m + out)) (o : Fin out) (x : Bitstring m) :
+    (snocBundleSubst B H).evalOutput (Fin.castAdd 1 o) x = B.evalOutput o x := by
+  have hC : (snocBundleSubst B H).asCircuit (Fin.castAdd 1 o)
+      = withOutput (substInputsWithBundle H (passthroughBundle B))
+          (weakenWireRight H.gates (B.output o)) := by
+    unfold DagBundle.asCircuit
+    rw [snocBundleSubst_output_old]
+    rfl
+  change eval ((snocBundleSubst B H).asCircuit (Fin.castAdd 1 o)) x = eval (B.asCircuit o) x
+  rw [hC]
+  cases hb : B.output o with
+  | input j =>
+      rw [weakenWireRight_input, eval_withOutput_input]
+      have hr : eval (B.asCircuit o) x = x j := by
+        unfold eval
+        simp only [show (B.asCircuit o).output = DagWire.input j from hb]
+      rw [hr]
+  | gate g =>
+      rw [weakenWireRight_gate, eval_withOutput_gate]
+      have hr : eval (B.asCircuit o) x
+          = eval.evalGateAt (C := B.asCircuit o) (x := x) g.1 g.2 := by
+        unfold eval
+        simp only [show (B.asCircuit o).output = DagWire.gate g from hb]
+      rw [hr,
+          evalGateAt_substInputsWithBundle_left H (passthroughBundle B)
+            (Fin.natAdd m o) (Fin.castAdd H.gates g).2 g.2 x]
+      exact evalGateAt_congr ((passthroughBundle B).asCircuit (Fin.natAdd m o))
+        (B.asCircuit o) (fun _ _ _ => rfl) g.2 g.2 x
 
 end DagCircuit
 end ComplexityInterfaces

--- a/pnp4/Pnp4/Frontier/ContractExpansion/NaiveGreedySizeSpike.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/NaiveGreedySizeSpike.lean
@@ -1,0 +1,221 @@
+import Pnp4.Frontier.ContractExpansion.QueryComposition
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+open Pnp3.ComplexityInterfaces (DagCircuit)
+
+/-!
+# Size-feasibility spike for the naive per-bit greedy extraction (decision gate)
+
+This file is the **feasibility gate** for the downstream decision→search
+extraction.  It is a *note/lemma* brick: it proves, in Lean, the size behaviour
+of the **naive** per-bit greedy circuit construction, and records the resulting
+architectural decision.  It builds **no** greedy solver and makes **no** lower
+bound or `P ≠ NP` claim; it only quantifies the cost of one candidate
+construction so the next bricks pick the right shape.
+
+## The naive construction and why it blows up
+
+The extraction composes a DAG-decider with query-bit circuits via
+`composeDeciderWithQuery`, which is exactly the frozen `DagCircuit.substInputs`
+(`composeDeciderWithQuery_eq_substInputs`).  The crucial structural fact is that
+`substInputs` **does not share** subcircuits: its gate count is the *sum* of the
+substituted circuits' gate counts plus the decider's
+(`size (substInputs D G) = (∑ⱼ (G j).gates) + D.gates + 1`, from
+`DagCircuit.size_substInputs` + `DagCircuit.bundleOfFamily_gates`).
+
+In the naive greedy scheme, output bit `i` is produced by substituting the prior
+greedy bits `0, …, i-1` into the query circuit (they occupy the prefix-payload
+positions).  Hence the gate count `g i` of bit `i` satisfies the recurrence
+`g (i+1) ≥ ∑_{k ≤ i} g k`, which forces `g i ≥ g 0 · 2^i` — exponential in the
+number of output bits.  This is proved here twice:
+
+* abstractly, `geometric_lower_bound`: any `g` with `∑_{k<i+1} g k ≤ g (i+1)`
+  satisfies `g 0 · 2^i ≤ g (i+1)`;
+* concretely, `naiveGreedyModel_size_ge`: a faithful model of the recursion
+  (each step substitutes *all* prior steps via the real `composeDeciderWithQuery`)
+  has size `≥ seed.gates · 2^i` at depth `i+1`.
+
+## Magnification arithmetic (why this is fatal)
+
+The number of greedy output bits is `witnessBits n`, and the instance size is
+`N = tableLen n = 2^n`.  For the naive size `≈ 2^{witnessBits n}` to stay
+polynomial in `N = 2^n` we need `witnessBits n = O(n)`:
+
+* `pow_le_of_linear_witnessBits`: if `witnessBits n ≤ c·n + c` then
+  `2^{witnessBits n} ≤ (2^n)^c · 2^c = poly(N)` — naive is fine;
+* `pow_quadratic_gt_poly`: but for a super-linear witness length (e.g.
+  `witnessBits n = n²`), for *every* fixed polynomial degree `c` and all `n > c`,
+  `(2^n)^c < 2^{n²}` — the naive size outgrows every polynomial in `N`.
+
+Standard circuit-witness encodings have length `≈ s(n)·log s(n)`, so for any
+interesting MCSP threshold `s(n) ≥ n²` the witness is super-linear and the naive
+construction is super-polynomial in `N`.
+
+## Decision (the gate verdict)
+
+**Option ① — shared `DagBundle` multi-output — is the working default.**  The
+greedy bits must share one gate list (a `DagBundle`, projected per output bit) so
+that size is *uniform* in the bit index rather than re-embedding all priors.  This
+needs a new composition primitive generalizing `substInputsWithBundle` to retain
+all outputs while layering a group reading prior outputs and fresh inputs.
+
+**Option ② — naive per-bit, restricting `witnessBits n = O(n)` — is a fallback
+only** if a *concrete* codec proves `witnessBits n = O(n)` and the resulting
+threshold stays mathematically meaningful (unlikely for interesting thresholds).
+
+Consequently the prefix-state query builder (next brick) must expose its payload
+as reads of prior *bundle outputs*, not as a family of independent circuits.
+
+Scope discipline — feasibility note only: **no** greedy solver, **no**
+`BoundedSearchSolver`, **no** `PpolyDAG` bridge, **no** endpoint, **no**
+`P ≠ NP` / `NP ⊄ P/poly` consequence, **no** lower bound.
+-/
+
+/-! ## Part 1 — abstract geometric lower bound for the additive recurrence -/
+
+/--
+If `f (i+1)` dominates the running sum `∑_{k ≤ i} f k` at every step, then the
+running sum is at least `f 0 · 2^i`.  (Ordinary induction: the sum at least
+doubles each step.)
+-/
+theorem sum_geometric_lower (f : Nat → Nat)
+    (hstep : ∀ i, (∑ k ∈ Finset.range (i + 1), f k) ≤ f (i + 1)) :
+    ∀ i, f 0 * 2 ^ i ≤ ∑ k ∈ Finset.range (i + 1), f k := by
+  intro i
+  induction i with
+  | zero => simp
+  | succ i ih =>
+      have hsum := hstep i
+      have hdouble : f 0 * 2 ^ (i + 1) = (f 0 * 2 ^ i) + (f 0 * 2 ^ i) := by ring
+      rw [Finset.sum_range_succ]
+      omega
+
+/--
+The additive greedy recurrence forces exponential growth: if `f` dominates its
+running sum at every step, then `f (i+1) ≥ f 0 · 2^i`.
+-/
+theorem geometric_lower_bound (f : Nat → Nat)
+    (hstep : ∀ i, (∑ k ∈ Finset.range (i + 1), f k) ≤ f (i + 1)) (i : Nat) :
+    f 0 * 2 ^ i ≤ f (i + 1) :=
+  le_trans (sum_geometric_lower f hstep i) (hstep i)
+
+/-! ## Part 2 — concrete blow-up of the naive `composeDeciderWithQuery` recursion -/
+
+/-- `composeDeciderWithQuery` is exactly the frozen `substInputs`; the model below
+faithfully uses the real extraction composition op. -/
+theorem composeDeciderWithQuery_eq_substInputs
+    {inputBits queryBits : Nat}
+    (decider : C_DAG.Family queryBits)
+    (queryBit : Fin queryBits → C_DAG.Family inputBits) :
+    composeDeciderWithQuery decider queryBit
+      = DagCircuit.substInputs decider queryBit := rfl
+
+/--
+A faithful model of the naive per-bit greedy recursion: depth `0` is a seed
+circuit, and depth `i+1` substitutes **all** prior depths `0, …, i` (as the query
+bits) into a combiner decider, via the real `composeDeciderWithQuery`/`substInputs`.
+This reproduces exactly the "re-embed all priors" structure of the naive scheme.
+-/
+def naiveGreedyModel (m : Nat) (seed : DagCircuit m)
+    (decider : (q : Nat) → DagCircuit q) : Nat → DagCircuit m
+  | 0 => seed
+  | i + 1 =>
+      DagCircuit.substInputs (decider (i + 1))
+        (fun k : Fin (i + 1) => naiveGreedyModel m seed decider k.1)
+
+/-- One step of the model sums the gate counts of all prior steps (plus the
+combiner), exactly because `substInputs` does not share. -/
+theorem gates_naiveGreedyModel_succ (m : Nat) (seed : DagCircuit m)
+    (decider : (q : Nat) → DagCircuit q) (i : Nat) :
+    (naiveGreedyModel m seed decider (i + 1)).gates
+      = (∑ k ∈ Finset.range (i + 1), (naiveGreedyModel m seed decider k).gates)
+        + (decider (i + 1)).gates := by
+  have hunfold :
+      naiveGreedyModel m seed decider (i + 1)
+        = DagCircuit.substInputs (decider (i + 1))
+            (fun k : Fin (i + 1) => naiveGreedyModel m seed decider k.1) := by
+    simp only [naiveGreedyModel]
+  have hbundle :
+      (DagCircuit.bundleOfFamily (i + 1)
+          (fun k : Fin (i + 1) => naiveGreedyModel m seed decider k.1)).gates
+        = ∑ k ∈ Finset.range (i + 1), (naiveGreedyModel m seed decider k).gates := by
+    rw [DagCircuit.bundleOfFamily_gates]
+    exact Fin.sum_univ_eq_sum_range
+      (fun k => (naiveGreedyModel m seed decider k).gates) (i + 1)
+  have hsize :=
+    DagCircuit.size_substInputs (decider (i + 1))
+      (fun k : Fin (i + 1) => naiveGreedyModel m seed decider k.1)
+  rw [hbundle] at hsize
+  have hsz :
+      DagCircuit.size
+          (DagCircuit.substInputs (decider (i + 1))
+            (fun k : Fin (i + 1) => naiveGreedyModel m seed decider k.1))
+        = (DagCircuit.substInputs (decider (i + 1))
+            (fun k : Fin (i + 1) => naiveGreedyModel m seed decider k.1)).gates + 1 := rfl
+  rw [hunfold]
+  omega
+
+/-- **The naive construction blows up.**  At depth `i+1`, the model's gate count
+is at least `seed.gates · 2^i` — exponential in the depth (= number of bits). -/
+theorem naiveGreedyModel_gates_ge (m : Nat) (seed : DagCircuit m)
+    (decider : (q : Nat) → DagCircuit q) (i : Nat) :
+    seed.gates * 2 ^ i ≤ (naiveGreedyModel m seed decider (i + 1)).gates := by
+  have hstep : ∀ j,
+      (∑ k ∈ Finset.range (j + 1), (naiveGreedyModel m seed decider k).gates)
+        ≤ (naiveGreedyModel m seed decider (j + 1)).gates := by
+    intro j
+    rw [gates_naiveGreedyModel_succ]
+    exact Nat.le_add_right _ _
+  have h0 : naiveGreedyModel m seed decider 0 = seed := by
+    simp only [naiveGreedyModel]
+  have hge := geometric_lower_bound
+    (fun k => (naiveGreedyModel m seed decider k).gates) hstep i
+  rw [h0] at hge
+  exact hge
+
+/-- The size (`= gates + 1`) version of the blow-up. -/
+theorem naiveGreedyModel_size_ge (m : Nat) (seed : DagCircuit m)
+    (decider : (q : Nat) → DagCircuit q) (i : Nat) :
+    seed.gates * 2 ^ i ≤ DagCircuit.size (naiveGreedyModel m seed decider (i + 1)) := by
+  have h := naiveGreedyModel_gates_ge m seed decider i
+  have hsz : DagCircuit.size (naiveGreedyModel m seed decider (i + 1))
+      = (naiveGreedyModel m seed decider (i + 1)).gates + 1 := rfl
+  omega
+
+/-- With a nonempty seed (`1 ≤ seed.gates`), the size is at least `2^i`. -/
+theorem naiveGreedyModel_size_ge_pow (m : Nat) (seed : DagCircuit m)
+    (decider : (q : Nat) → DagCircuit q) (i : Nat) (hseed : 1 ≤ seed.gates) :
+    2 ^ i ≤ DagCircuit.size (naiveGreedyModel m seed decider (i + 1)) := by
+  have h := naiveGreedyModel_size_ge m seed decider i
+  have h2 : 1 * 2 ^ i ≤ seed.gates * 2 ^ i := by gcongr
+  rw [one_mul] at h2
+  exact le_trans h2 h
+
+/-! ## Part 3 — magnification arithmetic (linear ⇒ poly; quadratic ⇒ super-poly) -/
+
+/-- Linear witness length keeps the naive size polynomial in `N = 2^n`:
+`2^{witnessBits} ≤ (2^n)^c · 2^c`. -/
+theorem pow_le_of_linear_witnessBits (W n c : Nat) (h : W ≤ c * n + c) :
+    2 ^ W ≤ (2 ^ n) ^ c * 2 ^ c := by
+  calc
+    2 ^ W ≤ 2 ^ (c * n + c) := Nat.pow_le_pow_right (by norm_num) h
+    _ = (2 ^ n) ^ c * 2 ^ c := by
+        rw [pow_add, Nat.mul_comm c n, pow_mul]
+
+/-- Super-linear witness length outgrows every fixed polynomial degree in
+`N = 2^n`: for `witnessBits n = n²`, every degree `c`, and all `n > c`,
+`(2^n)^c < 2^{n²}`. -/
+theorem pow_quadratic_gt_poly (n c : Nat) (hn : 0 < n) (hc : c < n) :
+    (2 ^ n) ^ c < 2 ^ (n * n) := by
+  have hmul : n * c < n * n := by nlinarith [hc, hn]
+  calc
+    (2 ^ n) ^ c = 2 ^ (n * c) := (pow_mul 2 n c).symm
+    _ < 2 ^ (n * n) := Nat.pow_lt_pow_right (by norm_num) hmul
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPrefixQueryCircuits.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPrefixQueryCircuits.lean
@@ -1,0 +1,115 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
+import Pnp4.Frontier.ContractExpansion.QueryComposition
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Zero-prefix query-bit circuits (downstream decision→search extraction)
+
+Fifth reusable brick.  The previous brick
+(`TreeMCSPPrefixSerializer.zeroPrefixQueryValue`) gave the *semantic* zero-prefix
+query string and its parser round-trip, **without any circuits**.  This file
+supplies the missing per-bit `C_DAG` circuits: for each query-bit position `j`,
+a small `C_DAG` circuit over the instance bits (`tableLen n`) that computes the
+`j`-th bit of `zeroPrefixQueryValue codec n x`, together with a correctness proof
+and a uniform per-bit size bound (`≤ 2`).
+
+These are exactly the `queryBitCircuit`/`queryBit_correct`/`size_le` data a
+`QueryCircuitBuilder` needs; the concrete builder instance is the next brick.
+
+The construction is a direct mirror of `encodeTreeMCSPPrefixFields` specialized to
+the zero-prefix case `i = 0`: every encoded bit is either a constant (the version
+tag byte, the Elias-gamma length code of `n`, the all-zero index field, and the
+empty/padding suffix) or exactly one coordinate of the truth table `x` (the
+`tableLen n`-wide x-slice).  So each query-bit circuit is a `constCircuit` or an
+`inputProj`.
+
+Scope discipline — per-bit query circuits only:
+
+* **no** `QueryCircuitBuilder` / `PrefixQueryBuilder` instance (next brick);
+* **no** prefix-state `(i, p)` generalization;
+* **no** greedy witness-bit construction;
+* **no** `BoundedSearchSolver` assembly;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
+  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/--
+The `C_DAG` circuit (over the instance bits `tableLen n`) computing the `j`-th bit
+of the zero-prefix query string `zeroPrefixQueryValue codec n x`.
+
+This mirrors `encodeTreeMCSPPrefixFields` for `i = 0`: the tag, gamma, index, and
+(empty) prefix/pad regions are constants, while the x-slice region reads one
+coordinate of the instance via `inputProj`.
+-/
+def zeroPrefixQueryBitCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n) :=
+  if hTag : j.1 < tagLen then
+    Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _
+      (natBitBE treePrefixTag tagLen ⟨j.1, hTag⟩)
+  else
+    let gammaOffset := tagLen
+    if hGamma : j.1 < gammaOffset + gammaLen n then
+      Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _
+        (gammaBit n ⟨j.1 - gammaOffset, by omega⟩)
+    else
+      let xOffset := tagLen + gammaLen n
+      if hX : j.1 < xOffset + Pnp3.Models.Partial.tableLen n then
+        Pnp3.ComplexityInterfaces.DagCircuit.inputProj
+          ⟨j.1 - xOffset, by omega⟩
+      else
+        let iOffset := xOffset + Pnp3.Models.Partial.tableLen n
+        if hI : j.1 < iOffset + idxWidth codec.witnessBits n then
+          Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _
+            (natBitBE 0 (idxWidth codec.witnessBits n) ⟨j.1 - iOffset, by omega⟩)
+        else
+          Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _ false
+
+/--
+Each zero-prefix query-bit circuit really computes the corresponding bit of the
+semantic zero-prefix query string.  The proof is a region-by-region case split
+that exactly matches the `encodeTreeMCSPPrefixFields` cascade for `i = 0`.
+-/
+theorem eval_zeroPrefixQueryBitCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.eval (zeroPrefixQueryBitCircuit codec n j) x =
+      zeroPrefixQueryValue codec n x j := by
+  simp only [zeroPrefixQueryValue, zeroPrefixFields, encodeTreeMCSPPrefixFields,
+    zeroPrefixQueryBitCircuit]
+  -- The encoder cascade carries an extra (vacuous, `i = 0`) prefix-payload region
+  -- that the circuit has no branch for; that branch contradicts `hI` and is closed
+  -- by `omega`, the rest reduce via the leaf `eval` lemmas.
+  split_ifs with hTag hGamma hX hI hP <;>
+    first
+      | (exfalso; omega)
+      | simp [C_DAG,
+          Pnp3.ComplexityInterfaces.DagCircuit.eval_constCircuit,
+          Pnp3.ComplexityInterfaces.DagCircuit.eval_inputProj]
+
+/--
+Every zero-prefix query-bit circuit has size at most `2` (a `constCircuit` has
+size `2`, an `inputProj` has size `1`).
+-/
+theorem size_zeroPrefixQueryBitCircuit_le
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.size (zeroPrefixQueryBitCircuit codec n j) ≤ 2 := by
+  simp only [zeroPrefixQueryBitCircuit]
+  split_ifs <;> simp [C_DAG]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZeroPrefixBuilder.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZeroPrefixBuilder.lean
@@ -1,0 +1,90 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
+import Pnp4.Frontier.ContractExpansion.PrefixQueryBuilder
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Concrete zero-prefix `PrefixQueryBuilder` instance (downstream extraction)
+
+Sixth reusable brick.  The previous bricks supplied, separately, the *generic*
+builder interfaces (`QueryCircuitBuilder`, `PrefixQueryBuilder`), the *semantic*
+zero-prefix query string with its parser round-trip
+(`zeroPrefixQueryValue`, `zeroPrefixQueryValue_parses`), and the *per-bit query
+circuits* (`zeroPrefixQueryBitCircuit` + eval/size).  This file wires them
+together into a fully concrete `PrefixQueryBuilder` for the tree-MCSP prefix
+parser, specialized to the zero-prefix (`i = 0`) case.
+
+Concretely:
+
+* `zeroPrefixQueryCircuitBuilder codec` is the generic `QueryCircuitBuilder`
+  whose query value is `zeroPrefixQueryValue codec`, whose per-bit circuits are
+  `zeroPrefixQueryBitCircuit codec`, and whose uniform per-bit size bound is `2`;
+* `treeMCSPZeroPrefixQueryBuilder threshold codec` packages it as a
+  `PrefixQueryBuilder` for `treeMCSPConcretePrefixParser`, with the round-trip
+  contract discharged by `zeroPrefixQueryValue_parses`.
+
+This is the first fully-assembled `PrefixQueryBuilder` *instance* (every previous
+prefix-route brick was an interface or a single component).
+
+Scope discipline — concrete builder instance only:
+
+* this is still the *zero-prefix* serialization (`i = 0`); the prefix-state
+  `(i, p)` generalization is a later brick;
+* **no** greedy witness-bit construction;
+* **no** `BoundedSearchSolver` assembly;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
+  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+-/
+
+/--
+The generic query-circuit builder for the zero-prefix tree-MCSP query: instance
+bits are the truth table (`tableLen n`), query bits are the parser's ambient
+length (`treeMCSPPrefixM codec n`), assembled from the zero-prefix per-bit
+circuits and their eval/size lemmas.
+-/
+def zeroPrefixQueryCircuitBuilder
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold) :
+    QueryCircuitBuilder
+      (fun n => Pnp3.Models.Partial.tableLen n)
+      (fun n => treeMCSPPrefixM codec n) where
+  queryValue := zeroPrefixQueryValue codec
+  queryBitCircuit := zeroPrefixQueryBitCircuit codec
+  queryBit_correct := fun n i x => eval_zeroPrefixQueryBitCircuit codec n x i
+  sizeBound := fun _ => 2
+  size_le := fun n i => size_zeroPrefixQueryBitCircuit_le codec n i
+
+/--
+The concrete zero-prefix `PrefixQueryBuilder` instance for the tree-MCSP prefix
+parser: the generic builder above, packaged with the parser round-trip contract
+from `zeroPrefixQueryValue_parses`.
+-/
+def treeMCSPZeroPrefixQueryBuilder
+    (threshold : Nat → Nat)
+    (codec : TreeCircuitWitnessCodec threshold) :
+    PrefixQueryBuilder
+      (treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec))
+      (treeMCSPConcretePrefixParser threshold codec) where
+  builder := zeroPrefixQueryCircuitBuilder codec
+  parses_back := fun n x => zeroPrefixQueryValue_parses codec n x
+
+/--
+The instance's serialized query value is exactly `zeroPrefixQueryValue`
+(definitional sanity check that the wiring did not reshape the semantics).
+-/
+theorem treeMCSPZeroPrefixQueryBuilder_queryValue
+    {threshold : Nat → Nat}
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    (treeMCSPZeroPrefixQueryBuilder threshold codec).queryValue n x =
+      zeroPrefixQueryValue codec n x :=
+  rfl
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -35,6 +35,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 
 namespace Pnp4
 namespace Tests
@@ -289,6 +290,38 @@ theorem check_size_zeroPrefixQueryBitCircuit_le
   size_zeroPrefixQueryBitCircuit_le codec n j
 
 end TreeMCSPPrefixQueryCircuitsSurface
+
+section TreeMCSPZeroPrefixBuilderSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+def check_zeroPrefixQueryCircuitBuilder
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold) :
+    QueryCircuitBuilder
+      (fun n => Pnp3.Models.Partial.tableLen n)
+      (fun n => treeMCSPPrefixM codec n) :=
+  zeroPrefixQueryCircuitBuilder codec
+
+def check_treeMCSPZeroPrefixQueryBuilder
+    (threshold : Nat → Nat)
+    (codec : Frontier.TreeCircuitWitnessCodec threshold) :
+    PrefixQueryBuilder
+      (Frontier.treeMCSPSearchProblem threshold
+        (Frontier.TreeMCSPSearchWitnessEncoding.ofCodec codec))
+      (treeMCSPConcretePrefixParser threshold codec) :=
+  treeMCSPZeroPrefixQueryBuilder threshold codec
+
+theorem check_treeMCSPZeroPrefixQueryBuilder_queryValue
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    (treeMCSPZeroPrefixQueryBuilder threshold codec).queryValue n x =
+      zeroPrefixQueryValue codec n x :=
+  treeMCSPZeroPrefixQueryBuilder_queryValue codec n x
+
+end TreeMCSPZeroPrefixBuilderSurface
 
 section PrefixExtensionLanguageSurface
 

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -34,6 +34,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixQueryBuilder
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
 
 namespace Pnp4
 namespace Tests
@@ -256,6 +257,38 @@ theorem check_zeroPrefixQueryValue_parses
   zeroPrefixQueryValue_parses codec n x
 
 end TreeMCSPPrefixSerializerSurface
+
+section TreeMCSPPrefixQueryCircuitsSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+def check_zeroPrefixQueryBitCircuit
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n) :=
+  zeroPrefixQueryBitCircuit codec n j
+
+theorem check_eval_zeroPrefixQueryBitCircuit
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.eval (zeroPrefixQueryBitCircuit codec n j) x =
+      zeroPrefixQueryValue codec n x j :=
+  eval_zeroPrefixQueryBitCircuit codec n x j
+
+theorem check_size_zeroPrefixQueryBitCircuit_le
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.size (zeroPrefixQueryBitCircuit codec n j) ≤ 2 :=
+  size_zeroPrefixQueryBitCircuit_le codec n j
+
+end TreeMCSPPrefixQueryCircuitsSurface
 
 section PrefixExtensionLanguageSurface
 

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -36,6 +36,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
+import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
 namespace Pnp4
 namespace Tests
@@ -322,6 +323,44 @@ theorem check_treeMCSPZeroPrefixQueryBuilder_queryValue
   treeMCSPZeroPrefixQueryBuilder_queryValue codec n x
 
 end TreeMCSPZeroPrefixBuilderSurface
+
+section NaiveGreedySizeSpikeSurface
+
+open Pnp4.Frontier.ContractExpansion
+open Pnp3.ComplexityInterfaces (DagCircuit)
+
+theorem check_geometric_lower_bound (f : Nat → Nat)
+    (hstep : ∀ i, (∑ k ∈ Finset.range (i + 1), f k) ≤ f (i + 1)) (i : Nat) :
+    f 0 * 2 ^ i ≤ f (i + 1) :=
+  geometric_lower_bound f hstep i
+
+theorem check_composeDeciderWithQuery_eq_substInputs
+    {inputBits queryBits : Nat}
+    (decider : C_DAG.Family queryBits)
+    (queryBit : Fin queryBits → C_DAG.Family inputBits) :
+    composeDeciderWithQuery decider queryBit
+      = DagCircuit.substInputs decider queryBit :=
+  composeDeciderWithQuery_eq_substInputs decider queryBit
+
+theorem check_naiveGreedyModel_size_ge (m : Nat) (seed : DagCircuit m)
+    (decider : (q : Nat) → DagCircuit q) (i : Nat) :
+    seed.gates * 2 ^ i ≤ DagCircuit.size (naiveGreedyModel m seed decider (i + 1)) :=
+  naiveGreedyModel_size_ge m seed decider i
+
+theorem check_naiveGreedyModel_size_ge_pow (m : Nat) (seed : DagCircuit m)
+    (decider : (q : Nat) → DagCircuit q) (i : Nat) (hseed : 1 ≤ seed.gates) :
+    2 ^ i ≤ DagCircuit.size (naiveGreedyModel m seed decider (i + 1)) :=
+  naiveGreedyModel_size_ge_pow m seed decider i hseed
+
+theorem check_pow_le_of_linear_witnessBits (W n c : Nat) (h : W ≤ c * n + c) :
+    2 ^ W ≤ (2 ^ n) ^ c * 2 ^ c :=
+  pow_le_of_linear_witnessBits W n c h
+
+theorem check_pow_quadratic_gt_poly (n c : Nat) (hn : 0 < n) (hc : c < n) :
+    (2 ^ n) ^ c < 2 ^ (n * n) :=
+  pow_quadratic_gt_poly n c hn hc
+
+end NaiveGreedySizeSpikeSurface
 
 section PrefixExtensionLanguageSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -25,6 +25,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 
 namespace Pnp4
 namespace Tests
@@ -209,6 +210,10 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.eval_zeroPrefixQueryBitCircuit
 #print axioms Pnp4.Frontier.ContractExpansion.size_zeroPrefixQueryBitCircuit_le
+
+#print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
+#print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder
+#print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder_queryValue
 
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_accepts_iff
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_rejects_malformed

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -26,6 +26,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
+import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
 namespace Pnp4
 namespace Tests
@@ -214,6 +215,13 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder_queryValue
+
+#print axioms Pnp4.Frontier.ContractExpansion.geometric_lower_bound
+#print axioms Pnp4.Frontier.ContractExpansion.composeDeciderWithQuery_eq_substInputs
+#print axioms Pnp4.Frontier.ContractExpansion.naiveGreedyModel_size_ge
+#print axioms Pnp4.Frontier.ContractExpansion.naiveGreedyModel_size_ge_pow
+#print axioms Pnp4.Frontier.ContractExpansion.pow_le_of_linear_witnessBits
+#print axioms Pnp4.Frontier.ContractExpansion.pow_quadratic_gt_poly
 
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_accepts_iff
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_rejects_malformed

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -24,6 +24,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixQueryBuilder
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
 
 namespace Pnp4
 namespace Tests
@@ -205,6 +206,9 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.parse_zeroPrefixQueryValue
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryValue_parses
+
+#print axioms Pnp4.Frontier.ContractExpansion.eval_zeroPrefixQueryBitCircuit
+#print axioms Pnp4.Frontier.ContractExpansion.size_zeroPrefixQueryBitCircuit_le
 
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_accepts_iff
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_rejects_malformed

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -223,6 +223,11 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.pow_le_of_linear_witnessBits
 #print axioms Pnp4.Frontier.ContractExpansion.pow_quadratic_gt_poly
 
+#print axioms Pnp3.ComplexityInterfaces.DagCircuit.evalGateAt_congr
+#print axioms Pnp3.ComplexityInterfaces.DagCircuit.snocBundleSubst_gates
+#print axioms Pnp3.ComplexityInterfaces.DagCircuit.evalOutput_snocBundleSubst_new
+#print axioms Pnp3.ComplexityInterfaces.DagCircuit.evalOutput_snocBundleSubst_old
+
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_accepts_iff
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_rejects_malformed
 #print axioms Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage_accepts_of_parse_and_witness


### PR DESCRIPTION
## Summary

This PR closes the immediate zero-prefix bricks of the downstream decision→search
extraction and the feasibility gate, **selects shared `DagBundle` output sharing
(Option ①) as the architecture**, and adds the `snocBundleSubst` primitive that
the prefix-state builder will need before it can be implemented safely.

It deliberately **stops before Block 4** (the prefix-state `(i, p)` query builder):
`snocBundleSubst` extends the core pnp3 composition layer, so it should be
reviewed/merged on its own before anything is built on top of it.

## What's in scope

1. **Block 2 — zero-prefix query-bit circuits**
   (`pnp4/…/ContractExpansion/TreeMCSPPrefixQueryCircuits.lean`)
   `zeroPrefixQueryBitCircuit` mirrors `encodeTreeMCSPPrefixFields` for `i = 0`:
   every query bit is a `constCircuit` (tag/gamma/index/pad) or an `inputProj`
   (the x-slice). With `eval_zeroPrefixQueryBitCircuit` and a uniform size bound
   `≤ 2`.

2. **Block 3 — concrete zero-prefix `PrefixQueryBuilder` instance**
   (`pnp4/…/ContractExpansion/TreeMCSPZeroPrefixBuilder.lean`)
   `zeroPrefixQueryCircuitBuilder` + `treeMCSPZeroPrefixQueryBuilder`: the first
   fully-assembled `PrefixQueryBuilder` instance (zero-prefix only), with the
   parser round-trip discharged by `zeroPrefixQueryValue_parses`.

3. **Size-feasibility spike (the gate)**
   (`pnp4/…/ContractExpansion/NaiveGreedySizeSpike.lean`)
   Formalizes that the *naive* per-bit greedy construction blows up, tied to the
   actual composition op:
   - `composeDeciderWithQuery_eq_substInputs` — the extraction's composition **is**
     `substInputs` (which does not share);
   - `geometric_lower_bound` (abstract recurrence ⇒ exponential) and
     `naiveGreedyModel_size_ge` (concrete: size `≥ seed.gates · 2^i` at depth `i`);
   - `pow_le_of_linear_witnessBits` / `pow_quadratic_gt_poly` — linear witness
     length stays poly in `N = 2^n`, but any super-linear threshold (e.g. `n²`)
     beats every fixed polynomial degree.

   **Verdict (recorded in the module docstring): Option ① — shared `DagBundle`
   multi-output — is the working default.** Option ② (naive) is viable only if a
   concrete codec proves `witnessBits n = O(n)` with a meaningful threshold.

4. **pnp3 `snocBundleSubst` — shared-bundle composition primitive (Option ① infra)**
   (`pnp3/Complexity/DagCompose.lean`, "step 4d")
   Extends a bundle `B : DagBundle m out` by one new output computed by a head
   circuit `H : DagCircuit (m + out)` reading the real inputs **and** `B`'s
   outputs, with the bundle **shared**:
   - `snocBundleSubst_gates : (snocBundleSubst B H).gates = B.gates + H.gates`
     (additive in `H`, not multiplicative in prior bits — the whole point);
   - `evalOutput_snocBundleSubst_old` (old outputs preserved) and
     `evalOutput_snocBundleSubst_new` (new output = `H` over inputs ++ `B` outputs).

   Built on the already-proved `substInputsWithBundle` via a new `passthroughBundle`
   (exposes the `m` real inputs followed by `B`'s outputs over `B`'s shared gate
   list). Supporting lemmas: `evalGateAt_congr` (gate-level eval depends only on the
   gate list, not the output wire — the fact that makes shared-gate reuse valid in
   Lean) and `withOutput`.

   Iterating `snocBundleSubst` keeps circuit size **linear** in the number of
   outputs, versus the `B · 2^i` blow-up the spike proves for naive re-embedding.

## Note on scope

This is larger than "Block 2/3 + spike": it also adds a **core pnp3 composition
primitive** (`snocBundleSubst`). That primitive is the prerequisite for building
the prefix-state query builder in the selected Option ① shape, which is why it is
included here rather than left implicit — but **Block 4 is intentionally not in
this PR.**

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New theorem surfaces depend only on `propext` / `Classical.choice` / `Quot.sound`
  (registered in `pnp4/Pnp4/Tests/AxiomsAudit.lean`, including the `snocBundleSubst`
  lemmas and `evalGateAt_congr`).
- Surface re-exports added in `AlgorithmsToLowerBoundsSurfaceTests.lean`; modules
  registered in `lakefile.lean`.

## Scope discipline

Composition/query infrastructure only: **no** greedy `BoundedSearchSolver`
assembly, **no** `PpolyDAG` bridge, **no** endpoint wrapper, **no**
`P ≠ NP` / `NP ⊄ P/poly` consequence, and **no** lower bound. The genuine lower
bound remains the open problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_