### PR TITLE
Block 9b: forward PpolyDAG → BoundedSearchSolver bridge

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -290,6 +290,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver,
+    Glob.one `Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/BoundedSolverFromPpoly.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/BoundedSolverFromPpoly.lean
@@ -1,0 +1,72 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# `BoundedSearchSolver` from a `PpolyDAG` prefix-extension decider
+
+Block 9b of the downstream decision→search extraction — the **forward** bridge.
+
+If the prefix-extension language `PrefixExtensionLanguage (treeMCSPConcretePrefixParser
+threshold codec)` is in `PpolyDAG`, then there is a `BoundedSearchSolver` for the
+tree-MCSP search problem with an explicit *extracted* size schedule.
+
+Proof outline:
+
+* `PpolyDAG_decider_as_C_DAG_decider` extracts a global exponent `c` and, at every
+  length `m`, a `C_DAG` circuit deciding the language with `size ≤ m^c + c`;
+* instantiate it at `m = treeMCSPPrefixM codec n` to get a decider family
+  `dec n : C_DAG.Family (treeMCSPPrefixM codec n)` with language-correctness and the
+  size bound `(treeMCSPPrefixM codec n)^c + c`;
+* feed it to `boundedSearchSolver_of_deciderFamily` (Block 9, #1508).
+
+This is a purely *forward*, conditional statement: it turns a membership hypothesis
+into a solver.  It does **not** prove the contrapositive, define any no-solver
+target, or assert a lower bound.
+
+Scope discipline — forward bridge only:
+
+* takes `PpolyDAG (PrefixExtensionLanguage …)` as the hypothesis;
+* **no** `SearchProblemNoBoundedSolver` / contrapositive, **no**
+  `NoPolynomialBoundedSearchSolver`;
+* **no** `SearchMCSPMagnificationContract`, `VerifiedNPDAGLowerBoundSource`,
+  NP-membership, endpoint, or `P ≠ NP` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/--
+**Forward `PpolyDAG`→solver bridge.**  If the prefix-extension language is in
+`PpolyDAG`, then for some exponent `c` there is a `BoundedSearchSolver` for the
+tree-MCSP search problem with the extracted size schedule
+`witnessBits n · ((M n)^c + c + 2·M n) + 1` (where `M n = treeMCSPPrefixM codec n`).
+-/
+theorem boundedSearchSolver_of_PpolyDAG_prefixExtension
+    (codec : TreeCircuitWitnessCodec threshold)
+    (hPpoly : Pnp3.ComplexityInterfaces.PpolyDAG
+      (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec))) :
+    ∃ c : Nat,
+      Nonempty
+        (BoundedSearchSolver (treeProblem codec) C_DAG
+          (fun n =>
+            codec.witnessBits n *
+                ((treeMCSPPrefixM codec n) ^ c + c + 2 * treeMCSPPrefixM codec n)
+              + 1)) := by
+  obtain ⟨c, hc⟩ := PpolyDAG_decider_as_C_DAG_decider hPpoly
+  have hc' : ∀ n, ∃ C : C_DAG.Family (treeMCSPPrefixM codec n),
+      C_DAG.size C ≤ (treeMCSPPrefixM codec n) ^ c + c
+        ∧ ∀ x, C_DAG.eval C x
+            = PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec)
+                (treeMCSPPrefixM codec n) x :=
+    fun n => hc (treeMCSPPrefixM codec n)
+  choose dec hsize hlang using hc'
+  exact ⟨c, ⟨boundedSearchSolver_of_deciderFamily codec dec
+    (fun n => (treeMCSPPrefixM codec n) ^ c + c) hlang hsize⟩⟩
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -46,6 +46,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver
+import Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -743,6 +744,28 @@ def check_boundedSearchSolver_of_deciderFamily
   boundedSearchSolver_of_deciderFamily codec dec decSizeBound hlang hsize
 
 end TreeMCSPBoundedSolverSurface
+
+section BoundedSolverFromPpolySurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 9b surface: if the prefix-extension language is in `PpolyDAG`, a
+`BoundedSearchSolver` with the extracted size schedule exists. -/
+theorem check_boundedSearchSolver_of_PpolyDAG_prefixExtension
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (hPpoly : Pnp3.ComplexityInterfaces.PpolyDAG
+      (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec))) :
+    ∃ c : Nat,
+      Nonempty
+        (Frontier.BoundedSearchSolver (treeProblem codec) C_DAG
+          (fun n =>
+            codec.witnessBits n *
+                ((treeMCSPPrefixM codec n) ^ c + c + 2 * treeMCSPPrefixM codec n)
+              + 1)) :=
+  boundedSearchSolver_of_PpolyDAG_prefixExtension codec hPpoly
+
+end BoundedSolverFromPpolySurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -36,6 +36,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedyTrueOutputCircuits
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver
+import Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -263,6 +264,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.greedyTrueOutputCircuit_solves
 
 #print axioms Pnp4.Frontier.ContractExpansion.boundedSearchSolver_of_deciderFamily
+#print axioms Pnp4.Frontier.ContractExpansion.boundedSearchSolver_of_PpolyDAG_prefixExtension
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 9b of the downstream decision→search extraction — the **forward** bridge. If
the prefix-extension language is in `PpolyDAG`, then a `BoundedSearchSolver` for the
tree-MCSP search problem exists with an explicit *extracted* size schedule. New file
`BoundedSolverFromPpoly.lean`.

```
boundedSearchSolver_of_PpolyDAG_prefixExtension :
  PpolyDAG (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec))
  → ∃ c, Nonempty (BoundedSearchSolver (treeProblem codec) C_DAG
      (fun n => witnessBits n · ((treeMCSPPrefixM codec n)^c + c + 2·treeMCSPPrefixM codec n) + 1))
```

Proof: `PpolyDAG_decider_as_C_DAG_decider` extracts a global exponent `c` and a
length-indexed `C_DAG` decider family with `size ≤ m^c + c`; instantiate at
`m = treeMCSPPrefixM codec n` to get `dec n` with language-correctness and the size
bound `(treeMCSPPrefixM codec n)^c + c`; then apply
`boundedSearchSolver_of_deciderFamily` (#1508) with `decSizeBound n := (treeMCSPPrefixM codec n)^c + c`.

## What this is (and isn't)

A purely **forward, conditional** statement: it turns a membership hypothesis into a
solver. It does **not** prove the contrapositive, define a no-solver target, or
assert any lower bound.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- Surface + axioms audit entry for `boundedSearchSolver_of_PpolyDAG_prefixExtension`.

## Scope discipline

Forward bridge only. **No** `SearchProblemNoBoundedSolver` / contrapositive, **no**
`NoPolynomialBoundedSearchSolver`, **no** `SearchMCSPMagnificationContract` /
`VerifiedNPDAGLowerBoundSource`, NP-membership, endpoint, or `P ≠ NP` consequence.
The genuine lower bound remains the open problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_