### PR TITLE
Decoder D1a — tape-level unary-field reader + spec bridge

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -318,6 +318,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftOneProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCountdownLeft,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPRepeatBody,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBidirHeadBounds,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPUnaryFieldReader.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPUnaryFieldReader.lean
@@ -1,0 +1,136 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
+
+/-!
+# Tape-level unary-field reader (NP-verifier track — decoder brick D1a)
+
+The atomic step of the on-tape gate decoder/interpreter (`TM_VERIFIER_STRATEGY.md` §6k): reading one
+**unary field** `1^len 0` off the tape.  Every field of a gate record (the tag, the input index, each
+back-reference distance) is a unary field, so this one primitive is reused throughout.
+
+The *motion* is `selfLoopScanRightOne` (scan right over `1`s, stop on the `0` terminator); this file
+adds the **reader-framed** correctness — it advances exactly `len` cells over a `1^len 0` field — and
+the **bridge to the D0 spec**: the bits it scans, read off the tape as a `List Bool` (`tapeReadList`),
+are exactly `unaryField len`, and `decodeUnaryField` recovers `len`.  So the tape primitive realises the
+pure spec proved in `TreeMCSPGateRecordLayout`.
+
+Scope (D1a): the unary-field reader only.  *Not* here: the one-gate-record decoder (D1b), the
+witness→record-stream decoder (D2), the interpreter, the row loop, or any assembly.
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-! ### Reading the tape contents as a `List Bool` -/
+
+/-- `tapeReadList c h len` is the list of the `len` tape cells starting at offset `h` (out-of-range
+cells read as the blank `false`).  The pure-list view of a tape segment, used to bridge tape behaviour
+to the `List Bool` spec in `TreeMCSPGateRecordLayout`. -/
+def tapeReadList {M : TM} {L : Nat} (c : Configuration (M := M) L) : Nat → Nat → List Bool
+  | _, 0 => []
+  | h, (len + 1) =>
+      (if hp : h < M.tapeLength L then c.tape ⟨h, hp⟩ else false) :: tapeReadList c (h + 1) len
+
+/-- One-step unfolding of `tapeReadList` (the cons case), for controlled rewriting (avoids the
+recursive over-unfolding `simp [tapeReadList]` would do). -/
+theorem tapeReadList_succ {M : TM} {L : Nat} (c : Configuration (M := M) L) (h len : Nat) :
+    tapeReadList c h (len + 1)
+      = (if hp : h < M.tapeLength L then c.tape ⟨h, hp⟩ else false) :: tapeReadList c (h + 1) len :=
+  rfl
+
+/-- **Bridge to the spec**: a tape segment that holds a `1^len 0` field (the `len` cells from `h` are
+`true`, cell `h + len` is `false`) reads off as exactly `unaryField len`. -/
+theorem tapeReadList_eq_unaryField {M : TM} {L : Nat} (c : Configuration (M := M) L)
+    (h len : Nat) (hb : h + len < M.tapeLength L)
+    (hones : ∀ p : Fin (M.tapeLength L), h ≤ (p : Nat) → (p : Nat) < h + len → c.tape p = true)
+    (hterm : ∀ p : Fin (M.tapeLength L), (p : Nat) = h + len → c.tape p = false) :
+    tapeReadList c h (len + 1) = unaryField len := by
+  induction len generalizing h with
+  | zero =>
+      have hpb : h < M.tapeLength L := by omega
+      have hv : (⟨h, hpb⟩ : Fin (M.tapeLength L)).val = h := rfl
+      have hbit : c.tape ⟨h, hpb⟩ = false := hterm ⟨h, hpb⟩ (by omega)
+      rw [tapeReadList_succ, dif_pos hpb, hbit]
+      simp [tapeReadList, unaryField]
+  | succ len ih =>
+      have hpb : h < M.tapeLength L := by omega
+      have hv : (⟨h, hpb⟩ : Fin (M.tapeLength L)).val = h := rfl
+      have hbit : c.tape ⟨h, hpb⟩ = true := hones ⟨h, hpb⟩ (by omega) (by omega)
+      have hih : tapeReadList c (h + 1) (len + 1) = unaryField len :=
+        ih (h + 1) (by omega)
+          (fun p hp1 hp2 => hones p (by omega) (by omega))
+          (fun p hpe => hterm p (by omega))
+      rw [tapeReadList_succ, dif_pos hpb, hbit, hih]
+      simp [unaryField, List.replicate_succ]
+
+/-! ### Reader correctness (standalone) -/
+
+/-- Reading a `1^len 0` unary field at the head: after `len + 1` steps the machine has scanned the `len`
+ones and stopped on the `0` terminator (done phase `1`), with the head advanced exactly `len` cells and
+the tape unchanged.  The reader-framed specialisation of `selfLoopScanRightOne_runConfig_terminator`
+(terminator at `head + len`). -/
+theorem selfLoopScanRightOne_readsUnaryField {L : Nat}
+    (c0 : Configuration (M := selfLoopScanRightOne.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (len : Nat)
+    (hb : (c0.head : Nat) + len < selfLoopScanRightOne.toPhased.toTM.tapeLength L)
+    (hones : ∀ p : Fin (selfLoopScanRightOne.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + len → c0.tape p = true)
+    (hterm : ∀ p : Fin (selfLoopScanRightOne.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + len → c0.tape p = false) :
+    (((TM.runConfig (M := selfLoopScanRightOne.toPhased.toTM) c0 (len + 1)).state).fst : Nat) = 1
+      ∧ ((TM.runConfig (M := selfLoopScanRightOne.toPhased.toTM) c0 (len + 1)).head : Nat)
+          = (c0.head : Nat) + len
+      ∧ (TM.runConfig (M := selfLoopScanRightOne.toPhased.toTM) c0 (len + 1)).tape = c0.tape := by
+  have h := selfLoopScanRightOne_runConfig_terminator c0 hphase ((c0.head : Nat) + len)
+    (Nat.le_add_right _ _) hb hones hterm
+  have he : (c0.head : Nat) + len - (c0.head : Nat) = len := by omega
+  rw [he] at h
+  exact h
+
+/-- **Spec bridge for the reader**: the bits the reader scans (the `len + 1` cells from the head, read
+off as a `List Bool`) decode, via the D0 spec `decodeUnaryField`, to exactly `len` — tying the tape
+primitive's behaviour to the pure codec. -/
+theorem decodeUnaryField_tapeReadList_of_reads {L : Nat}
+    (c0 : Configuration (M := selfLoopScanRightOne.toPhased.toTM) L)
+    (len : Nat)
+    (hb : (c0.head : Nat) + len < selfLoopScanRightOne.toPhased.toTM.tapeLength L)
+    (hones : ∀ p : Fin (selfLoopScanRightOne.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + len → c0.tape p = true)
+    (hterm : ∀ p : Fin (selfLoopScanRightOne.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + len → c0.tape p = false) :
+    decodeUnaryField (tapeReadList c0 (c0.head : Nat) (len + 1)) = some (len, []) := by
+  rw [tapeReadList_eq_unaryField c0 (c0.head : Nat) len hb hones hterm]
+  simpa using decodeUnaryField_unaryField len []
+
+/-! ### Reader correctness as a non-first (P2-region) phase -/
+
+/-- The reader as a non-first phase of a `seq` (composition phase `P1.numPhases`): reads a `1^len 0`
+field, advancing the head `len` cells and stopping at the shifted done phase `P1.numPhases + 1`.  The
+reader-framed specialisation of `selfLoopScanRightOne_seqP2_runConfig_terminator`. -/
+theorem selfLoopScanRightOne_readsUnaryField_seqP2 (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c0 : Configuration (M := (seq P1 selfLoopScanRightOne).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases) (len : Nat)
+    (hb : (c0.head : Nat) + len < (seq P1 selfLoopScanRightOne).toPhased.toTM.tapeLength L)
+    (hones : ∀ p : Fin ((seq P1 selfLoopScanRightOne).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + len → c0.tape p = true)
+    (hterm : ∀ p : Fin ((seq P1 selfLoopScanRightOne).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + len → c0.tape p = false) :
+    (((TM.runConfig (M := (seq P1 selfLoopScanRightOne).toPhased.toTM) c0 (len + 1)).state).fst : Nat)
+        = P1.numPhases + 1
+      ∧ ((TM.runConfig (M := (seq P1 selfLoopScanRightOne).toPhased.toTM) c0 (len + 1)).head : Nat)
+          = (c0.head : Nat) + len
+      ∧ (TM.runConfig (M := (seq P1 selfLoopScanRightOne).toPhased.toTM) c0 (len + 1)).tape
+          = c0.tape := by
+  have h := selfLoopScanRightOne_seqP2_runConfig_terminator P1 c0 hphase ((c0.head : Nat) + len)
+    (Nat.le_add_right _ _) hb hones hterm
+  have he : (c0.head : Nat) + len - (c0.head : Nat) = len := by omega
+  rw [he] at h
+  exact h
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -74,6 +74,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
+import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCountdownLeft
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGammaFillProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGammaFillComposition
@@ -3774,6 +3775,12 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.decodeGateRecord
 #check @Pnp4.Frontier.ContractExpansion.decodeGateRecord_encodeGateRecord
 #check @Pnp4.Frontier.ContractExpansion.encodeGateRecord_length
+-- Tape-level unary-field reader (decoder brick D1a, §6k): reads 1^len 0 and bridges to the D0 spec.
+#check @Pnp4.Frontier.ContractExpansion.tapeReadList
+#check @Pnp4.Frontier.ContractExpansion.tapeReadList_eq_unaryField
+#check @Pnp4.Frontier.ContractExpansion.selfLoopScanRightOne_readsUnaryField
+#check @Pnp4.Frontier.ContractExpansion.decodeUnaryField_tapeReadList_of_reads
+#check @Pnp4.Frontier.ContractExpansion.selfLoopScanRightOne_readsUnaryField_seqP2
 -- Unary countdown self-loop (marker-free counter; §6c brick toward the row loop).
 #check @Pnp4.Frontier.ContractExpansion.selfLoopCountdownLeft
 #check @Pnp4.Frontier.ContractExpansion.selfLoopCountdownLeft_runConfig_consume

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -64,6 +64,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
+import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCountdownLeft
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGammaFillProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGammaFillComposition
@@ -539,6 +540,11 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.decodeUnaryField_unaryField
 #print axioms Pnp4.Frontier.ContractExpansion.decodeGateRecord_encodeGateRecord
 #print axioms Pnp4.Frontier.ContractExpansion.encodeGateRecord_length
+-- Tape-level unary-field reader (D1a): tape↔spec bridge + reader correctness.
+#print axioms Pnp4.Frontier.ContractExpansion.tapeReadList_eq_unaryField
+#print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanRightOne_readsUnaryField
+#print axioms Pnp4.Frontier.ContractExpansion.decodeUnaryField_tapeReadList_of_reads
+#print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanRightOne_readsUnaryField_seqP2
 #print axioms Pnp4.Frontier.ContractExpansion.runConfig_head_val_ge
 #print axioms Pnp4.Frontier.ContractExpansion.runConfig_head_dist_le
 #print axioms Pnp4.Frontier.ContractExpansion.gammaSelfLoopScan_locates_gamma_terminator


### PR DESCRIPTION
## Scope

The next small decoder brick (**D1a**) per the §6k roadmap — the **atomic step** of the on-tape gate decoder: reading one **unary field `1^len 0`** off the tape. Every gate-record field (tag, input index, back-reference distance) is a unary field, so this one primitive is reused throughout the interpreter. Stacked on `claude/elegant-noether-CnlU5` (which now contains D0).

### What it adds (`TreeMCSPUnaryFieldReader.lean`)

- **`selfLoopScanRightOne_readsUnaryField`** — reader-framed correctness: a `1^len 0` field at the head is consumed in `len + 1` steps, head advanced exactly `len`, stopping on the `0` (a specialisation of `selfLoopScanRightOne_runConfig_terminator` with terminator at `head + len`).
- **`tapeReadList` + `tapeReadList_eq_unaryField`** — the **bridge to the D0 spec**: a tape segment holding a `1^len 0` field reads off (as a `List Bool`) as exactly D0's `unaryField len`.
- **`decodeUnaryField_tapeReadList_of_reads`** — ties tape behaviour to the D0 codec: `decodeUnaryField` of the scanned bits `= some (len, [])`.
- **`selfLoopScanRightOne_readsUnaryField_seqP2`** — the same as a non-first `seq` phase (for composing into `M`).

### Verification

- Module + both test files build clean; wired into `lakefile`, surface tests (`#check`), axioms audit (`#print axioms`).
- All lemmas depend only on the standard `[propext, Classical.choice, Quot.sound]` (the spec bridge is `[propext, Quot.sound]`). No `sorry`/`admit`/`native_decide`/custom axiom.

### Explicitly out of scope (not here)

- ❌ One-gate-record decoder (D1b), full witness → record-stream decoder (D2)
- ❌ Gate interpreter (I), row loop (R), prefix compare (P), assembly (A)

No `P ≠ NP` claim; headline stays conditional.

### Brick order

`D0` ✅ → **`D1a` (this)** → `D1b` one-gate-record decoder → `D2` stream decoder → `I1` interpreter → `R1` row loop → `P1` prefix compare → `A1`/`A2` assembly.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_