### PR TITLE
Block 5: one-step shared-bundle greedy extension

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -280,6 +280,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder,
     Glob.one `Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyBundleStep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyBundleStep.lean
@@ -1,0 +1,156 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+open Pnp3.ComplexityInterfaces.DagCircuit
+
+/-!
+# One-step shared-bundle greedy extension
+
+Block 5 of the downstream decision→search extraction, in the **Option ①**
+architecture (merged in #1498 / #1499).
+
+This assembles a *single* greedy step in the shared-bundle shape, with no
+recursion.  Given:
+
+* a bundle `B : DagBundle (tableLen n) i` holding the prior greedy bits `0..i-1`
+  as functions of the instance `x` (over the `tableLen n` real inputs), and
+* a decider `dec : C_DAG.Family (treeMCSPPrefixM codec n)` over the `M(n)`-bit
+  prefix-query string,
+
+we build the head circuit
+`H = composeDeciderWithQuery dec (prefixStateQueryBitCircuit codec n i hi)`
+over `tableLen n + i` inputs — the decider run on the prefix-state `(i, ·)` query,
+whose payload region reads the prior bundle outputs (Block 4) — and apply the
+shared-bundle step `DagCircuit.snocBundleSubst B H` (the primitive from #1498).
+
+The result `greedyBundleStep … : DagBundle (tableLen n) (i + 1)`:
+
+* **retains** all prior outputs (`evalOutput_greedyBundleStep_old`), and
+* its **new** output is exactly the decider run on the prefix-state query for
+  `(i, p)` with `p` the prior bundle outputs on `x`
+  (`evalOutput_greedyBundleStep_new`), and
+* its gate count is **additive** — `B.gates + H.gates`
+  (`gates_greedyBundleStep`) — so `B` is shared, not re-embedded.
+
+Scope discipline — one greedy step only:
+
+* **no** recursion over the witness length (no fold of `greedyBundleStep`);
+* **no** `BoundedSearchSolver` assembly;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
+  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/--
+The head circuit for one greedy step: the decider `dec` composed with the
+prefix-state `(i, ·)` query-bit circuits, over `tableLen n + i` inputs (the real
+instance bits followed by the `i` prior bundle outputs).
+-/
+def greedyStepHead
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n + i) :=
+  composeDeciderWithQuery dec (prefixStateQueryBitCircuit codec n i hi)
+
+/--
+**One-step shared-bundle greedy extension.**  Extend the prior-bits bundle `B` by
+the bit decided by `dec` on the prefix-state `(i, ·)` query, sharing `B`'s gate
+list via `DagCircuit.snocBundleSubst`.
+-/
+def greedyBundleStep
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (B : DagBundle (Pnp3.Models.Partial.tableLen n) i) :
+    DagBundle (Pnp3.Models.Partial.tableLen n) (i + 1) :=
+  snocBundleSubst B (greedyStepHead codec n i hi dec)
+
+/-- The greedy step is *additive* in gate count: the prior bundle is shared, only
+the head circuit's gates are added.  Direct instance of `snocBundleSubst_gates`. -/
+theorem gates_greedyBundleStep
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (B : DagBundle (Pnp3.Models.Partial.tableLen n) i) :
+    (greedyBundleStep codec n i hi dec B).gates
+      = B.gates + (greedyStepHead codec n i hi dec).gates :=
+  snocBundleSubst_gates B (greedyStepHead codec n i hi dec)
+
+/-- The head circuit's size is bounded by the decider plus `2 · M(n)` (each
+prefix-state query bit has size `≤ 2`).  So one greedy step adds only this much,
+independent of the prior bits — the no-blow-up property. -/
+theorem size_greedyStepHead_le
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    C_DAG.size (greedyStepHead codec n i hi dec)
+      ≤ C_DAG.size dec + 2 * treeMCSPPrefixM codec n := by
+  refine le_trans
+    (size_composeDeciderWithQuery_le dec (prefixStateQueryBitCircuit codec n i hi)) ?_
+  have hbit : ∀ j : Fin (treeMCSPPrefixM codec n),
+      C_DAG.size (prefixStateQueryBitCircuit codec n i hi j) ≤ 2 :=
+    fun j => size_prefixStateQueryBitCircuit_le codec n i hi j
+  have hsum : (∑ j, C_DAG.size (prefixStateQueryBitCircuit codec n i hi j))
+      ≤ 2 * treeMCSPPrefixM codec n := by
+    calc
+      (∑ j, C_DAG.size (prefixStateQueryBitCircuit codec n i hi j))
+          ≤ ∑ _j : Fin (treeMCSPPrefixM codec n), 2 := Finset.sum_le_sum (fun j _ => hbit j)
+      _ = 2 * treeMCSPPrefixM codec n := by
+          simp [Finset.sum_const, Finset.card_univ, Nat.mul_comm]
+  omega
+
+/-- **Old outputs preserved.**  Each prior greedy bit is unchanged by the step. -/
+@[simp] theorem evalOutput_greedyBundleStep_old
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (B : DagBundle (Pnp3.Models.Partial.tableLen n) i)
+    (o : Fin i)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    (greedyBundleStep codec n i hi dec B).evalOutput (Fin.castAdd 1 o) x
+      = B.evalOutput o x :=
+  evalOutput_snocBundleSubst_old B (greedyStepHead codec n i hi dec) o x
+
+/--
+**New output correctness.**  The appended bit is exactly the decider run on the
+prefix-state `(i, p)` query string, where the payload `p` is the prior bundle's
+outputs on `x`.  This is the one-step greedy decision.
+-/
+theorem evalOutput_greedyBundleStep_new
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (B : DagBundle (Pnp3.Models.Partial.tableLen n) i)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    (greedyBundleStep codec n i hi dec B).evalOutput (Fin.natAdd i (0 : Fin 1)) x
+      = C_DAG.eval dec
+          (prefixStateQueryValue codec n i hi x (fun k => B.evalOutput k x)) := by
+  have hinput :
+      (fun j => (passthroughBundle B).evalOutput j x)
+        = Fin.append x (fun k => B.evalOutput k x) := by
+    funext j
+    induction j using Fin.addCases <;> simp
+  unfold greedyBundleStep greedyStepHead
+  rw [evalOutput_snocBundleSubst_new]
+  show C_DAG.eval (composeDeciderWithQuery dec (prefixStateQueryBitCircuit codec n i hi))
+      (fun j => (passthroughBundle B).evalOutput j x) = _
+  rw [hinput, eval_composeDeciderWithQuery]
+  congr 1
+  funext j
+  exact eval_prefixStateQueryBitCircuit codec n i hi x (fun k => B.evalOutput k x) j
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -36,6 +36,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -351,6 +352,75 @@ theorem check_size_prefixStateQueryBitCircuit_le
   size_prefixStateQueryBitCircuit_le codec n i hi j
 
 end TreeMCSPPrefixStateQueryCircuitsSurface
+
+section TreeMCSPGreedyBundleStepSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 5 surface: the one-step shared-bundle greedy extension. -/
+def check_greedyBundleStep
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (B : Pnp3.ComplexityInterfaces.DagCircuit.DagBundle (Pnp3.Models.Partial.tableLen n) i) :
+    Pnp3.ComplexityInterfaces.DagCircuit.DagBundle (Pnp3.Models.Partial.tableLen n) (i + 1) :=
+  greedyBundleStep codec n i hi dec B
+
+/-- Block 5 surface: the step is additive in gate count (prior bundle shared). -/
+theorem check_gates_greedyBundleStep
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (B : Pnp3.ComplexityInterfaces.DagCircuit.DagBundle (Pnp3.Models.Partial.tableLen n) i) :
+    (greedyBundleStep codec n i hi dec B).gates
+      = B.gates + (greedyStepHead codec n i hi dec).gates :=
+  gates_greedyBundleStep codec n i hi dec B
+
+/-- Block 5 surface: one greedy step adds at most `size dec + 2·M(n)`. -/
+theorem check_size_greedyStepHead_le
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    C_DAG.size (greedyStepHead codec n i hi dec)
+      ≤ C_DAG.size dec + 2 * treeMCSPPrefixM codec n :=
+  size_greedyStepHead_le codec n i hi dec
+
+/-- Block 5 surface: prior outputs preserved by the step. -/
+theorem check_evalOutput_greedyBundleStep_old
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (B : Pnp3.ComplexityInterfaces.DagCircuit.DagBundle (Pnp3.Models.Partial.tableLen n) i)
+    (o : Fin i)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    (greedyBundleStep codec n i hi dec B).evalOutput (Fin.castAdd 1 o) x
+      = B.evalOutput o x :=
+  evalOutput_greedyBundleStep_old codec n i hi dec B o x
+
+/-- Block 5 surface: the new bit is the decider run on the prefix-state `(i, p)`
+query, `p` the prior bundle outputs on `x`. -/
+theorem check_evalOutput_greedyBundleStep_new
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (B : Pnp3.ComplexityInterfaces.DagCircuit.DagBundle (Pnp3.Models.Partial.tableLen n) i)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    (greedyBundleStep codec n i hi dec B).evalOutput (Fin.natAdd i (0 : Fin 1)) x
+      = C_DAG.eval dec
+          (prefixStateQueryValue codec n i hi x (fun k => B.evalOutput k x)) :=
+  evalOutput_greedyBundleStep_new codec n i hi dec B x
+
+end TreeMCSPGreedyBundleStepSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -26,6 +26,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixSerializer
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -217,6 +218,11 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.prefixStateQueryValue_parses
 #print axioms Pnp4.Frontier.ContractExpansion.eval_prefixStateQueryBitCircuit
 #print axioms Pnp4.Frontier.ContractExpansion.size_prefixStateQueryBitCircuit_le
+
+#print axioms Pnp4.Frontier.ContractExpansion.gates_greedyBundleStep
+#print axioms Pnp4.Frontier.ContractExpansion.size_greedyStepHead_le
+#print axioms Pnp4.Frontier.ContractExpansion.evalOutput_greedyBundleStep_old
+#print axioms Pnp4.Frontier.ContractExpansion.evalOutput_greedyBundleStep_new
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 5 of the downstream decision→search extraction: a **single greedy step in
the Option ① shared-bundle shape** (no recursion). It combines the two primitives
merged in #1498 / #1499:

- `DagCircuit.snocBundleSubst` — the shared-bundle multi-output step, and
- `prefixStateQueryBitCircuit` — the prefix-state `(i, p)` query bits over
  `tableLen n + i` inputs.

New file `TreeMCSPGreedyBundleStep.lean`.

```
greedyStepHead  codec n i hi dec   : C_DAG.Family (tableLen n + i)
  := composeDeciderWithQuery dec (prefixStateQueryBitCircuit codec n i hi)
greedyBundleStep codec n i hi dec B : DagBundle (tableLen n) (i + 1)
  := snocBundleSubst B (greedyStepHead …)
```

The head is the decider run on the prefix-state `(i, ·)` query, whose payload
region reads the `i` prior bundle outputs; `snocBundleSubst` appends the decided
bit while **sharing** `B`'s gate list.

## Results (all verified, standard axioms only)

- `gates_greedyBundleStep` — `(greedyBundleStep …).gates = B.gates + (head).gates`
  (additive: the prior bundle is shared, not re-embedded — the no-blow-up property);
- `size_greedyStepHead_le` — `size (head) ≤ size dec + 2·M(n)` (one step's added
  cost is bounded independently of the prior bits);
- `evalOutput_greedyBundleStep_old` — old outputs preserved (`= B.evalOutput o x`);
- `evalOutput_greedyBundleStep_new` — the new bit `= C_DAG.eval dec` applied to the
  prefix-state query value for `(i, p)`, with `p` the prior bundle outputs on `x` —
  i.e. exactly the one-step greedy decision.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surfaces registered in `AlgorithmsToLowerBoundsSurfaceTests.lean` and
  `AxiomsAudit.lean`; clean axioms (`gates_…`, both `evalOutput_…` are just
  `propext` / `Quot.sound`).
- Module registered in `lakefile.lean`.

## Scope discipline

One greedy step only. **No** recursion / fold over the witness length, **no**
`BoundedSearchSolver` assembly, **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint
wrapper, or `P ≠ NP` / `NP ⊄ P/poly` consequence. The genuine lower bound remains
the open problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_