### PR TITLE
Block 8b: discharge CorrectNextBitDecider from a prefix-extension decider

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -287,6 +287,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDeciderCorrect.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDeciderCorrect.lean
@@ -1,0 +1,81 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# `CorrectNextBitDecider` from a real prefix-extension decider
+
+Block 8b of the downstream decision→search extraction.
+
+Block 8a (#1504) proved the greedy extendability invariant *under* the abstract
+hypothesis `CorrectNextBitDecider`.  This file **discharges** that hypothesis from a
+concrete assumption that is actually about the prefix-extension *language*: if `dec`
+decides `PrefixExtensionLanguage` at the parser's ambient length `treeMCSPPrefixM
+codec n`, then it is a correct next-bit decider.
+
+The bridge is the true-extension query round-trip (Block 4 / #1504):
+the query `prefixStateQueryValue codec n (i+1) hi x (Fin.snoc p true)` *parses* back
+to the canonical prefix-input for `(i+1, p ++ true)`, whose
+`PrefixExtendableInput` is exactly `WitnessPrefixExtendable … (Fin.snoc p true)`
+(Block 7.5).  So the language's verdict on the encoded `p ++ true` is precisely the
+next-bit extendability `CorrectNextBitDecider` needs.
+
+Scope discipline — decider-correctness bridge only:
+
+* the decider's language-correctness is still an **explicit hypothesis**;
+* **no** `BoundedSearchSolver`, **no** full `solves` conclusion;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint, or `P ≠ NP` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/-- `dec` decides the prefix-extension language at the parser's ambient length: at
+every query string it agrees with `PrefixExtensionLanguage`. -/
+def DecidesPrefixExtensionLanguage
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n)) : Prop :=
+  ∀ y : PrefixBitVec (treeMCSPPrefixM codec n),
+    C_DAG.eval dec y
+      = PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec)
+          (treeMCSPPrefixM codec n) y
+
+/--
+**Discharge of `CorrectNextBitDecider`.**  A decider for the prefix-extension
+language is a correct next-bit decider: run on the encoded `p ++ true` query it
+answers exactly whether `p ++ true` is extendable.
+
+The forward/backward directions both go through the query parser round-trip
+(`parse_prefixStateQueryValue`) and `prefixExtendableInput_iff_witnessPrefixExtendable`.
+-/
+theorem correctNextBitDecider_of_decidesLanguage
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (hdec : DecidesPrefixExtensionLanguage codec n dec) :
+    CorrectNextBitDecider codec n x dec := by
+  intro i hi p
+  rw [hdec (prefixStateQueryValue codec n (i + 1) hi x (Fin.snoc p true)),
+      PrefixExtensionLanguage_accepts_iff]
+  constructor
+  · rintro ⟨input, hparse, hext⟩
+    have hpeq : parsePrefixInput (treeMCSPConcretePrefixParser threshold codec)
+          (prefixStateQueryValue codec n (i + 1) hi x (Fin.snoc p true))
+          = some (CanonicalRawTreeMCSPPrefixFields.toPrefixInput codec
+              (prefixStateFields codec n (i + 1) hi x (Fin.snoc p true))) :=
+      parse_prefixStateQueryValue codec n (i + 1) hi x (Fin.snoc p true)
+    rw [hpeq] at hparse
+    obtain rfl := Option.some.inj hparse.symm
+    exact (prefixExtendableInput_iff_witnessPrefixExtendable _).mp hext
+  · intro hwit
+    exact ⟨_, parse_prefixStateQueryValue codec n (i + 1) hi x (Fin.snoc p true),
+      (prefixExtendableInput_iff_witnessPrefixExtendable _).mpr hwit⟩
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -43,6 +43,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -670,6 +671,24 @@ theorem check_size_greedyTrueOutputCircuit_le
   size_greedyTrueOutputCircuit_le codec n dec i
 
 end TreeMCSPGreedyTrueOutputCircuitsSurface
+
+section TreeMCSPDeciderCorrectSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 8b surface: a decider for the prefix-extension language is a correct
+next-bit decider (discharges the Block 8a hypothesis). -/
+theorem check_correctNextBitDecider_of_decidesLanguage
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (hdec : DecidesPrefixExtensionLanguage codec n dec) :
+    CorrectNextBitDecider codec n x dec :=
+  correctNextBitDecider_of_decidesLanguage codec n dec x hdec
+
+end TreeMCSPDeciderCorrectSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -33,6 +33,7 @@ import Pnp4.Frontier.ContractExpansion.PrefixExtendableSplit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -252,6 +253,8 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.gates_greedyTrueBundleUpTo_le
 #print axioms Pnp4.Frontier.ContractExpansion.eval_greedyTrueOutputCircuit
 #print axioms Pnp4.Frontier.ContractExpansion.size_greedyTrueOutputCircuit_le
+
+#print axioms Pnp4.Frontier.ContractExpansion.correctNextBitDecider_of_decidesLanguage
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 8b of the downstream decision→search extraction. Block 8a (#1504) proved the
greedy extendability invariant *under* the abstract hypothesis
`CorrectNextBitDecider`. This **discharges** that hypothesis from an assumption
about the actual prefix-extension *language*. New file `TreeMCSPDeciderCorrect.lean`.

```
DecidesPrefixExtensionLanguage codec n dec : Prop
  := ∀ y, C_DAG.eval dec y = PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec) (treeMCSPPrefixM codec n) y

correctNextBitDecider_of_decidesLanguage :
  DecidesPrefixExtensionLanguage codec n dec → CorrectNextBitDecider codec n x dec
```

## The bridge

The true-extension query `prefixStateQueryValue codec n (i+1) hi x (Fin.snoc p true)`
**parses back** (via `parse_prefixStateQueryValue`) to the canonical prefix-input
for `(i+1, p ++ true)`, whose `PrefixExtendableInput` is exactly
`WitnessPrefixExtendable … (Fin.snoc p true)` (`prefixExtendableInput_iff_witnessPrefixExtendable`,
Block 7.5). So a real decider's verdict on the *encoded* `p ++ true` is precisely the
next-bit extendability the greedy needs — completing the link the semantic-mismatch
fix (#1504) set up. Both directions of the iff go through this round-trip +
`PrefixExtensionLanguage_accepts_iff`.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surfaces in `AlgorithmsToLowerBoundsSurfaceTests.lean` + `AxiomsAudit.lean`.

## Scope discipline

Decider-correctness bridge only. The decider's language-correctness is still an
**explicit hypothesis** (`DecidesPrefixExtensionLanguage`). **No**
`BoundedSearchSolver`, **no** full `solves` conclusion, **no**
`PpolyDAG`/`InPpolyDAG` bridge, endpoint, or `P ≠ NP` / `NP ⊄ P/poly` consequence.
The genuine lower bound remains the open problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_