### PR TITLE
Block 8c: full true-greedy prefix is a solving witness

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -288,6 +288,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedySolves.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGreedySolves.lean
@@ -1,0 +1,88 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# The full true-greedy prefix is a solving witness
+
+Block 8c of the downstream decision→search extraction.
+
+Block 8a (#1504) proved the greedy prefix stays *extendable* at every length
+`i ≤ witnessBits n`.  At the **full** length `i = witnessBits n` the prefix already
+occupies every witness coordinate, so "extendable" collapses to "solving": the
+witness `w` that the extendability gives must equal the greedy prefix itself (they
+agree on all `witnessBits n` coordinates), hence the greedy prefix satisfies the
+search relation.
+
+Tying back to the circuit surface (Block 7′), the joint output of the
+true-greedy output circuits `greedyTrueOutputCircuit` is exactly that full greedy
+prefix (`searchSolverOutput_greedyTrueOutputCircuit`), so it too solves
+(`greedyTrueOutputCircuit_solves`).
+
+Scope discipline — pre-solver witness correctness only:
+
+* still under the explicit `CorrectNextBitDecider` hypothesis (and the promise);
+* **no** `BoundedSearchSolver` assembly (this proves the output solves, it does not
+  package the size bound + correctness into the solver structure);
+* **no** `PpolyDAG`/`InPpolyDAG` bridge, endpoint, or `P ≠ NP` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/--
+**Full greedy prefix solves.**  On a promise instance, with a correct next-bit
+decider, the greedy prefix of the full length `witnessBits n` satisfies the search
+relation — it is a valid witness for `x`.
+-/
+theorem greedyPrefix_solves
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (hpromise : (treeProblem codec).promise n x)
+    (hdec : CorrectNextBitDecider codec n x dec) :
+    (treeProblem codec).relation n x
+      (greedyPrefix codec n dec x (codec.witnessBits n) (Nat.le_refl _)) := by
+  obtain ⟨w, hagree, hrel⟩ :=
+    greedyPrefix_extendable codec n dec x hpromise hdec (codec.witnessBits n) (Nat.le_refl _)
+  have hweq : w = greedyPrefix codec n dec x (codec.witnessBits n) (Nat.le_refl _) := by
+    funext k
+    exact hagree k
+  rwa [hweq] at hrel
+
+/-- The joint output of the true-greedy output circuits is the full greedy prefix. -/
+theorem searchSolverOutput_greedyTrueOutputCircuit
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n)) :
+    searchSolverOutput (problem := treeProblem codec) (greedyTrueOutputCircuit codec n dec) x
+      = greedyPrefix codec n dec x (codec.witnessBits n) (Nat.le_refl _) := by
+  funext i
+  simp only [searchSolverOutput, eval_greedyTrueOutputCircuit, greedyPrefix, fullGreedyTrueBundle]
+
+/--
+**True-greedy output circuits solve.**  On a promise instance, with a correct
+next-bit decider, the joint output of the per-witness-bit true-greedy circuits
+satisfies the search relation.  This is the witness-correctness fact a later
+`BoundedSearchSolver` will package together with the size bound (Block 7′).
+-/
+theorem greedyTrueOutputCircuit_solves
+    (codec : TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (hpromise : (treeProblem codec).promise n x)
+    (hdec : CorrectNextBitDecider codec n x dec) :
+    (treeProblem codec).relation n x
+      (searchSolverOutput (problem := treeProblem codec) (greedyTrueOutputCircuit codec n dec) x) := by
+  rw [searchSolverOutput_greedyTrueOutputCircuit]
+  exact greedyPrefix_solves codec n dec x hpromise hdec
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -44,6 +44,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -689,6 +690,39 @@ theorem check_correctNextBitDecider_of_decidesLanguage
   correctNextBitDecider_of_decidesLanguage codec n dec x hdec
 
 end TreeMCSPDeciderCorrectSurface
+
+section TreeMCSPGreedySolvesSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 8c surface: the full true-greedy prefix is a solving witness. -/
+theorem check_greedyPrefix_solves
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (hpromise : (treeProblem codec).promise n x)
+    (hdec : CorrectNextBitDecider codec n x dec) :
+    (treeProblem codec).relation n x
+      (greedyPrefix codec n dec x (codec.witnessBits n) (Nat.le_refl _)) :=
+  greedyPrefix_solves codec n dec x hpromise hdec
+
+/-- Block 8c surface (headline): the joint output of the true-greedy output circuits
+satisfies the search relation. -/
+theorem check_greedyTrueOutputCircuit_solves
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (n : Nat)
+    (dec : C_DAG.Family (treeMCSPPrefixM codec n))
+    (x : PrefixBitVec (Pnp3.Models.Partial.tableLen n))
+    (hpromise : (treeProblem codec).promise n x)
+    (hdec : CorrectNextBitDecider codec n x dec) :
+    (treeProblem codec).relation n x
+      (Frontier.searchSolverOutput (problem := treeProblem codec) (greedyTrueOutputCircuit codec n dec) x) :=
+  greedyTrueOutputCircuit_solves codec n dec x hpromise hdec
+
+end TreeMCSPGreedySolvesSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -34,6 +34,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPTrueExtensionQuery
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -255,6 +256,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.size_greedyTrueOutputCircuit_le
 
 #print axioms Pnp4.Frontier.ContractExpansion.correctNextBitDecider_of_decidesLanguage
+
+#print axioms Pnp4.Frontier.ContractExpansion.greedyPrefix_solves
+#print axioms Pnp4.Frontier.ContractExpansion.searchSolverOutput_greedyTrueOutputCircuit
+#print axioms Pnp4.Frontier.ContractExpansion.greedyTrueOutputCircuit_solves
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 8c of the downstream decision→search extraction. At the **full** length
`i = witnessBits n`, the greedy extendability invariant (Block 8a, #1504) collapses
to a *solving* witness: the prefix occupies every witness coordinate, so the witness
`w` that extendability provides must equal the greedy prefix itself (they agree on
all `witnessBits n` coordinates), hence the greedy prefix satisfies the search
relation. New file `TreeMCSPGreedySolves.lean`.

## Results (all verified, standard axioms only)

- `greedyPrefix_solves` — `(treeProblem codec).relation n x (greedyPrefix … (witnessBits n) …)`
  (agreement over all of `Fin (witnessBits n)` forces `w = greedyPrefix` by `funext`);
- `searchSolverOutput_greedyTrueOutputCircuit` — the joint output of the per-bit
  true-greedy output circuits **is** the full greedy prefix;
- **`greedyTrueOutputCircuit_solves`** — `(treeProblem codec).relation n x
  (searchSolverOutput (greedyTrueOutputCircuit codec n dec) x)`: the true-greedy
  output circuits jointly solve the search relation.

## Where this sits

The under-hypothesis chain is now complete (still pre-solver):

```
DecidesPrefixExtensionLanguage (#1506) → CorrectNextBitDecider
  → greedyPrefix_extendable (8a) → greedyPrefix_solves / greedyTrueOutputCircuit_solves (8c)
```
realized by the polynomial-size, correctness-bearing true-greedy output circuits (7′).

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surfaces + axioms audit; the new theorems depend only on `propext` / `Quot.sound`.

## Scope discipline

Witness correctness only — still under the explicit decider hypothesis + promise.
**No** `BoundedSearchSolver` assembly (this proves the output solves; it does not
package size + correctness into the solver structure), **no** `PpolyDAG`/`InPpolyDAG`
bridge, endpoint, or `P ≠ NP` / `NP ⊄ P/poly` consequence. The genuine lower bound
remains the open problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_