### PR TITLE
Block 12b: Circuit↔CircuitTree bridge + native prefix-free encoder round-trip

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -298,6 +298,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness,
     Glob.one `Pnp4.Frontier.ContractExpansion.ExplicitConditionalSource,
     Glob.one `Pnp4.Frontier.ContractExpansion.ConcreteCodecGap,
+    Glob.one `Pnp4.Frontier.ContractExpansion.CircuitTreeBridge,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/CircuitTreeBridge.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/CircuitTreeBridge.lean
@@ -1,0 +1,117 @@
+import Pnp4.Frontier.SearchMCSPConcreteTargets
+import Complexity.TMVerifier.TuringToolkit.Encoding
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-!
+# Circuit ↔ CircuitTree bridge and a native prefix-free `Circuit` encoder
+
+Block 12b of the downstream extraction effort — the first of the two obligations the
+concrete-codec blocker (#1516, `ConcreteCodecGap.lean`) reduced the codec to.
+
+The pnp3 TM-verifier toolkit
+(`Complexity/TMVerifier/TuringToolkit/Encoding.lean`) provides a prefix-free
+encoder `encodeCircuitTree` / depth-budgeted decoder `decodeCircuitTreeAtDepth` for
+its own `CircuitTree` type, with a proven round-trip
+`decodeCircuitTreeAtDepth_encodeCircuitTree`.  `CircuitTree` is *structurally
+identical* to `Pnp3.Models.Circuit` (the same `input`/`const`/`not`/`and`/`or`
+constructors).
+
+This file builds the obvious bridge `toTree` / `fromTree` (a structural
+isomorphism), ports the encoder/decoder to native `Pnp3.Models.Circuit` through it,
+and **proves the native round-trip** `decodeCircuit (encodeCircuit c ++ rest) =
+some (c, rest)` for `size c ≤ d`.
+
+Scope discipline — bridge + native round-trip only:
+
+* the **encoding-length upper bound** (the second obligation, needed to choose
+  `witnessBits n`) is **not** proved here — it is the next brick;
+* **no** `SelfDelimitingCircuitCode` is assembled (that needs the length bound);
+* **no** lower-bound proof, **no** NP-verifier construction, **no**
+  `SearchMCSPMagnificationContract` / `VerifiedNPDAGLowerBoundSource` change, **no**
+  endpoint.
+-/
+
+/-- Forward bridge: a native `Circuit` maps to the structurally-identical
+`CircuitTree`. -/
+def toTree {n : Nat} : Pnp3.Models.Circuit n → CircuitTree n
+  | .input i => .input i
+  | .const b => .const b
+  | .not c => .not (toTree c)
+  | .and a b => .and (toTree a) (toTree b)
+  | .or a b => .or (toTree a) (toTree b)
+
+/-- Backward bridge. -/
+def fromTree {n : Nat} : CircuitTree n → Pnp3.Models.Circuit n
+  | .input i => .input i
+  | .const b => .const b
+  | .not c => .not (fromTree c)
+  | .and a b => .and (fromTree a) (fromTree b)
+  | .or a b => .or (fromTree a) (fromTree b)
+
+/-- The bridge is a left inverse: `fromTree ∘ toTree = id`. -/
+theorem fromTree_toTree {n : Nat} (c : Pnp3.Models.Circuit n) :
+    fromTree (toTree c) = c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | not c ih => simp only [toTree, fromTree, ih]
+  | and a b iha ihb => simp only [toTree, fromTree, iha, ihb]
+  | or a b iha ihb => simp only [toTree, fromTree, iha, ihb]
+
+/-- The bridge is also a right inverse: `toTree ∘ fromTree = id`. -/
+theorem toTree_fromTree {n : Nat} (t : CircuitTree n) :
+    toTree (fromTree t) = t := by
+  induction t with
+  | input i => rfl
+  | const b => rfl
+  | not c ih => simp only [toTree, fromTree, ih]
+  | and a b iha ihb => simp only [toTree, fromTree, iha, ihb]
+  | or a b iha ihb => simp only [toTree, fromTree, iha, ihb]
+
+/-- The bridge preserves gate count. -/
+theorem size_toTree {n : Nat} (c : Pnp3.Models.Circuit n) :
+    (toTree c).size = Pnp3.Models.Circuit.size c := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | not c ih =>
+      simp only [toTree, CircuitTree.size, Pnp3.Models.Circuit.size, ih]
+  | and a b iha ihb =>
+      simp only [toTree, CircuitTree.size, Pnp3.Models.Circuit.size, iha, ihb]
+  | or a b iha ihb =>
+      simp only [toTree, CircuitTree.size, Pnp3.Models.Circuit.size, iha, ihb]
+
+/-- Native self-delimiting encoder for `Pnp3.Models.Circuit`, via the bridge. -/
+def encodeCircuit {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (c : Pnp3.Models.Circuit n) : List Bool :=
+  encodeCircuitTree width h_width (toTree c)
+
+/-- Native prefix-free (depth-budgeted) decoder for `Pnp3.Models.Circuit`, via the
+bridge. -/
+def decodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat) (d : Nat)
+    (bits : List Bool) : Option (Pnp3.Models.Circuit n × List Bool) :=
+  (decodeCircuitTreeAtDepth h_pos width d bits).map (fun p => (fromTree p.1, p.2))
+
+/--
+**Native round-trip.**  Decoding the native encoding of a circuit (followed by any
+tail) recovers the circuit and the untouched tail, provided the depth budget covers
+its size.  Inherited from the `CircuitTree` round-trip through the bridge.
+-/
+theorem decodeCircuit_encodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat)
+    (h_width : n ≤ 2 ^ width) (c : Pnp3.Models.Circuit n)
+    (d : Nat) (h_d : Pnp3.Models.Circuit.size c ≤ d) (rest : List Bool) :
+    decodeCircuit h_pos width d (encodeCircuit width h_width c ++ rest)
+      = some (c, rest) := by
+  unfold decodeCircuit encodeCircuit
+  rw [decodeCircuitTreeAtDepth_encodeCircuitTree h_pos width h_width (toTree c) d
+        (by rw [size_toTree c]; exact h_d) rest]
+  simp [fromTree_toTree]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -54,6 +54,7 @@ import Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness
 import Pnp4.Frontier.ContractExpansion.ExplicitConditionalSource
 import Pnp4.Frontier.ContractExpansion.ConcreteCodecGap
+import Pnp4.Frontier.ContractExpansion.CircuitTreeBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -949,6 +950,30 @@ def check_SelfDelimitingCircuitCode_toCodec
   S.toCodec
 
 end ConcreteCodecGapSurface
+
+section CircuitTreeBridgeSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 12b surface: the bridge is a left inverse. -/
+theorem check_fromTree_toTree {n : Nat} (c : Pnp3.Models.Circuit n) :
+    fromTree (toTree c) = c :=
+  fromTree_toTree c
+
+/-- Block 12b surface: the bridge preserves gate count. -/
+theorem check_size_toTree {n : Nat} (c : Pnp3.Models.Circuit n) :
+    (toTree c).size = Pnp3.Models.Circuit.size c :=
+  size_toTree c
+
+/-- Block 12b surface (headline): the native `Circuit` encoder/decoder round-trips. -/
+theorem check_decodeCircuit_encodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat)
+    (h_width : n ≤ 2 ^ width) (c : Pnp3.Models.Circuit n)
+    (d : Nat) (h_d : Pnp3.Models.Circuit.size c ≤ d) (rest : List Bool) :
+    decodeCircuit h_pos width d (encodeCircuit width h_width c ++ rest)
+      = some (c, rest) :=
+  decodeCircuit_encodeCircuit h_pos width h_width c d h_d rest
+
+end CircuitTreeBridgeSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -44,6 +44,7 @@ import Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction
 import Pnp4.Frontier.ContractExpansion.PrefixExtensionNPWitness
 import Pnp4.Frontier.ContractExpansion.ExplicitConditionalSource
 import Pnp4.Frontier.ContractExpansion.ConcreteCodecGap
+import Pnp4.Frontier.ContractExpansion.CircuitTreeBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -293,6 +294,11 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.ofFn_listToFixedBitVec
 #print axioms Pnp4.Frontier.ContractExpansion.SelfDelimitingCircuitCode.toCodec
+
+#print axioms Pnp4.Frontier.ContractExpansion.fromTree_toTree
+#print axioms Pnp4.Frontier.ContractExpansion.toTree_fromTree
+#print axioms Pnp4.Frontier.ContractExpansion.size_toTree
+#print axioms Pnp4.Frontier.ContractExpansion.decodeCircuit_encodeCircuit
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 12b of the downstream extraction effort — the **first** of the two obligations the concrete-codec blocker (#1516) reduced the codec to: port the existing prefix-free `CircuitTree` encoder/decoder (pnp3 TM-verifier toolkit) to native `Pnp3.Models.Circuit` via a structural isomorphism, and **prove the native round-trip**. New file `CircuitTreeBridge.lean`.

`CircuitTree` (in `Complexity/TMVerifier/TuringToolkit/Encoding.lean`) is structurally identical to `Pnp3.Models.Circuit` (same `input`/`const`/`not`/`and`/`or` constructors) and already has `encodeCircuitTree` / `decodeCircuitTreeAtDepth` with a proven round-trip. This brick bridges to it.

## Contents

- **`toTree` / `fromTree`** — the structural bridge between `Pnp3.Models.Circuit n` and `CircuitTree n`.
- **`fromTree_toTree` / `toTree_fromTree`** — the bridge is a two-sided inverse.
- **`size_toTree`** — the bridge preserves gate count.
- **`encodeCircuit` / `decodeCircuit`** — native encoder/decoder defined through the bridge on top of `encodeCircuitTree` / `decodeCircuitTreeAtDepth`.
- **`decodeCircuit_encodeCircuit`** — the native round-trip `decodeCircuit h_pos width d (encodeCircuit width h_width c ++ rest) = some (c, rest)` for `size c ≤ d`, inherited from the `CircuitTree` round-trip through the bridge.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surface re-exports + axioms-audit entries; the bridge lemmas depend only on `[propext]`; the round-trip additionally on `[Classical.choice, Quot.sound]` (inherited from the existing `CircuitTree` decoder machinery).

## Scope discipline

Bridge + native round-trip only. The **encoding-length upper bound** (the second obligation, needed to choose `witnessBits n`) is **not** proved here — it is the next brick. **No** `SelfDelimitingCircuitCode` is assembled. **No** lower-bound proof, **no** NP-verifier construction, **no** `SearchMCSPMagnificationContract` / `VerifiedNPDAGLowerBoundSource` change, **no** endpoint.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_