### PR TITLE
Decoder D1b (1/2) — gate-tag dispatcher

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -319,6 +319,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCountdownLeft,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPRepeatBody,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBidirHeadBounds,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGateTagDispatch.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGateTagDispatch.lean
@@ -1,0 +1,198 @@
+import Complexity.TMVerifier.TuringToolkit.ConstStatePhasedProgram
+import Pnp4.Frontier.ContractExpansion.BoundedLoopProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
+
+/-!
+# Gate-tag dispatcher (NP-verifier track — decoder brick D1b, part 1 of 2)
+
+The control core of the one-gate-record on-tape decoder (`TM_VERIFIER_STRATEGY.md` §6k, D1b): read the
+self-delimiting **unary tag** `1^t 0` (`t ∈ {0..4}` selects `input/const/notGate/andGate/orGate`) off
+the tape and **dispatch** to a per-tag phase — exactly the phase-routing pattern of `tagCheckProgramU`,
+specialised to a unary counter with a malformed-tag (`t ≥ 5`) reject sink.
+
+Because the five tags route to five continuations that read *different numbers* of operand fields, the
+tag value must reach finite control; so (unlike a `selfLoopScanRightOne` field read, which collapses the
+count into head position) the tag is read **cell-by-cell**, one phase per `1`, with the count encoded in
+the phase. The dispatch phase `5 + t` then selects the operand-reading continuation (built in part 2).
+
+Phase layout (`numPhases = 11`): `0..4` read the unary tag (phase `i` = "seen `i` ones"); on a `0` at
+phase `i` dispatch to phase `5 + i` (tag `= i`); a `1` at phase `4` is a sixth-or-later `1` (`t ≥ 5`,
+malformed) routing to the sink phase `10`; phases `5..10` idle. This part proves the dispatcher's run
+behaviour (reads `1^t 0` in `t + 1` steps, lands in phase `5 + t`, head advanced `t + 1`, tape
+unchanged) and its correspondence to D0's `decodeUnaryField` on the tag field. Operand consumption and
+the full `decodeGateRecord` correspondence are part 2.
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+
+/-- Gate-tag dispatcher: reads the unary tag `1^t 0` cell-by-cell, routing to dispatch phase `5 + t`
+(`t ∈ {0..4}`) or the malformed sink `10` (`t ≥ 5`). -/
+def gateTagDispatch : ConstStatePhasedProgram Unit where
+  numPhases := 11
+  startPhase := ⟨0, by omega⟩
+  startState := ()
+  acceptPhase := ⟨5, by omega⟩
+  acceptState := ()
+  transition := fun i _ b =>
+    if h5 : i.val < 5 then
+      if b then
+        ((if i.val < 4 then ⟨i.val + 1, by omega⟩ else ⟨10, by omega⟩ : Fin 11), (), b, Move.right)
+      else
+        ((⟨5 + i.val, by omega⟩ : Fin 11), (), b, Move.right)
+    else
+      (i, (), b, Move.stay)
+  timeBound := fun _ => 5
+
+@[simp] theorem gateTagDispatch_timeBound (n : Nat) : gateTagDispatch.timeBound n = 5 := rfl
+@[simp] theorem gateTagDispatch_numPhases : gateTagDispatch.numPhases = 11 := rfl
+@[simp] theorem gateTagDispatch_startPhase_val : (gateTagDispatch.startPhase : Nat) = 0 := rfl
+
+/-- The dispatcher never moves the head left (it advances right while reading the tag, and idles
+otherwise). -/
+theorem gateTagDispatch_transition_move (i : Fin 11) (s : Unit) (b : Bool) :
+    (gateTagDispatch.transition i s b).2.2.2 ≠ Move.left := by
+  unfold gateTagDispatch
+  dsimp only
+  split_ifs <;> simp
+
+theorem gateTagDispatch_neverMovesLeft : TMNeverMovesLeft (gateTagDispatch.toPhased.toTM) := by
+  intro st b
+  obtain ⟨i, s⟩ := st
+  exact gateTagDispatch_transition_move i s b
+
+/-- Every step writes back the scanned bit, so the tape is unchanged. -/
+theorem gateTagDispatch_transition_bit (i : Fin 11) (s : Unit) (b : Bool) :
+    (gateTagDispatch.transition i s b).2.2.1 = b := by
+  unfold gateTagDispatch
+  dsimp only
+  split_ifs <;> simp
+
+theorem gateTagDispatch_stepConfig_tape {L : Nat}
+    (c : Configuration (M := gateTagDispatch.toPhased.toTM) L)
+    {i : Fin 11} {s : Unit} (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := gateTagDispatch.toPhased.toTM) c).tape = c.tape := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_tape gateTagDispatch c hstate,
+    gateTagDispatch_transition_bit]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-! ### Single-step lemmas -/
+
+/-- Read-`1` step at phase `i < 4`: advance to phase `i + 1`. -/
+theorem gateTagDispatch_stepConfig_one_phase {L : Nat}
+    (c : Configuration (M := gateTagDispatch.toPhased.toTM) L)
+    {i : Fin 11} {s : Unit} (hi : i.val < 4) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := gateTagDispatch.toPhased.toTM) c).state).fst.val = i.val + 1 := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_phase gateTagDispatch c hstate]
+  simp only [gateTagDispatch, dif_pos (show i.val < 5 by omega), hbit, if_true, if_pos hi]
+
+/-- Read-`1` step at phase `i < 4`: advance the head by one. -/
+theorem gateTagDispatch_stepConfig_one_head {L : Nat}
+    (c : Configuration (M := gateTagDispatch.toPhased.toTM) L)
+    {i : Fin 11} {s : Unit} (hi : i.val < 4) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true)
+    (hbound : (c.head : Nat) + 1 < gateTagDispatch.toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := gateTagDispatch.toPhased.toTM) c).head : Nat) = (c.head : Nat) + 1 := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_head gateTagDispatch c hstate]
+  have hmove : (gateTagDispatch.transition i s (c.tape c.head)).2.2.2 = Move.right := by
+    simp only [gateTagDispatch, dif_pos (show i.val < 5 by omega), hbit, if_true, if_pos hi]
+  rw [hmove]
+  simp only [Configuration.moveHead, dif_pos hbound]
+
+/-- Read-`0` (terminator) step at phase `i < 5`: dispatch to phase `5 + i` (tag `= i`). -/
+theorem gateTagDispatch_stepConfig_term_phase {L : Nat}
+    (c : Configuration (M := gateTagDispatch.toPhased.toTM) L)
+    {i : Fin 11} {s : Unit} (hi : i.val < 5) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := gateTagDispatch.toPhased.toTM) c).state).fst.val = 5 + i.val := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_phase gateTagDispatch c hstate]
+  simp [gateTagDispatch, dif_pos hi, hbit]
+
+/-- Read-`0` (terminator) step at phase `i < 5`: advance the head by one (past the terminator). -/
+theorem gateTagDispatch_stepConfig_term_head {L : Nat}
+    (c : Configuration (M := gateTagDispatch.toPhased.toTM) L)
+    {i : Fin 11} {s : Unit} (hi : i.val < 5) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false)
+    (hbound : (c.head : Nat) + 1 < gateTagDispatch.toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := gateTagDispatch.toPhased.toTM) c).head : Nat) = (c.head : Nat) + 1 := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_head gateTagDispatch c hstate]
+  have hmove : (gateTagDispatch.transition i s (c.tape c.head)).2.2.2 = Move.right := by
+    simp [gateTagDispatch, dif_pos hi, hbit]
+  rw [hmove]
+  simp only [Configuration.moveHead, dif_pos hbound]
+
+/-! ### Scanning invariant and dispatch -/
+
+/-- Scanning invariant: from a start `c0` in read phase `0`, if the `j` cells from the head are all `1`
+(`j ≤ 4`, in bounds), then after `j` steps the phase is `j`, the head has advanced to `c0.head + j`, and
+the tape is unchanged. -/
+theorem gateTagDispatch_runConfig_scanning {L : Nat}
+    (c0 : Configuration (M := gateTagDispatch.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) :
+    ∀ j : Nat, j ≤ 4 → (c0.head : Nat) + j < gateTagDispatch.toPhased.toTM.tapeLength L →
+      (∀ p : Fin (gateTagDispatch.toPhased.toTM.tapeLength L),
+        (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + j → c0.tape p = true) →
+      (((TM.runConfig (M := gateTagDispatch.toPhased.toTM) c0 j).state).fst : Nat) = j
+      ∧ ((TM.runConfig (M := gateTagDispatch.toPhased.toTM) c0 j).head : Nat) = (c0.head : Nat) + j
+      ∧ (TM.runConfig (M := gateTagDispatch.toPhased.toTM) c0 j).tape = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _ _; exact ⟨hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj hb h1
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (by omega) (fun p hp1 hp2 => h1 p hp1 (by omega))
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := gateTagDispatch.toPhased.toTM) c0 j with hc
+      have hi4 : (c.state.fst : Nat) < 4 := by rw [hph]; omega
+      have hbit : c.tape c.head = true := by
+        rw [htp]; exact h1 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hbnd : (c.head : Nat) + 1 < gateTagDispatch.toPhased.toTM.tapeLength L := by
+        rw [hhd]; omega
+      refine ⟨?_, ?_, ?_⟩
+      · rw [gateTagDispatch_stepConfig_one_phase c (i := c.state.fst) (s := c.state.snd) hi4 rfl hbit,
+          hph]
+      · rw [gateTagDispatch_stepConfig_one_head c (i := c.state.fst) (s := c.state.snd) hi4 rfl hbit
+          hbnd]
+        omega
+      · rw [gateTagDispatch_stepConfig_tape c (i := c.state.fst) (s := c.state.snd) rfl, htp]
+
+/-- **Dispatch correctness.** From a start `c0` in read phase `0` whose head sits at a unary tag field
+`1^t 0` (`t ≤ 4`: the `t` cells from the head are `1`, cell `c0.head + t` is `0`, all in bounds), after
+`t + 1` steps the dispatcher is in phase `5 + t` (tag identified `= t`), the head has advanced to
+`c0.head + t + 1` (past the terminator, at the first operand cell), and the tape is unchanged. -/
+theorem gateTagDispatch_runConfig_dispatch {L : Nat}
+    (c0 : Configuration (M := gateTagDispatch.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (t : Nat) (ht : t ≤ 4)
+    (hb : (c0.head : Nat) + t + 1 < gateTagDispatch.toPhased.toTM.tapeLength L)
+    (hones : ∀ p : Fin (gateTagDispatch.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + t → c0.tape p = true)
+    (hterm : ∀ p : Fin (gateTagDispatch.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + t → c0.tape p = false) :
+    (((TM.runConfig (M := gateTagDispatch.toPhased.toTM) c0 (t + 1)).state).fst : Nat) = 5 + t
+      ∧ ((TM.runConfig (M := gateTagDispatch.toPhased.toTM) c0 (t + 1)).head : Nat)
+          = (c0.head : Nat) + t + 1
+      ∧ (TM.runConfig (M := gateTagDispatch.toPhased.toTM) c0 (t + 1)).tape = c0.tape := by
+  obtain ⟨hph, hhd, htp⟩ := gateTagDispatch_runConfig_scanning c0 hphase t ht (by omega) hones
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := gateTagDispatch.toPhased.toTM) c0 t with hc
+  have hi5 : (c.state.fst : Nat) < 5 := by rw [hph]; omega
+  have hbit : c.tape c.head = false := by rw [htp]; exact hterm c.head (by rw [hhd])
+  have hbnd : (c.head : Nat) + 1 < gateTagDispatch.toPhased.toTM.tapeLength L := by rw [hhd]; omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [gateTagDispatch_stepConfig_term_phase c (i := c.state.fst) (s := c.state.snd) hi5 rfl hbit,
+      hph]
+  · rw [gateTagDispatch_stepConfig_term_head c (i := c.state.fst) (s := c.state.snd) hi5 rfl hbit
+      hbnd]
+    omega
+  · rw [gateTagDispatch_stepConfig_tape c (i := c.state.fst) (s := c.state.snd) rfl, htp]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGateTagDispatch.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPGateTagDispatch.lean
@@ -19,9 +19,23 @@ Phase layout (`numPhases = 11`): `0..4` read the unary tag (phase `i` = "seen `i
 phase `i` dispatch to phase `5 + i` (tag `= i`); a `1` at phase `4` is a sixth-or-later `1` (`t ≥ 5`,
 malformed) routing to the sink phase `10`; phases `5..10` idle. This part proves the dispatcher's run
 behaviour (reads `1^t 0` in `t + 1` steps, lands in phase `5 + t`, head advanced `t + 1`, tape
-unchanged) and its correspondence to D0's `decodeUnaryField` on the tag field. Operand consumption and
-the full `decodeGateRecord` correspondence are part 2.
--/
+unchanged). Operand consumption and the full `decodeGateRecord` correspondence are part 2.
+
+**Progress classification (AGENTS.md): Infrastructure** — toolkit toward the NP-membership leg of
+`VerifiedNPDAGLowerBoundSource`; it does not itself reduce a source obligation and is **not**
+reportable as `P ≠ NP` mainline progress.
+
+**Composition note (why per-tag exit phases, not `seq`).** Per the repo's all-`Unit`
+state-uniformity discipline (§6a), control is **phase-encoded**, not state-carried (every self-loop
+brick is `ConstStatePhasedProgram Unit`). `ConstStatePhasedProgram.seq` hands off at a *single*
+`acceptPhase` **and resets the state to `startState`**, so it cannot carry a 5-way tag branch — neither
+via phases (one handoff phase) nor via state (reset, and a non-`Unit` tag state would break uniformity
+with the self-loops). The five dispatch phases `5..9` are therefore **internal entrypoints** for the
+per-tag operand sub-sequences of the *monolithic* one-record decoder (D1b part 2), reached by
+phase-routing **within one program**, not by `seq`. Accordingly `acceptPhase` here is a **nominal
+placeholder** (the malformed sink `10`, a non-dispatch phase); the dispatcher's real API is its
+`runConfig` phase-position lemmas below, and the genuine single accept phase is the convergence point of
+the part-2 decoder. -/
 
 namespace Pnp4
 namespace Frontier
@@ -35,7 +49,7 @@ def gateTagDispatch : ConstStatePhasedProgram Unit where
   numPhases := 11
   startPhase := ⟨0, by omega⟩
   startState := ()
-  acceptPhase := ⟨5, by omega⟩
+  acceptPhase := ⟨10, by omega⟩  -- nominal (the malformed sink); see the composition note above
   acceptState := ()
   transition := fun i _ b =>
     if h5 : i.val < 5 then

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -75,6 +75,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCountdownLeft
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGammaFillProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGammaFillComposition
@@ -3781,6 +3782,11 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanRightOne_readsUnaryField
 #check @Pnp4.Frontier.ContractExpansion.decodeUnaryField_tapeReadList_of_reads
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanRightOne_readsUnaryField_seqP2
+-- Gate-tag dispatcher (decoder brick D1b part 1, §6k): read unary tag 1^t 0, dispatch to per-tag phase.
+#check @Pnp4.Frontier.ContractExpansion.gateTagDispatch
+#check @Pnp4.Frontier.ContractExpansion.gateTagDispatch_neverMovesLeft
+#check @Pnp4.Frontier.ContractExpansion.gateTagDispatch_runConfig_scanning
+#check @Pnp4.Frontier.ContractExpansion.gateTagDispatch_runConfig_dispatch
 -- Unary countdown self-loop (marker-free counter; §6c brick toward the row loop).
 #check @Pnp4.Frontier.ContractExpansion.selfLoopCountdownLeft
 #check @Pnp4.Frontier.ContractExpansion.selfLoopCountdownLeft_runConfig_consume

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -65,6 +65,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCountdownLeft
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGammaFillProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGammaFillComposition
@@ -545,6 +546,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanRightOne_readsUnaryField
 #print axioms Pnp4.Frontier.ContractExpansion.decodeUnaryField_tapeReadList_of_reads
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanRightOne_readsUnaryField_seqP2
+-- Gate-tag dispatcher (D1b part 1): scanning invariant + dispatch run-behaviour.
+#print axioms Pnp4.Frontier.ContractExpansion.gateTagDispatch_runConfig_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.gateTagDispatch_runConfig_dispatch
 #print axioms Pnp4.Frontier.ContractExpansion.runConfig_head_val_ge
 #print axioms Pnp4.Frontier.ContractExpansion.runConfig_head_dist_le
 #print axioms Pnp4.Frontier.ContractExpansion.gammaSelfLoopScan_locates_gamma_terminator


### PR DESCRIPTION
## Scope

The **control core of the one-gate-record on-tape decoder (D1b)**, delivered as the first of two small stacked PRs (D1b is 7/10 in the roadmap; splitting matches the D1→D1a/D1b precedent). Stacked on `claude/elegant-noether-CnlU5` (which now has D0 + D1a).

### Why cell-by-cell (not the D1a reader) for the tag

The five `SLGate` tags route to continuations that read **different numbers of operand fields**, so the tag value must reach finite control. A `selfLoopScanRightOne` field read collapses the count into head position (lost from control), so the unary tag `1^t 0` is instead read **cell-by-cell**, one phase per `1`, with the count encoded in the phase — the `tagCheckProgramU` phase-routing pattern specialised to a unary counter with a malformed-tag (`t ≥ 5`) reject sink.

### What it adds (`TreeMCSPGateTagDispatch.lean`)

`gateTagDispatch` (`numPhases = 11`: `0..4` read the tag, `5..9` per-tag dispatch, `10` sink):
- structural lemmas (`timeBound`/`numPhases`, `transition_move`, `neverMovesLeft`, tape-unchanged);
- single-step lemmas (read-`1` advance; read-`0` terminator → dispatch to phase `5 + t`);
- **`gateTagDispatch_runConfig_scanning`**: `j ≤ 4` ones ⇒ phase `j`, head `+j`, tape unchanged;
- **`gateTagDispatch_runConfig_dispatch`**: a `1^t 0` tag (`t ≤ 4`) ⇒ after `t + 1` steps, phase `5 + t` (tag identified), head advanced `t + 1` (past the terminator, at the first operand cell), tape unchanged.

### Verification

- Module + both test files build clean; wired into `lakefile`, surface tests (`#check`), axioms audit (`#print axioms`). Standard axioms only; no `sorry`/`admit`/`native_decide`/custom axiom.

### Out of scope (→ D1b part 2)

- ❌ Operand-field consumption (read the per-tag unary operand fields with the D1a reader)
- ❌ Full correspondence to D0's `decodeGateRecord`
- ❌ Interpreter (I1), row loop (R1), prefix compare (P1), assembly (A)

No `P ≠ NP` claim; headline stays conditional.

https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9STjC1sevjFrfFQtJoMg4)_