### PR TITLE
transcoder(D2t-3c-γ): binToUnaryBody definition (left-nested) + structural facts

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -336,6 +336,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryBody.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryBody.lean
@@ -1,0 +1,84 @@
+import Complexity.TMVerifier.TuringToolkit.ConstStatePhasedProgram
+import Pnp4.Frontier.ContractExpansion.BoundedLoopProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPSelfLoopCounter
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftOneProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendLeftProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-!
+# The binary→unary loop body (NP-verifier track — D2 transcoder, D2t-3c-γ)
+
+`binToUnaryBody` is one pass of the binary→unary conversion loop (`TM_VERIFIER_STRATEGY.md` §12,
+D2t-3c-γ): starting at **HOME** (the `0`-sentinel just left of the little-endian binary counter `B`,
+with the unary output `U` to its left) and assuming `B > 0`, it
+
+1. `stepRightOnce` — steps off the sentinel onto `B`'s low cell;
+2. `selfLoopDecrement` — decrements `B` (borrow ripple; head ends on the cleared lowest set bit);
+3. `stepLeftOnce ; selfLoopScanLeftOne` — the **home-seek**: one left step onto the flipped `1`-block,
+   then a leftward scan-over-`1`s back to the sentinel;
+4. `stepLeftOnce` — steps off the sentinel onto `U`'s block;
+5. `selfLoopAppendLeftOne` — grows `U` by one `1` on its left end;
+6. `selfLoopScanRightOne` — scans back right over `U` to HOME (the sentinel).
+
+## Left-nested composition (the key design choice)
+
+`seq` does **not** reassociate, so a primitive at chain-depth `d` of a *right*-nested `seqList`
+`seq p₁ (seq p₂ …)` is reached only through `d−1` nested `seq_stepConfig_P2_*` unfolds — forcing a
+distinct `seqNested`-at-depth-`d` re-derivation per element.  Building the chain **left**-nested instead,
+`seq (seq (… (seq p₁ p₂) …) p₆) p₇`, makes every element `pᵢ` (`i ≥ 2`) the **depth-1 `P2`** of
+`seq ⟨prefixᵢ₋₁⟩ pᵢ`, so each is characterised by its already-merged `…_seqP2_*` lemma with
+`P1 := prefixᵢ₋₁` (an arbitrary prefix; only its `numPhases` matters).  No deeper nesting is needed; the
+one-pass run behaviour is then an inductive thread over the six handoffs.
+
+This module ships the definition and its structural facts (`numPhases`/`startPhase`/`acceptPhase`); the
+one-pass `runConfig` behaviour (`counterValue B − 1`, `|U| + 1`, head back at HOME) is the follow-up.
+Builds no verifier and proves no separation; all surfaces carry only the standard
+`[propext, Classical.choice, Quot.sound]` triple.  **No `P ≠ NP` claim.**
+-/
+
+/-- One pass of the binary→unary loop body, **left-nested** so every element is a depth-1 `seqP2`
+phase (see the module docstring).  Order: step onto `B`, decrement, seek home (step left + scan left),
+step onto `U`, append one `1`, scan right back to HOME. -/
+def binToUnaryBody : ConstStatePhasedProgram Unit :=
+  seq (seq (seq (seq (seq (seq stepRightOnce selfLoopDecrement)
+    stepLeftOnce) selfLoopScanLeftOne) stepLeftOnce) selfLoopAppendLeftOne) selfLoopScanRightOne
+
+@[simp] theorem binToUnaryBody_numPhases : binToUnaryBody.numPhases = 14 := rfl
+
+@[simp] theorem binToUnaryBody_startPhase_val : (binToUnaryBody.startPhase : Nat) = 0 := rfl
+
+@[simp] theorem binToUnaryBody_acceptPhase_val : (binToUnaryBody.acceptPhase : Nat) = 13 := rfl
+
+/-- The six prefixes' phase counts, recorded as defeq facts so the run-behaviour proof can address each
+element's offset (`P1.numPhases` for its `seqP2` lift) without re-unfolding the whole chain.  Each is the
+left-nested prefix ending just before the correspondingly-numbered element. -/
+theorem binToUnaryBody_prefix1_numPhases :
+    (seq stepRightOnce selfLoopDecrement).numPhases = 4 := rfl
+
+theorem binToUnaryBody_prefix2_numPhases :
+    (seq (seq stepRightOnce selfLoopDecrement) stepLeftOnce).numPhases = 6 := rfl
+
+theorem binToUnaryBody_prefix3_numPhases :
+    (seq (seq (seq stepRightOnce selfLoopDecrement) stepLeftOnce) selfLoopScanLeftOne).numPhases
+      = 8 := rfl
+
+theorem binToUnaryBody_prefix4_numPhases :
+    (seq (seq (seq (seq stepRightOnce selfLoopDecrement) stepLeftOnce) selfLoopScanLeftOne)
+      stepLeftOnce).numPhases = 10 := rfl
+
+theorem binToUnaryBody_prefix5_numPhases :
+    (seq (seq (seq (seq (seq stepRightOnce selfLoopDecrement) stepLeftOnce) selfLoopScanLeftOne)
+      stepLeftOnce) selfLoopAppendLeftOne).numPhases = 12 := rfl
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -94,6 +94,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -4045,6 +4046,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqNested_runConfig_borrow
 #check @Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqNested_runConfig_stop
 #check @Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqNested_runConfig_counterValue
+-- D2t-3c-γ: the left-nested binary→unary loop body (definition + structural facts; run behaviour TBD).
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryBody
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryBody_acceptPhase_val
 -- State lifting + heterogeneous-state skeleton composition (assembly milestone).
 #check @Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram.liftUnitProgram
 #check @Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram.liftUnitProgram_neverMovesLeft

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -84,6 +84,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryAppendLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -680,6 +681,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqNested_runConfig_borrow
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqNested_runConfig_stop
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopDecrement_seqNested_runConfig_counterValue
+-- D2t-3c-γ: the left-nested binary→unary loop body (structural facts; run behaviour TBD).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryBody_numPhases
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryBody_acceptPhase_val
 -- State lifting + heterogeneous-state skeleton composition (assembly milestone).
 #print axioms Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram.liftUnitProgram_neverMovesLeft
 #print axioms Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram.liftUnitProgram_stepConfig_phase


### PR DESCRIPTION
## Summary

Establishes the **binary→unary loop body** `binToUnaryBody` (`TM_VERIFIER_STRATEGY.md` §12, D2t-3c-γ)
as a **left-nested** `seq` chain of the seven atomic primitives (all already merged):
`stepRightOnce ; selfLoopDecrement ; stepLeftOnce ; selfLoopScanLeftOne ; stepLeftOnce ;
selfLoopAppendLeftOne ; selfLoopScanRightOne` (step onto `B` → decrement → home-seek → step onto `U` →
append one `1` → scan right back to HOME).

## Why left-nested (the key design choice)

`seq` does not reassociate, so an element at chain-depth `d` of a **right**-nested `seqList` is reached
through `d−1` nested `seq_stepConfig_P2_*` unfolds — forcing a distinct `seqNested`-at-depth-`d`
re-derivation per element. Building the chain **left**-nested, `seq (seq (… (seq p₁ p₂) …) p₆) p₇`,
makes every element `pᵢ` (`i ≥ 2`) the **depth-1 `P2`** of `seq ⟨prefixᵢ₋₁⟩ pᵢ`, so each is characterised
by its **already-merged `…_seqP2_*` lift** (with `P1 := prefixᵢ₋₁`). No deeper nesting / per-depth rungs;
the one-pass run behaviour becomes an inductive thread over the six handoffs.

## What lands
- `def binToUnaryBody` + structural facts: `numPhases = 14`, `startPhase = 0`, `acceptPhase = 13`, and the
  six prefix phase-counts (the offsets the run proof feeds to each element's `seqP2` lift).
- The one-pass `runConfig` behaviour (`counterValue B − 1`, `|U| + 1`, head back at HOME) is the
  follow-up brick.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- Surface tests + `AxiomsAudit` extended (structural lemmas are `rfl`; zero axioms).
  **0 `sorry`/`admit`/`native_decide`/custom axiom.**

**Infrastructure** (AGENTS.md): toolkit toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_