### PR TITLE
docs(transcoder): D2t-3c design — binary→unary loop (groundwork for the loop build)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
@@ -940,9 +940,10 @@ completed records to WORK; the row-loop interpreter then runs over WORK (the exi
   brick closed: the down-counter's `seqP2` composition lift was incomplete (only `borrow` + the `stop`
   single-steps) — `selfLoopDecrement_seqP2_runConfig_{stop,counterValue}` now complete it, so the
   down-counter composes as a non-first phase (needed for binary→unary and the parser's pending-subtree
-  scan). What remains genuinely missing is a **pnp4-style copier** (or a `PhasedProgram`→`seq` bridge)
-  for the doubling step of D2t-3 — but every binary→unary path needs cross-region head shuttling, which
-  is the real cost from here on.
+  scan). The chosen D2t-3 design (the **decrement loop** below) **avoids the copier entirely**; a
+  pnp4-style copier (or a `PhasedProgram`→`seq` bridge) would only be needed for the *doubling-loop*
+  variant, which we do **not** pursue. The real remaining cost from here on is the cross-region
+  head-shuttling **composition** (D2t-3c), not any missing primitive.
 * **D2t-3 — binary→unary.** Read `encodeFin width i` (width-counter-bounded), emit `unaryField i`.
   **Primitive groundwork DONE** (D2t-3a/b merged): the per-step pieces all exist in pnp4 with
   run-behaviour *and* `seqP2` lifts — `selfLoopDecrement` (`counterValue−1`), `selfLoopAppendOne`
@@ -959,7 +960,10 @@ completed records to WORK; the row-loop interpreter then runs over WORK (the exi
     marker** at the `B|U` boundary — each body pass returns the head to the marker by a marker-seek, and
     the decrement / append / zero-test run at known offsets from it via the `seqP2`-offset lemmas
     (`…_seqP2_runConfig_*`, which take an arbitrary start `c0` at phase `P1.numPhases`).  The
-    `B = 0` test is `gammaSelfLoopScan` over `B` reaching the boundary marker without hitting a `1`.
+    `B = 0` test runs `gammaSelfLoopScan` from `B`'s low end — recall it advances right over `0`s and
+    **halts on the first `1`**.  The boundary marker placed at `B|U` is a `1`, so it *is* that
+    terminating `1`: the scan halts **on the marker** iff `B` held no `1` before it (so `B = 0`), and
+    halts **strictly before** the marker iff some bit of `B` is set (so `B > 0`).
   - **Sub-bricks:** D2t-3c-1 body (one pass: `counterValue B − 1` ∧ `|U| + 1` ∧ head back at the
     marker) → D2t-3c-2 the `loopUntilSink` wrapper + the `counterValue`-induction → D2t-3c-3 the bridge
     to `decodeFin` / `unaryField`.

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
@@ -943,8 +943,26 @@ completed records to WORK; the row-loop interpreter then runs over WORK (the exi
   scan). What remains genuinely missing is a **pnp4-style copier** (or a `PhasedProgram`→`seq` bridge)
   for the doubling step of D2t-3 — but every binary→unary path needs cross-region head shuttling, which
   is the real cost from here on.
-* **D2t-3 — binary→unary.** Read `encodeFin width i` (width-counter-bounded), emit `unaryField i` into
-  WORK via a doubling loop (`acc := 2·acc + bit`, MSB→LSB), proven against `decodeFin`.
+* **D2t-3 — binary→unary.** Read `encodeFin width i` (width-counter-bounded), emit `unaryField i`.
+  **Primitive groundwork DONE** (D2t-3a/b merged): the per-step pieces all exist in pnp4 with
+  run-behaviour *and* `seqP2` lifts — `selfLoopDecrement` (`counterValue−1`), `selfLoopAppendOne`
+  (append one `1`), `selfLoopScanRightOne` / `selfLoopScanLeftOne` (the U-region shuttle),
+  `gammaSelfLoopScan` (the `B`-region zero-test scan), and the counters. What remains is the **loop
+  composition D2t-3c**, a substantial cross-region proof (≈ the decoder's `reachesSink`):
+  - **Algorithm (decrement loop, avoids the copier):** `acc := 0`; while `B > 0` { `decrement B`;
+    `append 1 to U` }.  Correctness = induction on `counterValue B`: each pass is `counterValue B − 1`
+    (the decrement lift) and `|U| + 1` (the append lift); termination at `B = 0` (the value reaches the
+    spec `decodeFin`).
+  - **The navigation crux (why it is a real construction, not a `seqList`):** after `selfLoopDecrement`
+    the head rests **mid-`B` at a data-dependent cell**, and `B`'s remaining cells are **mixed `0/1`**,
+    so the `B → U` hop *cannot* be a uniform `scan-over-bit` seek.  Resolution: a **fixed reference
+    marker** at the `B|U` boundary — each body pass returns the head to the marker by a marker-seek, and
+    the decrement / append / zero-test run at known offsets from it via the `seqP2`-offset lemmas
+    (`…_seqP2_runConfig_*`, which take an arbitrary start `c0` at phase `P1.numPhases`).  The
+    `B = 0` test is `gammaSelfLoopScan` over `B` reaching the boundary marker without hitting a `1`.
+  - **Sub-bricks:** D2t-3c-1 body (one pass: `counterValue B − 1` ∧ `|U| + 1` ∧ head back at the
+    marker) → D2t-3c-2 the `loopUntilSink` wrapper + the `counterValue`-induction → D2t-3c-3 the bridge
+    to `decodeFin` / `unaryField`.
 * **D2t-4 — leaf emit.** `input`: D2t-3 then write `unaryField 0 ++ unaryField i`. `const`: read the
   literal bit, write `unaryField 1 ++ [b]`. (Leaves push an index onto STACK.)
 * **D2t-5 — the stack discipline (the core).** Internal-node handling: on `not/and/or`, recurse via a


### PR DESCRIPTION
## Summary

Records the concrete design for **D2t-3c (the binary→unary loop)** in `TM_VERIFIER_STRATEGY.md` §11,
now that all per-step primitives are merged (D2t-3a/b). Docs only — no code change.

This is the design groundwork; the loop **code** is the substantial next build (see "navigation crux").

## What it captures

- **Algorithm (decrement loop — avoids the missing copier):** `while B > 0 { decrement B; append 1 to U }`;
  correctness by induction on `counterValue B` (each pass: `counterValue B − 1` via the decrement lift,
  `|U| + 1` via the append lift; termination at `B = 0` = `decodeFin`).
- **The navigation crux (why D2t-3c is a real construction, not a `seqList`):** after `selfLoopDecrement`
  the head rests **mid-`B` at a data-dependent cell** with `B`'s remaining cells **mixed `0/1`**, so the
  `B → U` hop can't be a uniform `scan-over-bit` seek. Resolution: a **fixed boundary marker** at `B|U`;
  each body pass returns the head to it (marker-seek), and decrement / append / zero-test run at known
  offsets via the `seqP2`-offset lemmas. The `B = 0` test is `gammaSelfLoopScan` over `B` reaching the
  marker without hitting a `1`.
- **Sub-brick decomposition:** D2t-3c-1 (one body pass) → D2t-3c-2 (`loopUntilSink` + `counterValue`
  induction) → D2t-3c-3 (bridge to `decodeFin`/`unaryField`).

## Status

All primitives for the loop now exist in pnp4 with run-behaviour + `seqP2` lifts (`selfLoopDecrement`,
`selfLoopAppendOne`, `selfLoopScanRightOne`/`selfLoopScanLeftOne`, `gammaSelfLoopScan`, counters), so the
loop build is de-risked at the primitive level.

Honesty linter (`scripts/check_doc_honesty.sh`) green; conditional-only, **no `P ≠ NP` claim**.

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_