### PR TITLE
Block 12f: concrete-codec conditional verified source

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -302,6 +302,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.CircuitEncodingLength,
     Glob.one `Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree,
     Glob.one `Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec,
+    Glob.one `Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/ConcreteTreeCodecSource.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/ConcreteTreeCodecSource.lean
@@ -1,0 +1,76 @@
+import Pnp4.Frontier.ContractExpansion.ExplicitConditionalSource
+import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Concrete-codec conditional verified source
+
+Block 12f of the downstream extraction effort — instantiating the capstone
+(`ExplicitConditionalSource.lean`, #1515) at the **concrete** tree-circuit codec
+`treeCircuitWitnessCodec` (#1522).
+
+The capstone `verifiedSource_of_explicit_interfaces` takes three explicit interfaces
+(a `PolynomialWitnessCodec`, the open polynomial lower bound, an NP TM-witness) and
+returns a `VerifiedNPDAGLowerBoundSource`.  With the concrete codec now in hand, the
+`PolynomialWitnessCodec` input is provided by `treePolynomialWitnessCodec` under the
+single growth premise `PolyBoundedInTable threshold` — so the codec/growth leg is no
+longer an abstract `codec`, but the concrete `treeCircuitWitnessCodec threshold`.
+
+After this brick the three remaining open inputs are, for the concrete codec:
+
+1. `PolyBoundedInTable threshold` — an arithmetic growth hypothesis on the chosen
+   threshold;
+2. `NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec threshold)` — the genuine
+   weak lower bound (hard, research-level mathematics);
+3. `PrefixExtensionNPWitness (treeMCSPConcretePrefixParser threshold …)` — a concrete
+   NP verifier TM with runtime/correctness.
+
+Everything stays **strictly conditional**: all three are explicit hypotheses, none
+proved here.
+
+Scope discipline — concrete-codec instantiation of the conditional source only:
+
+* the three inputs are **explicit hypotheses** — **none** proved here;
+* **no** `SearchMCSPMagnificationContract` change, **no** `P ≠ NP` endpoint, **no**
+  unconditional claim.
+-/
+
+/--
+**Concrete-codec verified source.**  For the concrete tree-circuit codec, the three
+explicit interfaces — the threshold growth hypothesis (via `treePolynomialWitnessCodec`),
+the open polynomial weak lower bound, and an NP TM-witness — assemble a
+`VerifiedNPDAGLowerBoundSource`.
+-/
+noncomputable def verifiedSource_of_treeCodec_noPolynomialBoundedSearchSolver
+    (threshold : Nat → Nat)
+    (hThresholdPoly : PolyBoundedInTable threshold)
+    (hNoPoly : NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec threshold))
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser threshold (treeCircuitWitnessCodec threshold))) :
+    VerifiedNPDAGLowerBoundSource :=
+  verifiedSource_of_explicit_interfaces
+    (treePolynomialWitnessCodec threshold hThresholdPoly) hNoPoly hNPWit
+
+/--
+Convenience wrapper: the same three concrete-codec inputs yield the conditional
+`NP ⊄ PpolyDAG` separation.  Still strictly conditional; **not** the `P ≠ NP`
+endpoint.
+-/
+theorem NP_not_subset_PpolyDAG_of_treeCodec_interfaces
+    (threshold : Nat → Nat)
+    (hThresholdPoly : PolyBoundedInTable threshold)
+    (hNoPoly : NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec threshold))
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser threshold (treeCircuitWitnessCodec threshold))) :
+    Pnp3.ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_explicit_interfaces
+    (treePolynomialWitnessCodec threshold hThresholdPoly) hNoPoly hNPWit
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -58,6 +58,7 @@ import Pnp4.Frontier.ContractExpansion.CircuitTreeBridge
 import Pnp4.Frontier.ContractExpansion.CircuitEncodingLength
 import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec
+import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -1030,6 +1031,36 @@ def check_treePolynomialWitnessCodec (threshold : Nat → Nat)
   treePolynomialWitnessCodec threshold hT
 
 end ConcreteTreeCodecSurface
+
+section ConcreteTreeCodecSourceSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 12f surface: the concrete-codec verified source from the three explicit
+interfaces (threshold growth, no-poly solver, NP TM-witness). -/
+noncomputable def check_verifiedSource_of_treeCodec_noPolynomialBoundedSearchSolver
+    (threshold : Nat → Nat)
+    (hThresholdPoly : PolyBoundedInTable threshold)
+    (hNoPoly : NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec threshold))
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser threshold (treeCircuitWitnessCodec threshold))) :
+    AlgorithmsToLowerBounds.VerifiedNPDAGLowerBoundSource :=
+  verifiedSource_of_treeCodec_noPolynomialBoundedSearchSolver
+    threshold hThresholdPoly hNoPoly hNPWit
+
+/-- Block 12f surface (headline): the concrete-codec conditional `NP ⊄ PpolyDAG`
+separation. -/
+theorem check_NP_not_subset_PpolyDAG_of_treeCodec_interfaces
+    (threshold : Nat → Nat)
+    (hThresholdPoly : PolyBoundedInTable threshold)
+    (hNoPoly : NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec threshold))
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser threshold (treeCircuitWitnessCodec threshold))) :
+    Pnp3.ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_treeCodec_interfaces
+    threshold hThresholdPoly hNoPoly hNPWit
+
+end ConcreteTreeCodecSourceSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -48,6 +48,7 @@ import Pnp4.Frontier.ContractExpansion.CircuitTreeBridge
 import Pnp4.Frontier.ContractExpansion.CircuitEncodingLength
 import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec
+import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -312,6 +313,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.treeCircuitWitnessCodec
 #print axioms Pnp4.Frontier.ContractExpansion.polyBoundedInTable_treeWitnessBits_of_thresholdPoly
 #print axioms Pnp4.Frontier.ContractExpansion.treePolynomialWitnessCodec
+
+#print axioms Pnp4.Frontier.ContractExpansion.verifiedSource_of_treeCodec_noPolynomialBoundedSearchSolver
+#print axioms Pnp4.Frontier.ContractExpansion.NP_not_subset_PpolyDAG_of_treeCodec_interfaces
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 12f of the downstream extraction effort — instantiating the capstone (`ExplicitConditionalSource.lean`, #1515) at the **concrete** tree-circuit codec `treeCircuitWitnessCodec` (#1522). New file `ConcreteTreeCodecSource.lean`.

The capstone takes three explicit interfaces (a `PolynomialWitnessCodec`, the open polynomial lower bound, an NP TM-witness) → `VerifiedNPDAGLowerBoundSource`. With the concrete codec now in hand, the `PolynomialWitnessCodec` input is supplied by `treePolynomialWitnessCodec` under the single growth premise `PolyBoundedInTable threshold` — so the codec/growth leg is the **concrete** `treeCircuitWitnessCodec threshold`, not an abstract `codec`.

## Contents

- **`verifiedSource_of_treeCodec_noPolynomialBoundedSearchSolver`** — `PolyBoundedInTable threshold` + `NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec threshold)` + `PrefixExtensionNPWitness (treeMCSPConcretePrefixParser threshold (treeCircuitWitnessCodec threshold))` → `VerifiedNPDAGLowerBoundSource`.
- **`NP_not_subset_PpolyDAG_of_treeCodec_interfaces`** — the same three concrete-codec inputs yield the conditional `NP ⊄ PpolyDAG` separation.

After this brick, the three remaining open inputs, **for the concrete codec**, are:
1. `PolyBoundedInTable threshold` — arithmetic growth hypothesis on the chosen threshold;
2. `NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec threshold)` — the genuine weak lower bound (research-level);
3. `PrefixExtensionNPWitness (…)` — a concrete NP verifier TM with runtime/correctness.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surface re-exports + axioms-audit entries; the new declarations depend only on `[propext, Classical.choice, Quot.sound]`.

## Scope discipline

Concrete-codec instantiation of the conditional source only. All three inputs are **explicit hypotheses — none proved here**. **No** `SearchMCSPMagnificationContract` change, **no** `P ≠ NP` endpoint, **no** unconditional claim.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_