### PR TITLE
Block 12e: the first concrete TreeCircuitWitnessCodec (final assembly)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -301,6 +301,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.CircuitTreeBridge,
     Glob.one `Pnp4.Frontier.ContractExpansion.CircuitEncodingLength,
     Glob.one `Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree,
+    Glob.one `Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/ConcreteTreeCodec.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/ConcreteTreeCodec.lean
@@ -1,0 +1,95 @@
+import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
+import Pnp4.Frontier.ContractExpansion.ConcreteCodecGap
+import Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction
+import Pnp4.Frontier.ContractExpansion.PrefixParserConvention
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+/-!
+# A concrete `TreeCircuitWitnessCodec`
+
+Block 12e of the downstream extraction effort — the **final assembly**.  This is the
+**first concrete `TreeCircuitWitnessCodec`** in the development, closing the
+"no concrete codec exists" finding from Block 12a (`ConcreteCodecGap.lean`).
+
+All the encoder-level ingredients are now in hand:
+
+* a native prefix-free encoder/decoder over `Pnp3.Models.Circuit` and a round-trip
+  for **all** `n` (`CircuitTreeBridge.lean`, after the `h_pos` removal);
+* a depth-free decoder `decodeCircuitFull` (`CircuitDecodeDepthFree.lean`);
+* matching encoding-length **upper** and **lower** bounds
+  (`CircuitEncodingLength.lean`, `CircuitDecodeDepthFree.lean`);
+* the packing reduction `SelfDelimitingCircuitCode.toCodec` (`ConcreteCodecGap.lean`).
+
+Assembly choices:
+
+* **width schedule** `width n := bitLength n`, valid because `n < 2 ^ bitLength n`
+  (`nat_lt_two_pow_bitLength`);
+* **witness width** `witnessBits n := (bitLength n + 4) · threshold n`, which
+  dominates the encoding length of every circuit of size `≤ threshold n` (upper
+  bound `(bitLength n + 4) · size`).
+
+`treeCircuitWitnessCodec threshold` is then `(treeSelfDelimitingCode threshold).toCodec`.
+
+Finally, **under the explicit assumption** `PolyBoundedInTable threshold` (the
+threshold is polynomial in the truth-table length), the codec's `witnessBits` is
+`PolyBoundedInTable`, so it packages as a `PolynomialWitnessCodec` — which (Block 10a)
+yields the full `TreeMCSPExtractionGrowthAssumptions`.  This is the point at which the
+growth premise becomes the *single* honest assumption `PolyBoundedInTable threshold`.
+
+Scope discipline — concrete codec construction only:
+
+* `PolyBoundedInTable threshold` is an **explicit assumption** for the
+  `PolynomialWitnessCodec` packaging — **not** proved here;
+* **no** `NoPolynomialBoundedSearchSolver` / lower-bound proof, **no** NP-verifier
+  construction, **no** `SearchMCSPMagnificationContract` change, **no** endpoint.
+-/
+
+/-- The concrete self-delimiting circuit code for the tree-MCSP codec: encode through
+the bridge at width `bitLength n`, decode with the depth-free decoder, and bound the
+length by `(bitLength n + 4) · threshold n`. -/
+def treeSelfDelimitingCode (threshold : Nat → Nat) : SelfDelimitingCircuitCode threshold where
+  witnessBits := fun n => (bitLength n + 4) * threshold n
+  enc := fun n c => encodeCircuit (bitLength n) (Nat.le_of_lt (nat_lt_two_pow_bitLength n)) c
+  dec := fun n bits => decodeCircuitFull n (bitLength n) bits
+  dec_enc := fun n c rest =>
+    decodeCircuitFull_encodeCircuit n (bitLength n)
+      (Nat.le_of_lt (nat_lt_two_pow_bitLength n)) c rest
+  enc_len_le := fun n c h =>
+    le_trans
+      (length_encodeCircuit_le (bitLength n) (Nat.le_of_lt (nat_lt_two_pow_bitLength n)) c)
+      (Nat.mul_le_mul (le_refl _) h)
+
+/-- **The concrete tree-circuit witness codec.**  Assembled from the self-delimiting
+code by the zero-padding packing reduction. -/
+def treeCircuitWitnessCodec (threshold : Nat → Nat) : TreeCircuitWitnessCodec threshold :=
+  (treeSelfDelimitingCode threshold).toCodec
+
+/-- The truth-table length dominates `bitLength`: `bitLength n ≤ n ≤ tableLen n`. -/
+theorem polyBoundedInTable_bitLength : PolyBoundedInTable bitLength :=
+  PolyBoundedInTable.of_le
+    (fun n => le_trans (bitLength_le_self n) (Nat.le_of_lt Nat.lt_two_pow_self))
+    polyBoundedInTable_tableLen
+
+/-- Under `PolyBoundedInTable threshold`, the concrete codec's witness width
+`(bitLength n + 4) · threshold n` is polynomially bounded in the truth-table length. -/
+theorem polyBoundedInTable_treeWitnessBits_of_thresholdPoly
+    (threshold : Nat → Nat) (hT : PolyBoundedInTable threshold) :
+    PolyBoundedInTable (treeCircuitWitnessCodec threshold).witnessBits := by
+  show PolyBoundedInTable (fun n => (bitLength n + 4) * threshold n)
+  exact (polyBoundedInTable_bitLength.add (PolyBoundedInTable.const 4)).mul hT
+
+/-- **Concrete `PolynomialWitnessCodec`, under the single threshold-growth premise.**
+Given `PolyBoundedInTable threshold`, the concrete codec packages as a
+`PolynomialWitnessCodec`, hence (via `toGrowthAssumptions`) yields the full extraction
+growth assumptions for a *concrete* codec. -/
+def treePolynomialWitnessCodec (threshold : Nat → Nat) (hT : PolyBoundedInTable threshold) :
+    PolynomialWitnessCodec threshold where
+  codec := treeCircuitWitnessCodec threshold
+  witness_poly := polyBoundedInTable_treeWitnessBits_of_thresholdPoly threshold hT
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -57,6 +57,7 @@ import Pnp4.Frontier.ContractExpansion.ConcreteCodecGap
 import Pnp4.Frontier.ContractExpansion.CircuitTreeBridge
 import Pnp4.Frontier.ContractExpansion.CircuitEncodingLength
 import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
+import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -1010,6 +1011,25 @@ theorem check_decodeCircuitFull_encodeCircuit (n : Nat) (width : Nat)
   decodeCircuitFull_encodeCircuit n width h_width c rest
 
 end CircuitDecodeDepthFreeSurface
+
+section ConcreteTreeCodecSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 12e surface (headline): a concrete `TreeCircuitWitnessCodec` exists for
+every `threshold`. -/
+def check_treeCircuitWitnessCodec (threshold : Nat → Nat) :
+    Frontier.TreeCircuitWitnessCodec threshold :=
+  treeCircuitWitnessCodec threshold
+
+/-- Block 12e surface: under the single threshold-growth premise, the concrete codec
+packages as a `PolynomialWitnessCodec`. -/
+def check_treePolynomialWitnessCodec (threshold : Nat → Nat)
+    (hT : PolyBoundedInTable threshold) :
+    PolynomialWitnessCodec threshold :=
+  treePolynomialWitnessCodec threshold hT
+
+end ConcreteTreeCodecSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -47,6 +47,7 @@ import Pnp4.Frontier.ContractExpansion.ConcreteCodecGap
 import Pnp4.Frontier.ContractExpansion.CircuitTreeBridge
 import Pnp4.Frontier.ContractExpansion.CircuitEncodingLength
 import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
+import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -307,6 +308,10 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.length_encodeCircuit_ge
 #print axioms Pnp4.Frontier.ContractExpansion.decodeCircuitFull_encodeCircuit
+
+#print axioms Pnp4.Frontier.ContractExpansion.treeCircuitWitnessCodec
+#print axioms Pnp4.Frontier.ContractExpansion.polyBoundedInTable_treeWitnessBits_of_thresholdPoly
+#print axioms Pnp4.Frontier.ContractExpansion.treePolynomialWitnessCodec
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 12e of the downstream extraction effort — the **final assembly**, and a milestone: the **first concrete `TreeCircuitWitnessCodec`** in the development. Closes the "no concrete codec exists" finding from Block 12a (`ConcreteCodecGap.lean`). New file `ConcreteTreeCodec.lean`.

All encoder-level ingredients were in place (native all-`n` round-trip after the `h_pos` removal, depth-free decoder, matching upper/lower length bounds, the packing reduction). This wires them together.

## Contents

- **`treeSelfDelimitingCode threshold : SelfDelimitingCircuitCode threshold`** — `enc := encodeCircuit` at width `bitLength n` (valid via `nat_lt_two_pow_bitLength`), `dec := decodeCircuitFull`, `dec_enc` from the all-`n` round-trip, `enc_len_le` from `length_encodeCircuit_le` with `witnessBits n := (bitLength n + 4) · threshold n`.
- **`treeCircuitWitnessCodec threshold : TreeCircuitWitnessCodec threshold`** — `:= (treeSelfDelimitingCode threshold).toCodec`. The concrete codec.
- **`polyBoundedInTable_bitLength`** and **`polyBoundedInTable_treeWitnessBits_of_thresholdPoly`** — under `PolyBoundedInTable threshold`, the codec's `witnessBits` is `PolyBoundedInTable`.
- **`treePolynomialWitnessCodec threshold hT : PolynomialWitnessCodec threshold`** — under that single premise, the concrete codec packages as a `PolynomialWitnessCodec`, hence (via `toGrowthAssumptions`) yields the full `TreeMCSPExtractionGrowthAssumptions` for a *concrete* codec.

The growth premise is now the **single honest assumption** `PolyBoundedInTable threshold`.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surface re-exports + axioms-audit entries; the new declarations depend only on `[propext, Classical.choice, Quot.sound]`.

## Scope discipline

Concrete codec construction only. `PolyBoundedInTable threshold` is an **explicit assumption** for the `PolynomialWitnessCodec` packaging — **not** proved here. **No** `NoPolynomialBoundedSearchSolver` / lower-bound proof, **no** NP-verifier construction, **no** `SearchMCSPMagnificationContract` change, **no** endpoint.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_