### PR TITLE
transcoder(D2t-2): complete the down-counter's seqP2 composition lift (reuse, not rebuild)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
@@ -931,8 +931,18 @@ completed records to WORK; the row-loop interpreter then runs over WORK (the exi
 * **D2t-1 — tag dispatcher (DONE, this PR).** `treeTagDispatch` (`TreeMCSPTreeTagDispatch.lean`): the
   3-bit binary-tag trie in finite control; reads the tag, dispatches `input/const/not/and/or`, rejects
   `101/110/111`. Scratch-free; per-tag run-behaviour proven (head +3, tape unchanged).
-* **D2t-2 — scratch primitives.** A tape-region **copy** (`1^k`-block copier) and a **unary-block
-  writer**, with run-behaviour lemmas. The reusable write/scratch layer the rest depends on.
+* **D2t-2 — scratch primitives (LARGELY ALREADY PRESENT — recon).** The reusable write/scratch layer
+  mostly exists and must be **reused, not rebuilt**: the unary-block **writer** is `gammaSelfLoopFill`
+  (pnp4, proven, with its `seqP2` lift); **counters both directions** are `selfLoopIncrement` /
+  `selfLoopDecrement` (pnp4, with `counterValue ± 1` correctness); the **countdown/consume** is
+  `selfLoopCountdownLeft`; and a **cell-copier** `copyAtOffsetProgram` exists in the pnp3 toolkit
+  (a `PhasedProgram`, not yet in the pnp4 `ConstStatePhasedProgram Unit` lineage). The *gap* this
+  brick closed: the down-counter's `seqP2` composition lift was incomplete (only `borrow` + the `stop`
+  single-steps) — `selfLoopDecrement_seqP2_runConfig_{stop,counterValue}` now complete it, so the
+  down-counter composes as a non-first phase (needed for binary→unary and the parser's pending-subtree
+  scan). What remains genuinely missing is a **pnp4-style copier** (or a `PhasedProgram`→`seq` bridge)
+  for the doubling step of D2t-3 — but every binary→unary path needs cross-region head shuttling, which
+  is the real cost from here on.
 * **D2t-3 — binary→unary.** Read `encodeFin width i` (width-counter-bounded), emit `unaryField i` into
   WORK via a doubling loop (`acc := 2·acc + bit`, MSB→LSB), proven against `decodeFin`.
 * **D2t-4 — leaf emit.** `input`: D2t-3 then write `unaryField 0 ++ unaryField i`. `const`: read the

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterComposition.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterComposition.lean
@@ -905,6 +905,99 @@ theorem selfLoopDecrement_seqP2_runConfig_borrow (P1 : ConstStatePhasedProgram U
           · rw [if_neg hin, if_neg (by
               intro hcon; exact hin ⟨hcon.1, by omega⟩)]
 
+/-- After-decrement configuration as a non-first phase, from an arbitrary start `c0` (phase
+`P1.numPhases`, head `c0.head`): if the window `[c0.head, c0.head + j)` is all `0` and cell
+`c0.head + j` is `1`, then after `j + 1` steps the phase is `P1.numPhases + 1` (the shifted accept
+phase), head `c0.head + j`, cells `[c0.head, c0.head + j)` set and cell `c0.head + j` cleared.
+Offset/non-first-phase analogue of `selfLoopDecrement_runConfig_stop`; dual of
+`selfLoopIncrement_seqP2_runConfig_stop`. -/
+theorem selfLoopDecrement_seqP2_runConfig_stop (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c0 : Configuration (M := (seq P1 selfLoopDecrement).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases) (j : Nat) (hj : (c0.head : Nat) + j ≤ L)
+    (h_zeros : ∀ p : Fin ((seq P1 selfLoopDecrement).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + j → c0.tape p = false)
+    (h_one : ∀ hb : (c0.head : Nat) + j < (seq P1 selfLoopDecrement).toPhased.toTM.tapeLength L,
+      c0.tape ⟨(c0.head : Nat) + j, hb⟩ = true) :
+    (((TM.runConfig (M := (seq P1 selfLoopDecrement).toPhased.toTM) c0 (j + 1)).state).fst : Nat)
+        = P1.numPhases + 1
+      ∧ ((TM.runConfig (M := (seq P1 selfLoopDecrement).toPhased.toTM) c0 (j + 1)).head : Nat)
+          = (c0.head : Nat) + j
+      ∧ ∀ p : Fin ((seq P1 selfLoopDecrement).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (seq P1 selfLoopDecrement).toPhased.toTM) c0 (j + 1)).tape p
+            = (if (c0.head : Nat) ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + j then true
+                else if (p : Nat) = (c0.head : Nat) + j then false
+                else c0.tape p) := by
+  obtain ⟨hph, hhd, htp⟩ := selfLoopDecrement_seqP2_runConfig_borrow P1 c0 hphase j hj h_zeros
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := (seq P1 selfLoopDecrement).toPhased.toTM) c0 j with hc
+  have hhead_eq : c.head = ⟨(c0.head : Nat) + j, by rw [← hhd]; exact c.head.isLt⟩ := Fin.ext hhd
+  have hbit : c.tape c.head = true := by
+    rw [htp, if_neg (by rw [hhd]; omega), hhead_eq]
+    exact h_one _
+  refine ⟨?_, ?_, ?_⟩
+  · exact selfLoopDecrement_seqP2_stepConfig_stop_phase P1 c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit
+  · rw [selfLoopDecrement_seqP2_stepConfig_stop_head P1 c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
+    exact hhd
+  · rw [selfLoopDecrement_seqP2_stepConfig_stop_tape P1 c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
+    intro p
+    by_cases hp : p = c.head
+    · subst hp
+      rw [Configuration.write_self]
+      have h1 : ¬ ((c0.head : Nat) ≤ (c.head : Nat) ∧ (c.head : Nat) < (c0.head : Nat) + j) := by
+        rw [hhd]; omega
+      rw [if_neg h1, if_pos (by rw [hhd])]
+    · rw [Configuration.write_other c hp false, htp p]
+      have hpc : (p : Nat) ≠ (c0.head : Nat) + j := by
+        intro h; exact hp (Fin.ext (by rw [hhd]; exact h))
+      by_cases hin : (c0.head : Nat) ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + j
+      · rw [if_pos hin, if_pos hin]
+      · rw [if_neg hin, if_neg hin, if_neg hpc]
+
+/-- Decrement `counterValue` (`before = after + 1`) survives composition **as a non-first phase**: on
+`seq P1 selfLoopDecrement` from an arbitrary start `c0` (phase `P1.numPhases`), if the window
+`[c0.head, c0.head + k)` has first-one at offset `j` (`j < k`, `c0.head + k ≤ L`, so the value is
+positive), then after `j + 1` steps the little-endian value over that window has decreased by exactly
+one.  Offset analogue of `selfLoopDecrement_runConfig_counterValue`, via the dual bit-flip arithmetic
+`counterValue_first_one_diff` at `start := c0.head`.  Completes the down-counter's P2-region lift. -/
+theorem selfLoopDecrement_seqP2_runConfig_counterValue (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c0 : Configuration (M := (seq P1 selfLoopDecrement).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases) (j k : Nat) (hjk : j < k)
+    (hk : (c0.head : Nat) + k ≤ L)
+    (h_zeros : ∀ p : Fin ((seq P1 selfLoopDecrement).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + j → c0.tape p = false)
+    (h_one : ∀ hb : (c0.head : Nat) + j < (seq P1 selfLoopDecrement).toPhased.toTM.tapeLength L,
+      c0.tape ⟨(c0.head : Nat) + j, hb⟩ = true) :
+    counterValue c0 (c0.head : Nat) k
+      = counterValue (TM.runConfig (M := (seq P1 selfLoopDecrement).toPhased.toTM) c0 (j + 1))
+          (c0.head : Nat) k + 1 := by
+  obtain ⟨_, _, htp⟩ := selfLoopDecrement_seqP2_runConfig_stop P1 c0 hphase j (by omega) h_zeros h_one
+  refine counterValue_first_one_diff c0
+    (TM.runConfig (M := (seq P1 selfLoopDecrement).toPhased.toTM) c0 (j + 1))
+    (c0.head : Nat) j k hjk (by
+      show (c0.head : Nat) + k ≤ L + (P1.timeBound L + L + 1) + 1; omega) ?_ ?_ ?_ ?_ ?_
+  · intro i hij hb
+    exact h_zeros ⟨(c0.head : Nat) + i, hb⟩ (Nat.le_add_right _ _) (Nat.add_lt_add_left hij _)
+  · intro hb
+    exact h_one hb
+  · intro i hij hb
+    have hv : ((⟨(c0.head : Nat) + i, hb⟩ :
+        Fin ((seq P1 selfLoopDecrement).toPhased.toTM.tapeLength L)) : Nat) = (c0.head : Nat) + i :=
+      rfl
+    rw [htp ⟨(c0.head : Nat) + i, hb⟩, hv, if_pos (by omega)]
+  · intro hb
+    have hv : ((⟨(c0.head : Nat) + j, hb⟩ :
+        Fin ((seq P1 selfLoopDecrement).toPhased.toTM.tapeLength L)) : Nat) = (c0.head : Nat) + j :=
+      rfl
+    rw [htp ⟨(c0.head : Nat) + j, hb⟩, hv, if_neg (by omega), if_pos rfl]
+  · intro i hji hik hb
+    have hv : ((⟨(c0.head : Nat) + i, hb⟩ :
+        Fin ((seq P1 selfLoopDecrement).toPhased.toTM.tapeLength L)) : Nat) = (c0.head : Nat) + i :=
+      rfl
+    rw [htp ⟨(c0.head : Nat) + i, hb⟩, hv, if_neg (by omega), if_neg (by omega)]
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -4000,6 +4000,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_stepConfig_stop_head
 #check @Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_stepConfig_stop_tape
 #check @Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_runConfig_borrow
+#check @Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_runConfig_stop
+#check @Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_runConfig_counterValue
 -- State lifting + heterogeneous-state skeleton composition (assembly milestone).
 #check @Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram.liftUnitProgram
 #check @Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram.liftUnitProgram_neverMovesLeft

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -650,6 +650,8 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_stepConfig_borrow_tape
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_stepConfig_stop_tape
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_runConfig_borrow
+#print axioms Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_runConfig_stop
+#print axioms Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqP2_runConfig_counterValue
 -- State lifting + heterogeneous-state skeleton composition (assembly milestone).
 #print axioms Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram.liftUnitProgram_neverMovesLeft
 #print axioms Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram.liftUnitProgram_stepConfig_phase


### PR DESCRIPTION
## Summary

D2t-2 of the on-tape transcoder (`TM_VERIFIER_STRATEGY.md` §11). Recon for "scratch primitives" found
the scratch/counter layer is **largely already present** and must be **reused, not rebuilt**:

- unary-block **writer** → `gammaSelfLoopFill` (pnp4, proven, with `seqP2` lift);
- **counters both directions** → `selfLoopIncrement` / `selfLoopDecrement` (pnp4, `counterValue ± 1`);
- **consume/countdown** → `selfLoopCountdownLeft`;
- **cell-copier** → `copyAtOffsetProgram` (exists in the pnp3 toolkit).

So rather than duplicate proven code, this brick closes the one genuine **gap**: the down-counter's
`seqP2` composition lift was incomplete (it had `borrow` + the `stop` single-steps but no run-level
results), unlike the increment's complete lift.

## What lands

Mirroring `selfLoopIncrement_seqP2_runConfig_{stop,counterValue}` (borrow/stop roles swapped):

- **`selfLoopDecrement_seqP2_runConfig_stop`** — after-decrement configuration as a non-first phase:
  phase `P1.numPhases + 1`, head `c0.head + j`, window `[c0.head, c0.head + j)` set to `1`, cell
  `c0.head + j` cleared to `0`, rest unchanged.
- **`selfLoopDecrement_seqP2_runConfig_counterValue`** — the little-endian value over the window
  decreases by exactly one (`before = after + 1`), via the dual bit-flip arithmetic
  `counterValue_first_one_diff` at `start := c0.head`.

The down-counter now composes as a non-first phase in either `seq` position — required for the
transcoder's binary→unary step and the parser's pending-subtree scan. §11 updated to record the
accurate primitive inventory and that the remaining genuinely-missing work is the cross-region
composition (binary→unary doubling) and the preorder→postorder tape stack.

## Verification

- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **17/17**.
- Surface tests + `AxiomsAudit` extended; both new surfaces carry only
  `[propext, Classical.choice, Quot.sound]`. **0 `sorry`/`admit`/`native_decide`/custom axiom.**

**Infrastructure** (AGENTS.md): toolkit toward the NP-membership leg. **No `P ≠ NP` claim; headline
stays conditional.** No `SearchMCSPMagnificationContract` mutation.

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_