### PR TITLE
transcoder(D2t): iteration plan (§12) + D2t-3c-α leftward unary-append

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -331,6 +331,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBidirHeadBounds,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSelfLoopCounter,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendProgram,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendLeftProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
@@ -984,3 +984,65 @@ Each emit brick is proven against the **pure** spec it realises (`decodeFin`, `e
 `transcodeWitness` faithfulness, which `transcodeWitness_faithful` already lifts to `Circuit.eval`. No
 `P ≠ NP` claim; headline stays conditional; honesty baseline (0 holes, standard triple) preserved
 throughout.
+
+## 12. D2t iteration plan — small finishable stages
+
+The remaining transcoder (D2t-3c…D2t-6) is closed by **small, individually-completable iterations**,
+each a single self-loop or a short `seq`/`loopUntilSink` composition with a proven `runConfig`
+behaviour and only the standard axiom triple — the same brick discipline that closed D0…D2t-3b.
+
+### D2t-3c — binary→unary loop (the navigation crux, resolved)
+
+**Layout that makes the body navigation uniform** (the key design decision): place the unary output
+`U` to the **left** of the binary counter `B`, with a `0` **sentinel** between them, and a `1`
+**right-marker** just past `B`:
+```
+[ … blank | U = 1^|U| | sentinel(0) | B = b_0 b_1 … b_{w-1} | rightMarker(1) | … ]
+                         ^HOME            (little-endian, b_0 next to sentinel)
+```
+Because the loop only ever scans over **uniform** stretches — `B`'s just-flipped low `1`s, or `U`'s
+`1`s — it **never crosses `B`'s mixed high bits**, which was the blocker. Iterations:
+
+* **D2t-3c-α — `selfLoopAppendLeftOne`** (leftward unary single-append): scan **left** over `U`'s `1`s,
+  write one `1` at `U`'s left `0`-end (`U` grows leftward). Mirror of `selfLoopAppendOne` with
+  `Move.left`. Standalone run-behaviour + `seqP2` lift. *(first iteration — clean mirror)*
+* **D2t-3c-β — `seekHomeAfterDecrement`**: from the post-`decrement` config (cells `0..j-1 = 1`, cell
+  `j = 0`, head at `j`), one `Move.left` then `selfLoopScanLeftOne` over the flipped `1`s lands the head
+  on the sentinel (HOME); the `j = 0` edge collapses to the same target. A short `seq`/run lemma.
+* **D2t-3c-γ — `binToUnaryBody`**: `seq`-compose one pass — `[ stepRight ; selfLoopDecrement ;
+  seekHomeAfterDecrement ; stepLeft ; selfLoopAppendLeftOne ; selfLoopScanRightOne ]` — proving from HOME
+  with `B > 0`: `counterValue B − 1`, `|U| + 1`, head back at HOME, all via the `seqP2`-offset lemmas.
+* **D2t-3c-δ — `bZeroTest`**: from HOME decide `B = 0` vs `B > 0` (a `gammaSelfLoopScan` over `B` whose
+  stop cell is the right-marker iff `B = 0`); supplies `loopUntilSink`'s `hstep`/`hbase`.
+* **D2t-3c-ε — the loop**: `loopUntilSink binToUnaryBody (sink := done)`; `loopUntilSink_reachesSink`
+  with measure `counterValue B`, giving `|U| = value(B)` after termination.
+* **D2t-3c-ζ — correctness**: bridge `|U| = value(B) = (decodeFin w …).val`, i.e. the produced block is
+  `unaryField (decodeFin …)`.
+
+(Tiny helpers `stepRight`/`stepLeft` — unconditional one-cell moves — are 1-phase sub-bricks, or folded
+into the adjacent `seq`.)
+
+### D2t-4 — leaf emit (iterations)
+* **D2t-4a — `emitConstRecord`**: from the `const` dispatch phase, read the literal bit and write the
+  fixed 3-cell record `1 0 b` into WORK (uses the U-left write discipline; fixed width, no loop).
+* **D2t-4b — `emitInputRecord`**: `D2t-3c` (binary→unary of the index) then frame it as
+  `unaryField 0 ++ unaryField i`. Each leaf pushes its WORK index onto STACK (feeds D2t-5).
+
+### D2t-5 — the preorder→postorder tape stack (the research-grade core; its own iterations)
+* **D2t-5a — frame format + `pushFrame` / `popFrame`** (each a bounded self-loop over a fixed frame
+  layout: pending-child count + the gate tag + accumulated child WORK-indices).
+* **D2t-5b — the recursion driver**: on `not/and/or` push a frame (children pending); on a completed
+  subtree pop, compute the back-reference **distances** from the child indices, append the gate record
+  to WORK, and decrement the parent's pending count. Driven by `loopUntilSink` with the stack-empty sink.
+* **D2t-5c — correctness**: the emitted WORK equals `encodeGateRecordStream (flatten (toTree c)).gates`
+  (the postorder linearisation), by induction on the tree via `flattenAt`'s index arithmetic.
+
+### D2t-6 — assembly
+* **D2t-6a**: prepend the unary gate-count (`encodeGateStream`); **D2t-6b**: compose the whole transcoder
+  TM and prove its output `= transcodeWitness …` (lifting D2t-1…D2t-5), closing §9 against
+  `transcodeWitness_faithful`.
+
+**Discipline (every iteration):** new module / lemmas under `Frontier/ContractExpansion/`; register in
+`lakefile.lean`; extend surface tests + `AxiomsAudit`; `lake build PnP3 Pnp4` + `./scripts/check.sh`
+green; standard triple only; small stacked PR into staging, Qodo-reviewed, merged; **no `sorry`/holes**,
+no `P ≠ NP` claim.

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPUnaryAppendLeftProgram.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPUnaryAppendLeftProgram.lean
@@ -1,5 +1,4 @@
 import Complexity.TMVerifier.TuringToolkit.ConstStatePhasedProgram
-import Complexity.TMVerifier.TuringToolkit.BinaryCounter
 
 namespace Pnp4
 namespace Frontier

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPUnaryAppendLeftProgram.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPUnaryAppendLeftProgram.lean
@@ -1,0 +1,212 @@
+import Complexity.TMVerifier.TuringToolkit.ConstStatePhasedProgram
+import Complexity.TMVerifier.TuringToolkit.BinaryCounter
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+
+/-!
+# Self-loop leftward unary-append (NP-verifier track — D2 transcoder, D2t-3c-α)
+
+The binary→unary loop (`TM_VERIFIER_STRATEGY.md` §12, D2t-3c) keeps the unary output `U` to the **left**
+of the binary counter `B`, and grows `U` **leftward**, so the loop body navigates only over uniform
+`1`-stretches (never `B`'s mixed bits — the resolution of the navigation crux).  `selfLoopAppendLeftOne`
+is that growth step: starting on `U`'s `1`-block it scans **left** over the `1`s (writing each back) to
+the first `0`, where it writes a single `1` (the append) and stops — extending `U` by one cell on its
+left end.
+
+It is the writing dual of `selfLoopScanLeftOne` (which scans the same `1`-block leftward but stops
+*without* writing) and the leftward mirror of `selfLoopAppendOne`.  Fixed 2-phase, variable-width.  This
+ships the program and its standalone run-behaviour (scan invariant + append-stop); the `seqP2`
+composition lift is the follow-up iteration.  Builds no verifier and proves no separation; all surfaces
+carry only the standard `[propext, Classical.choice, Quot.sound]` triple.
+-/
+
+/-- Leftward unary single-append: phase `0` reading a `1` writes it back and moves **left** (scanning
+`U`'s block); reading the first `0` writes a `1` (the append) and stops (phase `1`). -/
+def selfLoopAppendLeftOne : ConstStatePhasedProgram Unit where
+  numPhases := 2
+  startPhase := ⟨0, by omega⟩
+  startState := ()
+  acceptPhase := ⟨1, by omega⟩
+  acceptState := ()
+  transition := fun i _ b =>
+    if i.val = 0 then
+      if b then (⟨0, by omega⟩, (), true, Move.left)
+      else (⟨1, by omega⟩, (), true, Move.stay)
+    else
+      (⟨1, by omega⟩, (), b, Move.stay)
+  timeBound := fun n => n
+
+@[simp] theorem selfLoopAppendLeftOne_timeBound (n : Nat) : selfLoopAppendLeftOne.timeBound n = n := rfl
+@[simp] theorem selfLoopAppendLeftOne_numPhases : selfLoopAppendLeftOne.numPhases = 2 := rfl
+@[simp] theorem selfLoopAppendLeftOne_startPhase_val :
+    (selfLoopAppendLeftOne.startPhase : Nat) = 0 := rfl
+@[simp] theorem selfLoopAppendLeftOne_acceptPhase_val :
+    (selfLoopAppendLeftOne.acceptPhase : Nat) = 1 := rfl
+
+/-- The leftward append never moves the head right (it moves left while scanning, otherwise stays). -/
+theorem selfLoopAppendLeftOne_transition_move (i : Fin 2) (s : Unit) (b : Bool) :
+    (selfLoopAppendLeftOne.transition i s b).2.2.2 ≠ Move.right := by
+  unfold selfLoopAppendLeftOne
+  dsimp only
+  split_ifs <;> simp
+
+/-! ### Single-step lemmas -/
+
+/-- Scan step (phase `0`, bit `1`): the phase stays `0` (the leftward self-loop). -/
+theorem selfLoopAppendLeftOne_stepConfig_scan_phase {L : Nat}
+    (c : Configuration (M := selfLoopAppendLeftOne.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c).state).fst.val = 0 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, selfLoopAppendLeftOne, hi, hbit]
+
+/-- Scan step (phase `0`, bit `1`): the head moves left. -/
+theorem selfLoopAppendLeftOne_stepConfig_scan_head {L : Nat}
+    (c : Configuration (M := selfLoopAppendLeftOne.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, selfLoopAppendLeftOne, hi, hbit]
+
+/-- Scan step (phase `0`, bit `1`): the tape is unchanged (the `1` is written back). -/
+theorem selfLoopAppendLeftOne_stepConfig_scan_tape {L : Nat}
+    (c : Configuration (M := selfLoopAppendLeftOne.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c).tape
+      = c.write c.head true := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, selfLoopAppendLeftOne, hi, hbit]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+/-- Append step (phase `0`, bit `0`): the phase becomes the done phase `1`. -/
+theorem selfLoopAppendLeftOne_stepConfig_stop_phase {L : Nat}
+    (c : Configuration (M := selfLoopAppendLeftOne.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c).state).fst.val = 1 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, selfLoopAppendLeftOne, hi, hbit]
+
+/-- Append step (phase `0`, bit `0`): the head stays put. -/
+theorem selfLoopAppendLeftOne_stepConfig_stop_head {L : Nat}
+    (c : Configuration (M := selfLoopAppendLeftOne.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c).head = c.head := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, selfLoopAppendLeftOne, hi, hbit, Configuration.moveHead]
+
+/-- Append step (phase `0`, bit `0`): the terminating `0` is overwritten with `1` (the append). -/
+theorem selfLoopAppendLeftOne_stepConfig_stop_tape {L : Nat}
+    (c : Configuration (M := selfLoopAppendLeftOne.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c).tape = c.write c.head true := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, selfLoopAppendLeftOne, hi, hbit]
+
+/-- Leftward scan invariant (over `U`'s `1`-block): from `c0` in phase `0`, if the `j` cells
+`(c0.head − j, c0.head]` are all `1`, then after `j ≤ c0.head` steps the phase is still `0`, the head
+has retreated to `c0.head − j`, and the tape is unchanged.  Identical to `selfLoopScanLeftOne`'s
+scanning (the append only differs at the terminating `0`). -/
+theorem selfLoopAppendLeftOne_runConfig_scan {L : Nat}
+    (c0 : Configuration (M := selfLoopAppendLeftOne.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) :
+    ∀ j : Nat, j ≤ (c0.head : Nat) →
+      (∀ p : Fin (selfLoopAppendLeftOne.toPhased.toTM.tapeLength L),
+        (c0.head : Nat) - j < (p : Nat) → (p : Nat) ≤ (c0.head : Nat) → c0.tape p = true) →
+      (((TM.runConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c0 j).state).fst : Nat) = 0
+      ∧ ((TM.runConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c0 j).head : Nat)
+          = (c0.head : Nat) - j
+      ∧ (TM.runConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c0 j).tape = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _; exact ⟨hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj h1
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (fun p hp1 hp2 => h1 p (by omega) hp2)
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c0 j with hc
+      have hbit : c.tape c.head = true := by
+        rw [htp]; exact h1 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hheadne : ¬ (c.head : Nat) = 0 := by rw [hhd]; omega
+      refine ⟨?_, ?_, ?_⟩
+      · exact selfLoopAppendLeftOne_stepConfig_scan_phase c
+          (i := c.state.fst) (s := c.state.snd) hph rfl hbit
+      · rw [selfLoopAppendLeftOne_stepConfig_scan_head c
+          (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
+        simp only [Configuration.moveHead, dif_neg hheadne]
+        rw [hhd]; omega
+      · rw [selfLoopAppendLeftOne_stepConfig_scan_tape c
+          (i := c.state.fst) (s := c.state.snd) hph rfl hbit, htp]
+
+/-- Leftward append: from `c0` in phase `0`, if the cells `(k, c0.head]` are all `1` and cell `k` is
+`0` (`k < c0.head`), then after `(c0.head − k) + 1` steps the head rests on `k` at the done phase `1`,
+with cell `k` now set to `1` (the unary block extended by one on its left end), everything else
+unchanged.  Combines the leftward scan to the marker with one append step. -/
+theorem selfLoopAppendLeftOne_runConfig_append {L : Nat}
+    (c0 : Configuration (M := selfLoopAppendLeftOne.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (k : Nat) (hk : k < (c0.head : Nat))
+    (hones : ∀ p : Fin (selfLoopAppendLeftOne.toPhased.toTM.tapeLength L),
+      k < (p : Nat) → (p : Nat) ≤ (c0.head : Nat) → c0.tape p = true)
+    (hterm : ∀ p : Fin (selfLoopAppendLeftOne.toPhased.toTM.tapeLength L),
+      (p : Nat) = k → c0.tape p = false) :
+    (((TM.runConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c0 (((c0.head : Nat) - k) + 1)).state).fst
+        : Nat) = 1
+      ∧ ((TM.runConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c0 (((c0.head : Nat) - k) + 1)).head
+          : Nat) = k
+      ∧ ∀ p : Fin (selfLoopAppendLeftOne.toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c0 (((c0.head : Nat) - k) + 1)).tape p
+            = (if (p : Nat) = k then true else c0.tape p) := by
+  obtain ⟨hph, hhd, htp⟩ :=
+    selfLoopAppendLeftOne_runConfig_scan c0 hphase ((c0.head : Nat) - k) (by omega)
+      (fun p hp1 hp2 => hones p (by omega) hp2)
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := selfLoopAppendLeftOne.toPhased.toTM) c0 ((c0.head : Nat) - k) with hc
+  have hhdk : (c.head : Nat) = k := by rw [hhd]; omega
+  have hhead_eq : c.head = ⟨k, by rw [← hhdk]; exact c.head.isLt⟩ := Fin.ext hhdk
+  have hbit : c.tape c.head = false := by rw [htp]; exact hterm c.head hhdk
+  refine ⟨?_, ?_, ?_⟩
+  · exact selfLoopAppendLeftOne_stepConfig_stop_phase c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit
+  · rw [selfLoopAppendLeftOne_stepConfig_stop_head c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
+    exact hhdk
+  · rw [selfLoopAppendLeftOne_stepConfig_stop_tape c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
+    intro p
+    by_cases hp : p = c.head
+    · subst hp
+      rw [Configuration.write_self, if_pos hhdk]
+    · rw [Configuration.write_other c hp true, congrFun htp p]
+      have hpc : (p : Nat) ≠ k := fun h => hp (by rw [hhead_eq]; exact Fin.ext h)
+      rw [if_neg hpc]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -89,6 +89,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPRepeatBody
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBidirHeadBounds
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSelfLoopCounter
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
@@ -3906,6 +3907,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendOne_runConfig_done
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendOne_seqP2_runConfig_scan
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendOne_seqP2_runConfig_stop
+-- D2t-3c-α: leftward unary single-append (grows U leftward — the navigation-uniform direction).
+#check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne
+#check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_scan
+#check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_append
 -- Two-sided head-displacement bound (bidirectional accounting foundation).
 #check @Pnp4.Frontier.ContractExpansion.runConfig_head_val_ge
 #check @Pnp4.Frontier.ContractExpansion.runConfig_head_dist_le

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -79,6 +79,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPRepeatBody
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBidirHeadBounds
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSelfLoopCounter
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
@@ -535,6 +536,8 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendOne_runConfig_stop
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendOne_seqP2_runConfig_scan
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendOne_seqP2_runConfig_stop
+#print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_scan
+#print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_append
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeft_seqP2_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeft_seqP2_runConfig_terminator
 -- Leftward scan-over-`1`s (bit-dual; completes the four-way scan vocabulary).


### PR DESCRIPTION
## Summary

Per the directive to make the rest of D2t finishable in **small stages** and then close them
iteratively: this lands the **decomposition** (§12) plus the **first iteration**.

### §12 — D2t iteration plan
Decomposes D2t-3c…D2t-6 into small, individually-completable iterations (each a self-loop or short
`seq`/`loopUntilSink` composition with proven `runConfig` behaviour, standard triple only).

**Key design resolution for D2t-3c (the navigation crux):** put the unary output `U` to the **left** of
the binary counter `B` (a `0` sentinel between them) and grow `U` **leftward**. Then every head hop in
the loop body travels over a **uniform `1`-stretch** (`B`'s just-flipped low bits, or `U`'s `1`s) and
**never crosses `B`'s mixed high bits** — which was the blocker. D2t-3c becomes a chain of small
mirror-of-existing bricks (α…ζ); D2t-4/5/6 are likewise broken into sub-bricks.

### D2t-3c-α — `selfLoopAppendLeftOne` (first iteration, code)
The leftward unary single-append: scan **left** over `U`'s `1`s, write one `1` at `U`'s left `0`-end
(`U` grows leftward). Writing dual of `selfLoopScanLeftOne`, leftward mirror of `selfLoopAppendOne`.
Proven:
- `selfLoopAppendLeftOne_runConfig_scan` — leftward scan invariant (head retreats `j ≤ c0.head`, tape
  unchanged);
- `selfLoopAppendLeftOne_runConfig_append` — after `(c0.head − k) + 1` steps: phase `1`, head `k`, cell
  `k` set to `1` (block extended on its left end), rest unchanged;
- plus single-step lemmas.

The `seqP2` lift is the next iteration.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass; doc-honesty linter green.
- Surface tests + `AxiomsAudit` extended; new surfaces carry only `[propext, Classical.choice, Quot.sound]`.
  **0 `sorry`/`admit`/`native_decide`/custom axiom.**

**Infrastructure** (AGENTS.md): toolkit toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_