### PR TITLE
Block 9e: conditional verified DAG-lower-bound source packaging

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -293,6 +293,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly,
     Glob.one `Pnp4.Frontier.ContractExpansion.NoSolverContrapositive,
     Glob.one `Pnp4.Frontier.ContractExpansion.ExtractedScheduleGrowth,
+    Glob.one `Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/ConditionalVerifiedSource.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/ConditionalVerifiedSource.lean
@@ -1,0 +1,97 @@
+import Pnp4.Frontier.ContractExpansion.ExtractedScheduleGrowth
+import Pnp4.AlgorithmsToLowerBounds.BridgeToPpolyDAG
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Conditional verified DAG-lower-bound source
+
+Block 9e of the downstream decision→search extraction.
+
+The polynomial-target contrapositive (#1511, Block 9d) gives the `¬ PpolyDAG`
+half of a `VerifiedNPDAGLowerBoundSource`:
+
+```
+TreeMCSPExtractionGrowthAssumptions codec
+→ NoPolynomialBoundedSearchSolver codec
+→ ¬ PpolyDAG (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec))
+```
+
+A `VerifiedNPDAGLowerBoundSource` needs one orthogonal extra input — `NP`
+membership of the same language — which lives on a *separate* verifier/runtime
+track and is **not** proved here.  This file just *packages* the two halves: given
+the growth assumptions, the (open) polynomial weak lower bound, **and** an explicit
+`NP`-membership hypothesis, it constructs the source record, and (as a convenience)
+derives the `NP ⊄ PpolyDAG` separation from it via the existing
+`NP_not_subset_PpolyDAG_of_verified_source` bridge.
+
+Everything is **conditional**: all three inputs are explicit hypotheses.  Nothing
+new is asserted unconditionally.
+
+Scope discipline — conditional source packaging only:
+
+* `NP`-membership is an **explicit hypothesis** — **not** proved here;
+* `NoPolynomialBoundedSearchSolver` (the open weak lower bound) and the growth
+  assumptions are **explicit hypotheses** — **not** proved here;
+* **no** change to `SearchMCSPMagnificationContract`;
+* **no** `P ≠ NP` endpoint theorem and **no** unconditional endpoint claim.
+-/
+
+variable {threshold : Nat → Nat}
+
+/--
+**Conditional verified DAG-lower-bound source.**
+
+Given, for a tree-circuit witness codec:
+
+1. the explicit polynomial growth assumptions `TreeMCSPExtractionGrowthAssumptions`;
+2. the (open) polynomial weak lower bound `NoPolynomialBoundedSearchSolver`;
+3. an explicit `NP`-membership proof for the prefix-extension language,
+
+assemble a `VerifiedNPDAGLowerBoundSource`.  The `notInPpolyDAG` field is supplied by
+the Block-9d contrapositive
+`not_PpolyDAG_prefixExtension_of_noPolynomialBoundedSearchSolver`; the `inNP` field is
+exactly the supplied hypothesis.
+-/
+noncomputable def verifiedSource_of_noPolynomialBoundedSearchSolver
+    (codec : TreeCircuitWitnessCodec threshold)
+    (hGrowth : TreeMCSPExtractionGrowthAssumptions codec)
+    (hNoPoly : NoPolynomialBoundedSearchSolver codec)
+    (hNP :
+      Pnp3.ComplexityInterfaces.NP
+        (PrefixExtensionLanguage
+          (treeMCSPConcretePrefixParser threshold codec))) :
+    VerifiedNPDAGLowerBoundSource where
+  L := PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec)
+  inNP := hNP
+  notInPpolyDAG :=
+    not_PpolyDAG_prefixExtension_of_noPolynomialBoundedSearchSolver
+      codec hGrowth hNoPoly
+
+/--
+Convenience wrapper: the same three explicit hypotheses yield the canonical
+DAG-separation target `NP ⊄ PpolyDAG`, via the existing
+`NP_not_subset_PpolyDAG_of_verified_source` bridge applied to the source package.
+
+This is still strictly **conditional** on the `NP`-membership and no-poly-solver
+hypotheses; it is **not** the `P ≠ NP` endpoint and asserts nothing unconditionally.
+-/
+theorem NP_not_subset_PpolyDAG_of_noPolynomialBoundedSearchSolver
+    (codec : TreeCircuitWitnessCodec threshold)
+    (hGrowth : TreeMCSPExtractionGrowthAssumptions codec)
+    (hNoPoly : NoPolynomialBoundedSearchSolver codec)
+    (hNP :
+      Pnp3.ComplexityInterfaces.NP
+        (PrefixExtensionLanguage
+          (treeMCSPConcretePrefixParser threshold codec))) :
+    Pnp3.ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_verified_source
+    (verifiedSource_of_noPolynomialBoundedSearchSolver codec hGrowth hNoPoly hNP)
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -49,6 +49,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver
 import Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly
 import Pnp4.Frontier.ContractExpansion.NoSolverContrapositive
 import Pnp4.Frontier.ContractExpansion.ExtractedScheduleGrowth
+import Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -811,6 +812,39 @@ theorem check_not_PpolyDAG_prefixExtension_of_noPolynomialBoundedSearchSolver
   not_PpolyDAG_prefixExtension_of_noPolynomialBoundedSearchSolver codec hGrowth hNoPoly
 
 end ExtractedScheduleGrowthSurface
+
+section ConditionalVerifiedSourceSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 9e surface: under explicit growth assumptions, the open polynomial weak
+lower bound, and an explicit `NP`-membership hypothesis, assemble a
+`VerifiedNPDAGLowerBoundSource`. -/
+noncomputable def check_verifiedSource_of_noPolynomialBoundedSearchSolver
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (hGrowth : TreeMCSPExtractionGrowthAssumptions codec)
+    (hNoPoly : NoPolynomialBoundedSearchSolver codec)
+    (hNP :
+      Pnp3.ComplexityInterfaces.NP
+        (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec))) :
+    AlgorithmsToLowerBounds.VerifiedNPDAGLowerBoundSource :=
+  verifiedSource_of_noPolynomialBoundedSearchSolver codec hGrowth hNoPoly hNP
+
+/-- Block 9e surface (headline): the same three explicit hypotheses yield the
+conditional `NP ⊄ PpolyDAG` separation. -/
+theorem check_NP_not_subset_PpolyDAG_of_noPolynomialBoundedSearchSolver
+    {threshold : Nat → Nat}
+    (codec : Frontier.TreeCircuitWitnessCodec threshold)
+    (hGrowth : TreeMCSPExtractionGrowthAssumptions codec)
+    (hNoPoly : NoPolynomialBoundedSearchSolver codec)
+    (hNP :
+      Pnp3.ComplexityInterfaces.NP
+        (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec))) :
+    Pnp3.ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_noPolynomialBoundedSearchSolver codec hGrowth hNoPoly hNP
+
+end ConditionalVerifiedSourceSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -39,6 +39,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBoundedSolver
 import Pnp4.Frontier.ContractExpansion.BoundedSolverFromPpoly
 import Pnp4.Frontier.ContractExpansion.NoSolverContrapositive
 import Pnp4.Frontier.ContractExpansion.ExtractedScheduleGrowth
+import Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -272,6 +273,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.nonempty_boundedSearchSolver_mono_sizeBound
 #print axioms Pnp4.Frontier.ContractExpansion.noExtractedScheduleSolver_of_noPolynomial
 #print axioms Pnp4.Frontier.ContractExpansion.not_PpolyDAG_prefixExtension_of_noPolynomialBoundedSearchSolver
+
+#print axioms Pnp4.Frontier.ContractExpansion.verifiedSource_of_noPolynomialBoundedSearchSolver
+#print axioms Pnp4.Frontier.ContractExpansion.NP_not_subset_PpolyDAG_of_noPolynomialBoundedSearchSolver
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 9e of the downstream decision→search extraction. Packages the verified
`¬ PpolyDAG` half (#1511, Block 9d) together with the two orthogonal extra inputs
into a `VerifiedNPDAGLowerBoundSource`. New file `ConditionalVerifiedSource.lean`.

The Block-9d contrapositive gives

```
TreeMCSPExtractionGrowthAssumptions codec
→ NoPolynomialBoundedSearchSolver codec
→ ¬ PpolyDAG (PrefixExtensionLanguage (treeMCSPConcretePrefixParser threshold codec))
```

A `VerifiedNPDAGLowerBoundSource` needs one orthogonal extra input — `NP`
membership of the same language — which lives on a separate verifier/runtime track.
This brick just *assembles the record* once that hypothesis is supplied.

## Contents

- **`verifiedSource_of_noPolynomialBoundedSearchSolver`** — given the growth
  assumptions, the (open) polynomial weak lower bound
  `NoPolynomialBoundedSearchSolver`, and an explicit `NP`-membership proof, builds a
  `VerifiedNPDAGLowerBoundSource`. The `notInPpolyDAG` field is supplied by
  `not_PpolyDAG_prefixExtension_of_noPolynomialBoundedSearchSolver`; the `inNP`
  field is exactly the supplied hypothesis. (`noncomputable`, since
  `PrefixExtensionLanguage` is.)
- **`NP_not_subset_PpolyDAG_of_noPolynomialBoundedSearchSolver`** — convenience
  wrapper deriving the conditional `NP ⊄ PpolyDAG` separation from the source
  package via the existing `NP_not_subset_PpolyDAG_of_verified_source` bridge.

Everything is **strictly conditional**: all three inputs are explicit hypotheses,
and nothing new is asserted unconditionally.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surface re-exports + axioms-audit entries; the two new declarations depend
  only on `[propext, Classical.choice, Quot.sound]` (`Classical.choice` enters via
  the noncomputable `PrefixExtensionLanguage`), consistent with the sibling
  ContractExpansion surfaces.

## Scope discipline

Conditional source packaging only:

- `NP`-membership is an **explicit hypothesis** — **not** proved here;
- `NoPolynomialBoundedSearchSolver` (the open weak lower bound) and the growth
  assumptions are **explicit hypotheses** — **not** proved here;
- **no** change to `SearchMCSPMagnificationContract`;
- **no** `P ≠ NP` endpoint theorem and **no** unconditional endpoint claim.

The genuine lower bound and the `NP`-membership track both remain open.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_