### PR TITLE
transcoder(D2t-3): bZeroRouteProgram run-through, P1 terminator step

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunP1.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunP1.lean
@@ -108,6 +108,73 @@ theorem bZeroRouteProgram_P1_scanning {L : Nat} (x : Boolcube.Point L) (z : Nat)
           · simp [Configuration.write, hj]
         rw [hself, htp]
 
+/-- In the scan phase (`i.val = 0`) reading a `1`, `gammaSelfLoopScan` jumps to its done phase (`1`). -/
+private theorem gscan_trans_phase1 (i : Fin gammaSelfLoopScan.numPhases) (s : Unit) (h : i.val = 0) :
+    (gammaSelfLoopScan.transition i s true).fst.val = 1 := by
+  simp [gammaSelfLoopScan, h]
+
+/-- In the scan phase (`i.val = 0`) reading a `1`, `gammaSelfLoopScan` stays put (rests on the marker). -/
+private theorem gscan_trans_movestay (i : Fin gammaSelfLoopScan.numPhases) (s : Unit) (h : i.val = 0) :
+    (gammaSelfLoopScan.transition i s true).snd.snd.snd = Move.stay := by
+  simp [gammaSelfLoopScan, h]
+
+/-- Terminator step inside `seq`'s P1 region: with the first `z` cells `0` and cell `z` a `1`, after
+`z + 1` steps the scan rests in phase `1` (`gammaSelfLoopScan`'s accept = `seq`'s P1-accept), head on the
+marker (`= z`), tape unchanged.  Applies `bZeroRouteProgram_P1_scanning` at `k = z`, then one terminator
+step (reading the `1` → phase `1`, stay).  Phase `1` is where `runConfig_seq_succ_P1_boundary` then hands
+off into `stepRightThenBranch` (phase `2`). -/
+theorem bZeroRouteProgram_P1_runConfig_terminator {L : Nat} (x : Boolcube.Point L) (z : Nat)
+    (hz : z < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) < z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+    (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) = z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true) :
+    (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).state).fst : Nat) = 1
+      ∧ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).head : Nat) = z
+      ∧ (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).tape
+          = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
+  obtain ⟨hph, hhd, htp⟩ := bZeroRouteProgram_P1_scanning x z hz hzeros z (le_refl z)
+  have hbit : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).tape
+      (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).head = true := by
+    rw [htp]; exact hterm _ hhd
+  have h1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).state).fst : Nat)
+      < gammaSelfLoopScan.numPhases := by rw [hph]; decide
+  have hne : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).state).fst : Nat)
+      ≠ gammaSelfLoopScan.acceptPhase.val := by rw [hph]; decide
+  refine ⟨?_, ?_, ?_⟩
+  · rw [runConfig_seq_succ_P1_normal_phase gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z h1 hne, hbit]
+    exact gscan_trans_phase1 _ _ hph
+  · rw [runConfig_seq_succ_P1_normal_head gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z h1 hne, hbit,
+      gscan_trans_movestay _ _ hph]
+    simp only [Configuration.moveHead]
+    exact hhd
+  · rw [runConfig_seq_succ_P1_normal_tape gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z h1 hne, hbit,
+      gscan_trans_write]
+    have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).write
+        (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).head true
+        = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).tape := by
+      funext j
+      by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).head
+      · subst hj; simp [Configuration.write, hbit]
+      · simp [Configuration.write, hj]
+    rw [hself, htp]
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3832,6 +3832,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false
 -- D2t-3 routing run-through (P1 region): scan stays in phase 0, head advances, tape unchanged (seq sim).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_scanning
+#check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_terminator
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -618,6 +618,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false
 -- D2t-3 routing run-through (P1 region): scan stays in phase 0, head advances, tape unchanged (seq sim).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_terminator
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

Completes the **P1 region** of the routing run-through (after the scanning invariant, #1554). From the
scanning invariant at `k = z`, one **terminator step** (reading the marker `1` at cell `z`) reaches phase
`1` — `gammaSelfLoopScan`'s accept = `seq`'s P1-accept — head resting on the marker (`= z`), tape
unchanged.

**`bZeroRouteProgram_P1_runConfig_terminator`** — `z + 1` steps from the start ⇒ phase `1`, head `= z`,
tape unchanged.

Reuses the isolated-helper technique: two new helpers (`gscan_trans_phase1`, `gscan_trans_movestay`)
evaluate the phase-`0`-reading-`1` transition (→ phase `1`, `Move.stay`), kept out of the `seq`
`runConfig` goal; the step uses `rw`/`exact` + `runConfig_seq_succ_P1_normal_*`.

## Scope / remaining

Phase `1` is exactly where `runConfig_seq_succ_P1_boundary` hands off into `stepRightThenBranch` (phase
`2`). Remaining to finish the run-through: the **handoff** + **compose** — `P1 (z+1)` + handoff `(1)` +
`P2` (#1553, `2`) via `runConfig_add` ⇒ phase `4` iff `B=0`; then `ε` (`loopUntilSink`) and `ζ`.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- Extends `TreeMCSPBZeroRouteRunP1.lean`; surface tests + `AxiomsAudit` updated. **0
  `sorry`/`admit`/`native_decide`/custom axiom**; standard `[propext, Classical.choice, Quot.sound]`
  triple.

**Infrastructure** (AGENTS.md): run-behaviour toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_