### PR TITLE
Block 13b: consolidated conditional separation at a concrete polynomial threshold (+ honest docs)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -551,14 +551,27 @@ language it extracts a bounded search solver, and contrapositively
 NP-membership witness it assembles a `VerifiedNPDAGLowerBoundSource`.
 
 This is **not** unconditional progress: it proves neither `P ≠ NP` nor
-`NP_not_subset_PpolyDAG`.  It only exposes the remaining mathematics as three
-explicit, open inputs — (1) a genuine weak lower bound
-`NoPolynomialBoundedSearchSolver`, (2) a concrete NP verifier witness
-`PrefixExtensionNPWitness`, (3) a concrete witness codec (reduced, after the
-`Circuit ↔ CircuitTree` bridge and encoding-length bound, to final assembly).
-Input (1) is the same research-level lower-bound gap described above.  See
-`pnp4/Pnp4/Frontier/ContractExpansion/README.md` for the full module map and the
-proved-vs-open breakdown.
+`NP_not_subset_PpolyDAG`.  The codec/growth machinery is now concrete: the **first
+concrete `TreeCircuitWitnessCodec`** is constructed (`ConcreteTreeCodec.lean`), and
+`PolyBoundedInTable` is proved for the canonical polynomial thresholds
+(`ThresholdGrowth.lean`).  So at a concrete polynomial threshold the consolidated
+theorem (`ConsolidatedTreeSeparation.lean`,
+`verifiedSource_treePoly` / `NP_not_subset_PpolyDAG_treePoly`) reduces the whole chain
+to **exactly two** explicit open inputs:
+
+1. `NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec (thresholdPoly k))` — a
+   genuine `P/poly` circuit lower bound for the concrete tree-MCSP search problem
+   (the same research-level lower-bound gap described above);
+2. `PrefixExtensionNPWitness (…)` — a concrete NP verifier (TM + runtime + certificate
+   correctness).
+
+**Honest caveat.**  The decision→search extraction is an *equivalence*
+(`PpolyDAG(prefix-extension language) ⟺ polynomial-size search solver`); since the
+instance length is `2^n`, input (1) is the **full-strength** `P/poly` lower bound,
+**not** a weak/local bound amplified by hardness magnification.  No magnification
+theorem is formalized — the chain makes the target precise and verified-conditional,
+not easier.  See `pnp4/Pnp4/Frontier/ContractExpansion/README.md` for the full module
+map and proved-vs-open breakdown.
 
 ## Repository-Wide Honesty Policy
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -304,6 +304,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec,
     Glob.one `Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource,
     Glob.one `Pnp4.Frontier.ContractExpansion.ThresholdGrowth,
+    Glob.one `Pnp4.Frontier.ContractExpansion.ConsolidatedTreeSeparation,
     Glob.one `Pnp4.Tests.AlgorithmsToLowerBoundsSurfaceTests,
     Glob.one `Pnp4.Tests.AxiomsAudit
   ]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/ConsolidatedTreeSeparation.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/ConsolidatedTreeSeparation.lean
@@ -1,0 +1,84 @@
+import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource
+import Pnp4.Frontier.ContractExpansion.ThresholdGrowth
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open AlgorithmsToLowerBounds
+
+/-!
+# Consolidated conditional separation at a concrete polynomial threshold
+
+Block 13b — the consolidation milestone for the downstream decision→search
+extraction.
+
+At a **concrete polynomial threshold** `thresholdPoly k` the growth premise is
+already discharged (`polyBoundedInTable_thresholdPoly`, Block 13a), so the whole
+verified chain — concrete codec (#1522), conditional source (#1523), growth
+reduction, decision→search extraction — collapses to depend on **exactly two**
+explicit hypotheses:
+
+* `NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec (thresholdPoly k))` — a
+  genuine `P/poly` circuit lower bound for the concrete tree-MCSP search problem;
+* `PrefixExtensionNPWitness (treeMCSPConcretePrefixParser (thresholdPoly k) …)` — a
+  concrete NP verifier (TM + runtime + certificate correctness).
+
+This file states that collapsed form once and for all.
+
+## Honest status — what this is, and is **not**
+
+* It **is** a complete, machine-checked, vacuity-free *conditional* chain: the two
+  hypotheses above (for some polynomial degree `k`) yield a
+  `VerifiedNPDAGLowerBoundSource`, hence `NP ⊄ PpolyDAG`, hence (via the existing
+  pnp3 bridge) `P ≠ NP`.  All links are theorems with complete proofs (no proof
+  holes) and only the standard axioms.
+* It is **not** unconditional progress, and it is **not** a hardness-*magnification*
+  result.  The decision→search extraction proves the *equivalence*
+  `PpolyDAG(prefix-extension language) ⟺ polynomial-size search solver`, so
+  `NoPolynomialBoundedSearchSolver` is the **full-strength** lower bound — "this
+  concrete NP language is not in `P/poly`" — *not* a weak/local bound amplified by a
+  magnification theorem.  The chain makes the target **precise, concrete, and
+  verified-conditional**; it does **not** make the open mathematics easier.
+
+The two remaining hypotheses are exactly the genuine frontier: a circuit lower bound
+(open research) and an NP-verifier construction (engineering/verification).
+
+Scope discipline — consolidation only:
+
+* the two inputs are **explicit hypotheses** — **neither** proved here;
+* **no** `SearchMCSPMagnificationContract` change, **no** `P ≠ NP` endpoint wrapper,
+  **no** unconditional claim.
+-/
+
+/--
+**Consolidated verified source at a concrete polynomial threshold.**  For
+`thresholdPoly k` the growth premise is discharged, so the verified
+DAG-lower-bound source depends on only the two genuinely-open inputs.
+-/
+noncomputable def verifiedSource_treePoly
+    (k : Nat)
+    (hNoPoly : NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec (thresholdPoly k)))
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser (thresholdPoly k) (treeCircuitWitnessCodec (thresholdPoly k)))) :
+    VerifiedNPDAGLowerBoundSource :=
+  verifiedSource_of_treeCodec_noPolynomialBoundedSearchSolver
+    (thresholdPoly k) (polyBoundedInTable_thresholdPoly k) hNoPoly hNPWit
+
+/--
+**Consolidated conditional separation.**  The same two inputs (at any polynomial
+threshold degree `k`) yield the conditional `NP ⊄ PpolyDAG`.  Still strictly
+conditional; **not** the `P ≠ NP` endpoint.
+-/
+theorem NP_not_subset_PpolyDAG_treePoly
+    (k : Nat)
+    (hNoPoly : NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec (thresholdPoly k)))
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser (thresholdPoly k) (treeCircuitWitnessCodec (thresholdPoly k)))) :
+    Pnp3.ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_of_treeCodec_interfaces
+    (thresholdPoly k) (polyBoundedInTable_thresholdPoly k) hNoPoly hNPWit
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/README.md
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/README.md
@@ -150,18 +150,39 @@ NP ⊄ PpolyDAG     (and thence  P ≠ NP)        — both kept strictly conditi
 - the assembly of `VerifiedNPDAGLowerBoundSource` (hence conditional `NP ⊄ PpolyDAG`)
   from three explicit interfaces;
 - the growth reduction (two growth premises → one);
-- the concrete-codec packing reduction, the `Circuit ↔ CircuitTree` bridge with
-  round-trip, and the encoding-length upper bound.
+- the concrete-codec packing reduction, the `Circuit ↔ CircuitTree` bridge with an
+  **all-`n`** round-trip, and matching encoding-length upper and lower bounds;
+- the **first concrete `TreeCircuitWitnessCodec`** (`treeCircuitWitnessCodec`,
+  `ConcreteTreeCodec.lean`) — closing the "no concrete codec" gap — and its
+  instantiation of the conditional source (`ConcreteTreeCodecSource.lean`);
+- `PolyBoundedInTable` for the canonical polynomial thresholds
+  (`thresholdLinear/Quadratic/Poly`, `ThresholdGrowth.lean`), which **discharges**
+  the growth leg for those thresholds;
+- the **consolidated** conditional separation at a concrete polynomial threshold
+  (`verifiedSource_treePoly` / `NP_not_subset_PpolyDAG_treePoly`,
+  `ConsolidatedTreeSeparation.lean`): at `thresholdPoly k` only the two genuinely-hard
+  inputs below remain as hypotheses.
 
-**Open — the three explicit remaining inputs:**
-1. **`NoPolynomialBoundedSearchSolver codec`** — the genuine weak lower bound. This
-   is the hard, research-level mathematics; it is *not* a Lean engineering task.
-2. **`PrefixExtensionNPWitness parser`** — a concrete verifier Turing machine with a
-   polynomial runtime bound and certificate correctness (the NP / runtime track).
-3. **Concrete codec final assembly** — after Blocks 12a–12c the codec gap is reduced
-   to *final assembly*: choose a width / `witnessBits` schedule, eliminate the
-   decoder's depth budget, build a `SelfDelimitingCircuitCode`, apply
-   `.toCodec`, and supply `PolyBoundedInTable codec.witnessBits`.
+**Open — for a concrete polynomial threshold, exactly two inputs:**
+1. **`NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec (thresholdPoly k))`** —
+   a genuine `P/poly` circuit lower bound for the concrete tree-MCSP search problem.
+   The hard, research-level mathematics; **not** a Lean engineering task.
+2. **`PrefixExtensionNPWitness (treeMCSPConcretePrefixParser …)`** — a concrete
+   verifier Turing machine with a polynomial runtime bound and certificate
+   correctness (the NP / runtime track; engineering-heavy but in-principle closable).
+
+(For an *arbitrary* threshold there is a third input, `PolyBoundedInTable threshold`;
+it is proved for the canonical polynomial thresholds, so it disappears there.)
+
+### Honest caveat — this is a reduction, not a magnification win
+
+The decision→search extraction proves the **equivalence**
+`PpolyDAG(prefix-extension language) ⟺ polynomial-size search solver`.  Because the
+instance length is `tableLen n = 2^n`, the no-solver input is the **full-strength**
+lower bound — "this concrete NP language is not in `P/poly`" — **not** a weak/local
+bound amplified by a hardness-*magnification* theorem.  The chain makes the target
+precise, concrete, and verified-conditional; it does **not** make the open
+mathematics easier, and **no** magnification theorem is formalized here.
 
 This directory adds **no** unconditional claim, does **not** modify
 `SearchMCSPMagnificationContract`, and adds **no** `P ≠ NP` endpoint wrapper.

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -60,6 +60,7 @@ import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource
 import Pnp4.Frontier.ContractExpansion.ThresholdGrowth
+import Pnp4.Frontier.ContractExpansion.ConsolidatedTreeSeparation
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -1080,6 +1081,32 @@ theorem check_polyBoundedInTable_thresholdPoly (k : Nat) :
   polyBoundedInTable_thresholdPoly k
 
 end ThresholdGrowthSurface
+
+section ConsolidatedTreeSeparationSurface
+
+open Pnp4.Frontier.ContractExpansion
+
+/-- Block 13b surface: at a concrete polynomial threshold, the verified source rests
+on only the two genuinely-hard inputs (lower bound + NP witness). -/
+noncomputable def check_verifiedSource_treePoly
+    (k : Nat)
+    (hNoPoly : NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec (thresholdPoly k)))
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser (thresholdPoly k) (treeCircuitWitnessCodec (thresholdPoly k)))) :
+    AlgorithmsToLowerBounds.VerifiedNPDAGLowerBoundSource :=
+  verifiedSource_treePoly k hNoPoly hNPWit
+
+/-- Block 13b surface (headline): the consolidated conditional `NP ⊄ PpolyDAG` at a
+concrete polynomial threshold. -/
+theorem check_NP_not_subset_PpolyDAG_treePoly
+    (k : Nat)
+    (hNoPoly : NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec (thresholdPoly k)))
+    (hNPWit : PrefixExtensionNPWitness
+        (treeMCSPConcretePrefixParser (thresholdPoly k) (treeCircuitWitnessCodec (thresholdPoly k)))) :
+    Pnp3.ComplexityInterfaces.NP_not_subset_PpolyDAG :=
+  NP_not_subset_PpolyDAG_treePoly k hNoPoly hNPWit
+
+end ConsolidatedTreeSeparationSurface
 
 section TreeMCSPZeroPrefixBuilderSurface
 

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -50,6 +50,7 @@ import Pnp4.Frontier.ContractExpansion.CircuitDecodeDepthFree
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodec
 import Pnp4.Frontier.ContractExpansion.ConcreteTreeCodecSource
 import Pnp4.Frontier.ContractExpansion.ThresholdGrowth
+import Pnp4.Frontier.ContractExpansion.ConsolidatedTreeSeparation
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZeroPrefixBuilder
 import Pnp4.Frontier.ContractExpansion.NaiveGreedySizeSpike
 
@@ -321,6 +322,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.polyBoundedInTable_thresholdLinear
 #print axioms Pnp4.Frontier.ContractExpansion.polyBoundedInTable_thresholdQuadratic
 #print axioms Pnp4.Frontier.ContractExpansion.polyBoundedInTable_thresholdPoly
+
+#print axioms Pnp4.Frontier.ContractExpansion.verifiedSource_treePoly
+#print axioms Pnp4.Frontier.ContractExpansion.NP_not_subset_PpolyDAG_treePoly
 
 #print axioms Pnp4.Frontier.ContractExpansion.zeroPrefixQueryCircuitBuilder
 #print axioms Pnp4.Frontier.ContractExpansion.treeMCSPZeroPrefixQueryBuilder


### PR DESCRIPTION
## Summary

Consolidation milestone for the downstream decision→search extraction (the "Consolidate + document" step). At a **concrete polynomial threshold** `thresholdPoly k` the growth premise is already discharged (`polyBoundedInTable_thresholdPoly`, #1524), so the whole verified chain collapses to depend on **exactly two** explicit hypotheses. New file `ConsolidatedTreeSeparation.lean`, plus honest README/STATUS updates.

## Contents (code)

- **`verifiedSource_treePoly k hNoPoly hNPWit : VerifiedNPDAGLowerBoundSource`**
- **`NP_not_subset_PpolyDAG_treePoly k hNoPoly hNPWit : NP_not_subset_PpolyDAG`**

where the **only** inputs are the two genuinely-hard legs:
- `hNoPoly : NoPolynomialBoundedSearchSolver (treeCircuitWitnessCodec (thresholdPoly k))`
- `hNPWit : PrefixExtensionNPWitness (treeMCSPConcretePrefixParser (thresholdPoly k) …)`

## Contents (docs — honest)

- `ContractExpansion/README.md`: refreshed proved-vs-open (concrete codec done, growth discharged for poly thresholds, the consolidated theorem) **and** added the explicit caveat below.
- `STATUS.md`: the same honest refinement of the extraction-chain paragraph.

**The caveat, stated plainly in both docs:** the decision→search extraction is an *equivalence* (`PpolyDAG(prefix-extension language) ⟺ polynomial-size search solver`); since the instance length is `2^n`, `NoPolynomialBoundedSearchSolver` is the **full-strength** `P/poly` lower bound — **not** a weak/local bound amplified by a hardness-*magnification* theorem. No magnification is formalized; the chain makes the target precise, concrete, and verified-conditional, **not** easier.

## Verification

- `lake build PnP3 Pnp4`, `lake test`, `./scripts/check.sh` — all green (including the doc-honesty linter and the proof-hole scan).
- New surface re-exports + axioms-audit entries; the two new declarations depend only on `[propext, Classical.choice, Quot.sound]`.

## Scope discipline

Consolidation only. The two inputs are explicit hypotheses, **neither proved here**. **No** `SearchMCSPMagnificationContract` change, **no** `P ≠ NP` endpoint wrapper, **no** unconditional claim.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_