### PR TITLE
Block 7: final greedy bundle outputs as per-witness-bit circuits

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -282,6 +282,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyOutputCircuits.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyOutputCircuits.lean
@@ -1,0 +1,96 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+open Pnp3.ComplexityInterfaces.DagCircuit
+
+/-!
+# Final greedy bundle outputs as per-witness-bit C_DAG circuits
+
+Block 7 of the downstream decision→search extraction, in the **Option ①**
+architecture (#1498–#1501).
+
+Block 6 built the full greedy bundle `greedyBundleUpTo … (witnessBits n)` — one
+shared gate list with `witnessBits n` output wires, of total size linear in
+`witnessBits n`.  This file exposes each witness bit as an ordinary `C_DAG` output
+circuit over the instance bits (`tableLen n`), via the bundle's `asCircuit`
+projection, and records:
+
+* `eval_greedyOutputCircuit` — the `i`-th output circuit computes the `i`-th bundle
+  output (the `i`-th greedy bit), and
+* `size_greedyOutputCircuit_le` — a **uniform** size bound `≤ witnessBits n ·
+  (size dec + 2·M(n)) + 1`, *independent of `i`*, because every output circuit
+  shares the one bundle gate list (`gates_greedyBundleUpTo_le`).
+
+This is the `Fin (witnessBits n) → C_DAG.Family (tableLen n)` output-circuit family a
+later `BoundedSearchSolver` will consume — but assembled and size-bounded only.
+
+Scope discipline — output-circuit surface + size bound only:
+
+* **no** `solves` / solver-correctness theorem (the greedy bits are not yet claimed
+  to be a valid witness);
+* **no** `BoundedSearchSolver` assembly;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
+  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/-- The full greedy bundle: all `witnessBits n` greedy bits over `tableLen n`
+inputs, as one shared gate list. -/
+def fullGreedyBundle
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    DagBundle (Pnp3.Models.Partial.tableLen n) (codec.witnessBits n) :=
+  greedyBundleUpTo codec n dec (codec.witnessBits n) (Nat.le_refl _)
+
+/-- The per-witness-bit output circuit: the `i`-th output of the full greedy bundle
+as a single `C_DAG` circuit over the instance bits, sharing the bundle's gate
+list. -/
+def greedyOutputCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n) :=
+  (fullGreedyBundle codec n dec).asCircuit i
+
+/-- The `i`-th output circuit computes the `i`-th bundle output (the `i`-th greedy
+bit).  Definitional, via `DagBundle.evalOutput`. -/
+@[simp] theorem eval_greedyOutputCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    C_DAG.eval (greedyOutputCircuit codec n dec i) x
+      = (fullGreedyBundle codec n dec).evalOutput i x :=
+  rfl
+
+/-- **Uniform size bound.**  Every output circuit shares the single bundle gate
+list, so its size is at most `witnessBits n · (size dec + 2·M(n)) + 1`,
+independent of `i`.  Follows from the linear bundle bound
+`gates_greedyBundleUpTo_le`. -/
+theorem size_greedyOutputCircuit_le
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n)) :
+    C_DAG.size (greedyOutputCircuit codec n dec i)
+      ≤ codec.witnessBits n * (C_DAG.size dec + 2 * treeMCSPPrefixM codec n) + 1 := by
+  have hs : C_DAG.size (greedyOutputCircuit codec n dec i)
+      = (greedyOutputCircuit codec n dec i).gates + 1 := rfl
+  have hg : (greedyOutputCircuit codec n dec i).gates = (fullGreedyBundle codec n dec).gates := rfl
+  have hb : (fullGreedyBundle codec n dec).gates
+      ≤ codec.witnessBits n * (C_DAG.size dec + 2 * treeMCSPPrefixM codec n) :=
+    gates_greedyBundleUpTo_le codec n dec (codec.witnessBits n) (Nat.le_refl _)
+  rw [hs, hg]
+  omega
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -38,6 +38,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -480,6 +481,46 @@ theorem check_evalOutput_greedyBundleUpTo_new
   evalOutput_greedyBundleUpTo_new codec n i dec hi x
 
 end TreeMCSPGreedyBundleFoldSurface
+
+section TreeMCSPGreedyOutputCircuitsSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 7 surface: per-witness-bit output circuit over the instance bits. -/
+def check_greedyOutputCircuit
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n) :=
+  greedyOutputCircuit codec n dec i
+
+/-- Block 7 surface: the `i`-th output circuit computes the `i`-th greedy bit. -/
+theorem check_eval_greedyOutputCircuit
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    C_DAG.eval (greedyOutputCircuit codec n dec i) x
+      = (fullGreedyBundle codec n dec).evalOutput i x :=
+  eval_greedyOutputCircuit codec n dec i x
+
+/-- Block 7 surface (headline): uniform size bound on every output circuit,
+independent of `i`. -/
+theorem check_size_greedyOutputCircuit_le
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n)) :
+    C_DAG.size (greedyOutputCircuit codec n dec i)
+      ≤ codec.witnessBits n * (C_DAG.size dec + 2 * treeMCSPPrefixM codec n) + 1 :=
+  size_greedyOutputCircuit_le codec n dec i
+
+end TreeMCSPGreedyOutputCircuitsSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -28,6 +28,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -229,6 +230,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.gates_greedyBundleUpTo_le
 #print axioms Pnp4.Frontier.ContractExpansion.evalOutput_greedyBundleUpTo_old
 #print axioms Pnp4.Frontier.ContractExpansion.evalOutput_greedyBundleUpTo_new
+
+#print axioms Pnp4.Frontier.ContractExpansion.eval_greedyOutputCircuit
+#print axioms Pnp4.Frontier.ContractExpansion.size_greedyOutputCircuit_le
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 7 of the downstream decision→search extraction: exposes the full greedy
bundle (Block 6, #1501) as an ordinary **per-witness-bit `C_DAG` output-circuit
family** over the instance bits, with a uniform size bound. New file
`TreeMCSPGreedyOutputCircuits.lean`.

```
fullGreedyBundle   codec n dec      : DagBundle (tableLen n) (codec.witnessBits n)
                                      := greedyBundleUpTo … (witnessBits n) (le_refl _)
greedyOutputCircuit codec n dec i   : C_DAG.Family (tableLen n)
                                      := (fullGreedyBundle …).asCircuit i
```

## Results (all verified, standard axioms only)

- `eval_greedyOutputCircuit` — the `i`-th output circuit computes the `i`-th bundle
  output (the `i`-th greedy bit); definitional via `DagBundle.evalOutput`;
- `size_greedyOutputCircuit_le` —
  `C_DAG.size (greedyOutputCircuit … i) ≤ witnessBits n · (size dec + 2·M(n)) + 1`,
  **uniform in `i`**: every output circuit shares the single bundle gate list, so
  the bound follows directly from the linear bundle bound `gates_greedyBundleUpTo_le`.

This is the `Fin (witnessBits n) → C_DAG.Family (tableLen n)` output-circuit family a
later solver will consume — assembled and size-bounded only.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surfaces in `AlgorithmsToLowerBoundsSurfaceTests.lean` + `AxiomsAudit.lean`;
  `eval_greedyOutputCircuit` is just `propext` / `Quot.sound`.
- Module registered in `lakefile.lean`.

## Scope discipline

Output-circuit surface + size bound only. **No** `solves` / solver-correctness
theorem (the greedy bits are not yet claimed to be a valid witness), **no**
`BoundedSearchSolver` assembly, **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint
wrapper, or `P ≠ NP` / `NP ⊄ P/poly` consequence. The genuine lower bound remains
the open problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_