### PR TITLE
Block 12d (partial): depth-budget elimination for the native Circuit decoder

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -300,6 +300,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.ConcreteCodecGap,
     Glob.one `Pnp4.Frontier.ContractExpansion.CircuitTreeBridge,
     Glob.one `Pnp4.Frontier.ContractExpansion.CircuitEncodingLength,
+    Glob.one `Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/CircuitDecodeDepthFree.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/CircuitDecodeDepthFree.lean
@@ -1,0 +1,85 @@
+import Pnp4.Frontier.ContractExpansion.CircuitEncodingLength
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-!
+# Depth-budget elimination for the native `Circuit` decoder
+
+Block 12d (partial) of the downstream extraction effort — toward assembling a
+concrete `TreeCircuitWitnessCodec`.
+
+The bridge decoder `decodeCircuit` (#1517) carries an explicit depth budget `d` and
+round-trips only when `size c ≤ d`.  A `SelfDelimitingCircuitCode.dec`
+(`ConcreteCodecGap.lean`) is **depth-free** (`List Bool → Option (… × …)`).  This
+file removes the external budget by taking `d := bits.length`: since a prefix-free
+codeword has length `≥ 3·size` (the existing lower bound, lifted here), `bits.length`
+always covers the size, so the round-trip survives.
+
+* `length_encodeCircuit_ge` — the native encoding-length **lower** bound
+  `3·size c ≤ (encodeCircuit …).length` (the complement of #1518's upper bound),
+  lifted from `encodeCircuitTree_length_ge` through the bridge.
+* `decodeCircuitFull` — the depth-free decoder `bits ↦ decodeCircuit … bits.length bits`.
+* `decodeCircuitFull_encodeCircuit` — its round-trip, with no `size ≤ d` side
+  condition.
+
+## Remaining obstacle to a full `∀ n` `SelfDelimitingCircuitCode`
+
+`decodeCircuitFull` (like the underlying `decodeCircuitTreeAtDepth`) still requires
+`h_pos : 0 < n`.  That parameter is **vestigial** — the pnp3 decoder never uses it
+(the `input` branch guards on a runtime `i_fin.val < n` check) — but it makes the
+decoder *uncallable* at `n = 0`, while `SelfDelimitingCircuitCode.dec` / the eventual
+`TreeCircuitWitnessCodec.decode` are quantified over **all** `n`.  So the encoder, the
+`n ≥ 1` decoder, and both length bounds are now in hand; the only piece left for the
+full assembly is an `n = 0` decoder (equivalently, dropping the unused `h_pos` in the
+pnp3 `Encoding.lean` decoder).  That step is intentionally **not** taken here.
+
+Scope discipline — depth elimination only:
+
+* **no** full `SelfDelimitingCircuitCode` / `TreeCircuitWitnessCodec` is assembled
+  (blocked by the `n = 0` decoder above);
+* **no** change to the pnp3 `Encoding.lean` decoder;
+* **no** lower-bound proof, **no** NP-verifier construction, **no**
+  `SearchMCSPMagnificationContract` change, **no** endpoint.
+-/
+
+/-- **Encoding-length lower bound for the native encoder** (complement of
+`length_encodeCircuit_le`): `3 · size c ≤ (encodeCircuit …).length`, lifted from
+`encodeCircuitTree_length_ge` through the bridge. -/
+theorem length_encodeCircuit_ge {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (c : Pnp3.Models.Circuit n) :
+    3 * Pnp3.Models.Circuit.size c ≤ (encodeCircuit width h_width c).length := by
+  unfold encodeCircuit
+  rw [← size_toTree c]
+  exact encodeCircuitTree_length_ge width h_width (toTree c)
+
+/-- Depth-free native decoder: use the input length itself as the depth budget. -/
+def decodeCircuitFull {n : Nat} (h_pos : 0 < n) (width : Nat)
+    (bits : List Bool) : Option (Pnp3.Models.Circuit n × List Bool) :=
+  decodeCircuit h_pos width bits.length bits
+
+/--
+**Depth-free round-trip.**  With the budget taken to be the input length, decoding
+the native encoding (followed by any tail) recovers the circuit and the untouched
+tail — with **no** `size ≤ d` side condition, because `(encodeCircuit … c ++ rest).length
+≥ 3 · size c ≥ size c`.
+-/
+theorem decodeCircuitFull_encodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat)
+    (h_width : n ≤ 2 ^ width) (c : Pnp3.Models.Circuit n) (rest : List Bool) :
+    decodeCircuitFull h_pos width (encodeCircuit width h_width c ++ rest)
+      = some (c, rest) := by
+  unfold decodeCircuitFull
+  have hge : 3 * Pnp3.Models.Circuit.size c ≤ (encodeCircuit width h_width c).length :=
+    length_encodeCircuit_ge width h_width c
+  have hlen : Pnp3.Models.Circuit.size c
+      ≤ (encodeCircuit width h_width c ++ rest).length := by
+    rw [List.length_append]; omega
+  exact decodeCircuit_encodeCircuit h_pos width h_width c
+    (encodeCircuit width h_width c ++ rest).length hlen rest
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -56,6 +56,7 @@ import Pnp4.Frontier.ContractExpansion.ExplicitConditionalSource
 import Pnp4.Frontier.ContractExpansion.ConcreteCodecGap
 import Pnp4.Frontier.ContractExpansion.CircuitTreeBridge
 import Pnp4.Frontier.ContractExpansion.CircuitEncodingLength
+import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -988,6 +989,26 @@ theorem check_length_encodeCircuit_le {n : Nat} (width : Nat) (h_width : n ≤ 2
   length_encodeCircuit_le width h_width c
 
 end CircuitEncodingLengthSurface
+
+section CircuitDecodeDepthFreeSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 12d surface: the native encoding-length lower bound. -/
+theorem check_length_encodeCircuit_ge {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (c : Pnp3.Models.Circuit n) :
+    3 * Pnp3.Models.Circuit.size c ≤ (encodeCircuit width h_width c).length :=
+  length_encodeCircuit_ge width h_width c
+
+/-- Block 12d surface (headline): the depth-free decoder round-trips with no
+`size ≤ d` side condition. -/
+theorem check_decodeCircuitFull_encodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat)
+    (h_width : n ≤ 2 ^ width) (c : Pnp3.Models.Circuit n) (rest : List Bool) :
+    decodeCircuitFull h_pos width (encodeCircuit width h_width c ++ rest)
+      = some (c, rest) :=
+  decodeCircuitFull_encodeCircuit h_pos width h_width c rest
+
+end CircuitDecodeDepthFreeSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -46,6 +46,7 @@ import Pnp4.Frontier.ContractExpansion.ExplicitConditionalSource
 import Pnp4.Frontier.ContractExpansion.ConcreteCodecGap
 import Pnp4.Frontier.ContractExpansion.CircuitTreeBridge
 import Pnp4.Frontier.ContractExpansion.CircuitEncodingLength
+import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -303,6 +304,9 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.length_encodeCircuitTree_le
 #print axioms Pnp4.Frontier.ContractExpansion.length_encodeCircuit_le
+
+#print axioms Pnp4.Frontier.ContractExpansion.length_encodeCircuit_ge
+#print axioms Pnp4.Frontier.ContractExpansion.decodeCircuitFull_encodeCircuit
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 12d (**partial**) of the downstream extraction effort — toward concrete `TreeCircuitWitnessCodec` assembly. New file `CircuitDecodeDepthFree.lean`.

The bridge decoder `decodeCircuit` (#1517) carries an explicit depth budget `d` and round-trips only when `size c ≤ d`; a `SelfDelimitingCircuitCode.dec` (`ConcreteCodecGap.lean`) is **depth-free**. This removes the external budget by taking `d := bits.length`: a prefix-free codeword has length `≥ 3·size` (lower bound, lifted here), so the input length always covers the size.

## Contents

- **`length_encodeCircuit_ge`** — the native encoding-length **lower** bound `3·size c ≤ (encodeCircuit …).length` (complement of #1518's upper bound), lifted from `encodeCircuitTree_length_ge` through the bridge.
- **`decodeCircuitFull`** — the depth-free decoder `bits ↦ decodeCircuit … bits.length bits`.
- **`decodeCircuitFull_encodeCircuit`** — its round-trip, with **no** `size ≤ d` side condition.

## Remaining obstacle (honest)

`decodeCircuitFull` (like the pnp3 `decodeCircuitTreeAtDepth`) still requires `h_pos : 0 < n`. That parameter is **vestigial** — the decoder body never uses it (the `input` branch guards on a runtime `i_fin.val < n` check) — but it makes the decoder *uncallable* at `n = 0`, while a `SelfDelimitingCircuitCode` / `TreeCircuitWitnessCodec` is quantified over **all** `n`. So after this brick: the encoder, the `n ≥ 1` decoder, and both length bounds are in hand; the **only** piece left for a full `∀ n` assembly is an `n = 0` decoder (equivalently, dropping the unused `h_pos` in pnp3 `Encoding.lean`). That step is intentionally **not** taken here.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surface re-exports + axioms-audit entries; the lower bound is `[propext, Quot.sound]`; the round-trip carries the decoder's `[propext, Classical.choice, Quot.sound]`.

## Scope discipline

Depth elimination only. **No** full `SelfDelimitingCircuitCode` / codec assembly (blocked by the `n = 0` decoder above), **no** change to pnp3 `Encoding.lean`, **no** lower-bound proof, **no** NP-verifier construction, **no** `SearchMCSPMagnificationContract` change, **no** endpoint.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_