### PR TITLE
Remove vestigial h_pos from the CircuitTree decoder (decodes for all n)

### DIFF
--- a/pnp3/Complexity/TMVerifier/TuringToolkit/Encoding.lean
+++ b/pnp3/Complexity/TMVerifier/TuringToolkit/Encoding.lean
@@ -171,7 +171,7 @@ is always enough since the tree depth is bounded by its size.
 The round-trip theorem shows `decodeCircuitTreeAtDepth` (at depth
 `c.size`) recovers `c` and leaves any tail unchanged:
 
-  decodeCircuitTreeAtDepth (h_pos : 0 < n) width c.size
+  decodeCircuitTreeAtDepth n width c.size
       (encodeCircuitTree width h_width c ++ rest)
     = some (c, rest).
 -/
@@ -179,7 +179,7 @@ The round-trip theorem shows `decodeCircuitTreeAtDepth` (at depth
 /-- Recursive decoder with a structural depth budget.  Returns the
 parsed tree plus the remaining bit list, or `none` on malformed
 input. -/
-def decodeCircuitTreeAtDepth {n : Nat} (h_pos : 0 < n) (width : Nat) :
+def decodeCircuitTreeAtDepth (n : Nat) (width : Nat) :
     Nat → List Bool → Option (CircuitTree n × List Bool)
   | 0, _ => none
   | _ + 1, [] => none
@@ -199,21 +199,21 @@ def decodeCircuitTreeAtDepth {n : Nat} (h_pos : 0 < n) (width : Nat) :
   | _ + 1, false :: false :: true :: b :: rest =>
     some (CircuitTree.const b, rest)
   | d + 1, false :: true :: false :: rest =>
-    match decodeCircuitTreeAtDepth h_pos width d rest with
+    match decodeCircuitTreeAtDepth n width d rest with
     | none => none
     | some (c, remainder) => some (CircuitTree.not c, remainder)
   | d + 1, false :: true :: true :: rest =>
-    match decodeCircuitTreeAtDepth h_pos width d rest with
+    match decodeCircuitTreeAtDepth n width d rest with
     | none => none
     | some (c1, rest1) =>
-      match decodeCircuitTreeAtDepth h_pos width d rest1 with
+      match decodeCircuitTreeAtDepth n width d rest1 with
       | none => none
       | some (c2, rest2) => some (CircuitTree.and c1 c2, rest2)
   | d + 1, true :: false :: false :: rest =>
-    match decodeCircuitTreeAtDepth h_pos width d rest with
+    match decodeCircuitTreeAtDepth n width d rest with
     | none => none
     | some (c1, rest1) =>
-      match decodeCircuitTreeAtDepth h_pos width d rest1 with
+      match decodeCircuitTreeAtDepth n width d rest1 with
       | none => none
       | some (c2, rest2) => some (CircuitTree.or c1 c2, rest2)
   | _ + 1, _ :: _ :: _ :: _ => none
@@ -234,23 +234,23 @@ are reserved for Session 8f so the current commit keeps its
 scope tight and its individual proofs readable.
 -/
 
-theorem decode_encode_const {n : Nat} (h_pos : 0 < n) (width : Nat)
+theorem decode_encode_const {n : Nat} (width : Nat)
     (h_width : n ≤ 2 ^ width) (b : Bool) (d : Nat) (hd : 1 ≤ d)
     (rest : List Bool) :
-    decodeCircuitTreeAtDepth h_pos width d
+    decodeCircuitTreeAtDepth n width d
         (encodeCircuitTree width h_width (CircuitTree.const b) ++ rest) =
       some (CircuitTree.const b, rest) := by
   obtain ⟨d', rfl⟩ : ∃ d', d = d' + 1 := ⟨d - 1, by omega⟩
   simp [encodeCircuitTree, decodeCircuitTreeAtDepth]
 
-theorem decode_encode_not {n : Nat} (h_pos : 0 < n) (width : Nat)
+theorem decode_encode_not {n : Nat} (width : Nat)
     (h_width : n ≤ 2 ^ width) (c : CircuitTree n) (d : Nat)
     (hd : c.size + 1 ≤ d)
     (rest : List Bool)
     (ih : ∀ (d' : Nat), c.size ≤ d' → ∀ (r : List Bool),
-      decodeCircuitTreeAtDepth h_pos width d'
+      decodeCircuitTreeAtDepth n width d'
           (encodeCircuitTree width h_width c ++ r) = some (c, r)) :
-    decodeCircuitTreeAtDepth h_pos width d
+    decodeCircuitTreeAtDepth n width d
         (encodeCircuitTree width h_width (CircuitTree.not c) ++ rest) =
       some (CircuitTree.not c, rest) := by
   obtain ⟨d', rfl⟩ : ∃ d', d = d' + 1 := ⟨d - 1, by omega⟩
@@ -259,17 +259,17 @@ theorem decode_encode_not {n : Nat} (h_pos : 0 < n) (width : Nat)
              decodeCircuitTreeAtDepth]
   rw [ih d' hd' rest]
 
-theorem decode_encode_and {n : Nat} (h_pos : 0 < n) (width : Nat)
+theorem decode_encode_and {n : Nat} (width : Nat)
     (h_width : n ≤ 2 ^ width) (c1 c2 : CircuitTree n) (d : Nat)
     (hd : c1.size + c2.size + 1 ≤ d)
     (rest : List Bool)
     (ih1 : ∀ (d' : Nat), c1.size ≤ d' → ∀ (r : List Bool),
-      decodeCircuitTreeAtDepth h_pos width d'
+      decodeCircuitTreeAtDepth n width d'
           (encodeCircuitTree width h_width c1 ++ r) = some (c1, r))
     (ih2 : ∀ (d' : Nat), c2.size ≤ d' → ∀ (r : List Bool),
-      decodeCircuitTreeAtDepth h_pos width d'
+      decodeCircuitTreeAtDepth n width d'
           (encodeCircuitTree width h_width c2 ++ r) = some (c2, r)) :
-    decodeCircuitTreeAtDepth h_pos width d
+    decodeCircuitTreeAtDepth n width d
         (encodeCircuitTree width h_width (CircuitTree.and c1 c2) ++ rest) =
       some (CircuitTree.and c1 c2, rest) := by
   obtain ⟨d', rfl⟩ : ∃ d', d = d' + 1 := ⟨d - 1, by omega⟩
@@ -280,17 +280,17 @@ theorem decode_encode_and {n : Nat} (h_pos : 0 < n) (width : Nat)
              ih1 d' hd1 (encodeCircuitTree width h_width c2 ++ rest),
              ih2 d' hd2 rest]
 
-theorem decode_encode_or {n : Nat} (h_pos : 0 < n) (width : Nat)
+theorem decode_encode_or {n : Nat} (width : Nat)
     (h_width : n ≤ 2 ^ width) (c1 c2 : CircuitTree n) (d : Nat)
     (hd : c1.size + c2.size + 1 ≤ d)
     (rest : List Bool)
     (ih1 : ∀ (d' : Nat), c1.size ≤ d' → ∀ (r : List Bool),
-      decodeCircuitTreeAtDepth h_pos width d'
+      decodeCircuitTreeAtDepth n width d'
           (encodeCircuitTree width h_width c1 ++ r) = some (c1, r))
     (ih2 : ∀ (d' : Nat), c2.size ≤ d' → ∀ (r : List Bool),
-      decodeCircuitTreeAtDepth h_pos width d'
+      decodeCircuitTreeAtDepth n width d'
           (encodeCircuitTree width h_width c2 ++ r) = some (c2, r)) :
-    decodeCircuitTreeAtDepth h_pos width d
+    decodeCircuitTreeAtDepth n width d
         (encodeCircuitTree width h_width (CircuitTree.or c1 c2) ++ rest) =
       some (CircuitTree.or c1 c2, rest) := by
   obtain ⟨d', rfl⟩ : ∃ d', d = d' + 1 := ⟨d - 1, by omega⟩
@@ -301,10 +301,10 @@ theorem decode_encode_or {n : Nat} (h_pos : 0 < n) (width : Nat)
              ih1 d' hd1 (encodeCircuitTree width h_width c2 ++ rest),
              ih2 d' hd2 rest]
 
-theorem decode_encode_input {n : Nat} (h_pos : 0 < n) (width : Nat)
+theorem decode_encode_input {n : Nat} (width : Nat)
     (h_width : n ≤ 2 ^ width) (i : Fin n) (d : Nat) (hd : 1 ≤ d)
     (rest : List Bool) :
-    decodeCircuitTreeAtDepth h_pos width d
+    decodeCircuitTreeAtDepth n width d
         (encodeCircuitTree width h_width (CircuitTree.input i) ++ rest) =
       some (CircuitTree.input i, rest) := by
   obtain ⟨d', rfl⟩ : ∃ d', d = d' + 1 := ⟨d - 1, by omega⟩
@@ -324,7 +324,7 @@ theorem decode_encode_input {n : Nat} (h_pos : 0 < n) (width : Nat)
     simp
   have hvlt : ifin.val < n := by rw [hifin]; exact i.isLt
   -- Reduce the goal to the exposed decoder-match form.
-  show decodeCircuitTreeAtDepth h_pos width (d' + 1)
+  show decodeCircuitTreeAtDepth n width (d' + 1)
       (false :: false :: false :: (encodeFin width ifin ++ rest)) =
     some (CircuitTree.input i, rest)
   unfold decodeCircuitTreeAtDepth
@@ -346,32 +346,32 @@ theorem decode_encode_input {n : Nat} (h_pos : 0 < n) (width : Nat)
 /-- Full round-trip: combines all five constructor-level lemmas
 into a single induction on the circuit tree. -/
 theorem decodeCircuitTreeAtDepth_encodeCircuitTree
-    {n : Nat} (h_pos : 0 < n) (width : Nat)
+    {n : Nat} (width : Nat)
     (h_width : n ≤ 2 ^ width) (c : CircuitTree n) :
     ∀ (d : Nat), c.size ≤ d →
     ∀ (rest : List Bool),
-      decodeCircuitTreeAtDepth h_pos width d
+      decodeCircuitTreeAtDepth n width d
           (encodeCircuitTree width h_width c ++ rest) = some (c, rest) := by
   induction c with
   | input i =>
     intro d h_d rest
-    exact decode_encode_input h_pos width h_width i d
+    exact decode_encode_input width h_width i d
       (by simpa [CircuitTree.size] using h_d) rest
   | const b =>
     intro d h_d rest
-    exact decode_encode_const h_pos width h_width b d
+    exact decode_encode_const width h_width b d
       (by simpa [CircuitTree.size] using h_d) rest
   | not c ih =>
     intro d h_d rest
-    exact decode_encode_not h_pos width h_width c d
+    exact decode_encode_not width h_width c d
       (by simpa [CircuitTree.size] using h_d) rest ih
   | and c1 c2 ih1 ih2 =>
     intro d h_d rest
-    exact decode_encode_and h_pos width h_width c1 c2 d
+    exact decode_encode_and width h_width c1 c2 d
       (by simpa [CircuitTree.size] using h_d) rest ih1 ih2
   | or c1 c2 ih1 ih2 =>
     intro d h_d rest
-    exact decode_encode_or h_pos width h_width c1 c2 d
+    exact decode_encode_or width h_width c1 c2 d
       (by simpa [CircuitTree.size] using h_d) rest ih1 ih2
 
 /-!

--- a/pnp4/Pnp4/Frontier/ContractExpansion/CircuitDecodeDepthFree.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/CircuitDecodeDepthFree.lean
@@ -26,22 +26,24 @@ always covers the size, so the round-trip survives.
 * `decodeCircuitFull_encodeCircuit` — its round-trip, with no `size ≤ d` side
   condition.
 
-## Remaining obstacle to a full `∀ n` `SelfDelimitingCircuitCode`
+## The `n = 0` obstacle is now resolved
 
-`decodeCircuitFull` (like the underlying `decodeCircuitTreeAtDepth`) still requires
-`h_pos : 0 < n`.  That parameter is **vestigial** — the pnp3 decoder never uses it
-(the `input` branch guards on a runtime `i_fin.val < n` check) — but it makes the
-decoder *uncallable* at `n = 0`, while `SelfDelimitingCircuitCode.dec` / the eventual
-`TreeCircuitWitnessCodec.decode` are quantified over **all** `n`.  So the encoder, the
-`n ≥ 1` decoder, and both length bounds are now in hand; the only piece left for the
-full assembly is an `n = 0` decoder (equivalently, dropping the unused `h_pos` in the
-pnp3 `Encoding.lean` decoder).  That step is intentionally **not** taken here.
+Earlier this decoder (via the pnp3 `decodeCircuitTreeAtDepth`) carried a vestigial
+`h_pos : 0 < n` that made it *uncallable* at `n = 0`, even though the body never used
+it (the `input` branch guards on a runtime `i_fin.val < n` check).  That parameter has
+since been removed: the pnp3 decoder now takes `n` as a plain explicit argument, so
+`decodeCircuit` / `decodeCircuitFull` decode for **all** `n`, including `n = 0`.
 
-Scope discipline — depth elimination only:
+Together with the encoder, the round-trip, and both length bounds (upper #1518, lower
+here), every *encoder-level* ingredient for a full `∀ n` `SelfDelimitingCircuitCode`
+is now in hand.  Only the **final assembly** — choosing a width / `witnessBits`
+schedule and packaging via `SelfDelimitingCircuitCode.toCodec` — remains, and is left
+to a separate PR.
+
+Scope discipline — depth elimination + lower bound only:
 
 * **no** full `SelfDelimitingCircuitCode` / `TreeCircuitWitnessCodec` is assembled
-  (blocked by the `n = 0` decoder above);
-* **no** change to the pnp3 `Encoding.lean` decoder;
+  (final assembly is a separate PR);
 * **no** lower-bound proof, **no** NP-verifier construction, **no**
   `SearchMCSPMagnificationContract` change, **no** endpoint.
 -/
@@ -57,9 +59,9 @@ theorem length_encodeCircuit_ge {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ wid
   exact encodeCircuitTree_length_ge width h_width (toTree c)
 
 /-- Depth-free native decoder: use the input length itself as the depth budget. -/
-def decodeCircuitFull {n : Nat} (h_pos : 0 < n) (width : Nat)
+def decodeCircuitFull (n : Nat) (width : Nat)
     (bits : List Bool) : Option (Pnp3.Models.Circuit n × List Bool) :=
-  decodeCircuit h_pos width bits.length bits
+  decodeCircuit n width bits.length bits
 
 /--
 **Depth-free round-trip.**  With the budget taken to be the input length, decoding
@@ -67,9 +69,9 @@ the native encoding (followed by any tail) recovers the circuit and the untouche
 tail — with **no** `size ≤ d` side condition, because `(encodeCircuit … c ++ rest).length
 ≥ 3 · size c ≥ size c`.
 -/
-theorem decodeCircuitFull_encodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat)
+theorem decodeCircuitFull_encodeCircuit (n : Nat) (width : Nat)
     (h_width : n ≤ 2 ^ width) (c : Pnp3.Models.Circuit n) (rest : List Bool) :
-    decodeCircuitFull h_pos width (encodeCircuit width h_width c ++ rest)
+    decodeCircuitFull n width (encodeCircuit width h_width c ++ rest)
       = some (c, rest) := by
   unfold decodeCircuitFull
   have hge : 3 * Pnp3.Models.Circuit.size c ≤ (encodeCircuit width h_width c).length :=
@@ -77,7 +79,7 @@ theorem decodeCircuitFull_encodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat)
   have hlen : Pnp3.Models.Circuit.size c
       ≤ (encodeCircuit width h_width c ++ rest).length := by
     rw [List.length_append]; omega
-  exact decodeCircuit_encodeCircuit h_pos width h_width c
+  exact decodeCircuit_encodeCircuit n width h_width c
     (encodeCircuit width h_width c ++ rest).length hlen rest
 
 end ContractExpansion

--- a/pnp4/Pnp4/Frontier/ContractExpansion/CircuitTreeBridge.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/CircuitTreeBridge.lean
@@ -93,22 +93,22 @@ def encodeCircuit {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
 
 /-- Native prefix-free (depth-budgeted) decoder for `Pnp3.Models.Circuit`, via the
 bridge. -/
-def decodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat) (d : Nat)
+def decodeCircuit (n : Nat) (width : Nat) (d : Nat)
     (bits : List Bool) : Option (Pnp3.Models.Circuit n × List Bool) :=
-  (decodeCircuitTreeAtDepth h_pos width d bits).map (fun p => (fromTree p.1, p.2))
+  (decodeCircuitTreeAtDepth n width d bits).map (fun p => (fromTree p.1, p.2))
 
 /--
 **Native round-trip.**  Decoding the native encoding of a circuit (followed by any
 tail) recovers the circuit and the untouched tail, provided the depth budget covers
 its size.  Inherited from the `CircuitTree` round-trip through the bridge.
 -/
-theorem decodeCircuit_encodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat)
+theorem decodeCircuit_encodeCircuit (n : Nat) (width : Nat)
     (h_width : n ≤ 2 ^ width) (c : Pnp3.Models.Circuit n)
     (d : Nat) (h_d : Pnp3.Models.Circuit.size c ≤ d) (rest : List Bool) :
-    decodeCircuit h_pos width d (encodeCircuit width h_width c ++ rest)
+    decodeCircuit n width d (encodeCircuit width h_width c ++ rest)
       = some (c, rest) := by
   unfold decodeCircuit encodeCircuit
-  rw [decodeCircuitTreeAtDepth_encodeCircuitTree h_pos width h_width (toTree c) d
+  rw [decodeCircuitTreeAtDepth_encodeCircuitTree width h_width (toTree c) d
         (by rw [size_toTree c]; exact h_d) rest]
   simp [fromTree_toTree]
 

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -967,13 +967,14 @@ theorem check_size_toTree {n : Nat} (c : Pnp3.Models.Circuit n) :
     (toTree c).size = Pnp3.Models.Circuit.size c :=
   size_toTree c
 
-/-- Block 12b surface (headline): the native `Circuit` encoder/decoder round-trips. -/
-theorem check_decodeCircuit_encodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat)
+/-- Block 12b surface (headline): the native `Circuit` encoder/decoder round-trips
+(for all `n`, including `n = 0`). -/
+theorem check_decodeCircuit_encodeCircuit (n : Nat) (width : Nat)
     (h_width : n ≤ 2 ^ width) (c : Pnp3.Models.Circuit n)
     (d : Nat) (h_d : Pnp3.Models.Circuit.size c ≤ d) (rest : List Bool) :
-    decodeCircuit h_pos width d (encodeCircuit width h_width c ++ rest)
+    decodeCircuit n width d (encodeCircuit width h_width c ++ rest)
       = some (c, rest) :=
-  decodeCircuit_encodeCircuit h_pos width h_width c d h_d rest
+  decodeCircuit_encodeCircuit n width h_width c d h_d rest
 
 end CircuitTreeBridgeSurface
 
@@ -1001,12 +1002,12 @@ theorem check_length_encodeCircuit_ge {n : Nat} (width : Nat) (h_width : n ≤ 2
   length_encodeCircuit_ge width h_width c
 
 /-- Block 12d surface (headline): the depth-free decoder round-trips with no
-`size ≤ d` side condition. -/
-theorem check_decodeCircuitFull_encodeCircuit {n : Nat} (h_pos : 0 < n) (width : Nat)
+`size ≤ d` side condition (for all `n`, including `n = 0`). -/
+theorem check_decodeCircuitFull_encodeCircuit (n : Nat) (width : Nat)
     (h_width : n ≤ 2 ^ width) (c : Pnp3.Models.Circuit n) (rest : List Bool) :
-    decodeCircuitFull h_pos width (encodeCircuit width h_width c ++ rest)
+    decodeCircuitFull n width (encodeCircuit width h_width c ++ rest)
       = some (c, rest) :=
-  decodeCircuitFull_encodeCircuit h_pos width h_width c rest
+  decodeCircuitFull_encodeCircuit n width h_width c rest
 
 end CircuitDecodeDepthFreeSurface
 


### PR DESCRIPTION
## Summary

The pnp3 `decodeCircuitTreeAtDepth` carried `h_pos : 0 < n` but **never used it** (the `input` branch guards on a runtime `i_fin.val < n` check). It made the decoder uncallable at `n = 0`, while a `SelfDelimitingCircuitCode` / `TreeCircuitWitnessCodec` `decode` is quantified over **all** `n`. This removes `h_pos`, so the native decoder round-trip now holds for **all `n`, including `n = 0`** — closing the only obstacle the Block-12d partial (#1520) had left.

Since `h_pos : 0 < n` was *also* (incidentally) the argument that pinned the otherwise return-type-only implicit `n`, `n` is made an **explicit** parameter of the decoder instead. The decoder body and the round-trip proofs are otherwise unchanged.

## Changes

**pnp3** (`Complexity/TMVerifier/TuringToolkit/Encoding.lean`):
- `decodeCircuitTreeAtDepth`, the five `decode_encode_{const,not,and,or,input}` helper lemmas, and `decodeCircuitTreeAtDepth_encodeCircuitTree` lose `h_pos`; `n` is explicit on the function. The separate `SLGate`/`SLProgram` decoder cluster is **untouched**.

**pnp4 bridge** (updated to the new signature):
- `CircuitTreeBridge`: `decodeCircuit` / `decodeCircuit_encodeCircuit` drop `h_pos`, pass `n` explicitly.
- `CircuitDecodeDepthFree`: `decodeCircuitFull` / `decodeCircuitFull_encodeCircuit` drop `h_pos`; docstring updated — the `n = 0` obstacle is now **resolved**, so every encoder-level ingredient for a full `∀ n` codec is in hand and only final assembly remains (separate PR).
- Surface `check_` theorems updated to the new signatures.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green (the pnp3 change rebuilds downstream; nothing else uses `decodeCircuitTreeAtDepth`).
- Round-trip axioms unchanged: `[propext, Classical.choice, Quot.sound]`.

## Scope discipline

Decoder signature fix only. **No** codec assembly, **no** lower-bound proof, **no** NP-verifier construction, **no** `SearchMCSPMagnificationContract` change, **no** endpoint.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_