### PR TITLE
Block 11a: TM-witness interface for NP-membership of the prefix-extension language

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -295,6 +295,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.ExtractedScheduleGrowth,
     Glob.one `Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource,
     Glob.one `Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction,
+    Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionNPWitness.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/PrefixExtensionNPWitness.lean
@@ -1,0 +1,96 @@
+import Pnp4.Frontier.ContractExpansion.PrefixExtensionLanguage
+import Complexity.Interfaces
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# TM-witness interface for NP-membership of the prefix-extension language
+
+Block 11a of the downstream decision→search extraction — the **NP-membership**
+track (orthogonal to the `¬ PpolyDAG` extraction chain).
+
+A `VerifiedNPDAGLowerBoundSource` needs an `inNP : NP L` field.  The canonical
+`NP` in this development is `NP_TM` (`pnp3/Complexity/Interfaces.lean`):
+
+```
+NP_TM L := ∃ (M : TM) (c k : Nat),
+  (∀ n, M.runTime (n + certificateLength n k) ≤ (n + certificateLength n k)^c + c) ∧
+  (∀ n x, L n x = true ↔ ∃ w, TM.accepts M (concatBitstring x w) = true)
+```
+
+so a proof of `NP (PrefixExtensionLanguage parser)` is exactly: a concrete verifier
+Turing machine, a polynomial runtime bound, and a certificate-correctness
+equivalence.  This file packages those three obligations as an explicit structure
+`PrefixExtensionNPWitness` and proves the one-line bridge to `NP`, mirroring the
+established `GapPartialMCSP_TMWitness` / `gapPartialMCSP_in_NP_TM_of_witness` idiom
+(`pnp3/Models/Model_PartialMCSP.lean`).
+
+This is the minimal "obligations → NP-membership" interface: it makes the genuine
+constructive obligations visible to callers (a real machine + runtime + correctness)
+and is **not** a duplicate of the existing bare-`Prop` enumeration records
+`PrefixExtensionNPVerifierBudget` / `PrefixExtensionNPVerifierPlan` (those itemize the
+sub-tasks a *future* serialization/runtime proof must discharge in order to *build*
+such a witness; this structure is the assembled TM-level package that directly yields
+`NP`).
+
+Scope discipline — NP-membership obligation interface only:
+
+* the verifier TM, its runtime bound, and the certificate correctness are **explicit
+  obligations** carried as fields — **none are proved here**;
+* **no** lower-bound proof, **no** `VerifiedNPDAGLowerBoundSource` packaging change,
+  **no** `SearchMCSPMagnificationContract` change, **no** endpoint or `P ≠ NP`
+  consequence.
+-/
+
+/--
+Concrete TM-witness package for NP-membership of the prefix-extension language.
+
+Keeping this as an explicit structure (rather than a bare `Prop`) makes the
+constructive obligations visible: a concrete verifier machine `M`, a polynomial
+runtime bound, and a certificate-correctness equivalence for
+`PrefixExtensionLanguage parser`.  This is precisely the data the canonical `NP_TM`
+existential consumes.
+-/
+structure PrefixExtensionNPWitness
+    {problem : SearchMCSPCompressionProblem}
+    (parser : PrefixParser problem) where
+  /-- The verifier Turing machine reading the concatenated input+certificate. -/
+  M : Pnp3.Internal.PsubsetPpoly.TM.{0}
+  /-- Runtime polynomial exponent. -/
+  c : Nat
+  /-- Certificate-length polynomial exponent. -/
+  k : Nat
+  /-- The verifier runs in polynomial time in the concatenated length. -/
+  runTime_poly : ∀ n,
+    M.runTime (n + Pnp3.ComplexityInterfaces.certificateLength n k)
+      ≤ (n + Pnp3.ComplexityInterfaces.certificateLength n k) ^ c + c
+  /-- Certificate correctness: membership iff some certificate is accepted. -/
+  correct : ∀ n (x : Pnp3.ComplexityInterfaces.Bitstring n),
+    PrefixExtensionLanguage parser n x = true ↔
+      ∃ w : Pnp3.ComplexityInterfaces.Bitstring
+              (Pnp3.ComplexityInterfaces.certificateLength n k),
+        Pnp3.Internal.PsubsetPpoly.TM.accepts
+            (M := M)
+            (n := n + Pnp3.ComplexityInterfaces.certificateLength n k)
+            (Pnp3.ComplexityInterfaces.concatBitstring x w) = true
+
+/--
+**NP-membership from a TM witness.**  Any concrete `PrefixExtensionNPWitness`
+yields `NP (PrefixExtensionLanguage parser)`, by unpacking the witness fields into
+the canonical `NP_TM` existential.  (One-line bridge, mirroring
+`gapPartialMCSP_in_NP_TM_of_witness`.)
+-/
+theorem prefixExtensionLanguage_in_NP_of_witness
+    {problem : SearchMCSPCompressionProblem}
+    (parser : PrefixParser problem)
+    (W : PrefixExtensionNPWitness parser) :
+    Pnp3.ComplexityInterfaces.NP (PrefixExtensionLanguage parser) := by
+  exact ⟨W.M, W.c, W.k, W.runTime_poly, W.correct⟩
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -51,6 +51,7 @@ import Pnp4.Frontier.ContractExpansion.NoSolverContrapositive
 import Pnp4.Frontier.ContractExpansion.ExtractedScheduleGrowth
 import Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource
 import Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction
+import Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -882,6 +883,21 @@ theorem check_PolynomialWitnessCodec_toGrowthAssumptions
   P.toGrowthAssumptions
 
 end WitnessGrowthReductionSurface
+
+section PrefixExtensionNPWitnessSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 11a surface (headline): a concrete TM-witness package yields NP-membership
+of the prefix-extension language. -/
+theorem check_prefixExtensionLanguage_in_NP_of_witness
+    {problem : Frontier.SearchMCSPCompressionProblem}
+    (parser : PrefixParser problem)
+    (W : PrefixExtensionNPWitness parser) :
+    Pnp3.ComplexityInterfaces.NP (PrefixExtensionLanguage parser) :=
+  prefixExtensionLanguage_in_NP_of_witness parser W
+
+end PrefixExtensionNPWitnessSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -41,6 +41,7 @@ import Pnp4.Frontier.ContractExpansion.NoSolverContrapositive
 import Pnp4.Frontier.ContractExpansion.ExtractedScheduleGrowth
 import Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource
 import Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction
+import Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -282,6 +283,8 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.polyBoundedInTable_treeMCSPPrefixM_of_witnessPoly
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPExtractionGrowthAssumptions_of_witnessPoly
 #print axioms Pnp4.Frontier.ContractExpansion.PolynomialWitnessCodec.toGrowthAssumptions
+
+#print axioms Pnp4.Frontier.ContractExpansion.prefixExtensionLanguage_in_NP_of_witness
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 11a of the downstream decision→search extraction — the **NP-membership** track (orthogonal to the `¬ PpolyDAG` extraction chain). New file `PrefixExtensionNPWitness.lean`.

**Audit finding.** The canonical `NP` in this development is `NP_TM` (`pnp3/Complexity/Interfaces.lean`):

```
NP_TM L := ∃ (M : TM) (c k : Nat),
  (∀ n, M.runTime (n + certificateLength n k) ≤ (n + certificateLength n k)^c + c) ∧
  (∀ n x, L n x = true ↔ ∃ w, TM.accepts M (concatBitstring x w) = true)
```

So a proof of `NP (PrefixExtensionLanguage parser)` is exactly: a concrete verifier Turing machine, a polynomial runtime bound, and a certificate-correctness equivalence. There is **no existing NP-membership theorem** for `PrefixExtensionLanguage`; the existing `PrefixExtensionNPVerifierBudget` / `PrefixExtensionNPVerifierPlan` records only enumerate bare-`Prop` sub-obligations. The repo *does* already have the right idiom for the assembled package: `GapPartialMCSP_TMWitness` + `gapPartialMCSP_in_NP_TM_of_witness` (`pnp3/Models/Model_PartialMCSP.lean`).

## Contents

- **`PrefixExtensionNPWitness parser`** — a concrete verifier TM `M`, exponents `c k`, a polynomial runtime bound, and the certificate-correctness equivalence for `PrefixExtensionLanguage parser` (precisely the data the `NP_TM` existential consumes). This is the minimal "obligations → NP" interface, and is **distinct from — not a duplicate of —** the existing bare-`Prop` budget/plan records (those itemize the sub-tasks a *future* serialization/runtime proof must discharge to *build* such a witness; this is the assembled TM-level package).
- **`prefixExtensionLanguage_in_NP_of_witness`** — `PrefixExtensionNPWitness parser → NP (PrefixExtensionLanguage parser)`, by unpacking the witness into the `NP_TM` existential (one-line bridge, mirroring `gapPartialMCSP_in_NP_TM_of_witness`).

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surface re-export + axioms-audit entry; the new theorem depends only on `[propext, Classical.choice, Quot.sound]` (`Classical.choice` enters via the noncomputable classical `PrefixExtensionLanguage` and `concatBitstring`).

## Scope discipline

NP-membership obligation interface only. The verifier TM, its runtime bound, and the certificate correctness are **explicit obligations carried as fields — none are proved here**. **No** lower-bound proof, **no** `VerifiedNPDAGLowerBoundSource` packaging change, **no** `SearchMCSPMagnificationContract` change, **no** endpoint or `P ≠ NP` consequence.

> Naming note: the structure is `PrefixExtensionNPWitness` (matching the existing `GapPartialMCSP_TMWitness` idiom) — this is the `PrefixExtensionNPObligations`-style "obligations → NP" interface from the brief.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_