### PR TITLE
Block 9: assemble BoundedSearchSolver from a prefix-extension decider family

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -289,6 +289,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBoundedSolver.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBoundedSolver.lean
@@ -1,0 +1,80 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# `BoundedSearchSolver` assembly from a prefix-extension decider family
+
+Block 9 of the downstream decision→search extraction.
+
+This packages the verified greedy machinery into the `BoundedSearchSolver`
+structure that the search-MCSP magnification contract consumes.  Given a *family*
+of prefix-extension deciders `dec : ∀ n, C_DAG.Family (treeMCSPPrefixM codec n)`
+with two explicit hypotheses —
+
+* **language-correctness**: each `dec n` decides `PrefixExtensionLanguage`
+  (`DecidesPrefixExtensionLanguage`, #1506), and
+* **size**: `C_DAG.size (dec n) ≤ decSizeBound n` —
+
+we build a `BoundedSearchSolver (treeProblem codec) C_DAG solverSizeBound` whose
+
+* `outputCircuit n` is the true-greedy per-bit output family `greedyTrueOutputCircuit`
+  (Block 7′);
+* `solves` chains `correctNextBitDecider_of_decidesLanguage` (8b) →
+  `greedyTrueOutputCircuit_solves` (8c);
+* `size_le` uses the uniform bound `size_greedyTrueOutputCircuit_le` (7′), so
+  `solverSizeBound n = witnessBits n · (decSizeBound n + 2·M(n)) + 1`.
+
+This is the first object that lives on the `SearchMCSPMagnification` side, but it is
+still **honestly conditional**: it takes the decider family and its correctness/size
+as explicit hypotheses.  It does *not* construct such a decider, invoke the
+magnification contrapositive, or assert any lower bound.
+
+Scope discipline — solver assembly only:
+
+* the prefix-extension decider family + its language-correctness + size are
+  **explicit hypotheses**;
+* **no** `PpolyDAG`/`InPpolyDAG` bridge or decider construction;
+* **no** `SearchProblemNoBoundedSolver` / contrapositive, endpoint, or
+  `P ≠ NP` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/-- The solver size schedule realized by the true-greedy circuits over a decider
+family bounded by `decSizeBound`. -/
+def boundedSolverSizeBound
+    (codec : TreeCircuitWitnessCodec threshold)
+    (decSizeBound : Nat → Nat) (n : Nat) : Nat :=
+  codec.witnessBits n * (decSizeBound n + 2 * treeMCSPPrefixM codec n) + 1
+
+/--
+**Bounded-solver assembly.**  A prefix-extension decider family that is
+language-correct and size-bounded yields a `BoundedSearchSolver` for the tree-MCSP
+search problem, with the true-greedy output circuits as its per-bit circuits.
+-/
+def boundedSearchSolver_of_deciderFamily
+    (codec : TreeCircuitWitnessCodec threshold)
+    (dec : ∀ n, C_DAG.Family (treeMCSPPrefixM codec n))
+    (decSizeBound : Nat → Nat)
+    (hlang : ∀ n, DecidesPrefixExtensionLanguage codec n (dec n))
+    (hsize : ∀ n, C_DAG.size (dec n) ≤ decSizeBound n) :
+    BoundedSearchSolver (treeProblem codec) C_DAG (boundedSolverSizeBound codec decSizeBound) where
+  outputCircuit := fun n i => greedyTrueOutputCircuit codec n (dec n) i
+  size_le := fun n i => by
+    refine le_trans (size_greedyTrueOutputCircuit_le codec n (dec n) i) ?_
+    unfold boundedSolverSizeBound
+    gcongr
+    exact hsize n
+  solves := fun n x hpromise =>
+    greedyTrueOutputCircuit_solves codec n (dec n) x hpromise
+      (correctNextBitDecider_of_decidesLanguage codec n (dec n) x (hlang n))
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -45,6 +45,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -723,6 +724,25 @@ theorem check_greedyTrueOutputCircuit_solves
   greedyTrueOutputCircuit_solves codec n dec x hpromise hdec
 
 end TreeMCSPGreedySolvesSurface
+
+section TreeMCSPBoundedSolverSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 9 surface: a language-correct, size-bounded prefix-extension decider
+family assembles into a `BoundedSearchSolver` for the tree-MCSP search problem. -/
+def check_boundedSearchSolver_of_deciderFamily
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (dec : ∀ n, C_DAG.Family (treeMCSPPrefixM codec n))
+    (decSizeBound : Nat → Nat)
+    (hlang : ∀ n, DecidesPrefixExtensionLanguage codec n (dec n))
+    (hsize : ∀ n, C_DAG.size (dec n) ≤ decSizeBound n) :
+    Frontier.BoundedSearchSolver (treeProblem codec) C_DAG
+      (boundedSolverSizeBound codec decSizeBound) :=
+  boundedSearchSolver_of_deciderFamily codec dec decSizeBound hlang hsize
+
+end TreeMCSPBoundedSolverSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -35,6 +35,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyExtendable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -260,6 +261,8 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.greedyPrefix_solves
 #print axioms Pnp4.Frontier.ContractExpansion.searchSolverOutput_greedyTrueOutputCircuit
 #print axioms Pnp4.Frontier.ContractExpansion.greedyTrueOutputCircuit_solves
+
+#print axioms Pnp4.Frontier.ContractExpansion.boundedSearchSolver_of_deciderFamily
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 9 of the downstream decision→search extraction: assembles the verified greedy
machinery into the `BoundedSearchSolver` structure that the search-MCSP
magnification contract consumes. New file `TreeMCSPBoundedSolver.lean`.

```
boundedSearchSolver_of_deciderFamily :
  (dec : ∀ n, C_DAG.Family (treeMCSPPrefixM codec n))
  → (hlang : ∀ n, DecidesPrefixExtensionLanguage codec n (dec n))   -- language correctness
  → (hsize : ∀ n, C_DAG.size (dec n) ≤ decSizeBound n)              -- size bound
  → BoundedSearchSolver (treeProblem codec) C_DAG (boundedSolverSizeBound codec decSizeBound)
```
with `boundedSolverSizeBound codec decSizeBound n = witnessBits n · (decSizeBound n + 2·M(n)) + 1`.

The three structure fields:
- `outputCircuit n := greedyTrueOutputCircuit codec n (dec n)` (Block 7′);
- `solves` chains `correctNextBitDecider_of_decidesLanguage` (8b) →
  `greedyTrueOutputCircuit_solves` (8c);
- `size_le` uses `size_greedyTrueOutputCircuit_le` (7′) + monotonicity in the decider
  size (`gcongr`).

## What this is

The first object that lives on the `SearchMCSPMagnification` side — but **honestly
conditional**: the prefix-extension decider family and its language-correctness/size
are explicit hypotheses. It does **not** construct such a decider, invoke the
magnification contrapositive, or assert any lower bound.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surface + axioms audit entry for `boundedSearchSolver_of_deciderFamily`.

## Scope discipline

Solver assembly only. **No** `PpolyDAG`/`InPpolyDAG` bridge or decider construction,
**no** `SearchProblemNoBoundedSolver` / contrapositive, endpoint, or
`P ≠ NP` / `NP ⊄ P/poly` consequence. The genuine lower bound remains the open
problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_