### PR TITLE
transcoder(D2t-3c-ε): one-pass measure-decrease (counterValue − 1) + output bit

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -337,6 +337,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryMeasure.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryMeasure.lean
@@ -1,0 +1,125 @@
+import Complexity.TMVerifier.TuringToolkit.BinaryCounter
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
+
+/-!
+# One-pass measure/output arithmetic (NP-verifier track — D2 transcoder, D2t-3c-ε ingredient)
+
+`binToUnaryBody_runConfig_onePass` (the merged HOME→HOME engine) returns its post-tape explicitly: the
+binary counter `B`'s low block `[head+1, head+1+j)` flips `0 → 1`, its lowest set bit `head+1+j` flips
+`1 → 0` (a borrow), and the unary block `U` gains one `1` at `head-u-1`.  This module reads the **net
+arithmetic effect** off that post-tape:
+
+* `binToUnaryBody_onePass_counterValue` — the borrow drops `counterValue B` by exactly one.  This is
+  the strict measure-decrease `loopUntilSink_reachesSink`'s `hstep` consumes (with measure
+  `μ := counterValue B`) when wrapping `binToUnaryBody` into the conversion loop (D2t-3c-ε).
+* `binToUnaryBody_onePass_appendedBit` — the produced `U`-bit at `head-u-1` is set, recording the
+  `|U| + 1` growth (the output side, toward ζ's `|U| = value(B)`).
+
+The counter step reuses the toolkit's `counterValue_first_zero_diff` (the bit-flip arithmetic of a
+borrow): the post-tape matches its hypotheses with `c := after`, `c' := c0`, `start := head+1`.  `U`'s
+new bit sits at `head-u-1 < head+1`, strictly left of the `counterValue` window `[head+1, head+1+w)`, so
+it leaves the counter value untouched.
+
+Builds no verifier and proves no separation; standard `[propext, Classical.choice, Quot.sound]` triple.
+**No `P ≠ NP` claim.**
+-/
+
+/-- **One-pass measure-decrease.**  From HOME with `B > 0` (lowest set bit at `head+1+j`), one pass of
+`binToUnaryBody` drops the little-endian counter value of the width-`w` block `[head+1, head+1+w)` by
+exactly one: `counterValue (after) + 1 = counterValue (before)`.  This is the strict measure decrease
+for `loopUntilSink_reachesSink`'s `hstep` with `μ := counterValue B`.  Hypotheses match
+`binToUnaryBody_runConfig_onePass`; `w` (with `j < w`) is the counter window's width. -/
+theorem binToUnaryBody_onePass_counterValue {L : Nat}
+    (c0 : Configuration (M := bodyFull.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (j : Nat)
+    (hj : (c0.head : Nat) + 1 + j ≤ L)
+    (hbnd : (c0.head : Nat) + 1 < bodyFull.toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin (bodyFull.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ hb : (c0.head : Nat) + 1 + j < bodyFull.toPhased.toTM.tapeLength L,
+      c0.tape ⟨(c0.head : Nat) + 1 + j, hb⟩ = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat))
+    (u : Nat) (hUfit : u + 1 ≤ (c0.head : Nat))
+    (hU : ∀ p : Fin (bodyFull.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - u ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) → c0.tape p = true)
+    (hUboundary : ∀ hb : (c0.head : Nat) - u - 1 < bodyFull.toPhased.toTM.tapeLength L,
+      c0.tape ⟨(c0.head : Nat) - u - 1, hb⟩ = false)
+    (w : Nat) (hjw : j < w)
+    (hwfit : (c0.head : Nat) + 1 + w ≤ bodyFull.toPhased.toTM.tapeLength L) :
+    counterValue (TM.runConfig (M := bodyFull.toPhased.toTM) c0
+          (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1))
+          ((c0.head : Nat) + 1) w + 1
+      = counterValue c0 ((c0.head : Nat) + 1) w := by
+  obtain ⟨_, _, hTape⟩ :=
+    binToUnaryBody_runConfig_onePass c0 hphase j hj hbnd h_zeros h_one h_sentinel hHOME u hUfit hU
+      hUboundary
+  set cF := TM.runConfig (M := bodyFull.toPhased.toTM) c0
+    (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1) with hcF
+  refine (counterValue_first_zero_diff cF c0 ((c0.head : Nat) + 1) j w hjw hwfit
+    ?_ ?_ ?_ ?_ ?_).symm
+  · -- after: low block `[head+1, head+1+j)` is all `1` (the borrow filled it in).
+    intro i hi hb
+    rw [hTape ⟨(c0.head : Nat) + 1 + i, hb⟩,
+      if_neg (by show ¬((c0.head : Nat) + 1 + i = (c0.head : Nat) - u - 1); omega),
+      if_pos (by show (c0.head : Nat) + 1 ≤ (c0.head : Nat) + 1 + i
+        ∧ (c0.head : Nat) + 1 + i < (c0.head : Nat) + 1 + j; omega)]
+  · -- after: the lowest set bit `head+1+j` was cleared to `0`.
+    intro hb
+    rw [hTape ⟨(c0.head : Nat) + 1 + j, hb⟩,
+      if_neg (by show ¬((c0.head : Nat) + 1 + j = (c0.head : Nat) - u - 1); omega),
+      if_neg (by show ¬((c0.head : Nat) + 1 ≤ (c0.head : Nat) + 1 + j
+        ∧ (c0.head : Nat) + 1 + j < (c0.head : Nat) + 1 + j); omega),
+      if_pos rfl]
+  · -- before: low block was all `0` (input hypothesis `h_zeros`).
+    intro i hi hb
+    exact h_zeros ⟨(c0.head : Nat) + 1 + i, hb⟩
+      (by show (c0.head : Nat) + 1 ≤ (c0.head : Nat) + 1 + i; omega)
+      (by show (c0.head : Nat) + 1 + i < (c0.head : Nat) + 1 + j; omega)
+  · -- before: the lowest set bit `head+1+j` was `1` (input hypothesis `h_one`).
+    intro hb
+    exact h_one hb
+  · -- beyond `j`, the counter cells are untouched by the pass.
+    intro i hij hiw hb
+    rw [hTape ⟨(c0.head : Nat) + 1 + i, hb⟩,
+      if_neg (by show ¬((c0.head : Nat) + 1 + i = (c0.head : Nat) - u - 1); omega),
+      if_neg (by show ¬((c0.head : Nat) + 1 ≤ (c0.head : Nat) + 1 + i
+        ∧ (c0.head : Nat) + 1 + i < (c0.head : Nat) + 1 + j); omega),
+      if_neg (by show ¬((c0.head : Nat) + 1 + i = (c0.head : Nat) + 1 + j); omega)]
+
+/-- **One-pass output bit.**  One pass sets the cell `head-u-1` (the new left end of the unary block
+`U`) to `1`, recording the `|U| + 1` growth.  Read directly off `onePass`'s post-tape. -/
+theorem binToUnaryBody_onePass_appendedBit {L : Nat}
+    (c0 : Configuration (M := bodyFull.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (j : Nat)
+    (hj : (c0.head : Nat) + 1 + j ≤ L)
+    (hbnd : (c0.head : Nat) + 1 < bodyFull.toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin (bodyFull.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ hb : (c0.head : Nat) + 1 + j < bodyFull.toPhased.toTM.tapeLength L,
+      c0.tape ⟨(c0.head : Nat) + 1 + j, hb⟩ = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat))
+    (u : Nat) (hUfit : u + 1 ≤ (c0.head : Nat))
+    (hU : ∀ p : Fin (bodyFull.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - u ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) → c0.tape p = true)
+    (hUboundary : ∀ hb : (c0.head : Nat) - u - 1 < bodyFull.toPhased.toTM.tapeLength L,
+      c0.tape ⟨(c0.head : Nat) - u - 1, hb⟩ = false)
+    (hb : (c0.head : Nat) - u - 1 < bodyFull.toPhased.toTM.tapeLength L) :
+    (TM.runConfig (M := bodyFull.toPhased.toTM) c0
+        (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1)).tape
+        ⟨(c0.head : Nat) - u - 1, hb⟩ = true := by
+  obtain ⟨_, _, hTape⟩ :=
+    binToUnaryBody_runConfig_onePass c0 hphase j hj hbnd h_zeros h_one h_sentinel hHOME u hUfit hU
+      hUboundary
+  rw [hTape ⟨(c0.head : Nat) - u - 1, hb⟩, if_pos rfl]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryMeasure.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryMeasure.lean
@@ -32,6 +32,12 @@ Builds no verifier and proves no separation; standard `[propext, Classical.choic
 **No `P ≠ NP` claim.**
 -/
 
+/-- The one-pass `runConfig` step count — the argument `binToUnaryBody_runConfig_onePass` runs for
+(the per-element step tally of the seven-element body).  Factored out so the statements below don't
+repeat the literal; each proof `unfold`s it to the form the engine theorem returns. -/
+abbrev onePassSteps (j u : Nat) : Nat :=
+  2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1
+
 /-- **One-pass measure-decrease.**  From HOME with `B > 0` (lowest set bit at `head+1+j`), one pass of
 `binToUnaryBody` drops the little-endian counter value of the width-`w` block `[head+1, head+1+w)` by
 exactly one: `counterValue (after) + 1 = counterValue (before)`.  This is the strict measure decrease
@@ -54,15 +60,15 @@ theorem binToUnaryBody_onePass_counterValue {L : Nat}
       c0.tape ⟨(c0.head : Nat) - u - 1, hb⟩ = false)
     (w : Nat) (hjw : j < w)
     (hwfit : (c0.head : Nat) + 1 + w ≤ bodyFull.toPhased.toTM.tapeLength L) :
-    counterValue (TM.runConfig (M := bodyFull.toPhased.toTM) c0
-          (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1))
+    counterValue (TM.runConfig (M := bodyFull.toPhased.toTM) c0 (onePassSteps j u))
           ((c0.head : Nat) + 1) w + 1
       = counterValue c0 ((c0.head : Nat) + 1) w := by
+  unfold onePassSteps
   obtain ⟨_, _, hTape⟩ :=
     binToUnaryBody_runConfig_onePass c0 hphase j hj hbnd h_zeros h_one h_sentinel hHOME u hUfit hU
       hUboundary
   set cF := TM.runConfig (M := bodyFull.toPhased.toTM) c0
-    (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1) with hcF
+    (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1)
   refine (counterValue_first_zero_diff cF c0 ((c0.head : Nat) + 1) j w hjw hwfit
     ?_ ?_ ?_ ?_ ?_).symm
   · -- after: low block `[head+1, head+1+j)` is all `1` (the borrow filled it in).
@@ -112,9 +118,9 @@ theorem binToUnaryBody_onePass_appendedBit {L : Nat}
     (hUboundary : ∀ hb : (c0.head : Nat) - u - 1 < bodyFull.toPhased.toTM.tapeLength L,
       c0.tape ⟨(c0.head : Nat) - u - 1, hb⟩ = false)
     (hb : (c0.head : Nat) - u - 1 < bodyFull.toPhased.toTM.tapeLength L) :
-    (TM.runConfig (M := bodyFull.toPhased.toTM) c0
-        (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1)).tape
+    (TM.runConfig (M := bodyFull.toPhased.toTM) c0 (onePassSteps j u)).tape
         ⟨(c0.head : Nat) - u - 1, hb⟩ = true := by
+  unfold onePassSteps
   obtain ⟨_, _, hTape⟩ :=
     binToUnaryBody_runConfig_onePass c0 hphase j hj hbnd h_zeros h_one h_sentinel hHOME u hUfit hU
       hUboundary

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -95,6 +95,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -3801,6 +3802,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryBody_runConfig_afterAppend6Handoff
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryBody_runConfig_afterScanRight7
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryBody_runConfig_onePass
+-- D2t-3c-ε ingredient: one-pass measure-decrease (counterValue − 1) + output bit (|U| + 1).
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryBody_onePass_counterValue
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryBody_onePass_appendedBit
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -85,6 +85,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -587,6 +588,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryBody_runConfig_afterScanRight7
 -- D2t-3c-γ: the one-pass HOME→HOME headline (the assembled binary→unary loop body).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryBody_runConfig_onePass
+-- D2t-3c-ε ingredient: one-pass measure-decrease (counterValue − 1) + output bit (|U| + 1).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryBody_onePass_counterValue
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryBody_onePass_appendedBit
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

Reads the **net arithmetic effect** off the merged HOME→HOME engine `binToUnaryBody_runConfig_onePass`
(`TM_VERIFIER_STRATEGY.md` §12) — the ingredients the **D2t-3c-ε loop** (`loopUntilSink binToUnaryBody`)
and **ζ correctness bridge** consume:

- **`binToUnaryBody_onePass_counterValue`** — one pass drops `counterValue B` of the width-`w` window
  `[head+1, head+1+w)` by exactly one (`after + 1 = before`). The pass's B-region tape-effect is precisely
  a **borrow** at the lowest set bit `j` (cells `[head+1,head+1+j)` flip `0→1`, cell `head+1+j` flips
  `1→0`), so the toolkit `counterValue_first_zero_diff` applies with `c := after`, `c' := c0`,
  `start := head+1`. `U`'s new bit sits at `head-u-1 < head+1`, left of the window, so it leaves the
  counter value untouched. **This is the strict measure decrease `loopUntilSink_reachesSink`'s `hstep`
  needs** (with `μ := counterValue B`).
- **`binToUnaryBody_onePass_appendedBit`** — the produced `U`-bit at `head-u-1` is set (`|U| + 1`), the
  output side toward ζ's `|U| = value(B)`.

## Notes
- Lands in a **new module** `TreeMCSPBinToUnaryMeasure.lean`; **no edits** to the
  parallel-session-owned `TreeMCSPBinToUnaryBody.lean` (zero file-conflict surface).
- The `if`-condition / `h_zeros` `omega` discharges use the codebase's standard
  `show <Fin-free goal>; omega` idiom (cf. `BinaryCounter.lean`'s `counterValue_first_zero_diff`
  callers) to reduce `↑⟨head+1+i, hb⟩` to `head+1+i` by defeq.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- Surface tests + `AxiomsAudit` extended. **0 `sorry`/`admit`/`native_decide`/custom axiom**; standard
  `[propext, Classical.choice, Quot.sound]` triple.

**Infrastructure** (AGENTS.md): toolkit toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_