### PR TITLE
transcoder(D2t-3c): selfLoopAppendLeftOne seqP2 lift (non-first phase)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPUnaryAppendLeftProgram.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPUnaryAppendLeftProgram.lean
@@ -1,10 +1,12 @@
 import Complexity.TMVerifier.TuringToolkit.ConstStatePhasedProgram
+import Pnp4.Frontier.ContractExpansion.BoundedLoopProgram
 
 namespace Pnp4
 namespace Frontier
 namespace ContractExpansion
 
 open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
 /-!
 # Self-loop leftward unary-append (NP-verifier track — D2 transcoder, D2t-3c-α)
@@ -18,9 +20,10 @@ left end.
 
 It is the writing dual of `selfLoopScanLeftOne` (which scans the same `1`-block leftward but stops
 *without* writing) and the leftward mirror of `selfLoopAppendOne`.  Fixed 2-phase, variable-width.  This
-ships the program and its standalone run-behaviour (scan invariant + append-stop); the `seqP2`
-composition lift is the follow-up iteration.  Builds no verifier and proves no separation; all surfaces
-carry only the standard `[propext, Classical.choice, Quot.sound]` triple.
+ships the program, its standalone run-behaviour (scan invariant + append-stop), and the `seqP2`
+composition lift (the leftward append as a non-first phase of `seq P1 selfLoopAppendLeftOne`, used in the
+binary→unary loop body).  Builds no verifier and proves no separation; all surfaces carry only the
+standard `[propext, Classical.choice, Quot.sound]` triple.
 -/
 
 /-- Leftward unary single-append: phase `0` reading a `1` writes it back and moves **left** (scanning
@@ -197,6 +200,172 @@ theorem selfLoopAppendLeftOne_runConfig_append {L : Nat}
       (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
     exact hhdk
   · rw [selfLoopAppendLeftOne_stepConfig_stop_tape c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
+    intro p
+    by_cases hp : p = c.head
+    · subst hp
+      rw [Configuration.write_self, if_pos hhdk]
+    · rw [Configuration.write_other c hp true, congrFun htp p]
+      have hpc : (p : Nat) ≠ k := fun h => hp (by rw [hhead_eq]; exact Fin.ext h)
+      rw [if_neg hpc]
+
+/-! ### Composition lift: leftward unary-append as a non-first phase (`seqP2`)
+
+So `selfLoopAppendLeftOne` composes as a phase of `seq P1 selfLoopAppendLeftOne` (phase offset
+`P1.numPhases`) — used in the binary→unary loop body to grow `U` after the head returns to `U`'s block.
+The non-first single-step lemmas re-derive the scan/append steps via `seq_stepConfig_P2_*` (phase shifted
+by `P1.numPhases`), then the run inductions mirror the standalone ones from an arbitrary `c0` at phase
+`P1.numPhases`. -/
+
+/-- Scan step as a non-first phase (composition phase `P1.numPhases`, bit `1`): the phase stays. -/
+theorem selfLoopAppendLeftOne_seqP2_stepConfig_scan_phase (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) L)
+    {i : Fin (seq P1 selfLoopAppendLeftOne).numPhases} {s : Unit}
+    (hi : i.val = P1.numPhases) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c).state).fst.val
+      = P1.numPhases := by
+  have hsub : i.val - P1.numPhases = 0 := by omega
+  rw [seq_stepConfig_P2_phase P1 selfLoopAppendLeftOne c
+      (h2 := hi.ge) (hlt := by rw [hsub]; decide) hstate]
+  simp [selfLoopAppendLeftOne, hsub, hbit]
+
+/-- Scan step as a non-first phase (bit `1`): the head moves left. -/
+theorem selfLoopAppendLeftOne_seqP2_stepConfig_scan_head (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) L)
+    {i : Fin (seq P1 selfLoopAppendLeftOne).numPhases} {s : Unit}
+    (hi : i.val = P1.numPhases) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+  have hsub : i.val - P1.numPhases = 0 := by omega
+  rw [seq_stepConfig_P2_head P1 selfLoopAppendLeftOne c
+      (h2 := hi.ge) (hlt := by rw [hsub]; decide) hstate]
+  simp [selfLoopAppendLeftOne, hsub, hbit]
+
+/-- Scan step as a non-first phase (bit `1`): the tape is unchanged (the `1` is written back). -/
+theorem selfLoopAppendLeftOne_seqP2_stepConfig_scan_tape (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) L)
+    {i : Fin (seq P1 selfLoopAppendLeftOne).numPhases} {s : Unit}
+    (hi : i.val = P1.numPhases) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c).tape = c.tape := by
+  have hsub : i.val - P1.numPhases = 0 := by omega
+  have hwrite : (TM.stepConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c).tape
+      = c.write c.head true := by
+    rw [seq_stepConfig_P2_tape P1 selfLoopAppendLeftOne c
+        (h2 := hi.ge) (hlt := by rw [hsub]; decide) hstate]
+    simp [selfLoopAppendLeftOne, hsub, hbit]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+/-- Append step as a non-first phase (bit `0`): the phase becomes the shifted done phase
+`P1.numPhases + 1`. -/
+theorem selfLoopAppendLeftOne_seqP2_stepConfig_stop_phase (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) L)
+    {i : Fin (seq P1 selfLoopAppendLeftOne).numPhases} {s : Unit}
+    (hi : i.val = P1.numPhases) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c).state).fst.val
+      = P1.numPhases + 1 := by
+  have hsub : i.val - P1.numPhases = 0 := by omega
+  rw [seq_stepConfig_P2_phase P1 selfLoopAppendLeftOne c
+      (h2 := hi.ge) (hlt := by rw [hsub]; decide) hstate]
+  simp [selfLoopAppendLeftOne, hsub, hbit]
+
+/-- Append step as a non-first phase (bit `0`): the head stays put. -/
+theorem selfLoopAppendLeftOne_seqP2_stepConfig_stop_head (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) L)
+    {i : Fin (seq P1 selfLoopAppendLeftOne).numPhases} {s : Unit}
+    (hi : i.val = P1.numPhases) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c).head = c.head := by
+  have hsub : i.val - P1.numPhases = 0 := by omega
+  rw [seq_stepConfig_P2_head P1 selfLoopAppendLeftOne c
+      (h2 := hi.ge) (hlt := by rw [hsub]; decide) hstate]
+  simp [selfLoopAppendLeftOne, hsub, hbit, Configuration.moveHead]
+
+/-- Append step as a non-first phase (bit `0`): the terminating `0` is overwritten with `1`. -/
+theorem selfLoopAppendLeftOne_seqP2_stepConfig_stop_tape (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c : Configuration (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) L)
+    {i : Fin (seq P1 selfLoopAppendLeftOne).numPhases} {s : Unit}
+    (hi : i.val = P1.numPhases) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c).tape
+      = c.write c.head true := by
+  have hsub : i.val - P1.numPhases = 0 := by omega
+  rw [seq_stepConfig_P2_tape P1 selfLoopAppendLeftOne c
+      (h2 := hi.ge) (hlt := by rw [hsub]; decide) hstate]
+  simp [selfLoopAppendLeftOne, hsub, hbit]
+
+/-- Leftward scan invariant as a non-first phase, from an arbitrary start `c0` (phase `P1.numPhases`):
+if the window `(c0.head − j, c0.head]` is all `1`, then after `j ≤ c0.head` steps the phase still rests
+at `P1.numPhases`, the head has retreated to `c0.head − j`, and the tape is unchanged.  Offset analogue
+of `selfLoopAppendLeftOne_runConfig_scan`. -/
+theorem selfLoopAppendLeftOne_seqP2_runConfig_scan (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c0 : Configuration (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases) :
+    ∀ j : Nat, j ≤ (c0.head : Nat) →
+      (∀ p : Fin ((seq P1 selfLoopAppendLeftOne).toPhased.toTM.tapeLength L),
+        (c0.head : Nat) - j < (p : Nat) → (p : Nat) ≤ (c0.head : Nat) → c0.tape p = true) →
+      (((TM.runConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c0 j).state).fst : Nat)
+          = P1.numPhases
+      ∧ ((TM.runConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c0 j).head : Nat)
+          = (c0.head : Nat) - j
+      ∧ (TM.runConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c0 j).tape = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _; exact ⟨hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj h1
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (fun p hp1 hp2 => h1 p (by omega) hp2)
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c0 j with hc
+      have hbit : c.tape c.head = true := by
+        rw [htp]; exact h1 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hheadne : ¬ (c.head : Nat) = 0 := by rw [hhd]; omega
+      refine ⟨?_, ?_, ?_⟩
+      · exact selfLoopAppendLeftOne_seqP2_stepConfig_scan_phase P1 c
+          (i := c.state.fst) (s := c.state.snd) hph rfl hbit
+      · rw [selfLoopAppendLeftOne_seqP2_stepConfig_scan_head P1 c
+          (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
+        simp only [Configuration.moveHead, dif_neg hheadne]
+        rw [hhd]; omega
+      · rw [selfLoopAppendLeftOne_seqP2_stepConfig_scan_tape P1 c
+          (i := c.state.fst) (s := c.state.snd) hph rfl hbit, htp]
+
+/-- Leftward append as a non-first phase: from `c0` at phase `P1.numPhases`, if the cells `(k, c0.head]`
+are all `1` and cell `k` is `0` (`k < c0.head`), then after `(c0.head − k) + 1` steps the head rests on
+`k` at the shifted done phase `P1.numPhases + 1`, with cell `k` now set to `1`, everything else
+unchanged.  Offset analogue of `selfLoopAppendLeftOne_runConfig_append`. -/
+theorem selfLoopAppendLeftOne_seqP2_runConfig_append (P1 : ConstStatePhasedProgram Unit) {L : Nat}
+    (c0 : Configuration (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases) (k : Nat) (hk : k < (c0.head : Nat))
+    (hones : ∀ p : Fin ((seq P1 selfLoopAppendLeftOne).toPhased.toTM.tapeLength L),
+      k < (p : Nat) → (p : Nat) ≤ (c0.head : Nat) → c0.tape p = true)
+    (hterm : ∀ p : Fin ((seq P1 selfLoopAppendLeftOne).toPhased.toTM.tapeLength L),
+      (p : Nat) = k → c0.tape p = false) :
+    (((TM.runConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c0
+        (((c0.head : Nat) - k) + 1)).state).fst : Nat) = P1.numPhases + 1
+      ∧ ((TM.runConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c0
+          (((c0.head : Nat) - k) + 1)).head : Nat) = k
+      ∧ ∀ p : Fin ((seq P1 selfLoopAppendLeftOne).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c0
+            (((c0.head : Nat) - k) + 1)).tape p
+            = (if (p : Nat) = k then true else c0.tape p) := by
+  obtain ⟨hph, hhd, htp⟩ :=
+    selfLoopAppendLeftOne_seqP2_runConfig_scan P1 c0 hphase ((c0.head : Nat) - k) (by omega)
+      (fun p hp1 hp2 => hones p (by omega) hp2)
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := (seq P1 selfLoopAppendLeftOne).toPhased.toTM) c0
+    ((c0.head : Nat) - k) with hc
+  have hhdk : (c.head : Nat) = k := by rw [hhd]; omega
+  have hhead_eq : c.head = ⟨k, by rw [← hhdk]; exact c.head.isLt⟩ := Fin.ext hhdk
+  have hbit : c.tape c.head = false := by rw [htp]; exact hterm c.head hhdk
+  refine ⟨?_, ?_, ?_⟩
+  · exact selfLoopAppendLeftOne_seqP2_stepConfig_stop_phase P1 c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit
+  · rw [selfLoopAppendLeftOne_seqP2_stepConfig_stop_head P1 c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
+    exact hhdk
+  · rw [selfLoopAppendLeftOne_seqP2_stepConfig_stop_tape P1 c
       (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
     intro p
     by_cases hp : p = c.head

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3919,6 +3919,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_scan
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_append
+-- D2t-3c: leftward unary-append as a non-first phase (seqP2 lift) — for the loop-body composition.
+#check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqP2_runConfig_scan
+#check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqP2_runConfig_append
 -- D2t-3c-β building block: single leftward step (off the decrement's cleared cell, before the scan).
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_runConfig_one

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -541,6 +541,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendOne_seqP2_runConfig_stop
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_scan
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_runConfig_append
+-- D2t-3c: leftward unary-append seqP2 lift (non-first phase).
+#print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqP2_runConfig_scan
+#print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqP2_runConfig_append
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_runConfig_one
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqP2_runConfig_one
 -- D2t-3c-β: the binary→unary home-seek run behaviour.


### PR DESCRIPTION
## Summary

Completes `selfLoopAppendLeftOne` (D2t-3c-α, merged earlier) with its **composition lift** — the
leftward unary-append as a **non-first phase** of `seq P1 selfLoopAppendLeftOne` (phase offset
`P1.numPhases`). This is a prerequisite for the binary→unary loop-body composition (D2t-3c-γ), where
the append grows `U` after the head returns to `U`'s block.

## What lands
- Offset single-step lemmas (`selfLoopAppendLeftOne_seqP2_stepConfig_{scan,stop}_{phase,head,tape}`) via
  the generic `seq_stepConfig_P2_*`.
- The run inductions `selfLoopAppendLeftOne_seqP2_runConfig_scan` (leftward scan invariant) and
  `selfLoopAppendLeftOne_seqP2_runConfig_append` (scan-to-marker + append step), mirroring the standalone
  `_runConfig_scan` / `_runConfig_append`.

Pure mirror of `selfLoopScanLeftOne`'s seqP2 lift; no new primitive, no design change.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- Surface tests + `AxiomsAudit` extended; both new run lemmas carry only
  `[propext, Classical.choice, Quot.sound]`. **0 `sorry`/`admit`/`native_decide`/custom axiom.**

**Infrastructure** (AGENTS.md): toolkit toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_