### PR TITLE
Capstone: explicit conditional verified-source surface from the three interfaces

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -296,6 +296,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource,
     Glob.one `Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction,
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness,
+    Glob.one `Pnp4.Frontier.ContractExpansion.ExplicitConditionalSource,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/ExplicitConditionalSource.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/ExplicitConditionalSource.lean
@@ -1,0 +1,87 @@
+import Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource
+import Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction
+import Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Explicit conditional verified-source surface
+
+The capstone of the downstream decision→search extraction: a single clean
+conditional theorem assembling a `VerifiedNPDAGLowerBoundSource` from the **three
+explicit interfaces** the earlier bricks isolated, each carrying exactly one of the
+genuine open inputs:
+
+* `PolynomialWitnessCodec threshold` — the codec plus the single honest growth
+  premise (`PolyBoundedInTable codec.witnessBits`), which (Block 10a) yields the full
+  `TreeMCSPExtractionGrowthAssumptions`;
+* `NoPolynomialBoundedSearchSolver wcodec.codec` — the open weak lower bound (Block
+  9d);
+* `PrefixExtensionNPWitness (treeMCSPConcretePrefixParser threshold wcodec.codec)` —
+  the verifier-TM obligations that (Block 11a) yield `NP (PrefixExtensionLanguage …)`.
+
+Chaining the three through `verifiedSource_of_noPolynomialBoundedSearchSolver`
+(Block 9e) gives the source record, and thence (optionally) the `NP ⊄ PpolyDAG`
+separation.
+
+Everything is **strictly conditional**: all three inputs are explicit hypotheses,
+**none proved here**.  This is purely a packaging surface — the three honest open
+problems remain open.
+
+Scope discipline — conditional packaging only:
+
+* the growth premise, the lower bound, and the NP verifier-TM obligations are all
+  **explicit hypotheses** — **none proved here**;
+* **no** `SearchMCSPMagnificationContract` change, **no** `P ≠ NP` endpoint theorem,
+  **no** unconditional claim.
+-/
+
+variable {threshold : Nat → Nat}
+
+/--
+**Verified source from the three explicit interfaces.**  Given a
+`PolynomialWitnessCodec` (witness-growth premise), the open polynomial weak lower
+bound, and a TM-witness for NP-membership of the prefix-extension language, assemble
+a `VerifiedNPDAGLowerBoundSource`.
+
+The growth assumptions come from `wcodec.toGrowthAssumptions` (Block 10a) and the
+`NP`-membership from `prefixExtensionLanguage_in_NP_of_witness` (Block 11a); both feed
+`verifiedSource_of_noPolynomialBoundedSearchSolver` (Block 9e).
+-/
+noncomputable def verifiedSource_of_explicit_interfaces
+    (wcodec : PolynomialWitnessCodec threshold)
+    (hNoPoly : NoPolynomialBoundedSearchSolver wcodec.codec)
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser threshold wcodec.codec)) :
+    VerifiedNPDAGLowerBoundSource :=
+  verifiedSource_of_noPolynomialBoundedSearchSolver
+    wcodec.codec
+    wcodec.toGrowthAssumptions
+    hNoPoly
+    (prefixExtensionLanguage_in_NP_of_witness
+      (treeMCSPConcretePrefixParser threshold wcodec.codec) hNPWit)
+
+/--
+Convenience wrapper: the same three explicit interfaces yield the conditional
+`NP ⊄ PpolyDAG` separation, via the existing
+`NP_not_subset_PpolyDAG_of_verified_source` bridge applied to the assembled source.
+
+Still strictly **conditional** on all three inputs; **not** the `P ≠ NP` endpoint and
+asserts nothing unconditionally.
+-/
+theorem NP_not_subset_PpolyDAG_of_explicit_interfaces
+    (wcodec : PolynomialWitnessCodec threshold)
+    (hNoPoly : NoPolynomialBoundedSearchSolver wcodec.codec)
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser threshold wcodec.codec)) :
+    Pnp3.ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_verified_source
+    (verifiedSource_of_explicit_interfaces wcodec hNoPoly hNPWit)
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -52,6 +52,7 @@ import Pnp4.Frontier.ContractExpansion.ExtractedScheduleGrowth
 import Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource
 import Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness
+import Pnp4.Frontier.ContractExpansion.ExplicitConditionalSource
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -898,6 +899,34 @@ theorem check_prefixExtensionLanguage_in_NP_of_witness
   prefixExtensionLanguage_in_NP_of_witness parser W
 
 end PrefixExtensionNPWitnessSurface
+
+section ExplicitConditionalSourceSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Capstone surface: the three explicit interfaces (growth-witness codec, no-poly
+solver, NP TM-witness) assemble a `VerifiedNPDAGLowerBoundSource`. -/
+noncomputable def check_verifiedSource_of_explicit_interfaces
+    {threshold : Nat → Nat}
+    (wcodec : PolynomialWitnessCodec threshold)
+    (hNoPoly : NoPolynomialBoundedSearchSolver wcodec.codec)
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser threshold wcodec.codec)) :
+    AlgorithmsToLowerBounds.VerifiedNPDAGLowerBoundSource :=
+  verifiedSource_of_explicit_interfaces wcodec hNoPoly hNPWit
+
+/-- Capstone surface (headline): the three explicit interfaces yield the conditional
+`NP ⊄ PpolyDAG` separation. -/
+theorem check_NP_not_subset_PpolyDAG_of_explicit_interfaces
+    {threshold : Nat → Nat}
+    (wcodec : PolynomialWitnessCodec threshold)
+    (hNoPoly : NoPolynomialBoundedSearchSolver wcodec.codec)
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser threshold wcodec.codec)) :
+    Pnp3.ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_explicit_interfaces wcodec hNoPoly hNPWit
+
+end ExplicitConditionalSourceSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -42,6 +42,7 @@ import Pnp4.Frontier.ContractExpansion.ExtractedScheduleGrowth
 import Pnp4.Frontier.ContractExpansion.ConditionalVerifiedSource
 import Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness
+import Pnp4.Frontier.ContractExpansion.ExplicitConditionalSource
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -285,6 +286,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.PolynomialWitnessCodec.toGrowthAssumptions
 
 #print axioms Pnp4.Frontier.ContractExpansion.prefixExtensionLanguage_in_NP_of_witness
+
+#print axioms Pnp4.Frontier.ContractExpansion.verifiedSource_of_explicit_interfaces
+#print axioms Pnp4.Frontier.ContractExpansion.NP_not_subset_PpolyDAG_of_explicit_interfaces
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

The capstone of the downstream decision→search extraction: one clean conditional theorem assembling a `VerifiedNPDAGLowerBoundSource` from the **three explicit interfaces** the earlier bricks isolated, each carrying exactly one of the genuine open inputs. New file `ExplicitConditionalSource.lean`.

```
PolynomialWitnessCodec threshold          (Block 10a: single witness-growth premise)
NoPolynomialBoundedSearchSolver codec     (Block 9d:  open weak lower bound)
PrefixExtensionNPWitness parser           (Block 11a: NP verifier-TM obligations)
        │
        ▼  verifiedSource_of_explicit_interfaces
VerifiedNPDAGLowerBoundSource  ──►  (optionally) NP ⊄ PpolyDAG
```

## Contents

- **`verifiedSource_of_explicit_interfaces`** — `PolynomialWitnessCodec threshold` + `NoPolynomialBoundedSearchSolver wcodec.codec` + `PrefixExtensionNPWitness (treeMCSPConcretePrefixParser threshold wcodec.codec)` → `VerifiedNPDAGLowerBoundSource`. Internally: `wcodec.toGrowthAssumptions` (Block 10a) and `prefixExtensionLanguage_in_NP_of_witness` (Block 11a) feed `verifiedSource_of_noPolynomialBoundedSearchSolver` (Block 9e).
- **`NP_not_subset_PpolyDAG_of_explicit_interfaces`** — the same three interfaces yield the conditional `NP ⊄ PpolyDAG` separation via the existing `NP_not_subset_PpolyDAG_of_verified_source` bridge.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surface re-exports + axioms-audit entries; the new declarations depend only on `[propext, Classical.choice, Quot.sound]`.

## Scope discipline

Conditional packaging only. The growth premise, the lower bound, and the NP verifier-TM obligations are all **explicit hypotheses — none proved here**. **No** `SearchMCSPMagnificationContract` change, **no** `P ≠ NP` endpoint theorem, **no** unconditional claim. The three honest open problems remain open; this brick only makes the conditional extraction surface read as *three explicit inputs → verified source*.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_