### PR TITLE
transcoder(D2t-3): bZeroRouteProgram run-through, P1 region (scanning invariant)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -343,6 +343,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunP1.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunP1.lean
@@ -1,0 +1,113 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
+
+/-!
+# `bZeroRouteProgram` run-through, P1 region (NP-verifier track — D2t-3 routing run-through)
+
+The composed routing program `bZeroRouteProgram := seq gammaSelfLoopScan stepRightThenBranch` runs the
+scan in `seq`'s **first region** (phases `0..1`, which run `gammaSelfLoopScan`'s transitions directly),
+then hands off into `stepRightThenBranch`.  This module lifts the scan's behaviour through the `seq`
+P1-region simulation (`runConfig_seq_succ_P1_normal_*`): replicating `gammaSelfLoopScan`'s scanning loop
+inside `seq`.
+
+* `bZeroRouteProgram_P1_scanning` — while the leading cells are `0`, the scan stays in phase `0`,
+  advancing the head one cell per step, tape unchanged (the back-edge loop, in `seq`'s P1 region).
+
+`seq`'s P1-accept (phase `1`) is where the handoff fires (`runConfig_seq_succ_P1_boundary`), landing in
+`stepRightThenBranch` (phase `2`) = the input to the P2-region run-through
+(`bZeroRouteProgram_P2_runConfig_branch_*`).  The terminator step (reaching phase `1` at the first `1`),
+the handoff, and gluing P1 + handoff + P2 via `runConfig_add` are the next steps (then `ε`/`ζ`).
+
+The per-step `gammaSelfLoopScan.transition` values are evaluated by the isolated helpers below — keeping
+`simp [gammaSelfLoopScan]` out of the `seq` `runConfig` goal (where it would also unfold the machine and
+break the layout hypotheses' matching).
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- `gammaSelfLoopScan` writes the scanned bit back (the write field is the input bit in every branch). -/
+private theorem gscan_trans_write (i : Fin gammaSelfLoopScan.numPhases) (s : Unit) (b : Bool) :
+    (gammaSelfLoopScan.transition i s b).snd.snd.fst = b := by
+  simp only [gammaSelfLoopScan]; split <;> [split; skip] <;> rfl
+
+/-- In the scan phase (`i.val = 0`) reading a `0`, `gammaSelfLoopScan` stays in phase `0`. -/
+private theorem gscan_trans_phase0 (i : Fin gammaSelfLoopScan.numPhases) (s : Unit) (h : i.val = 0) :
+    (gammaSelfLoopScan.transition i s false).fst.val = 0 := by
+  simp [gammaSelfLoopScan, h]
+
+/-- In the scan phase (`i.val = 0`) reading a `0`, `gammaSelfLoopScan` moves right. -/
+private theorem gscan_trans_move0 (i : Fin gammaSelfLoopScan.numPhases) (s : Unit) (h : i.val = 0) :
+    (gammaSelfLoopScan.transition i s false).snd.snd.snd = Move.right := by
+  simp [gammaSelfLoopScan, h]
+
+/-- Scan back-edge loop inside `seq`'s P1 region: if the first `z` cells are `0` (and `z` is within the
+tape), then for every `k ≤ z` running `k` steps from the start leaves the program in phase `0` with the
+head advanced to `k` and the tape unchanged. -/
+theorem bZeroRouteProgram_P1_scanning {L : Nat} (x : Boolcube.Point L) (z : Nat)
+    (hz : z < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) < z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false) :
+    ∀ k, k ≤ z →
+      (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).state).fst : Nat) = 0
+      ∧ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head : Nat) = k
+      ∧ (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).tape
+          = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
+  intro k
+  induction k with
+  | zero => intro _; exact ⟨rfl, rfl, rfl⟩
+  | succ k ih =>
+      intro hk
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega)
+      have hbit : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).tape
+          (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head = false := by
+        rw [htp]; exact hzeros _ (by rw [hhd]; omega)
+      have h1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).state).fst : Nat)
+          < gammaSelfLoopScan.numPhases := by rw [hph]; decide
+      have hne : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).state).fst : Nat)
+          ≠ gammaSelfLoopScan.acceptPhase.val := by rw [hph]; decide
+      have hbnd : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head : Nat) + 1
+          < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by rw [hhd]; omega
+      refine ⟨?_, ?_, ?_⟩
+      · rw [runConfig_seq_succ_P1_normal_phase gammaSelfLoopScan stepRightThenBranch
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k h1 hne, hbit]
+        exact gscan_trans_phase0 _ _ hph
+      · rw [runConfig_seq_succ_P1_normal_head gammaSelfLoopScan stepRightThenBranch
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k h1 hne, hbit,
+          gscan_trans_move0 _ _ hph]
+        simp only [Configuration.moveHead, dif_pos hbnd]
+        omega
+      · rw [runConfig_seq_succ_P1_normal_tape gammaSelfLoopScan stepRightThenBranch
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k h1 hne, hbit,
+          gscan_trans_write]
+        have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+            ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).write
+            (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+            ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head false
+            = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+            ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).tape := by
+          funext j
+          by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+              ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head
+          · subst hj; simp [Configuration.write, hbit]
+          · simp [Configuration.write, hj]
+        rw [hself, htp]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -101,6 +101,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -3829,6 +3830,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false
+-- D2t-3 routing run-through (P1 region): scan stays in phase 0, head advances, tape unchanged (seq sim).
+#check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_scanning
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -91,6 +91,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -615,6 +616,8 @@ end Pnp4
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false
+-- D2t-3 routing run-through (P1 region): scan stays in phase 0, head advances, tape unchanged (seq sim).
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

The **P1-region** of the composed routing run-through (after the P2-region, #1553) — closing out D2t-3.
Lifts `gammaSelfLoopScan`'s scanning loop into `seq`'s first region:

**`bZeroRouteProgram_P1_scanning`** — with the leading `z` cells `0` (and `z` within the tape), for every
`k ≤ z` running `k` steps from the start leaves the program in **phase `0`**, head advanced to **`k`**,
tape **unchanged** — the back-edge loop simulated through `runConfig_seq_succ_P1_normal_*`.

## Note on technique

The per-step `gammaSelfLoopScan.transition` values are evaluated by **isolated helper lemmas**
(`gscan_trans_{write,phase0,move0}`), keeping `simp [gammaSelfLoopScan]` *out* of the `seq` `runConfig`
goal — there it would also unfold the machine inside `runConfig`/`initialConfig` and break the layout
hypotheses' syntactic matching. The induction uses only `rw`/`exact` with those helpers (no linter
suppression needed).

## Scope / remaining

This is the scanning loop (the data-dependent induction — the hard part). Remaining run-through pieces:
the **terminator step** (reaching phase `1` = `seq`'s P1-accept at the first `1`), the **handoff**
(`runConfig_seq_succ_P1_boundary`, already exists), then **gluing** P1 + handoff + P2 (#1553) via
`runConfig_add` ⇒ phase `4` iff `B=0`; then `ε` (`loopUntilSink`) and `ζ`.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- New module `TreeMCSPBZeroRouteRunP1.lean`; surface tests + `AxiomsAudit` extended. **0
  `sorry`/`admit`/`native_decide`/custom axiom**; standard `[propext, Classical.choice, Quot.sound]`
  triple.

**Infrastructure** (AGENTS.md): run-behaviour toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_