### PR TITLE
Block 13a: concrete polynomial thresholds and their growth

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -303,6 +303,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree,
     Glob.one `Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec,
     Glob.one `Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource,
+    Glob.one `Pnp4.Frontier.ContractExpansion.ThresholdGrowth,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/ThresholdGrowth.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/ThresholdGrowth.lean
@@ -1,0 +1,60 @@
+import Pnp4.Frontier.ContractExpansion.WitnessGrowthReduction
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+/-!
+# Concrete polynomial thresholds and their growth
+
+Block 13a of the downstream extraction effort.
+
+After the concrete codec (#1522) and its conditional source instantiation (#1523),
+the codec/growth leg reduces to the single arithmetic premise
+`PolyBoundedInTable threshold` for the chosen `threshold : Nat → Nat`.  This file
+discharges that premise for the canonical polynomial thresholds, so that — for these
+thresholds — the growth input is **closed** (no longer a hypothesis).
+
+`PolyBoundedInTable f` means `∃ k, ∀ n, f n ≤ (tableLen n + 1) ^ k`; since
+`n ≤ tableLen n` (as `n < 2 ^ n`), the identity and every fixed polynomial are
+polynomially bounded in the truth-table length.
+
+Scope discipline — threshold growth lemmas only:
+
+* **no** source wrapper / `VerifiedNPDAGLowerBoundSource` packaging is added here;
+* **no** `NoPolynomialBoundedSearchSolver` / lower-bound proof, **no** NP-verifier
+  construction, **no** `SearchMCSPMagnificationContract` change, **no** endpoint.
+-/
+
+/-- Linear threshold `n`. -/
+def thresholdLinear (n : Nat) : Nat := n
+
+/-- Quadratic threshold `n²`. -/
+def thresholdQuadratic (n : Nat) : Nat := n ^ 2
+
+/-- General polynomial threshold `nᵏ + k`. -/
+def thresholdPoly (k n : Nat) : Nat := n ^ k + k
+
+/-- The identity is polynomially bounded in the truth-table length: `n ≤ tableLen n`. -/
+theorem polyBoundedInTable_id : PolyBoundedInTable (fun n => n) :=
+  PolyBoundedInTable.of_le (fun _ => Nat.le_of_lt Nat.lt_two_pow_self) polyBoundedInTable_tableLen
+
+/-- The linear threshold is polynomially bounded in the truth-table length. -/
+theorem polyBoundedInTable_thresholdLinear : PolyBoundedInTable thresholdLinear :=
+  polyBoundedInTable_id
+
+/-- The quadratic threshold is polynomially bounded in the truth-table length. -/
+theorem polyBoundedInTable_thresholdQuadratic : PolyBoundedInTable thresholdQuadratic := by
+  show PolyBoundedInTable (fun n => n ^ 2)
+  exact polyBoundedInTable_id.pow 2
+
+/-- Every fixed polynomial threshold `nᵏ + k` is polynomially bounded in the
+truth-table length. -/
+theorem polyBoundedInTable_thresholdPoly (k : Nat) :
+    PolyBoundedInTable (thresholdPoly k) := by
+  show PolyBoundedInTable (fun n => n ^ k + k)
+  exact (polyBoundedInTable_id.pow k).add (PolyBoundedInTable.const k)
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -59,6 +59,7 @@ import Pnp4.Frontier.ContractExpansion.CircuitEncodingLength
 import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource
+import Pnp4.Frontier.ContractExpansion.ThresholdGrowth
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -1061,6 +1062,24 @@ theorem check_NP_not_subset_PpolyDAG_of_treeCodec_interfaces
     threshold hThresholdPoly hNoPoly hNPWit
 
 end ConcreteTreeCodecSourceSurface
+
+section ThresholdGrowthSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 13a surface: the quadratic threshold is polynomially bounded in the
+truth-table length. -/
+theorem check_polyBoundedInTable_thresholdQuadratic :
+    PolyBoundedInTable thresholdQuadratic :=
+  polyBoundedInTable_thresholdQuadratic
+
+/-- Block 13a surface (headline): every fixed polynomial threshold `nᵏ + k` is
+polynomially bounded in the truth-table length. -/
+theorem check_polyBoundedInTable_thresholdPoly (k : Nat) :
+    PolyBoundedInTable (thresholdPoly k) :=
+  polyBoundedInTable_thresholdPoly k
+
+end ThresholdGrowthSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -49,6 +49,7 @@ import Pnp4.Frontier.ContractExpansion.CircuitEncodingLength
 import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource
+import Pnp4.Frontier.ContractExpansion.ThresholdGrowth
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -316,6 +317,10 @@ end Pnp4
 
 #print axioms Pnp4.Frontier.ContractExpansion.verifiedSource_of_treeCodec_noPolynomialBoundedSearchSolver
 #print axioms Pnp4.Frontier.ContractExpansion.NP_not_subset_PpolyDAG_of_treeCodec_interfaces
+
+#print axioms Pnp4.Frontier.ContractExpansion.polyBoundedInTable_thresholdLinear
+#print axioms Pnp4.Frontier.ContractExpansion.polyBoundedInTable_thresholdQuadratic
+#print axioms Pnp4.Frontier.ContractExpansion.polyBoundedInTable_thresholdPoly
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Block 13a of the downstream extraction effort. After the concrete codec (#1522) and its conditional source instantiation (#1523), the codec/growth leg reduces to the single arithmetic premise `PolyBoundedInTable threshold`. This **discharges that premise for the canonical polynomial thresholds**, so for these the growth input is *closed* (no longer a hypothesis). New file `ThresholdGrowth.lean`.

## Contents

- `thresholdLinear n := n`, `thresholdQuadratic n := n^2`, `thresholdPoly k n := n^k + k`.
- **`polyBoundedInTable_id`** — the identity is `PolyBoundedInTable` (`n ≤ tableLen n`, since `n < 2^n`).
- **`polyBoundedInTable_thresholdLinear` / `_thresholdQuadratic` / `_thresholdPoly`** — each canonical threshold is `PolyBoundedInTable`, via the `PolyBoundedInTable` `.pow` / `.add` / `.const` closure API.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green.
- New surface re-exports + axioms-audit entries; the new lemmas depend only on `[propext]` (/ `[propext, Quot.sound]`) — **`Classical`-free**.

## Scope discipline

Threshold growth lemmas only. **No** source wrapper / `VerifiedNPDAGLowerBoundSource` packaging, **no** `NoPolynomialBoundedSearchSolver` / lower-bound proof, **no** NP-verifier construction, **no** `SearchMCSPMagnificationContract` change, **no** endpoint.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_