### PR TITLE
Block 8a: greedy extendability invariant (true-extension query)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -284,6 +284,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -284,6 +284,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyExtendable.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyExtendable.lean
@@ -1,4 +1,4 @@
-import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
+import Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery
 import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
 
 namespace Pnp4
@@ -9,36 +9,28 @@ open AlgorithmsToLowerBounds
 open Pnp3.ComplexityInterfaces.DagCircuit
 
 /-!
-# Greedy extendability invariant
+# Greedy extendability invariant (true-extension query)
 
-Block 8a of the downstream decision→search extraction.  This is the first place
-the circuit plumbing (Blocks 4–7) meets real semantic content (Block 7.5): under an
-explicit **correct-decider** hypothesis, the greedy bundle's outputs form a prefix
-that stays *extendable* on promise inputs.
+Block 8a of the downstream decision→search extraction — the first place the circuit
+plumbing meets real semantic content (Block 7.5).
 
-Concretely, let `dec` be the prefix-extension decider and
-`greedyBundleUpTo … i` the shared greedy bundle (Block 6).  The *greedy prefix*
-`greedyPrefix … i` is the length-`i` bit vector of that bundle's outputs on `x`.
-We prove, by induction on `i`:
+**Correction over the first draft.**  The greedy step must ask the decider
+*"is `p ++ true` extendable?"*, so it runs `dec` on the **true-extension** query
+`prefixTrueExtensionQueryValue` (which encodes the prefix-state `(i+1, p ++ true)`),
+*not* on the `(i, p)` query.  This is what makes the `CorrectNextBitDecider`
+hypothesis dischargeable from an ordinary `PrefixExtensionLanguage` decider: such a
+decider on the encoded `p ++ true` decides extendability of `p ++ true`.
 
-```
-WitnessPrefixExtendable (treeProblem codec) n x hi (greedyPrefix codec n dec x i hi)
-```
-
-i.e. the greedy prefix can always be completed to a valid witness — given
-(1) the promise that `x` is a yes-instance, and (2) `dec` correctly answering the
-next-bit extendability question (`CorrectNextBitDecider`).  The step uses the
-reject-branch split lemmas from #1503.
-
-This is **not** solver correctness: it does not yet conclude that the *full* greedy
-prefix is itself a valid witness, nor assemble a `BoundedSearchSolver`.
+`greedyTrueBundleUpTo` folds the true-extension greedy step (sharing the bundle via
+`snocBundleSubst`), `greedyPrefix` reads off its outputs, and `greedyPrefix_extendable`
+proves — by induction, using the reject-branch split lemma (#1503) — that the greedy
+prefix stays extendable on promise inputs under a correct next-bit decider.
 
 Scope discipline — the extendability invariant only:
 
 * the decider's correctness is an **explicit hypothesis**, not proved here;
 * **no** `BoundedSearchSolver` assembly and **no** `solves` conclusion;
-* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
-  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint, or `P ≠ NP` consequence.
 -/
 
 variable {threshold : Nat → Nat}
@@ -47,8 +39,57 @@ variable {threshold : Nat → Nat}
 abbrev treeProblem (codec : TreeCircuitWitnessCodec threshold) : SearchMCSPCompressionProblem :=
   treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec)
 
-/-- The greedy prefix of length `i`: the first `i` greedy bits (the bundle's
-outputs on `x`), as a witness prefix. -/
+/-- The head circuit for one true-extension greedy step: `dec` composed with the
+true-extension query-bit circuits, over `tableLen n + i` inputs. -/
+def greedyTrueStepHead
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat) (hi : i + 1 ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n + i) :=
+  composeDeciderWithQuery dec (prefixTrueExtensionQueryBitCircuit codec n i hi)
+
+/-- One greedy step adds at most `size dec + 2·M(n)` gates, independent of the prior
+bits. -/
+theorem size_greedyTrueStepHead_le
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat) (hi : i + 1 ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    C_DAG.size (greedyTrueStepHead codec n i hi dec)
+      ≤ C_DAG.size dec + 2 * treeMCSPPrefixM codec n := by
+  refine le_trans
+    (size_composeDeciderWithQuery_le dec (prefixTrueExtensionQueryBitCircuit codec n i hi)) ?_
+  have hsum : (∑ j, C_DAG.size (prefixTrueExtensionQueryBitCircuit codec n i hi j))
+      ≤ 2 * treeMCSPPrefixM codec n := by
+    calc
+      (∑ j, C_DAG.size (prefixTrueExtensionQueryBitCircuit codec n i hi j))
+          ≤ ∑ _j : Fin (treeMCSPPrefixM codec n), 2 :=
+            Finset.sum_le_sum (fun j _ => size_prefixTrueExtensionQueryBitCircuit_le codec n i hi j)
+      _ = 2 * treeMCSPPrefixM codec n := by
+          simp [Finset.sum_const, Finset.card_univ, Nat.mul_comm]
+  omega
+
+/-- The shared bundle of the first `i` greedy bits, folding the true-extension step. -/
+def greedyTrueBundleUpTo
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    (i : Nat) → i ≤ codec.witnessBits n → DagBundle (Pnp3.Models.Partial.tableLen n) i
+  | 0, _ => emptyBundle (Pnp3.Models.Partial.tableLen n)
+  | i + 1, hi =>
+      snocBundleSubst (greedyTrueBundleUpTo codec n dec i (Nat.le_of_succ_le hi))
+        (greedyTrueStepHead codec n i hi dec)
+
+theorem greedyTrueBundleUpTo_succ
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (hi : i + 1 ≤ codec.witnessBits n) :
+    greedyTrueBundleUpTo codec n dec (i + 1) hi =
+      snocBundleSubst (greedyTrueBundleUpTo codec n dec i (Nat.le_of_succ_le hi))
+        (greedyTrueStepHead codec n i hi dec) :=
+  rfl
+
+/-- The greedy prefix of length `i`: the first `i` greedy bits on `x`. -/
 def greedyPrefix
     (codec : TreeCircuitWitnessCodec threshold)
     (n : Nat)
@@ -56,25 +97,53 @@ def greedyPrefix
     (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
     (i : Nat) (hi : i ≤ codec.witnessBits n) :
     PrefixBitVec i :=
-  fun k => (greedyBundleUpTo codec n dec i hi).evalOutput k x
+  fun k => (greedyTrueBundleUpTo codec n dec i hi).evalOutput k x
 
-/--
-**Correct next-bit decider** (explicit hypothesis).  `dec`, run on the prefix-state
-`(i, p)` query for instance `x`, answers exactly whether the one-bit extension
-`p ++ true` is extendable.  This is the next-bit extendability oracle the greedy
-construction relies on.
--/
-def CorrectNextBitDecider
+/-- Old greedy bits are preserved across a fold step. -/
+theorem evalOutput_greedyTrueBundleUpTo_old
     (codec : TreeCircuitWitnessCodec threshold)
-    (n : Nat)
-    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
-    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) : Prop :=
-  ∀ (i : Nat) (hi : i + 1 ≤ codec.witnessBits n) (p : PrefixBitVec i),
-    C_DAG.eval dec (prefixStateQueryValue codec n i (Nat.le_of_succ_le hi) x p) = true
-      ↔ WitnessPrefixExtendable (problem := treeProblem codec) n x hi (Fin.snoc p true)
+    (n i : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (hi : i + 1 ≤ codec.witnessBits n)
+    (o : Fin i)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    (greedyTrueBundleUpTo codec n dec (i + 1) hi).evalOutput (Fin.castAdd 1 o) x
+      = (greedyTrueBundleUpTo codec n dec i (Nat.le_of_succ_le hi)).evalOutput o x := by
+  rw [greedyTrueBundleUpTo_succ]
+  exact evalOutput_snocBundleSubst_old _ (greedyTrueStepHead codec n i hi dec) o x
 
-/-- The greedy prefix grows by one bit per step: the next bit is the decider's
-verdict on the current prefix-state query. -/
+/-- The newest greedy bit is `dec`'s verdict on the true-extension query for the
+previous prefix — i.e. on the prefix-state `(i+1, p ++ true)` query. -/
+theorem evalOutput_greedyTrueBundleUpTo_new
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (hi : i + 1 ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    (greedyTrueBundleUpTo codec n dec (i + 1) hi).evalOutput (Fin.natAdd i (0 : Fin 1)) x
+      = C_DAG.eval dec
+          (prefixStateQueryValue codec n (i + 1) hi x
+            (Fin.snoc (greedyPrefix codec n dec x i (Nat.le_of_succ_le hi)) true)) := by
+  have hinput :
+      (fun j => (passthroughBundle (greedyTrueBundleUpTo codec n dec i (Nat.le_of_succ_le hi))).evalOutput j x)
+        = Fin.append x (greedyPrefix codec n dec x i (Nat.le_of_succ_le hi)) := by
+    funext j
+    induction j using Fin.addCases <;> simp [greedyPrefix]
+  rw [greedyTrueBundleUpTo_succ, evalOutput_snocBundleSubst_new]
+  show C_DAG.eval (composeDeciderWithQuery dec (prefixTrueExtensionQueryBitCircuit codec n i hi))
+      (fun j => (passthroughBundle (greedyTrueBundleUpTo codec n dec i (Nat.le_of_succ_le hi))).evalOutput j x)
+      = _
+  rw [hinput, eval_composeDeciderWithQuery]
+  have hbits : (fun j => C_DAG.eval (prefixTrueExtensionQueryBitCircuit codec n i hi j)
+          (Fin.append x (greedyPrefix codec n dec x i (Nat.le_of_succ_le hi))))
+        = prefixStateQueryValue codec n (i + 1) hi x
+            (Fin.snoc (greedyPrefix codec n dec x i (Nat.le_of_succ_le hi)) true) := by
+    funext j
+    rw [eval_prefixTrueExtensionQueryBitCircuit, prefixTrueExtensionQueryValue]
+  rw [hbits]
+
+/-- The greedy prefix grows by one bit per step: the next bit is `dec`'s verdict on
+the true-extension query for the current prefix. -/
 theorem greedyPrefix_succ
     (codec : TreeCircuitWitnessCodec threshold)
     (n : Nat)
@@ -84,27 +153,41 @@ theorem greedyPrefix_succ
     greedyPrefix codec n dec x (i + 1) hi'
       = Fin.snoc (greedyPrefix codec n dec x i (Nat.le_of_succ_le hi'))
           (C_DAG.eval dec
-            (prefixStateQueryValue codec n i (Nat.le_of_succ_le hi') x
-              (greedyPrefix codec n dec x i (Nat.le_of_succ_le hi')))) := by
+            (prefixStateQueryValue codec n (i + 1) hi' x
+              (Fin.snoc (greedyPrefix codec n dec x i (Nat.le_of_succ_le hi')) true))) := by
   funext k
   induction k using Fin.lastCases with
   | last =>
       simp only [Fin.snoc_last]
-      exact evalOutput_greedyBundleUpTo_new codec n i dec hi' x
+      exact evalOutput_greedyTrueBundleUpTo_new codec n i dec hi' x
   | cast j =>
       simp only [Fin.snoc_castSucc]
-      exact evalOutput_greedyBundleUpTo_old codec n i dec hi' j x
+      exact evalOutput_greedyTrueBundleUpTo_old codec n i dec hi' j x
+
+/--
+**Correct next-bit decider** (explicit hypothesis).  `dec`, run on the *encoded
+`p ++ true`* query (the prefix-state `(i+1, p ++ true)` query string), answers
+exactly whether `p ++ true` is extendable.  This is dischargeable from an ordinary
+`PrefixExtensionLanguage` decider, which on that query decides extendability of the
+encoded prefix `p ++ true`.
+-/
+def CorrectNextBitDecider
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) : Prop :=
+  ∀ (i : Nat) (hi : i + 1 ≤ codec.witnessBits n) (p : PrefixBitVec i),
+    C_DAG.eval dec (prefixStateQueryValue codec n (i + 1) hi x (Fin.snoc p true)) = true
+      ↔ WitnessPrefixExtendable (problem := treeProblem codec) n x hi (Fin.snoc p true)
 
 /--
 **Greedy extendability invariant.**  On a promise (yes-)instance `x`, with a correct
-next-bit decider, the greedy prefix of every length `i ≤ witnessBits n` is
-extendable to a full valid witness.
+next-bit decider, the greedy prefix of every length `i ≤ witnessBits n` is extendable
+to a full valid witness.
 
-Base case: the empty prefix is extendable because the promise instance has a
-witness (`totalOnPromise`).  Step: the new bit is `dec`'s verdict; if it accepts,
-`CorrectNextBitDecider` gives extendability of `p ++ true`; if it rejects, the
-reject-branch lemma (`witnessPrefixExtendable_snoc_false_of_not_true`) gives
-extendability of `p ++ false`.
+Base: the empty prefix is extendable via `totalOnPromise`.  Step: the new bit is
+`dec`'s verdict on the encoded `p ++ true` query; accept gives extendability of
+`p ++ true` directly, reject uses `witnessPrefixExtendable_snoc_false_of_not_true`.
 -/
 theorem greedyPrefix_extendable
     (codec : TreeCircuitWitnessCodec threshold)
@@ -127,7 +210,8 @@ theorem greedyPrefix_extendable
       have hi : i ≤ codec.witnessBits n := Nat.le_of_succ_le hi'
       rw [greedyPrefix_succ]
       by_cases hb : C_DAG.eval dec
-          (prefixStateQueryValue codec n i hi x (greedyPrefix codec n dec x i hi)) = true
+          (prefixStateQueryValue codec n (i + 1) hi' x
+            (Fin.snoc (greedyPrefix codec n dec x i hi) true)) = true
       · rw [hb]
         exact (hdec i hi' (greedyPrefix codec n dec x i hi)).mp hb
       · rw [Bool.not_eq_true] at hb

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyExtendable.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyExtendable.lean
@@ -1,0 +1,144 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
+import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+open Pnp3.ComplexityInterfaces.DagCircuit
+
+/-!
+# Greedy extendability invariant
+
+Block 8a of the downstream decision→search extraction.  This is the first place
+the circuit plumbing (Blocks 4–7) meets real semantic content (Block 7.5): under an
+explicit **correct-decider** hypothesis, the greedy bundle's outputs form a prefix
+that stays *extendable* on promise inputs.
+
+Concretely, let `dec` be the prefix-extension decider and
+`greedyBundleUpTo … i` the shared greedy bundle (Block 6).  The *greedy prefix*
+`greedyPrefix … i` is the length-`i` bit vector of that bundle's outputs on `x`.
+We prove, by induction on `i`:
+
+```
+WitnessPrefixExtendable (treeProblem codec) n x hi (greedyPrefix codec n dec x i hi)
+```
+
+i.e. the greedy prefix can always be completed to a valid witness — given
+(1) the promise that `x` is a yes-instance, and (2) `dec` correctly answering the
+next-bit extendability question (`CorrectNextBitDecider`).  The step uses the
+reject-branch split lemmas from #1503.
+
+This is **not** solver correctness: it does not yet conclude that the *full* greedy
+prefix is itself a valid witness, nor assemble a `BoundedSearchSolver`.
+
+Scope discipline — the extendability invariant only:
+
+* the decider's correctness is an **explicit hypothesis**, not proved here;
+* **no** `BoundedSearchSolver` assembly and **no** `solves` conclusion;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint wrapper, or
+  `P ≠ NP` / `NP ⊄ P/poly` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/-- The concrete tree-MCSP search problem attached to a codec. -/
+abbrev treeProblem (codec : TreeCircuitWitnessCodec threshold) : SearchMCSPCompressionProblem :=
+  treeMCSPSearchProblem threshold (TreeMCSPSearchWitnessEncoding.ofCodec codec)
+
+/-- The greedy prefix of length `i`: the first `i` greedy bits (the bundle's
+outputs on `x`), as a witness prefix. -/
+def greedyPrefix
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (i : Nat) (hi : i ≤ codec.witnessBits n) :
+    PrefixBitVec i :=
+  fun k => (greedyBundleUpTo codec n dec i hi).evalOutput k x
+
+/--
+**Correct next-bit decider** (explicit hypothesis).  `dec`, run on the prefix-state
+`(i, p)` query for instance `x`, answers exactly whether the one-bit extension
+`p ++ true` is extendable.  This is the next-bit extendability oracle the greedy
+construction relies on.
+-/
+def CorrectNextBitDecider
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) : Prop :=
+  ∀ (i : Nat) (hi : i + 1 ≤ codec.witnessBits n) (p : PrefixBitVec i),
+    C_DAG.eval dec (prefixStateQueryValue codec n i (Nat.le_of_succ_le hi) x p) = true
+      ↔ WitnessPrefixExtendable (problem := treeProblem codec) n x hi (Fin.snoc p true)
+
+/-- The greedy prefix grows by one bit per step: the next bit is the decider's
+verdict on the current prefix-state query. -/
+theorem greedyPrefix_succ
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (i : Nat) (hi' : i + 1 ≤ codec.witnessBits n) :
+    greedyPrefix codec n dec x (i + 1) hi'
+      = Fin.snoc (greedyPrefix codec n dec x i (Nat.le_of_succ_le hi'))
+          (C_DAG.eval dec
+            (prefixStateQueryValue codec n i (Nat.le_of_succ_le hi') x
+              (greedyPrefix codec n dec x i (Nat.le_of_succ_le hi')))) := by
+  funext k
+  induction k using Fin.lastCases with
+  | last =>
+      simp only [Fin.snoc_last]
+      exact evalOutput_greedyBundleUpTo_new codec n i dec hi' x
+  | cast j =>
+      simp only [Fin.snoc_castSucc]
+      exact evalOutput_greedyBundleUpTo_old codec n i dec hi' j x
+
+/--
+**Greedy extendability invariant.**  On a promise (yes-)instance `x`, with a correct
+next-bit decider, the greedy prefix of every length `i ≤ witnessBits n` is
+extendable to a full valid witness.
+
+Base case: the empty prefix is extendable because the promise instance has a
+witness (`totalOnPromise`).  Step: the new bit is `dec`'s verdict; if it accepts,
+`CorrectNextBitDecider` gives extendability of `p ++ true`; if it rejects, the
+reject-branch lemma (`witnessPrefixExtendable_snoc_false_of_not_true`) gives
+extendability of `p ++ false`.
+-/
+theorem greedyPrefix_extendable
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (hpromise : (treeProblem codec).promise n x)
+    (hdec : CorrectNextBitDecider codec n x dec) :
+    ∀ (i : Nat) (hi : i ≤ codec.witnessBits n),
+      WitnessPrefixExtendable (problem := treeProblem codec) n x hi
+        (greedyPrefix codec n dec x i hi) := by
+  intro i
+  induction i with
+  | zero =>
+      intro _
+      obtain ⟨w, hw⟩ := (treeProblem codec).totalOnPromise n x hpromise
+      exact ⟨w, fun k => k.elim0, hw⟩
+  | succ i ih =>
+      intro hi'
+      have hi : i ≤ codec.witnessBits n := Nat.le_of_succ_le hi'
+      rw [greedyPrefix_succ]
+      by_cases hb : C_DAG.eval dec
+          (prefixStateQueryValue codec n i hi x (greedyPrefix codec n dec x i hi)) = true
+      · rw [hb]
+        exact (hdec i hi' (greedyPrefix codec n dec x i hi)).mp hb
+      · rw [Bool.not_eq_true] at hb
+        rw [hb]
+        refine witnessPrefixExtendable_snoc_false_of_not_true (problem := treeProblem codec) n x hi'
+          (greedyPrefix codec n dec x i hi) (ih hi) ?_
+        intro hext
+        have hT := (hdec i hi' (greedyPrefix codec n dec x i hi)).mpr hext
+        rw [hT] at hb
+        exact absurd hb (by decide)
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPTrueExtensionQuery.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPTrueExtensionQuery.lean
@@ -1,0 +1,147 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPrefixStateQueryCircuits
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# True-extension prefix query circuits
+
+A correction layer for the greedy decision (Block 8a fix).
+
+The greedy step must ask the decider **"is `p ++ true` extendable?"**, where `p` is
+the current prefix of length `i`.  A `PrefixExtensionLanguage` decider answers about
+the *encoded* prefix inside the query string; so to make it answer about `p ++ true`
+the query must encode the prefix-state `(i + 1, p ++ true)`, **not** `(i, p)`.
+
+This file packages exactly that "true-extension" query:
+
+* `prefixTrueExtensionQueryValue codec n i hi x p
+    := prefixStateQueryValue codec n (i + 1) hi x (Fin.snoc p true)` — the serialized
+  query for the one-bit-true extension;
+* `prefixTrueExtensionQueryBitCircuit` — its per-bit `C_DAG` circuit, still over
+  `tableLen n + i` inputs (the real instance bits plus the `i` prior bundle outputs):
+  the witness-payload region reads the `i` prior outputs (`inputProj`) for positions
+  `< i` and is the constant `true` at position `i`; the index field encodes `i + 1`.
+
+With this, a greedy step `composeDeciderWithQuery dec (prefixTrueExtensionQueryBitCircuit …)`
+runs `dec` on the encoded `p ++ true`, so the resulting next-bit hypothesis is
+dischargeable from an ordinary prefix-extension decider.
+
+Scope discipline — corrected query value + per-bit circuits only:
+
+* **no** greedy fold / `BoundedSearchSolver`;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint, or `P ≠ NP` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/-- The serialized "true-extension" query for prefix `p` (length `i`): the
+prefix-state query string for `(i + 1, p ++ true)`. -/
+def prefixTrueExtensionQueryValue
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i + 1 ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i) :
+    PrefixBitVec (treeMCSPPrefixM codec n) :=
+  prefixStateQueryValue codec n (i + 1) hi x (Fin.snoc p true)
+
+/--
+The per-bit `C_DAG` circuit (over `tableLen n + i` inputs) computing the `j`-th bit
+of the true-extension query `prefixTrueExtensionQueryValue codec n i hi x p`.
+
+Like `prefixStateQueryBitCircuit` for state `(i + 1, ·)`, but the final witness
+payload bit is hard-wired to the constant `true` (so the circuit reads only the `i`
+prior bundle outputs, not an `(i+1)`-st input); the index field encodes `i + 1`.
+The bound `_hi` keeps the API inside the parser contract; the body does not use it.
+-/
+def prefixTrueExtensionQueryBitCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (_hi : i + 1 ≤ codec.witnessBits n)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n + i) :=
+  if hTag : j.1 < tagLen then
+    Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _
+      (natBitBE treePrefixTag tagLen ⟨j.1, hTag⟩)
+  else
+    let gammaOffset := tagLen
+    if hGamma : j.1 < gammaOffset + gammaLen n then
+      Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _
+        (gammaBit n ⟨j.1 - gammaOffset, by omega⟩)
+    else
+      let xOffset := tagLen + gammaLen n
+      if hX : j.1 < xOffset + Pnp3.Models.Partial.tableLen n then
+        Pnp3.ComplexityInterfaces.DagCircuit.inputProj
+          (Fin.castAdd i ⟨j.1 - xOffset, by omega⟩)
+      else
+        let iOffset := xOffset + Pnp3.Models.Partial.tableLen n
+        if hI : j.1 < iOffset + idxWidth codec.witnessBits n then
+          Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _
+            (natBitBE (i + 1) (idxWidth codec.witnessBits n) ⟨j.1 - iOffset, by omega⟩)
+        else
+          let pOffset := iOffset + idxWidth codec.witnessBits n
+          if hP : j.1 < pOffset + i then
+            Pnp3.ComplexityInterfaces.DagCircuit.inputProj
+              (Fin.natAdd (Pnp3.Models.Partial.tableLen n) ⟨j.1 - pOffset, by omega⟩)
+          else if hT : j.1 < pOffset + (i + 1) then
+            Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _ true
+          else
+            Pnp3.ComplexityInterfaces.DagCircuit.constCircuit _ false
+
+/--
+Evaluating the true-extension query-bit circuit on `Fin.append x p` reproduces the
+corresponding bit of `prefixTrueExtensionQueryValue codec n i hi x p` — i.e. the
+prefix-state query for `(i + 1, p ++ true)`.
+
+The payload region splits into the prior-output reads (`Fin.append_right`, and
+`Fin.snoc` at positions `< i` is `p`) and the hard-wired `true` (`Fin.snoc` at the
+last position is `true`).
+-/
+theorem eval_prefixTrueExtensionQueryBitCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i + 1 ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.eval (prefixTrueExtensionQueryBitCircuit codec n i hi j) (Fin.append x p) =
+      prefixTrueExtensionQueryValue codec n i hi x p j := by
+  simp only [prefixTrueExtensionQueryValue, prefixStateQueryValue, prefixStateFields,
+    encodeTreeMCSPPrefixFields, prefixTrueExtensionQueryBitCircuit]
+  split_ifs with hTag hGamma hX hI hP hT <;>
+    simp only [C_DAG,
+      Pnp3.ComplexityInterfaces.DagCircuit.eval_constCircuit,
+      Pnp3.ComplexityInterfaces.DagCircuit.eval_inputProj,
+      Fin.append_left, Fin.append_right]
+  · -- payload-prior region: `Fin.snoc p true` at a position `< i` is `p`
+    have hv : j.1 - (tagLen + gammaLen n + Pnp3.Models.Partial.tableLen n
+        + idxWidth codec.witnessBits n) < i := by omega
+    rw [show (⟨j.1 - (tagLen + gammaLen n + Pnp3.Models.Partial.tableLen n
+            + idxWidth codec.witnessBits n), by omega⟩ : Fin (i + 1))
+          = Fin.castSucc ⟨j.1 - (tagLen + gammaLen n + Pnp3.Models.Partial.tableLen n
+            + idxWidth codec.witnessBits n), hv⟩ from Fin.ext rfl,
+        Fin.snoc_castSucc]
+  · -- `hP ∧ ¬hT` is impossible
+    exfalso; omega
+  · -- payload-last region: `Fin.snoc p true` at the last position is `true`
+    rw [show (⟨j.1 - (tagLen + gammaLen n + Pnp3.Models.Partial.tableLen n
+            + idxWidth codec.witnessBits n), by omega⟩ : Fin (i + 1)) = Fin.last i
+          from Fin.ext (by simp only [Fin.val_last]; omega), Fin.snoc_last]
+
+/-- Every true-extension query-bit circuit has size at most `2`. -/
+theorem size_prefixTrueExtensionQueryBitCircuit_le
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i + 1 ≤ codec.witnessBits n)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.size (prefixTrueExtensionQueryBitCircuit codec n i hi j) ≤ 2 := by
+  simp only [prefixTrueExtensionQueryBitCircuit]
+  split_ifs <;> simp [C_DAG]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -40,6 +40,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
 import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -567,6 +568,38 @@ theorem check_witnessPrefixExtendable_snoc_true_of_not_false
   witnessPrefixExtendable_snoc_true_of_not_false n x hi' p hp hnf
 
 end PrefixExtendableSplitSurface
+
+section TreeMCSPGreedyExtendableSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 8a surface: the greedy prefix of length `i` (the bundle outputs on `x`). -/
+def check_greedyPrefix
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (i : Nat) (hi : i ≤ codec.witnessBits n) :
+    PrefixBitVec i :=
+  greedyPrefix codec n dec x i hi
+
+/-- Block 8a surface (headline): on a promise instance, with a correct next-bit
+decider, the greedy prefix of every length is extendable to a valid witness. -/
+theorem check_greedyPrefix_extendable
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (hpromise : (treeProblem codec).promise n x)
+    (hdec : CorrectNextBitDecider codec n x dec)
+    (i : Nat) (hi : i ≤ codec.witnessBits n) :
+    WitnessPrefixExtendable (problem := treeProblem codec) n x hi
+      (greedyPrefix codec n dec x i hi) :=
+  greedyPrefix_extendable codec n dec x hpromise hdec i hi
+
+end TreeMCSPGreedyExtendableSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -40,6 +40,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
 import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
+import Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
@@ -598,6 +599,33 @@ theorem check_greedyPrefix_extendable
     WitnessPrefixExtendable (problem := treeProblem codec) n x hi
       (greedyPrefix codec n dec x i hi) :=
   greedyPrefix_extendable codec n dec x hpromise hdec i hi
+
+/-- Block 8a surface: the true-extension query bit equals the encoded `p ++ true`
+prefix-state query bit (the alignment that makes `CorrectNextBitDecider`
+dischargeable from an ordinary prefix-extension decider). -/
+theorem check_eval_prefixTrueExtensionQueryBitCircuit
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i + 1 ≤ codec.witnessBits n)
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (p : PrefixBitVec i)
+    (j : Fin (treeMCSPPrefixM codec n)) :
+    C_DAG.eval (prefixTrueExtensionQueryBitCircuit codec n i hi j) (Fin.append x p)
+      = prefixStateQueryValue codec n (i + 1) hi x (Fin.snoc p true) j :=
+  eval_prefixTrueExtensionQueryBitCircuit codec n i hi x p j
+
+/-- Block 8a surface: one true-extension greedy step adds at most `size dec + 2·M(n)`
+gates (feasibility for the corrected greedy). -/
+theorem check_size_greedyTrueStepHead_le
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (hi : i + 1 ≤ codec.witnessBits n)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    C_DAG.size (greedyTrueStepHead codec n i hi dec)
+      ≤ C_DAG.size dec + 2 * treeMCSPPrefixM codec n :=
+  size_greedyTrueStepHead_le codec n i hi dec
 
 end TreeMCSPGreedyExtendableSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -30,6 +30,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
 import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -239,6 +240,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.witnessPrefixExtendable_split
 #print axioms Pnp4.Frontier.ContractExpansion.witnessPrefixExtendable_snoc_false_of_not_true
 #print axioms Pnp4.Frontier.ContractExpansion.witnessPrefixExtendable_snoc_true_of_not_false
+
+#print axioms Pnp4.Frontier.ContractExpansion.greedyPrefix_succ
+#print axioms Pnp4.Frontier.ContractExpansion.greedyPrefix_extendable
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -30,6 +30,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyBundleFold
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
 import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
+import Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
@@ -241,6 +242,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.witnessPrefixExtendable_snoc_false_of_not_true
 #print axioms Pnp4.Frontier.ContractExpansion.witnessPrefixExtendable_snoc_true_of_not_false
 
+#print axioms Pnp4.Frontier.ContractExpansion.eval_prefixTrueExtensionQueryBitCircuit
+#print axioms Pnp4.Frontier.ContractExpansion.size_prefixTrueExtensionQueryBitCircuit_le
+#print axioms Pnp4.Frontier.ContractExpansion.size_greedyTrueStepHead_le
 #print axioms Pnp4.Frontier.ContractExpansion.greedyPrefix_succ
 #print axioms Pnp4.Frontier.ContractExpansion.greedyPrefix_extendable
 


### PR DESCRIPTION
## Summary

Block 8a of the downstream decision→search extraction: the **greedy extendability
invariant** — the first place the circuit plumbing meets real semantic content
(Block 7.5, #1503).

> **Updated after review:** the first draft had a semantic mismatch (the greedy ran
> `dec` on the `(i, p)` query but claimed the answer was about `p ++ true`; a real
> `PrefixExtensionLanguage` decider on `(i, p)` decides extendability of `p`, not
> `p ++ true`, so the hypothesis was not dischargeable). Fixed by querying the
> **encoded `p ++ true`** (prefix-state `(i+1, p ++ true)`).

## New: true-extension query (`TreeMCSPTrueExtensionQuery.lean`)

```
prefixTrueExtensionQueryValue codec n i hi x p := prefixStateQueryValue codec n (i+1) hi x (Fin.snoc p true)
prefixTrueExtensionQueryBitCircuit codec n i hi : Fin (M n) → C_DAG.Family (tableLen n + i)
```
Per-bit circuit still over `tableLen n + i` inputs: the payload reads the `i` prior
bundle outputs for positions `< i` and is the constant `true` at position `i`; the
index field encodes `i + 1`. With `eval_…` (= the encoded `p ++ true` query bit) and
uniform size `≤ 2`.

## Corrected greedy + invariant (`TreeMCSPGreedyExtendable.lean`)

- `greedyTrueStepHead := composeDeciderWithQuery dec (prefixTrueExtensionQueryBitCircuit …)`
  (`size ≤ size dec + 2·M(n)`);
- `greedyTrueBundleUpTo` — the corrected greedy fold; `greedyPrefix` reads its outputs;
- `greedyPrefix_succ` — new bit `= dec (prefixStateQueryValue codec n (i+1) hi x (Fin.snoc p true))`;
- **`CorrectNextBitDecider`** (explicit hypothesis):
  `dec (prefixStateQueryValue codec n (i+1) hi x (Fin.snoc p true)) = true ↔ WitnessPrefixExtendable (treeProblem codec) n x hi (Fin.snoc p true)`
  — dischargeable from an ordinary prefix-extension decider on the encoded `p ++ true`;
- **`greedyPrefix_extendable`** — on a promise instance, with a correct next-bit
  decider, the greedy prefix of every length `i ≤ witnessBits n` is extendable
  (base: `totalOnPromise`; reject branch: `witnessPrefixExtendable_snoc_false_of_not_true`).

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- Surfaces + axioms audit updated; `greedyPrefix_extendable`, `eval_prefixTrueExtensionQueryBitCircuit`
  depend only on `propext` / `Quot.sound`.

## Scope discipline

Decider correctness is an explicit hypothesis (not proved). **No** `BoundedSearchSolver`
assembly, **no** `solves` conclusion, **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint,
or `P ≠ NP` / `NP ⊄ P/poly` consequence. The genuine lower bound remains the open
problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4