### PR TITLE
transcoder(D2t-3): distinguishable-marker discriminating read (fixed-phase routing core)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroTest.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroTest.lean
@@ -83,6 +83,74 @@ theorem bZeroTest_pos_halts_before_marker {L : Nat} (x : Boolcube.Point L) (j w 
   obtain ⟨hph, hhd, _⟩ := gammaSelfLoopScan_runConfig_terminator x j (by omega) hzeros hbit
   exact ⟨hph, hhd, by rw [hhd]; exact hjw⟩
 
+/-!
+## The distinguishable-marker discriminating read (fixed-phase routing core)
+
+The positional decision above (`head = w` iff `B = 0`) cannot become a *phase* branch by a local read:
+the rightMarker is a single `1`, identical to a B set-bit, and its position `w` is data-dependent, so
+a fixed-phase machine can neither read-distinguish it nor compare the head to a hardcoded `w`.
+
+The agreed resolution (the maintainer's "distinguishable end-marker"): make the marker **locally
+detectable by reading one extra cell**.  The layout invariant — call it *spread B + double marker* —
+
+* terminates the counter window with a **double `1`** (cells `w` and `w+1` both `1`); and
+* **separates** B's set bits, so the lowest set bit `j` is followed by a `0` (cell `j+1 = 0`).
+
+Then the cell **immediately past the scan-stop** decides in a single fixed-phase read:
+
+* `B = 0` ⇒ scan stops on the marker (`head = w`), and cell `head + 1 = w + 1` is the marker's second
+  `1` (`bZeroRoute_zero_reads_one`);
+* `B > 0` ⇒ scan stops on the lowest set bit (`head = j`), and cell `head + 1 = j + 1` is a separator
+  `0` (`bZeroRoute_pos_reads_zero`).
+
+So *read(scan-stop + 1) = `1` ⟺ `B = 0`* — a one-cell read a fixed-phase program can branch on
+(`B = 0 →` sink, `B > 0 →` body-entry).  Both lemmas read the post-scan tape off the terminator's
+**tape-invariance** clause, so the discriminating cell is whatever the layout placed there.
+
+These state the invariant as **hypotheses** (routing-agnostic, like the lemmas above); the program
+wiring (a phase that moves one cell right, reads, and branches) and the concrete spread-B layout
+construction are the follow-up assembly.  Still no routing program is built here, and no `P ≠ NP` claim.
+-/
+
+/-- **`B = 0`: the cell past the scan-stop is the marker's second `1`.**  Under *spread B + double
+marker* — counter cells `[0, w)` all `0`, marker cells `w` and `w + 1` both `1` — `gammaSelfLoopScan`
+stops on the marker (`head = w`) and the cell `head + 1 = w + 1` reads `true`.  The discriminating read
+sees `1`. -/
+theorem bZeroRoute_zero_reads_one {L : Nat} (x : Boolcube.Point L) (w : Nat) (hw1 : w + 1 ≤ L)
+    (hzeros : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (p : Nat) < w → (gammaSelfLoopScan.toPhased.toTM.initialConfig x).tape p = false)
+    (hmark1 : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (p : Nat) = w → (gammaSelfLoopScan.toPhased.toTM.initialConfig x).tape p = true)
+    (hmark2 : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (p : Nat) = w + 1 → (gammaSelfLoopScan.toPhased.toTM.initialConfig x).tape p = true) :
+    ((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM)
+        (gammaSelfLoopScan.toPhased.toTM.initialConfig x) (w + 1)).head : Nat) = w
+      ∧ ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L), (p : Nat) = w + 1 →
+          (TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM)
+            (gammaSelfLoopScan.toPhased.toTM.initialConfig x) (w + 1)).tape p = true := by
+  obtain ⟨_, hhd, htp⟩ := gammaSelfLoopScan_runConfig_terminator x w (by omega) hzeros hmark1
+  exact ⟨hhd, fun p hp => by rw [htp]; exact hmark2 p hp⟩
+
+/-- **`B > 0`: the cell past the scan-stop is a separator `0`.**  Under *spread B + double marker* —
+counter cells `[0, j)` all `0`, cell `j` set (`j < w`), and the separator cell `j + 1` is `0` —
+`gammaSelfLoopScan` stops on the set bit (`head = j`) and the cell `head + 1 = j + 1` reads `false`.
+The discriminating read sees `0`. -/
+theorem bZeroRoute_pos_reads_zero {L : Nat} (x : Boolcube.Point L) (j w : Nat)
+    (hjw : j < w) (hw1 : w + 1 ≤ L)
+    (hzeros : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (p : Nat) < j → (gammaSelfLoopScan.toPhased.toTM.initialConfig x).tape p = false)
+    (hbit : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (p : Nat) = j → (gammaSelfLoopScan.toPhased.toTM.initialConfig x).tape p = true)
+    (hsep : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (p : Nat) = j + 1 → (gammaSelfLoopScan.toPhased.toTM.initialConfig x).tape p = false) :
+    ((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM)
+        (gammaSelfLoopScan.toPhased.toTM.initialConfig x) (j + 1)).head : Nat) = j
+      ∧ ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L), (p : Nat) = j + 1 →
+          (TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM)
+            (gammaSelfLoopScan.toPhased.toTM.initialConfig x) (j + 1)).tape p = false := by
+  obtain ⟨_, hhd, htp⟩ := gammaSelfLoopScan_runConfig_terminator x j (by omega) hzeros hbit
+  exact ⟨hhd, fun p hp => by rw [htp]; exact hsep p hp⟩
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroTest.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroTest.lean
@@ -115,8 +115,10 @@ construction are the follow-up assembly.  Still no routing program is built here
 /-- **`B = 0`: the cell past the scan-stop is the marker's second `1`.**  Under *spread B + double
 marker* — counter cells `[0, w)` all `0`, marker cells `w` and `w + 1` both `1` — `gammaSelfLoopScan`
 stops on the marker (`head = w`) and the cell `head + 1 = w + 1` reads `true`.  The discriminating read
-sees `1`. -/
-theorem bZeroRoute_zero_reads_one {L : Nat} (x : Boolcube.Point L) (w : Nat) (hw1 : w + 1 ≤ L)
+sees `1`.  The bound is `w + 1 < L` (not merely `≤ L`): the second marker cell `w + 1` must lie in the
+input region `[0, L)` for `hmark2` to be realizable from `initialConfig` — at `w + 1 = L` the cell is
+definitionally `false` (input bits live only on `[0, L)`), which would make the hypothesis vacuous. -/
+theorem bZeroRoute_zero_reads_one {L : Nat} (x : Boolcube.Point L) (w : Nat) (hw1 : w + 1 < L)
     (hzeros : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
       (p : Nat) < w → (gammaSelfLoopScan.toPhased.toTM.initialConfig x).tape p = false)
     (hmark1 : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3809,6 +3809,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3c-δ: the bZeroTest loop-exit decision (scan halts on rightMarker iff B = 0; routing deferred).
 #check @Pnp4.Frontier.ContractExpansion.bZeroTest_zero_halts_on_marker
 #check @Pnp4.Frontier.ContractExpansion.bZeroTest_pos_halts_before_marker
+-- D2t-3 routing: the distinguishable-marker discriminating read (read past scan-stop = 1 iff B = 0).
+#check @Pnp4.Frontier.ContractExpansion.bZeroRoute_zero_reads_one
+#check @Pnp4.Frontier.ContractExpansion.bZeroRoute_pos_reads_zero
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -595,6 +595,9 @@ end Pnp4
 -- D2t-3c-δ: the bZeroTest loop-exit decision (scan halts on rightMarker iff B = 0; routing deferred).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroTest_zero_halts_on_marker
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroTest_pos_halts_before_marker
+-- D2t-3 routing: the distinguishable-marker discriminating read (read past scan-stop = 1 iff B = 0).
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroRoute_zero_reads_one
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroRoute_pos_reads_zero
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

The **B=0 routing crux** (the `loopUntilSink` `hbase`, `TM_VERIFIER_STRATEGY.md` §12). The positional
decision (#1548 — *scan halts on the rightMarker ⟺ B=0*) cannot become a **phase** branch by a local
read: the rightMarker is a single `1` (identical to a B set-bit) at a **data-dependent** position `w`,
so a fixed-phase machine can neither read-distinguish it nor compare the head to a hardcoded `w`.

Per the maintainer's design choice, the resolution is a **distinguishable end-marker**, locally
detectable by reading **one extra cell**. Layout invariant — *spread B + double marker*:
- the counter window ends with a **double `1`** (cells `w` and `w+1`); and
- B's set bits are **separated** (the lowest set bit `j` is followed by a `0`).

Then the cell **just past the scan-stop** decides in a single fixed-phase read:

- **`bZeroRoute_zero_reads_one`** — `B=0` ⇒ scan stops on the marker (`head = w`), and cell
  `head+1 = w+1` reads `true` (the marker's second `1`).
- **`bZeroRoute_pos_reads_zero`** — `B>0` (lowest set bit at `j < w`) ⇒ scan stops on the bit
  (`head = j`), and cell `head+1 = j+1` reads `false` (the separator).

So **`read(scan-stop + 1) = 1 ⟺ B = 0`** — a one-cell read a fixed-phase program can branch on
(`B=0 →` sink, `B>0 →` body-entry). Both read the post-scan tape off the terminator's **tape-invariance**
clause, so the discriminating cell is whatever the layout placed there.

## Scope / deferred

The invariant is stated as **hypotheses** (routing-agnostic, mirroring #1548). Still deferred to the
follow-up assembly: the **program wiring** (a phase that moves one cell right, reads, and branches to
sink/body) and the **concrete spread-B layout construction** (re-encoding B with separators + the double
marker). This PR fixes only the semantic *distinguisher* — the key that unblocks the phase routing.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- Surface tests + `AxiomsAudit` extended with both lemmas. **0 `sorry`/`admit`/`native_decide`/custom
  axiom**; standard `[propext, Classical.choice, Quot.sound]` triple. Extends `TreeMCSPBZeroTest.lean`
  (no new file, no edits to parallel-session-owned modules).

**Infrastructure** (AGENTS.md): toolkit toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_