### PR TITLE
Block 4: prefix-state (i,p) query circuits in shared-bundle shape

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -279,6 +279,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder,
     Glob.one `Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPrefixStateQueryCircuits.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPrefixStateQueryCircuits.lean
@@ -1,0 +1,200 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
+import Pnp4.Frontier.ContractExpansion.QueryComposition
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Prefix-state `(i, p)` query circuits, in the shared-bundle shape
+
+Block 4 of the downstream decision→search extraction, written directly in the
+**Option ①** architecture selected by the size-feasibility gate (`#1498`).
+
+Block 2 (`zeroPrefixQueryBitCircuit`) handled the zero-prefix case `i = 0`: per-bit
+`C_DAG` circuits over the instance bits (`tableLen n`).  This file generalizes to a
+prefix-state `(i, p)` — an active witness prefix of length `i` with payload `p` —
+**without re-embedding `p` as independent circuits**.  Instead the per-bit circuit
+reads `tableLen n + i` inputs: the first `tableLen n` are the real instance bits,
+the last `i` are the *prior bundle outputs* (the greedy bits `0..i-1`).  The payload
+region of the query string is therefore an `inputProj` onto a prior-output input
+(`Fin.natAdd`), exactly the head-circuit shape that plugs into the shared-bundle
+greedy step `DagCircuit.snocBundleSubst` (added in `#1498`):
+
+* x-slice region → `inputProj (Fin.castAdd i ·)` (a real instance bit);
+* payload region → `inputProj (Fin.natAdd (tableLen n) ·)` (a prior bundle output);
+* tag / gamma / index / pad regions → constants (the index field now encodes the
+  *actual* prefix length `i`).
+
+So each query-bit circuit is again a `constCircuit` or an `inputProj` (size `≤ 2`),
+and evaluating the family on an input `Fin.append x p` reproduces the canonical
+serialized prefix-state query string `encodeTreeMCSPPrefixFields` for `(n, x, i, p)`.
+The parser round-trip is a direct instance of the already-proved general
+`parse_encodeTreeMCSPPrefixFields`.
+
+Scope discipline — prefix-state query value + per-bit circuits only:
+
+* **no** `QueryCircuitBuilder` / `PrefixQueryBuilder` instance over `tableLen n + i`
+  inputs (a later brick);
+* **no** greedy recursion / `snocBundleSubst` threading;
+* **no** `BoundedSearchSolver` assembly;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
+  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/--
+Canonical raw fields for the prefix-state `(i, p)`: instance `x`, active prefix
+length `i ≤ codec.witnessBits n`, prefix payload `p`.  Generalizes
+`zeroPrefixFields` (the `i = 0` case).
+-/
+def prefixStateFields
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i) :
+    CanonicalRawTreeMCSPPrefixFields codec where
+  n := n
+  x := x
+  i := i
+  prefixLength_le := hi
+  p := p
+
+/--
+The serialized prefix-state query string for `(i, p)` about instance `x`, of the
+parser's ambient length `treeMCSPPrefixM codec n`.  Generalizes
+`zeroPrefixQueryValue`.
+-/
+def prefixStateQueryValue
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i) :
+    PrefixBitVec (treeMCSPPrefixM codec n) :=
+  encodeTreeMCSPPrefixFields codec (prefixStateFields codec n i hi x p)
+
+/--
+The concrete parser round-trips the prefix-state query string back to its
+canonical parsed input.  Direct instance of `parse_encodeTreeMCSPPrefixFields`.
+-/
+theorem parse_prefixStateQueryValue
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i) :
+    parseTreeMCSPPrefixInput threshold codec (prefixStateQueryValue codec n i hi x p) =
+      some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec
+        (prefixStateFields codec n i hi x p)) :=
+  parse_encodeTreeMCSPPrefixFields codec (prefixStateFields codec n i hi x p)
+
+/--
+Round-trip in the `PrefixQueryBuilder.parses_back` contract shape: the prefix-state
+query string parses to a prefix-input about `x` at target length `n`.
+
+`input.n = n` and `HEq input.x x` hold definitionally because the parsed input is
+the canonical `toPrefixInput`, whose `n`/`x` fields are exactly the raw `n`/`x`.
+-/
+theorem prefixStateQueryValue_parses
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i) :
+    ∃ input : PrefixInput
+        (treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec))
+        (treeMCSPPrefixM codec n),
+      parseTreeMCSPPrefixInput threshold codec (prefixStateQueryValue codec n i hi x p) = some input
+        ∧ input.n = n
+        ∧ HEq input.x x :=
+  ⟨CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec (prefixStateFields codec n i hi x p),
+    parse_prefixStateQueryValue codec n i hi x p, rfl, HEq.rfl⟩
+
+/--
+The bundle-shape `C_DAG` circuit (over `tableLen n + i` inputs) computing the
+`j`-th bit of the prefix-state query string `prefixStateQueryValue codec n i hi x p`.
+
+This mirrors `encodeTreeMCSPPrefixFields` for general `(i, p)`: tag/gamma/index/pad
+are constants (the index field is the big-endian code of the *actual* `i`), the
+x-slice reads a real instance bit via `inputProj (Fin.castAdd i ·)`, and the
+witness-prefix payload reads a prior bundle output via
+`inputProj (Fin.natAdd (tableLen n) ·)`.  The circuit itself does not depend on the
+bound `hi`; only the semantic value/parse do.
+-/
+def prefixStateQueryBitCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n + i) :=
+  if hTag : j.1 < tagLen then
+    Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _
+      (natBitBE treePrefixTag tagLen ⟨j.1, hTag⟩)
+  else
+    let gammaOffset := tagLen
+    if hGamma : j.1 < gammaOffset + gammaLen n then
+      Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _
+        (gammaBit n ⟨j.1 - gammaOffset, by omega⟩)
+    else
+      let xOffset := tagLen + gammaLen n
+      if hX : j.1 < xOffset + Pnp3.Models.Partial.tableLen n then
+        Pnp3.ComplexityInterfaces.DagCircuit.inputProj
+          (Fin.castAdd i ⟨j.1 - xOffset, by omega⟩)
+      else
+        let iOffset := xOffset + Pnp3.Models.Partial.tableLen n
+        if hI : j.1 < iOffset + idxWidth codec.witnessBits n then
+          Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _
+            (natBitBE i (idxWidth codec.witnessBits n) ⟨j.1 - iOffset, by omega⟩)
+        else
+          let pOffset := iOffset + idxWidth codec.witnessBits n
+          if hP : j.1 < pOffset + i then
+            Pnp3.ComplexityInterfaces.DagCircuit.inputProj
+              (Fin.natAdd (Pnp3.Models.Partial.tableLen n) ⟨j.1 - pOffset, by omega⟩)
+          else
+            Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _ false
+
+/--
+Each prefix-state query-bit circuit really computes the corresponding bit of the
+semantic prefix-state query string, when fed the combined input
+`Fin.append x p` (real instance bits followed by the prior-output payload).  The
+proof is a region-by-region case split matching the `encodeTreeMCSPPrefixFields`
+cascade; the x-slice and payload regions discharge via `Fin.append_left` /
+`Fin.append_right`.
+-/
+theorem eval_prefixStateQueryBitCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.eval (prefixStateQueryBitCircuit codec n i j) (Fin.append x p) =
+      prefixStateQueryValue codec n i hi x p j := by
+  simp only [prefixStateQueryValue, prefixStateFields, encodeTreeMCSPPrefixFields,
+    prefixStateQueryBitCircuit]
+  split_ifs with hTag hGamma hX hI hP <;>
+    simp only [C_DAG,
+      Pnp3.ComplexityInterfaces.DagCircuit.eval_constCircuit,
+      Pnp3.ComplexityInterfaces.DagCircuit.eval_inputProj,
+      Fin.append_left, Fin.append_right]
+
+/--
+Every prefix-state query-bit circuit has size at most `2` (a `constCircuit` has
+size `2`, an `inputProj` has size `1`) — uniform in `j`, `i`, and the prior
+outputs, as required for the shared-bundle greedy step to stay polynomial.
+-/
+theorem size_prefixStateQueryBitCircuit_le
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.size (prefixStateQueryBitCircuit codec n i j) ≤ 2 := by
+  simp only [prefixStateQueryBitCircuit]
+  split_ifs <;> simp [C_DAG]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPrefixStateQueryCircuits.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPrefixStateQueryCircuits.lean
@@ -123,12 +123,18 @@ This mirrors `encodeTreeMCSPPrefixFields` for general `(i, p)`: tag/gamma/index/
 are constants (the index field is the big-endian code of the *actual* `i`), the
 x-slice reads a real instance bit via `inputProj (Fin.castAdd i ·)`, and the
 witness-prefix payload reads a prior bundle output via
-`inputProj (Fin.natAdd (tableLen n) ·)`.  The circuit itself does not depend on the
-bound `hi`; only the semantic value/parse do.
+`inputProj (Fin.natAdd (tableLen n) ·)`.  The prefix-length bound
+`_hi : i ≤ codec.witnessBits n` is required in the signature so the circuit API
+cannot be instantiated outside the parser/round-trip contract: an out-of-range `i`
+would truncate the `idxWidth`-wide index field and spill payload bits into the
+region the parser treats as mandatory zero padding, yielding a circuit family that
+provably cannot parse as a valid prefix input.  The circuit *body* does not
+otherwise depend on it.
 -/
 def prefixStateQueryBitCircuit
     (codec : TreeCircuitWitnessCodec threshold)
     (n i : Nat)
+    (_hi : i ≤ codec.witnessBits n)
     (j : Fin (treeMCSPPrefixM codec n)) :
     C_DAG.Family (Pnp3.Models.Partial.tableLen n + i) :=
   if hTag : j.1 < tagLen then
@@ -172,7 +178,7 @@ theorem eval_prefixStateQueryBitCircuit
     (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
     (p : PrefixBitVec i)
     (j : Fin (treeMCSPPrefixM codec n)) :
-    C_DAG.eval (prefixStateQueryBitCircuit codec n i j) (Fin.append x p) =
+    C_DAG.eval (prefixStateQueryBitCircuit codec n i hi j) (Fin.append x p) =
       prefixStateQueryValue codec n i hi x p j := by
   simp only [prefixStateQueryValue, prefixStateFields, encodeTreeMCSPPrefixFields,
     prefixStateQueryBitCircuit]
@@ -190,8 +196,9 @@ outputs, as required for the shared-bundle greedy step to stay polynomial.
 theorem size_prefixStateQueryBitCircuit_le
     (codec : TreeCircuitWitnessCodec threshold)
     (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
     (j : Fin (treeMCSPPrefixM codec n)) :
-    C_DAG.size (prefixStateQueryBitCircuit codec n i j) ≤ 2 := by
+    C_DAG.size (prefixStateQueryBitCircuit codec n i hi j) ≤ 2 := by
   simp only [prefixStateQueryBitCircuit]
   split_ifs <;> simp [C_DAG]
 

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -321,9 +321,10 @@ def check_prefixStateQueryBitCircuit
     {threshold : Nat → Nat}
     (codec : Frontier.TreeCircuitWitnessCodec threshold)
     (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
     (j : Fin (treeMCSPPrefixM codec n)) :
     C_DAG.Family (Pnp3.Models.Partial.tableLen n + i) :=
-  prefixStateQueryBitCircuit codec n i j
+  prefixStateQueryBitCircuit codec n i hi j
 
 /-- Block 4 surface: evaluating the per-bit circuit on `Fin.append x p` reproduces
 the canonical prefix-state query bit. -/
@@ -335,7 +336,7 @@ theorem check_eval_prefixStateQueryBitCircuit
     (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
     (p : PrefixBitVec i)
     (j : Fin (treeMCSPPrefixM codec n)) :
-    C_DAG.eval (prefixStateQueryBitCircuit codec n i j) (Fin.append x p) =
+    C_DAG.eval (prefixStateQueryBitCircuit codec n i hi j) (Fin.append x p) =
       prefixStateQueryValue codec n i hi x p j :=
   eval_prefixStateQueryBitCircuit codec n i hi x p j
 
@@ -344,9 +345,10 @@ theorem check_size_prefixStateQueryBitCircuit_le
     {threshold : Nat → Nat}
     (codec : Frontier.TreeCircuitWitnessCodec threshold)
     (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
     (j : Fin (treeMCSPPrefixM codec n)) :
-    C_DAG.size (prefixStateQueryBitCircuit codec n i j) ≤ 2 :=
-  size_prefixStateQueryBitCircuit_le codec n i j
+    C_DAG.size (prefixStateQueryBitCircuit codec n i hi j) ≤ 2 :=
+  size_prefixStateQueryBitCircuit_le codec n i hi j
 
 end TreeMCSPPrefixStateQueryCircuitsSurface
 

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -35,6 +35,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -291,6 +292,63 @@ theorem check_size_zeroPrefixQueryBitCircuit_le
   size_zeroPrefixQueryBitCircuit_le codec n j
 
 end TreeMCSPPrefixQueryCircuitsSurface
+
+section TreeMCSPPrefixStateQueryCircuitsSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 4 surface: the prefix-state `(i, p)` query string parses back to a
+prefix-input about `x` at target length `n`. -/
+theorem check_prefixStateQueryValue_parses
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i) :
+    ∃ input : PrefixInput
+        (Frontier.treeMCSPSearchProblem threshold
+          (Frontier.TreeMCSPSearchWitnessEncoding.ofCodec codec))
+        (treeMCSPPrefixM codec n),
+      parseTreeMCSPPrefixInput threshold codec (prefixStateQueryValue codec n i hi x p) = some input
+        ∧ input.n = n
+        ∧ HEq input.x x :=
+  prefixStateQueryValue_parses codec n i hi x p
+
+/-- Block 4 surface: the bundle-shape per-bit query circuit, over
+`tableLen n + i` inputs (real instance bits ++ prior bundle outputs). -/
+def check_prefixStateQueryBitCircuit
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n + i) :=
+  prefixStateQueryBitCircuit codec n i j
+
+/-- Block 4 surface: evaluating the per-bit circuit on `Fin.append x p` reproduces
+the canonical prefix-state query bit. -/
+theorem check_eval_prefixStateQueryBitCircuit
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.eval (prefixStateQueryBitCircuit codec n i j) (Fin.append x p) =
+      prefixStateQueryValue codec n i hi x p j :=
+  eval_prefixStateQueryBitCircuit codec n i hi x p j
+
+/-- Block 4 surface: uniform per-bit size bound (`≤ 2`), independent of `i`. -/
+theorem check_size_prefixStateQueryBitCircuit_le
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.size (prefixStateQueryBitCircuit codec n i j) ≤ 2 :=
+  size_prefixStateQueryBitCircuit_le codec n i j
+
+end TreeMCSPPrefixStateQueryCircuitsSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -25,6 +25,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguageRuntime
 import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -211,6 +212,11 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.eval_zeroPrefixQueryBitCircuit
 #print axioms Pnp4.Frontier.ContractExpansion.size_zeroPrefixQueryBitCircuit_le
+
+#print axioms Pnp4.Frontier.ContractExpansion.parse_prefixStateQueryValue
+#print axioms Pnp4.Frontier.ContractExpansion.prefixStateQueryValue_parses
+#print axioms Pnp4.Frontier.ContractExpansion.eval_prefixStateQueryBitCircuit
+#print axioms Pnp4.Frontier.ContractExpansion.size_prefixStateQueryBitCircuit_le
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 4 of the downstream decision→search extraction: the **prefix-state `(i, p)`
query circuits**, written directly in the **Option ①** shared-bundle architecture
selected by the size-feasibility gate (merged in #1498). New file
`TreeMCSPPrefixStateQueryCircuits.lean`.

Block 2 (#1498) handled the zero-prefix case `i = 0`: per-bit circuits over the
instance bits (`tableLen n`). This generalizes to an active witness prefix of
length `i` with payload `p` **without re-embedding `p` as independent circuits**.
Instead each per-bit circuit reads `tableLen n + i` inputs — the real instance
bits followed by the `i` *prior bundle outputs* (the greedy bits `0..i-1`):

| query region | circuit |
|---|---|
| x-slice | `inputProj (Fin.castAdd i ·)` — a real instance bit |
| payload | `inputProj (Fin.natAdd (tableLen n) ·)` — a prior bundle output |
| tag / gamma / index / pad | constants (index encodes the actual prefix length `i`) |

This is exactly the head-circuit shape `H : DagCircuit (tableLen n + i)` that plugs
into the shared-bundle greedy step `DagCircuit.snocBundleSubst` (merged in #1498),
so iterating it keeps circuit size additive in `i`.

## Results (all verified, standard axioms only)

- `prefixStateFields` / `prefixStateQueryValue` — the canonical `(i, p)` raw fields
  and serialized query string (generalizing `zeroPrefixFields` /
  `zeroPrefixQueryValue`);
- `parse_prefixStateQueryValue`, `prefixStateQueryValue_parses` — the `(i, p)`
  parser round-trip, a direct instance of the general
  `parse_encodeTreeMCSPPrefixFields`;
- `prefixStateQueryBitCircuit` — the bundle-shape per-bit `C_DAG` circuit;
- `eval_prefixStateQueryBitCircuit` — evaluating on `Fin.append x p` reproduces the
  canonical query bit (x-slice via `Fin.append_left`, payload via
  `Fin.append_right`);
- `size_prefixStateQueryBitCircuit_le` — uniform per-bit size `≤ 2`, independent
  of `i`.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surfaces registered in `AlgorithmsToLowerBoundsSurfaceTests.lean` and
  `AxiomsAudit.lean`; they depend only on `propext` / `Classical.choice` /
  `Quot.sound` (`eval_prefixStateQueryBitCircuit` is just `propext` / `Quot.sound`).
- Module registered in `lakefile.lean`.

## Scope discipline

Prefix-state query value + per-bit circuits only. **No** `QueryCircuitBuilder` /
`PrefixQueryBuilder` instance over `tableLen n + i` inputs (a later brick), **no**
greedy recursion / `snocBundleSubst` threading, **no** `BoundedSearchSolver`
assembly, **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
`P ≠ NP` / `NP ⊄ P/poly` consequence. The genuine lower bound remains open.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_