### PR TITLE
Block 7.5: prefix-extendability split lemmas (pure semantics)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -283,6 +283,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits,
+    Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtendableSplit.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtendableSplit.lean
@@ -1,0 +1,113 @@
+import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Prefix-extendability split lemmas (pure semantics)
+
+Block 7.5 of the downstream decision→search extraction.  This is the semantic
+heart the greedy correctness argument will use, isolated **with no circuits**.
+
+A length-`i` witness prefix `p` for instance `(n, x)` is *extendable*
+(`WitnessPrefixExtendable`) when some full witness `w` agrees with `p` on its first
+`i` coordinates and solves the search relation.  This is exactly
+`PrefixExtendableInput` of the prefix-extension language, restated on the bare
+`(n, x, i, p)` data (`prefixExtendableInput_iff_witnessPrefixExtendable`).
+
+The greedy construction extends a prefix one bit at a time; its correctness rests
+on the **split** facts proved here:
+
+* `witnessPrefixExtendable_split` — if `p` is extendable then at least one of the
+  two next-bit extensions `p ++ true`, `p ++ false` is extendable;
+* `witnessPrefixExtendable_snoc_false_of_not_true` — the reject branch: if `p` is
+  extendable but `p ++ true` is not, then `p ++ false` is extendable;
+* `witnessPrefixExtendable_snoc_true_of_not_false` — the symmetric reject branch.
+
+Scope discipline — pure prefix-extension semantics only:
+
+* **no** circuits, deciders, or `C_DAG`;
+* **no** greedy bundle / `BoundedSearchSolver` assembly or solver-correctness;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
+  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+-/
+
+variable {problem : SearchMCSPCompressionProblem}
+
+/--
+A length-`i` witness prefix `p` for instance `(n, x)` is *extendable* when some full
+witness agrees with `p` on its first `i` coordinates and solves the search relation.
+This is the bare-data form of `PrefixExtendableInput`.
+-/
+def WitnessPrefixExtendable
+    (n : Nat) (x : PrefixBitVec (problem.instanceBits n))
+    {i : Nat} (hi : i ≤ problem.witnessBits n) (p : PrefixBitVec i) : Prop :=
+  ∃ w : PrefixBitVec (problem.witnessBits n),
+    (∀ k : Fin i, w ⟨k.1, Nat.lt_of_lt_of_le k.2 hi⟩ = p k) ∧ problem.relation n x w
+
+/-- The language's `PrefixExtendableInput` is exactly `WitnessPrefixExtendable` on the
+parsed input's `(n, x, i, p)` data. -/
+theorem prefixExtendableInput_iff_witnessPrefixExtendable
+    {m : Nat} (input : PrefixInput problem m) :
+    PrefixExtendableInput input ↔
+      WitnessPrefixExtendable input.n input.x input.prefixLength_le input.p :=
+  Iff.rfl
+
+/--
+**Greedy split.**  If a prefix `p` is extendable, then at least one of the two
+next-bit extensions `p ++ true`, `p ++ false` is extendable.
+
+The witnessing extension's own `i`-th bit decides which branch survives.
+-/
+theorem witnessPrefixExtendable_split
+    (n : Nat) (x : PrefixBitVec (problem.instanceBits n))
+    {i : Nat} (hi' : i + 1 ≤ problem.witnessBits n) (p : PrefixBitVec i)
+    (hp : WitnessPrefixExtendable n x (Nat.le_of_succ_le hi') p) :
+    WitnessPrefixExtendable n x hi' (Fin.snoc p true)
+      ∨ WitnessPrefixExtendable n x hi' (Fin.snoc p false) := by
+  obtain ⟨w, hagree, hrel⟩ := hp
+  have hlt : i < problem.witnessBits n := hi'
+  have hext : WitnessPrefixExtendable n x hi' (Fin.snoc p (w ⟨i, hlt⟩)) := by
+    refine ⟨w, ?_, hrel⟩
+    intro k
+    induction k using Fin.lastCases with
+    | last => simp [Fin.snoc_last]
+    | cast j => simpa [Fin.snoc_castSucc] using hagree j
+  cases hbit : w ⟨i, hlt⟩ with
+  | true => rw [hbit] at hext; exact Or.inl hext
+  | false => rw [hbit] at hext; exact Or.inr hext
+
+/--
+**Reject branch (false).**  If `p` is extendable but `p ++ true` is not, then
+`p ++ false` is extendable.
+-/
+theorem witnessPrefixExtendable_snoc_false_of_not_true
+    (n : Nat) (x : PrefixBitVec (problem.instanceBits n))
+    {i : Nat} (hi' : i + 1 ≤ problem.witnessBits n) (p : PrefixBitVec i)
+    (hp : WitnessPrefixExtendable n x (Nat.le_of_succ_le hi') p)
+    (hnt : ¬ WitnessPrefixExtendable n x hi' (Fin.snoc p true)) :
+    WitnessPrefixExtendable n x hi' (Fin.snoc p false) := by
+  rcases witnessPrefixExtendable_split n x hi' p hp with h | h
+  · exact absurd h hnt
+  · exact h
+
+/--
+**Reject branch (true).**  If `p` is extendable but `p ++ false` is not, then
+`p ++ true` is extendable.
+-/
+theorem witnessPrefixExtendable_snoc_true_of_not_false
+    (n : Nat) (x : PrefixBitVec (problem.instanceBits n))
+    {i : Nat} (hi' : i + 1 ≤ problem.witnessBits n) (p : PrefixBitVec i)
+    (hp : WitnessPrefixExtendable n x (Nat.le_of_succ_le hi') p)
+    (hnf : ¬ WitnessPrefixExtendable n x hi' (Fin.snoc p false)) :
+    WitnessPrefixExtendable n x hi' (Fin.snoc p true) := by
+  rcases witnessPrefixExtendable_split n x hi' p hp with h | h
+  · exact h
+  · exact absurd h hnf
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -39,6 +39,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
+import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -521,6 +522,51 @@ theorem check_size_greedyOutputCircuit_le
   size_greedyOutputCircuit_le codec n dec i
 
 end TreeMCSPGreedyOutputCircuitsSurface
+
+section PrefixExtendableSplitSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 7.5 surface: `PrefixExtendableInput` is `WitnessPrefixExtendable` on the
+parsed `(n, x, i, p)` data. -/
+theorem check_prefixExtendableInput_iff_witnessPrefixExtendable
+    {problem : Frontier.SearchMCSPCompressionProblem} {m : Nat} (input : PrefixInput problem m) :
+    PrefixExtendableInput input ↔
+      WitnessPrefixExtendable input.n input.x input.prefixLength_le input.p :=
+  prefixExtendableInput_iff_witnessPrefixExtendable input
+
+/-- Block 7.5 surface: the greedy split — an extendable prefix has an extendable
+next-bit extension. -/
+theorem check_witnessPrefixExtendable_split
+    {problem : Frontier.SearchMCSPCompressionProblem}
+    (n : Nat) (x : PrefixBitVec (problem.instanceBits n))
+    {i : Nat} (hi' : i + 1 ≤ problem.witnessBits n) (p : PrefixBitVec i)
+    (hp : WitnessPrefixExtendable n x (Nat.le_of_succ_le hi') p) :
+    WitnessPrefixExtendable n x hi' (Fin.snoc p true)
+      ∨ WitnessPrefixExtendable n x hi' (Fin.snoc p false) :=
+  witnessPrefixExtendable_split n x hi' p hp
+
+/-- Block 7.5 surface: the reject branch (false). -/
+theorem check_witnessPrefixExtendable_snoc_false_of_not_true
+    {problem : Frontier.SearchMCSPCompressionProblem}
+    (n : Nat) (x : PrefixBitVec (problem.instanceBits n))
+    {i : Nat} (hi' : i + 1 ≤ problem.witnessBits n) (p : PrefixBitVec i)
+    (hp : WitnessPrefixExtendable n x (Nat.le_of_succ_le hi') p)
+    (hnt : ¬ WitnessPrefixExtendable n x hi' (Fin.snoc p true)) :
+    WitnessPrefixExtendable n x hi' (Fin.snoc p false) :=
+  witnessPrefixExtendable_snoc_false_of_not_true n x hi' p hp hnt
+
+/-- Block 7.5 surface: the reject branch (true). -/
+theorem check_witnessPrefixExtendable_snoc_true_of_not_false
+    {problem : Frontier.SearchMCSPCompressionProblem}
+    (n : Nat) (x : PrefixBitVec (problem.instanceBits n))
+    {i : Nat} (hi' : i + 1 ≤ problem.witnessBits n) (p : PrefixBitVec i)
+    (hp : WitnessPrefixExtendable n x (Nat.le_of_succ_le hi') p)
+    (hnf : ¬ WitnessPrefixExtendable n x hi' (Fin.snoc p false)) :
+    WitnessPrefixExtendable n x hi' (Fin.snoc p true) :=
+  witnessPrefixExtendable_snoc_true_of_not_false n x hi' p hp hnf
+
+end PrefixExtendableSplitSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -29,6 +29,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
+import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -233,6 +234,11 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.eval_greedyOutputCircuit
 #print axioms Pnp4.Frontier.ContractExpansion.size_greedyOutputCircuit_le
+
+#print axioms Pnp4.Frontier.ContractExpansion.prefixExtendableInput_iff_witnessPrefixExtendable
+#print axioms Pnp4.Frontier.ContractExpansion.witnessPrefixExtendable_split
+#print axioms Pnp4.Frontier.ContractExpansion.witnessPrefixExtendable_snoc_false_of_not_true
+#print axioms Pnp4.Frontier.ContractExpansion.witnessPrefixExtendable_snoc_true_of_not_false
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 7.5 of the downstream decision→search extraction: the **prefix-extendability
split lemmas**, isolating the semantic heart of the greedy correctness argument
**with no circuits**. New file `PrefixExtendableSplit.lean`.

```
WitnessPrefixExtendable n x hi p
  := ∃ w, (∀ k : Fin i, w k = p k) ∧ problem.relation n x w
```
— a length-`i` witness prefix `p` for instance `(n, x)` is *extendable* when some
full witness agrees with `p` on its first `i` coordinates and solves the search
relation. This is the bare-`(n, x, i, p)` form of the language's
`PrefixExtendableInput`.

## Results (all verified, standard axioms only — no `Classical.choice`)

- `prefixExtendableInput_iff_witnessPrefixExtendable` — `PrefixExtendableInput` is
  exactly `WitnessPrefixExtendable` on the parsed input's data (`Iff.rfl`, depends
  on **no axioms**);
- `witnessPrefixExtendable_split` — an extendable prefix `p` has an extendable
  next-bit extension (`p ++ true` or `p ++ false`); the witnessing extension's own
  `i`-th bit decides which branch survives;
- `witnessPrefixExtendable_snoc_false_of_not_true` — reject branch: `p` extendable
  and `p ++ true` not extendable ⟹ `p ++ false` extendable;
- `witnessPrefixExtendable_snoc_true_of_not_false` — the symmetric reject branch.

These are exactly the facts greedy correctness needs at each accept/reject step,
proved independently of the circuit construction.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surfaces in `AlgorithmsToLowerBoundsSurfaceTests.lean` + `AxiomsAudit.lean`;
  the bridge needs **no axioms**, the splits just `propext`.
- Module registered in `lakefile.lean`.

## Scope discipline

Pure prefix-extension semantics only. **No** circuits / deciders / `C_DAG`, **no**
greedy bundle or `BoundedSearchSolver` assembly or solver-correctness, **no**
`PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or `P ≠ NP` / `NP ⊄ P/poly`
consequence. The genuine lower bound remains the open problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_