### PR TITLE
Block 7′: true-greedy output circuits; mark old state-query greedy legacy

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -286,6 +286,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyBundleFold.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyBundleFold.lean
@@ -10,6 +10,14 @@ open Pnp3.ComplexityInterfaces.DagCircuit
 /-!
 # Recursive shared-bundle greedy fold
 
+> **Legacy (state-query) surface — not solver-bearing.**  This fold iterates the
+> state-query step (`greedyBundleStep`, querying `(i, p)`), which is **not** the
+> correctness-bearing greedy.  Use the true-extension fold `greedyTrueBundleUpTo`
+> (`TreeMCSPGreedyExtendable.lean`) and its outputs `greedyTrueOutputCircuit`
+> (`TreeMCSPGreedyTrueOutputCircuits.lean`) for solver/witness construction.  The
+> definitions here remain valid constructions (with the same linear size bound) but
+> must not be used for correctness.
+
 Block 6 of the downstream decision→search extraction, in the **Option ①**
 architecture (#1498 / #1499 / #1500).
 

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyBundleStep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyBundleStep.lean
@@ -10,6 +10,14 @@ open Pnp3.ComplexityInterfaces.DagCircuit
 /-!
 # One-step shared-bundle greedy extension
 
+> **Legacy (state-query) surface — not solver-bearing.**  This step queries the
+> decider on the prefix-state `(i, p)`, which a real `PrefixExtensionLanguage`
+> decider answers as "is `p` extendable", *not* "is `p ++ true` extendable".  After
+> the Block 8a semantic-mismatch fix (#1504), the correctness-bearing greedy is the
+> **true-extension** fold `greedyTrueBundleUpTo` / `greedyTrueStepHead`
+> (`TreeMCSPGreedyExtendable.lean`).  This module remains a valid circuit
+> construction but must **not** be used for solver/witness construction.
+
 Block 5 of the downstream decision→search extraction, in the **Option ①**
 architecture (merged in #1498 / #1499).
 

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyOutputCircuits.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyOutputCircuits.lean
@@ -10,6 +10,15 @@ open Pnp3.ComplexityInterfaces.DagCircuit
 /-!
 # Final greedy bundle outputs as per-witness-bit C_DAG circuits
 
+> **Legacy (state-query) surface — NOT solver-bearing.**  `greedyOutputCircuit` here
+> projects the *state-query* bundle `fullGreedyBundle` (which queries `(i, p)`), and
+> after the Block 8a semantic-mismatch fix (#1504) that greedy is **not** the one
+> whose bits form a valid witness.  For the solver, use the correctness-bearing
+> `greedyTrueOutputCircuit` / `fullGreedyTrueBundle`
+> (`TreeMCSPGreedyTrueOutputCircuits.lean`), built on the true-extension fold.  These
+> output circuits remain valid (same uniform size bound) but must **not** be used as
+> solver/witness outputs.
+
 Block 7 of the downstream decision→search extraction, in the **Option ①**
 architecture (#1498–#1501).
 

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyTrueOutputCircuits.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedyTrueOutputCircuits.lean
@@ -1,0 +1,124 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+open Pnp3.ComplexityInterfaces.DagCircuit
+
+/-!
+# True-greedy output circuits (correctness-bearing)
+
+Block 7′ of the downstream decision→search extraction.
+
+`#1502` exposed per-witness-bit output circuits from the *state-query* greedy
+(`greedyBundleUpTo`).  After the Block 8a semantic-mismatch fix (#1504), the
+correctness-bearing greedy is the **true-extension** fold `greedyTrueBundleUpTo`
+(its decider queries the encoded `p ++ true`).  This file re-exposes the
+output-circuit surface — with the same linear size bound — on *that* fold, so the
+later solver construction consumes the correct greedy.
+
+* `fullGreedyTrueBundle` — the full true-greedy bundle of `witnessBits n` bits;
+* `greedyTrueOutputCircuit i` — the `i`-th output as a `C_DAG` circuit;
+* `eval_greedyTrueOutputCircuit`, `size_greedyTrueOutputCircuit_le` (uniform `≤
+  witnessBits n · (size dec + 2·M(n)) + 1`, via the linear fold bound proved here).
+
+The legacy `greedyBundleUpTo` / `greedyOutputCircuit` (state-query, `(i, p)`) remain
+in the tree as valid constructions but are **not** solver-bearing; their module
+docstrings now say so.
+
+Scope discipline — true-greedy output surface + size bound only:
+
+* **no** `solves` / solver-correctness, **no** `BoundedSearchSolver`;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint, or `P ≠ NP` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/-- Additive size recurrence for the true-greedy fold (prior bundle shared). -/
+theorem gates_greedyTrueBundleUpTo_succ
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n i : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (hi : i + 1 ≤ codec.witnessBits n) :
+    (greedyTrueBundleUpTo codec n dec (i + 1) hi).gates
+      = (greedyTrueBundleUpTo codec n dec i (Nat.le_of_succ_le hi)).gates
+          + (greedyTrueStepHead codec n i hi dec).gates := by
+  rw [greedyTrueBundleUpTo_succ]
+  exact snocBundleSubst_gates _ (greedyTrueStepHead codec n i hi dec)
+
+/-- **Linear size bound** for the true-greedy fold: `i` bits cost at most
+`i · (size dec + 2·M(n))` gates. -/
+theorem gates_greedyTrueBundleUpTo_le
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    ∀ (i : Nat) (hi : i ≤ codec.witnessBits n),
+      (greedyTrueBundleUpTo codec n dec i hi).gates
+        ≤ i * (C_DAG.size dec + 2 * treeMCSPPrefixM codec n) := by
+  intro i
+  induction i with
+  | zero =>
+      intro _
+      simp [greedyTrueBundleUpTo, emptyBundle]
+  | succ i ih =>
+      intro hi
+      rw [gates_greedyTrueBundleUpTo_succ, add_mul, one_mul]
+      have hhead : (greedyTrueStepHead codec n i hi dec).gates
+          ≤ C_DAG.size dec + 2 * treeMCSPPrefixM codec n := by
+        have h1 := size_greedyTrueStepHead_le codec n i hi dec
+        have h2 : C_DAG.size (greedyTrueStepHead codec n i hi dec)
+            = (greedyTrueStepHead codec n i hi dec).gates + 1 := rfl
+        omega
+      exact Nat.add_le_add (ih (Nat.le_of_succ_le hi)) hhead
+
+/-- The full true-greedy bundle: all `witnessBits n` greedy bits. -/
+def fullGreedyTrueBundle
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) :
+    DagBundle (Pnp3.Models.Partial.tableLen n) (codec.witnessBits n) :=
+  greedyTrueBundleUpTo codec n dec (codec.witnessBits n) (Nat.le_refl _)
+
+/-- The per-witness-bit output circuit of the correctness-bearing true greedy. -/
+def greedyTrueOutputCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n) :=
+  (fullGreedyTrueBundle codec n dec).asCircuit i
+
+/-- The `i`-th output circuit computes the `i`-th true-greedy bit. -/
+@[simp] theorem eval_greedyTrueOutputCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    C_DAG.eval (greedyTrueOutputCircuit codec n dec i) x
+      = (fullGreedyTrueBundle codec n dec).evalOutput i x :=
+  rfl
+
+/-- **Uniform size bound**, independent of `i` (every output circuit shares the one
+true-greedy bundle gate list). -/
+theorem size_greedyTrueOutputCircuit_le
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n)) :
+    C_DAG.size (greedyTrueOutputCircuit codec n dec i)
+      ≤ codec.witnessBits n * (C_DAG.size dec + 2 * treeMCSPPrefixM codec n) + 1 := by
+  have hs : C_DAG.size (greedyTrueOutputCircuit codec n dec i)
+      = (greedyTrueOutputCircuit codec n dec i).gates + 1 := rfl
+  have hg : (greedyTrueOutputCircuit codec n dec i).gates = (fullGreedyTrueBundle codec n dec).gates := rfl
+  have hb : (fullGreedyTrueBundle codec n dec).gates
+      ≤ codec.witnessBits n * (C_DAG.size dec + 2 * treeMCSPPrefixM codec n) :=
+    gates_greedyTrueBundleUpTo_le codec n dec (codec.witnessBits n) (Nat.le_refl _)
+  rw [hs, hg]
+  omega
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -42,6 +42,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
 import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -628,6 +629,47 @@ theorem check_size_greedyTrueStepHead_le
   size_greedyTrueStepHead_le codec n i hi dec
 
 end TreeMCSPGreedyExtendableSurface
+
+section TreeMCSPGreedyTrueOutputCircuitsSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 7′ surface: the correctness-bearing per-witness-bit output circuit. -/
+def check_greedyTrueOutputCircuit
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n)) :
+    C_DAG.Family (Pnp3.Models.Partial.tableLen n) :=
+  greedyTrueOutputCircuit codec n dec i
+
+/-- Block 7′ surface: the `i`-th true-greedy output circuit computes the `i`-th
+true-greedy bit. -/
+theorem check_eval_greedyTrueOutputCircuit
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    C_DAG.eval (greedyTrueOutputCircuit codec n dec i) x
+      = (fullGreedyTrueBundle codec n dec).evalOutput i x :=
+  eval_greedyTrueOutputCircuit codec n dec i x
+
+/-- Block 7′ surface (headline): uniform size bound on every true-greedy output
+circuit, independent of `i`. -/
+theorem check_size_greedyTrueOutputCircuit_le
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (i : Fin (codec.witnessBits n)) :
+    C_DAG.size (greedyTrueOutputCircuit codec n dec i)
+      ≤ codec.witnessBits n * (C_DAG.size dec + 2 * treeMCSPPrefixM codec n) + 1 :=
+  size_greedyTrueOutputCircuit_le codec n dec i
+
+end TreeMCSPGreedyTrueOutputCircuitsSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -32,6 +32,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyOutputCircuits
 import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -247,6 +248,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.size_greedyTrueStepHead_le
 #print axioms Pnp4.Frontier.ContractExpansion.greedyPrefix_succ
 #print axioms Pnp4.Frontier.ContractExpansion.greedyPrefix_extendable
+
+#print axioms Pnp4.Frontier.ContractExpansion.gates_greedyTrueBundleUpTo_le
+#print axioms Pnp4.Frontier.ContractExpansion.eval_greedyTrueOutputCircuit
+#print axioms Pnp4.Frontier.ContractExpansion.size_greedyTrueOutputCircuit_le
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Cleanup/replacement following the Block 8a semantic-mismatch fix (#1504). The
correctness-bearing greedy is now the **true-extension** fold `greedyTrueBundleUpTo`
(its decider queries the encoded `p ++ true`). This PR re-exposes the
per-witness-bit output-circuit surface on **that** fold — so the later solver
construction consumes the correct greedy — and marks the old state-query surface
(merged Blocks 5/6/7) as legacy / not solver-bearing.

## New: `TreeMCSPGreedyTrueOutputCircuits.lean`

- `gates_greedyTrueBundleUpTo_succ` / `gates_greedyTrueBundleUpTo_le` — additive
  recurrence + **linear** size bound: `(greedyTrueBundleUpTo … i).gates ≤ i ·
  (size dec + 2·M(n))`;
- `fullGreedyTrueBundle` — the full true-greedy bundle of `witnessBits n` bits;
- `greedyTrueOutputCircuit i` — the `i`-th output as a `C_DAG` circuit;
- `eval_greedyTrueOutputCircuit` (= the `i`-th true-greedy bit);
- `size_greedyTrueOutputCircuit_le` — uniform `≤ witnessBits n · (size dec + 2·M(n)) + 1`.

This mirrors #1502 but on the true-extension fold.

## Legacy marking (docstring-only)

`TreeMCSPGreedyBundleStep`, `TreeMCSPGreedyBundleFold`, `TreeMCSPGreedyOutputCircuits`
now carry a prominent note: they query the prefix-state `(i, p)` — which a real
`PrefixExtensionLanguage` decider answers as "is `p` extendable", **not** "is
`p ++ true` extendable" — so they are **not** the correctness-bearing greedy. They
remain valid circuit constructions (with the same size bounds) but must not be used
for solver/witness construction; use the true-greedy versions instead.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surfaces in `AlgorithmsToLowerBoundsSurfaceTests.lean` + `AxiomsAudit.lean`;
  `eval_greedyTrueOutputCircuit` is `propext` / `Quot.sound`.

## Scope discipline

True-greedy output surface + size bound + legacy marking only. **No** `solves` /
solver-correctness, **no** `BoundedSearchSolver`, **no** `PpolyDAG`/`InPpolyDAG`
bridge, endpoint, or `P ≠ NP` / `NP ⊄ P/poly` consequence. The genuine lower bound
remains the open problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_