### PR TITLE
transcoder(D2t-3c): stepLeftOnce — single leftward-move building block

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -332,6 +332,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSelfLoopCounter,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendLeftProgram,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPStepLeftProgram.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPStepLeftProgram.lean
@@ -1,0 +1,135 @@
+import Complexity.TMVerifier.TuringToolkit.ConstStatePhasedProgram
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+
+/-!
+# Single-step leftward move (NP-verifier track — D2 transcoder, D2t-3c building block)
+
+`stepLeftOnce` is the trivial one-cell **leftward** move: a fixed 2-phase program that, in phase `0`,
+writes the scanned bit back, moves the head **left** by one, and halts (phase `1`).  The binary→unary
+loop's home-seek (D2t-3c-β) uses it to step **off** the decrement's cleared `0`-cell onto the flipped
+`1`-block before `selfLoopScanLeftOne` scans that block back to the sentinel — a single deterministic
+left step that a `scan`-style self-loop (which is bit-conditional) cannot provide.
+
+This ships the program and its one-step run-behaviour.  Builds no verifier and proves no separation; all
+surfaces carry only the standard `[propext, Classical.choice, Quot.sound]` triple.
+-/
+
+/-- Single leftward step: phase `0` writes the scanned bit back, moves left, and halts (phase `1`). -/
+def stepLeftOnce : ConstStatePhasedProgram Unit where
+  numPhases := 2
+  startPhase := ⟨0, by omega⟩
+  startState := ()
+  acceptPhase := ⟨1, by omega⟩
+  acceptState := ()
+  transition := fun i _ b =>
+    if i.val = 0 then (⟨1, by omega⟩, (), b, Move.left)
+    else (⟨1, by omega⟩, (), b, Move.stay)
+  timeBound := fun _ => 1
+
+@[simp] theorem stepLeftOnce_timeBound (n : Nat) : stepLeftOnce.timeBound n = 1 := rfl
+@[simp] theorem stepLeftOnce_numPhases : stepLeftOnce.numPhases = 2 := rfl
+@[simp] theorem stepLeftOnce_startPhase_val : (stepLeftOnce.startPhase : Nat) = 0 := rfl
+@[simp] theorem stepLeftOnce_acceptPhase_val : (stepLeftOnce.acceptPhase : Nat) = 1 := rfl
+
+/-- The single left step never moves the head right (it moves left, then stays in the done phase). -/
+theorem stepLeftOnce_transition_move (i : Fin 2) (s : Unit) (b : Bool) :
+    (stepLeftOnce.transition i s b).2.2.2 ≠ Move.right := by
+  unfold stepLeftOnce
+  dsimp only
+  split_ifs <;> simp
+
+/-! ### Single-step lemmas (phase `0`) -/
+
+/-- Phase-`0` step: advance to the done phase `1`. -/
+theorem stepLeftOnce_stepConfig_phase {L : Nat}
+    (c : Configuration (M := stepLeftOnce.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).state).fst.val = 1 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, stepLeftOnce, hi]
+
+/-- Phase-`0` step: the head moves left by one (when not at the left end). -/
+theorem stepLeftOnce_stepConfig_head {L : Nat}
+    (c : Configuration (M := stepLeftOnce.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩)
+    (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).head : Nat) = (c.head : Nat) - 1 := by
+  have hmove : (TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, stepLeftOnce, hi]
+  rw [hmove]
+  have hne : ¬ (c.head : Nat) = 0 := by omega
+  simp only [Configuration.moveHead, dif_neg hne]
+
+/-- Phase-`0` step: the tape is unchanged (the scanned bit is written back). -/
+theorem stepLeftOnce_stepConfig_tape {L : Nat}
+    (c : Configuration (M := stepLeftOnce.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).tape
+      = c.write c.head (c.tape c.head) := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, stepLeftOnce, hi]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- One-step run behaviour: from phase `0` with the head not at the left end, after one step the program
+is in the done phase `1`, the head has moved one cell left, and the tape is unchanged. -/
+theorem stepLeftOnce_runConfig_one {L : Nat}
+    (c : Configuration (M := stepLeftOnce.toPhased.toTM) L)
+    (hphase : (c.state.fst : Nat) = 0) (hhead : 0 < (c.head : Nat)) :
+    (((TM.runConfig (M := stepLeftOnce.toPhased.toTM) c 1).state).fst : Nat) = 1
+      ∧ ((TM.runConfig (M := stepLeftOnce.toPhased.toTM) c 1).head : Nat) = (c.head : Nat) - 1
+      ∧ (TM.runConfig (M := stepLeftOnce.toPhased.toTM) c 1).tape = c.tape := by
+  rw [TM.runConfig_one]
+  refine ⟨?_, ?_, ?_⟩
+  · exact stepLeftOnce_stepConfig_phase c (i := c.state.fst) (s := c.state.snd) hphase rfl
+  · exact stepLeftOnce_stepConfig_head c (i := c.state.fst) (s := c.state.snd) hphase rfl hhead
+  · exact stepLeftOnce_stepConfig_tape c (i := c.state.fst) (s := c.state.snd) hphase rfl
+
+/-- Done-phase (`1`) idle: a step from phase `1` preserves phase, head, and tape. -/
+theorem stepLeftOnce_stepConfig_done {L : Nat}
+    (c : Configuration (M := stepLeftOnce.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).state).fst.val = 1
+    ∧ (TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).head = c.head
+    ∧ (TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, stepLeftOnce, hi]
+  · unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, stepLeftOnce, hi, Configuration.moveHead]
+  · have hwrite : (TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).tape
+        = c.write c.head (c.tape c.head) := by
+      unfold TM.stepConfig
+      rw [hstate]
+      simp only [PhasedProgram.toTM_step]
+      simp [ConstStatePhasedProgram.toPhased, stepLeftOnce, hi]
+    rw [hwrite]
+    funext j
+    by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPStepLeftProgram.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPStepLeftProgram.lean
@@ -1,16 +1,21 @@
 import Complexity.TMVerifier.TuringToolkit.ConstStatePhasedProgram
+import Pnp4.Frontier.ContractExpansion.BoundedLoopProgram
 
 namespace Pnp4
 namespace Frontier
 namespace ContractExpansion
 
 open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
 /-!
 # Single-step leftward move (NP-verifier track — D2 transcoder, D2t-3c building block)
 
 `stepLeftOnce` is the trivial one-cell **leftward** move: a fixed 2-phase program that, in phase `0`,
-writes the scanned bit back, moves the head **left** by one, and halts (phase `1`).  The binary→unary
+writes the scanned bit back, moves the head **left** by one — clamping at the tape's left end, i.e. at
+head `0` the head stays at `0` (`Move.left` semantics), so its run lemma `stepLeftOnce_runConfig_one`
+guards with `0 < c.head`; the boundary case is the explicit `stepLeftOnce_stepConfig_head_clamp` — and
+halts (phase `1`).  The binary→unary
 loop's home-seek (D2t-3c-β) uses it to step **off** the decrement's cleared `0`-cell onto the flipped
 `1`-block before `selfLoopScanLeftOne` scans that block back to the sentinel — a single deterministic
 left step that a `scan`-style self-loop (which is bit-conditional) cannot provide.
@@ -19,7 +24,8 @@ This ships the program and its one-step run-behaviour.  Builds no verifier and p
 surfaces carry only the standard `[propext, Classical.choice, Quot.sound]` triple.
 -/
 
-/-- Single leftward step: phase `0` writes the scanned bit back, moves left, and halts (phase `1`). -/
+/-- Single leftward step: phase `0` writes the scanned bit back, moves left (clamping at the tape's
+left end — at head `0` it stays `0`), and halts (phase `1`). -/
 def stepLeftOnce : ConstStatePhasedProgram Unit where
   numPhases := 2
   startPhase := ⟨0, by omega⟩
@@ -70,6 +76,22 @@ theorem stepLeftOnce_stepConfig_head {L : Nat}
   rw [hmove]
   have hne : ¬ (c.head : Nat) = 0 := by omega
   simp only [Configuration.moveHead, dif_neg hne]
+
+/-- Boundary clamp: a phase-`0` step at head `0` leaves the head at `0` (`Move.left` clamps at the left
+end) — the explicit witness that the "moves left by one" contract holds only for `head > 0`. -/
+theorem stepLeftOnce_stepConfig_head_clamp {L : Nat}
+    (c : Configuration (M := stepLeftOnce.toPhased.toTM) L)
+    {i : Fin 2} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩)
+    (hhead0 : (c.head : Nat) = 0) :
+    ((TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).head : Nat) = 0 := by
+  have hmove : (TM.stepConfig (M := stepLeftOnce.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, stepLeftOnce, hi]
+  rw [hmove]
+  simp [Configuration.moveHead, hhead0]
 
 /-- Phase-`0` step: the tape is unchanged (the scanned bit is written back). -/
 theorem stepLeftOnce_stepConfig_tape {L : Nat}
@@ -129,6 +151,72 @@ theorem stepLeftOnce_stepConfig_done {L : Nat}
     by_cases hj : j = c.head
     · subst hj; simp [Configuration.write]
     · simp [Configuration.write, hj]
+
+/-! ### Composition lift: the single left step as a non-first phase (`seqP2`)
+
+So `stepLeftOnce` composes as a phase of `seq P1 stepLeftOnce` (phase offset `P1.numPhases`) — used in
+the binary→unary loop body to step between the operations. -/
+
+/-- The single left step as a non-first phase: advance to the shifted done phase `P1.numPhases + 1`. -/
+theorem stepLeftOnce_seqP2_stepConfig_phase (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 stepLeftOnce).toPhased.toTM) L)
+    {i : Fin (seq P1 stepLeftOnce).numPhases} {s : Unit}
+    (hi : i.val = P1.numPhases) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (seq P1 stepLeftOnce).toPhased.toTM) c).state).fst.val
+      = P1.numPhases + 1 := by
+  have hsub : i.val - P1.numPhases = 0 := by omega
+  rw [seq_stepConfig_P2_phase P1 stepLeftOnce c
+      (h2 := hi.ge) (hlt := by rw [hsub]; decide) hstate]
+  simp [stepLeftOnce, hsub]
+
+/-- The single left step as a non-first phase: the head moves left by one (when not at the left end). -/
+theorem stepLeftOnce_seqP2_stepConfig_head (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 stepLeftOnce).toPhased.toTM) L)
+    {i : Fin (seq P1 stepLeftOnce).numPhases} {s : Unit}
+    (hi : i.val = P1.numPhases) (hstate : c.state = ⟨i, s⟩) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig (M := (seq P1 stepLeftOnce).toPhased.toTM) c).head : Nat) = (c.head : Nat) - 1 := by
+  have hsub : i.val - P1.numPhases = 0 := by omega
+  have hmove : (TM.stepConfig (M := (seq P1 stepLeftOnce).toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+    rw [seq_stepConfig_P2_head P1 stepLeftOnce c
+        (h2 := hi.ge) (hlt := by rw [hsub]; decide) hstate]
+    simp [stepLeftOnce, hsub]
+  rw [hmove]
+  have hne : ¬ (c.head : Nat) = 0 := by omega
+  simp only [Configuration.moveHead, dif_neg hne]
+
+/-- The single left step as a non-first phase: the tape is unchanged (scanned bit written back). -/
+theorem stepLeftOnce_seqP2_stepConfig_tape (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 stepLeftOnce).toPhased.toTM) L)
+    {i : Fin (seq P1 stepLeftOnce).numPhases} {s : Unit}
+    (hi : i.val = P1.numPhases) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (seq P1 stepLeftOnce).toPhased.toTM) c).tape = c.tape := by
+  have hsub : i.val - P1.numPhases = 0 := by omega
+  have hwrite : (TM.stepConfig (M := (seq P1 stepLeftOnce).toPhased.toTM) c).tape
+      = c.write c.head (c.tape c.head) := by
+    rw [seq_stepConfig_P2_tape P1 stepLeftOnce c
+        (h2 := hi.ge) (hlt := by rw [hsub]; decide) hstate]
+    simp [stepLeftOnce, hsub]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- One-step run behaviour as a non-first phase: from phase `P1.numPhases` with `0 < c.head`, after one
+step the phase is `P1.numPhases + 1`, the head has moved one cell left, and the tape is unchanged. -/
+theorem stepLeftOnce_seqP2_runConfig_one (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 stepLeftOnce).toPhased.toTM) L)
+    (hphase : (c.state.fst : Nat) = P1.numPhases) (hhead : 0 < (c.head : Nat)) :
+    (((TM.runConfig (M := (seq P1 stepLeftOnce).toPhased.toTM) c 1).state).fst : Nat)
+        = P1.numPhases + 1
+      ∧ ((TM.runConfig (M := (seq P1 stepLeftOnce).toPhased.toTM) c 1).head : Nat) = (c.head : Nat) - 1
+      ∧ (TM.runConfig (M := (seq P1 stepLeftOnce).toPhased.toTM) c 1).tape = c.tape := by
+  rw [TM.runConfig_one]
+  refine ⟨?_, ?_, ?_⟩
+  · exact stepLeftOnce_seqP2_stepConfig_phase P1 c (i := c.state.fst) (s := c.state.snd) hphase rfl
+  · exact stepLeftOnce_seqP2_stepConfig_head P1 c (i := c.state.fst) (s := c.state.snd) hphase rfl hhead
+  · exact stepLeftOnce_seqP2_stepConfig_tape P1 c (i := c.state.fst) (s := c.state.snd) hphase rfl
 
 end ContractExpansion
 end Frontier

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3915,6 +3915,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3c-β building block: single leftward step (off the decrement's cleared cell, before the scan).
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_runConfig_one
+#check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_stepConfig_head_clamp
+#check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqP2_runConfig_one
 -- Two-sided head-displacement bound (bidirectional accounting foundation).
 #check @Pnp4.Frontier.ContractExpansion.runConfig_head_val_ge
 #check @Pnp4.Frontier.ContractExpansion.runConfig_head_dist_le

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -90,6 +90,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBidirHeadBounds
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSelfLoopCounter
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendLeftProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
@@ -3911,6 +3912,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_scan
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_append
+-- D2t-3c-β building block: single leftward step (off the decrement's cleared cell, before the scan).
+#check @Pnp4.Frontier.ContractExpansion.stepLeftOnce
+#check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_runConfig_one
 -- Two-sided head-displacement bound (bidirectional accounting foundation).
 #check @Pnp4.Frontier.ContractExpansion.runConfig_head_val_ge
 #check @Pnp4.Frontier.ContractExpansion.runConfig_head_dist_le

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -80,6 +80,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBidirHeadBounds
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSelfLoopCounter
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendLeftProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
@@ -538,6 +539,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendOne_seqP2_runConfig_stop
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_scan
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_append
+#print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_runConfig_one
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeft_seqP2_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeft_seqP2_runConfig_terminator
 -- Leftward scan-over-`1`s (bit-dual; completes the four-way scan vocabulary).

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -540,6 +540,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_scan
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_append
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_runConfig_one
+#print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqP2_runConfig_one
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeft_seqP2_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeft_seqP2_runConfig_terminator
 -- Leftward scan-over-`1`s (bit-dual; completes the four-way scan vocabulary).


### PR DESCRIPTION
## Summary

Next D2t iteration (toward D2t-3c-β, the binary→unary home-seek): `stepLeftOnce` — a trivial fixed
2-phase primitive that writes the scanned bit back, moves the head **left** by one, and halts.

It is the building block the home-seek needs to step **off** the decrement's cleared `0`-cell onto the
flipped `1`-block, so `selfLoopScanLeftOne` can then scan that block back to the sentinel — a single
*deterministic* left step that a bit-conditional scan self-loop cannot provide. (Confirmed no such
pnp4 primitive existed.)

## What lands
- `stepLeftOnce` + one-step run-behaviour `stepLeftOnce_runConfig_one` (phase→`1`, head `−1` for
  `head>0`, tape unchanged), plus the single-step and done-phase-idle lemmas.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass.
- Surface tests + `AxiomsAudit` extended; new surface carries only
  `[propext, Classical.choice, Quot.sound]`. **0 `sorry`/`admit`/`native_decide`/custom axiom.**

**Infrastructure** (AGENTS.md): toolkit toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_