### PR TITLE
Block 9c: exact-schedule no-solver contrapositive

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -291,6 +291,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver,
     Glob.one `Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly,
+    Glob.one `Pnp4.Frontier.ContractExpansion.NoSolverContrapositive,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/NoSolverContrapositive.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/NoSolverContrapositive.lean
@@ -1,0 +1,73 @@
+import Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Exact-schedule no-solver contrapositive
+
+Block 9c of the downstream decision→search extraction — the **contrapositive** of
+the forward `PpolyDAG`→solver bridge (Block 9b, #1509), at the *exact extracted size
+schedule*.
+
+Block 9b showed: `PpolyDAG (PrefixExtensionLanguage …) → ∃ c, BoundedSearchSolver`
+with schedule `extractedSolverSizeBound codec c`.  Contrapositively, if **no** solver
+exists at any of those extracted schedules, the prefix-extension language is **not**
+in `PpolyDAG`.
+
+This is the cleanest, most faithful contrapositive: it keeps the lower-bound
+hypothesis at the *exact* schedule the extraction produces, with no polynomial
+reconciliation.  The no-solver hypothesis is, of course, **not proved here** — it is
+the open weak lower bound; this file only relates it to a `PpolyDAG` non-membership.
+
+Scope discipline — exact-schedule contrapositive only:
+
+* the no-solver hypothesis `NoExtractedScheduleSolver` is an **explicit hypothesis**;
+* **no** `NoPolynomialBoundedSearchSolver`, **no** growth/polynomial-schedule
+  reconciliation (`extractedSolverSizeBound ≤ (instanceBits n)^d + d`);
+* **no** `SearchMCSPMagnificationContract`, `VerifiedNPDAGLowerBoundSource`,
+  NP-membership, endpoint, or `P ≠ NP` / `NP ⊄ P/poly` consequence.
+-/
+
+variable {threshold : Nat → Nat}
+
+/-- The exact size schedule produced by the forward extraction (Block 9b) for a
+`PpolyDAG` decider of exponent `c`. -/
+def extractedSolverSizeBound
+    (codec : TreeCircuitWitnessCodec threshold)
+    (c : Nat) (n : Nat) : Nat :=
+  codec.witnessBits n *
+      ((treeMCSPPrefixM codec n) ^ c + c + 2 * treeMCSPPrefixM codec n)
+    + 1
+
+/-- The exact-schedule weak lower-bound target: no bounded search solver exists at
+any of the extracted schedules `extractedSolverSizeBound codec c`. -/
+def NoExtractedScheduleSolver
+    (codec : TreeCircuitWitnessCodec threshold) : Prop :=
+  ∀ c : Nat,
+    ¬ Nonempty
+      (BoundedSearchSolver (treeProblem codec) C_DAG (extractedSolverSizeBound codec c))
+
+/--
+**Exact-schedule contrapositive.**  If no bounded search solver exists at any
+extracted schedule, then the prefix-extension language is not in `PpolyDAG`.
+
+Direct contrapositive of `boundedSearchSolver_of_PpolyDAG_prefixExtension` (Block
+9b): a `PpolyDAG` membership would yield a solver at some extracted schedule
+`extractedSolverSizeBound codec c`, contradicting the hypothesis at that `c`.
+-/
+theorem not_PpolyDAG_prefixExtension_of_noExtractedScheduleSolver
+    (codec : TreeCircuitWitnessCodec threshold)
+    (hNo : NoExtractedScheduleSolver codec) :
+    ¬ Pnp3.ComplexityInterfaces.PpolyDAG
+        (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec)) := by
+  intro hPpoly
+  obtain ⟨c, hSolver⟩ := boundedSearchSolver_of_PpolyDAG_prefixExtension codec hPpoly
+  exact hNo c hSolver
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -47,6 +47,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver
 import Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly
+import Pnp4.Frontier.ContractExpansion.NoSolverContrapositive
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -766,6 +767,22 @@ theorem check_boundedSearchSolver_of_PpolyDAG_prefixExtension
   boundedSearchSolver_of_PpolyDAG_prefixExtension codec hPpoly
 
 end BoundedSolverFromPpolySurface
+
+section NoSolverContrapositiveSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 9c surface: if no bounded solver exists at any extracted schedule, the
+prefix-extension language is not in `PpolyDAG`. -/
+theorem check_not_PpolyDAG_prefixExtension_of_noExtractedScheduleSolver
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (hNo : NoExtractedScheduleSolver codec) :
+    ¬ Pnp3.ComplexityInterfaces.PpolyDAG
+        (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec)) :=
+  not_PpolyDAG_prefixExtension_of_noExtractedScheduleSolver codec hNo
+
+end NoSolverContrapositiveSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -37,6 +37,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDeciderCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGreedySolves
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver
 import Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly
+import Pnp4.Frontier.ContractExpansion.NoSolverContrapositive
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -265,6 +266,7 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.boundedSearchSolver_of_deciderFamily
 #print axioms Pnp4.Frontier.ContractExpansion.boundedSearchSolver_of_PpolyDAG_prefixExtension
+#print axioms Pnp4.Frontier.ContractExpansion.not_PpolyDAG_prefixExtension_of_noExtractedScheduleSolver
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 9c of the downstream decision→search extraction — the **contrapositive** of the
forward `PpolyDAG`→solver bridge (Block 9b, #1509), at the *exact extracted size
schedule*. New file `NoSolverContrapositive.lean`.

```
extractedSolverSizeBound codec c n := witnessBits n · ((treeMCSPPrefixM codec n)^c + c + 2·treeMCSPPrefixM codec n) + 1

NoExtractedScheduleSolver codec : Prop
  := ∀ c, ¬ Nonempty (BoundedSearchSolver (treeProblem codec) C_DAG (extractedSolverSizeBound codec c))

not_PpolyDAG_prefixExtension_of_noExtractedScheduleSolver :
  NoExtractedScheduleSolver codec → ¬ PpolyDAG (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec))
```

Proof: a `PpolyDAG` membership would yield (via #1509) a solver at some extracted
schedule `extractedSolverSizeBound codec c`, contradicting the hypothesis at that `c`.

## What this is

The cleanest, most faithful contrapositive — it keeps the lower-bound hypothesis at
the *exact* schedule the extraction produces, with no polynomial reconciliation. The
no-solver hypothesis `NoExtractedScheduleSolver` is the **open weak lower bound**;
it is **not proved here**. This only relates it to a `PpolyDAG` non-membership.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- Surface + axioms audit entry for the contrapositive.

## Scope discipline

Exact-schedule contrapositive only. **No** `NoPolynomialBoundedSearchSolver`, **no**
growth/polynomial-schedule reconciliation, **no** `SearchMCSPMagnificationContract` /
`VerifiedNPDAGLowerBoundSource`, NP-membership, endpoint, or `P ≠ NP` / `NP ⊄ P/poly`
consequence. The genuine lower bound remains the open problem.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_