### PR TITLE
transcoder(D2t-3): bZeroRouteProgram run-through, handoff step (reaches P2-entry)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunP1.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunP1.lean
@@ -175,6 +175,40 @@ theorem bZeroRouteProgram_P1_runConfig_terminator {L : Nat} (x : Boolcube.Point 
       · simp [Configuration.write, hj]
     rw [hself, htp]
 
+/-- Handoff step: from the P1-accept (phase `1`, reached by the terminator after `z + 1` steps), one
+more step hands off into `stepRightThenBranch`'s start (composed phase `2`), head and tape preserved.
+So after `z + 1 + 1` steps the routing program is in phase `2`, head on the marker (`= z`), tape
+unchanged — exactly the entry point for the P2-region run-through (`bZeroRouteProgram_P2_*`).  Uses the
+terminator plus `runConfig_seq_succ_P1_boundary`. -/
+theorem bZeroRouteProgram_P1_runConfig_handoff {L : Nat} (x : Boolcube.Point L) (z : Nat)
+    (hz : z < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) < z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+    (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) = z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true) :
+    (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst : Nat) = 2
+      ∧ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head : Nat) = z
+      ∧ (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape
+          = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
+  obtain ⟨hph, hhd, htp⟩ := bZeroRouteProgram_P1_runConfig_terminator x z hz hzeros hterm
+  have h1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).state).fst : Nat)
+      < gammaSelfLoopScan.numPhases := by rw [hph]; decide
+  have heq : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).state).fst : Nat)
+      = gammaSelfLoopScan.acceptPhase.val := by rw [hph]; decide
+  obtain ⟨hph2, _, hhd2, htp2⟩ := runConfig_seq_succ_P1_boundary gammaSelfLoopScan stepRightThenBranch
+    ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1) h1 heq
+  refine ⟨?_, ?_, ?_⟩
+  · rw [hph2]; decide
+  · rw [hhd2]; exact hhd
+  · rw [htp2]; exact htp
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3833,6 +3833,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3 routing run-through (P1 region): scan stays in phase 0, head advances, tape unchanged (seq sim).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_scanning
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_terminator
+#check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_handoff
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -619,6 +619,7 @@ end Pnp4
 -- D2t-3 routing run-through (P1 region): scan stays in phase 0, head advances, tape unchanged (seq sim).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_terminator
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_handoff
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

The **handoff step** of the routing run-through. From the P1-accept (phase `1`, reached by the
terminator #1555 after `z + 1` steps), one more step hands off into `stepRightThenBranch`'s start:

**`bZeroRouteProgram_P1_runConfig_handoff`** — after `z + 1 + 1` steps the routing program is in phase
`2` (the composed P2-start), head on the marker (`= z`), tape unchanged — exactly the entry point for the
P2-region run-through (#1553).

Uses the terminator (#1555) + `runConfig_seq_succ_P1_boundary` (the one free handoff step `seq` inserts at
`P1.acceptPhase`).

## Scope / remaining

The **final compose** — 2 P2 steps from this phase-`2` entry (reading the discriminator cell `z + 1`)
reach phase `4` (`B=0`) / `5` (`B>0`), gluing the full `bZeroRouteProgram` run-through — then `ε`
(`loopUntilSink`) and `ζ` (`|U| = value(B)`) close D2t-3.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- Extends `TreeMCSPBZeroRouteRunP1.lean`; surface tests + `AxiomsAudit` updated. **0
  `sorry`/`admit`/`native_decide`/custom axiom**; standard `[propext, Classical.choice, Quot.sound]`
  triple.

**Infrastructure** (AGENTS.md): run-behaviour toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_