### PR TITLE
transcoder(D2t-3): bZeroRouteProgram run-through, FULL compose (decides B=0 vs B>0)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -344,6 +344,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunCompose.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunCompose.lean
@@ -12,8 +12,11 @@ cell `z + 1` and land in the composed branch target:
   (`B = 0` → sink);
 * `bZeroRouteProgram_runConfig_decide_false` — discriminator `= 0` ⇒ phase `5` (`B > 0` → body-entry).
 
-This completes the composed routing run-through (the P1 region + handoff + P2 region, all on the one
-`bZeroRouteProgram`).  The remaining D2t-3 pieces are `ε` (`loopUntilSink`) and `ζ` (`|U| = value(B)`).
+The shared first P2 step (handoff → phase `3`, head `z + 1`, tape unchanged) is factored into the private
+`bZeroRouteProgram_runConfig_step1`; the two branch theorems differ only in the second step's read bit and
+branch lemma.  This completes the composed routing run-through (P1 region + handoff + P2 region, all on
+the one `bZeroRouteProgram`).  The remaining D2t-3 pieces are `ε` (`loopUntilSink`) and `ζ`
+(`|U| = value(B)`).
 
 The `stepRightThenBranch.transition` field values are evaluated by isolated helpers (same discipline as
 the `gscan_*` helpers), keeping `simp [stepRightThenBranch]` out of the `seq` `runConfig` goal.
@@ -55,10 +58,64 @@ private theorem srb_trans_p1_phase_false (i : Fin stepRightThenBranch.numPhases)
     (h : i.val = 1) : (stepRightThenBranch.transition i s false).fst.val = 3 := by
   simp [stepRightThenBranch, h]
 
-/-- Phase `1` of `stepRightThenBranch` stays put (reads in place). -/
-private theorem srb_trans_p1_move (i : Fin stepRightThenBranch.numPhases) (s : Unit) (b : Bool)
-    (h : i.val = 1) : (stepRightThenBranch.transition i s b).snd.snd.snd = Move.stay := by
-  simp [stepRightThenBranch, h]
+/-- Shared first P2 step: from the handoff (phase `2`, head `z`, tape unchanged) one step (step right)
+reaches phase `3`, head `z + 1`, tape unchanged — the common prefix of both branch run-throughs. -/
+private theorem bZeroRouteProgram_runConfig_step1 {L : Nat} (x : Boolcube.Point L) (z : Nat)
+    (hz1 : z + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) < z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+    (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) = z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true) :
+    (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst : Nat) = 3
+      ∧ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head : Nat) = z + 1
+      ∧ (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
+          = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
+  obtain ⟨hph_h, hhd_h, htp_h⟩ := bZeroRouteProgram_P1_runConfig_handoff x z (by omega) hzeros hterm
+  have h2a : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val := by
+    rw [hph_h]; decide
+  have hlt_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph_h]; decide
+  have hi0 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases = 0 := by rw [hph_h]; decide
+  have hbnd_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head : Nat) + 1
+      < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by rw [hhd_h]; omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
+      srb_trans_p0_phase _ _ _ hi0]
+    decide
+  · rw [runConfig_seq_succ_P2_head gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
+      srb_trans_p0_move _ _ _ hi0]
+    simp only [Configuration.moveHead, dif_pos hbnd_a]
+    rw [hhd_h]
+  · rw [runConfig_seq_succ_P2_tape gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
+      srb_trans_write]
+    have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).write
+        (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
+        ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape
+          (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head)
+        = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape := by
+      funext j; by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
+      · subst hj; simp [Configuration.write]
+      · simp [Configuration.write, hj]
+    rw [hself, htp_h]
 
 /-- **Full run-through, `B = 0` branch.**  Layout: cells `[0, z)` are `0`, cell `z` is the scan-stop `1`,
 and the discriminator cell `z + 1` is `1`.  Then `bZeroRouteProgram` runs: scan to `z` (`z + 1` steps,
@@ -78,55 +135,7 @@ theorem bZeroRouteProgram_runConfig_decide_true {L : Nat} (x : Boolcube.Point L)
     (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
         ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
         (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 4 := by
-  obtain ⟨hph_h, hhd_h, htp_h⟩ := bZeroRouteProgram_P1_runConfig_handoff x z (by omega) hzeros hterm
-  -- P2 step 1 (z+1+1 → z+1+1+1): phase 2 → 3, head z → z+1, tape unchanged.
-  have h2a : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val := by
-    rw [hph_h]; decide
-  have hlt_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
-      - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph_h]; decide
-  have hi0 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
-      - gammaSelfLoopScan.numPhases = 0 := by rw [hph_h]; decide
-  have hbnd_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head : Nat) + 1
-      < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by rw [hhd_h]; omega
-  have hph1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst : Nat) = 3 := by
-    rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
-      srb_trans_p0_phase _ _ _ hi0]
-    decide
-  have hhd1 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head : Nat) = z + 1 := by
-    rw [runConfig_seq_succ_P2_head gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
-      srb_trans_p0_move _ _ _ hi0]
-    simp only [Configuration.moveHead, dif_pos hbnd_a]
-    rw [hhd_h]
-  have htp1 : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
-      = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
-    rw [runConfig_seq_succ_P2_tape gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
-      srb_trans_write]
-    have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).write
-        (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
-        ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape
-          (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head)
-        = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape := by
-      funext j; by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
-      · subst hj; simp [Configuration.write]
-      · simp [Configuration.write, hj]
-    rw [hself, htp_h]
-  -- P2 step 2 (z+1+1+1 → z+1+1+1+1): phase 3, read discriminator z+1 = 1 → phase 4.
+  obtain ⟨hph1, hhd1, htp1⟩ := bZeroRouteProgram_runConfig_step1 x z hz1 hzeros hterm
   have h2b : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
       ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val := by
     rw [hph1]; decide
@@ -164,53 +173,7 @@ theorem bZeroRouteProgram_runConfig_decide_false {L : Nat} (x : Boolcube.Point L
     (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
         ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
         (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 5 := by
-  obtain ⟨hph_h, hhd_h, htp_h⟩ := bZeroRouteProgram_P1_runConfig_handoff x z (by omega) hzeros hterm
-  have h2a : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val := by
-    rw [hph_h]; decide
-  have hlt_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
-      - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph_h]; decide
-  have hi0 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
-      - gammaSelfLoopScan.numPhases = 0 := by rw [hph_h]; decide
-  have hbnd_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head : Nat) + 1
-      < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by rw [hhd_h]; omega
-  have hph1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst : Nat) = 3 := by
-    rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
-      srb_trans_p0_phase _ _ _ hi0]
-    decide
-  have hhd1 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head : Nat) = z + 1 := by
-    rw [runConfig_seq_succ_P2_head gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
-      srb_trans_p0_move _ _ _ hi0]
-    simp only [Configuration.moveHead, dif_pos hbnd_a]
-    rw [hhd_h]
-  have htp1 : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
-      = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
-    rw [runConfig_seq_succ_P2_tape gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
-      srb_trans_write]
-    have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).write
-        (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
-        ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape
-          (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head)
-        = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape := by
-      funext j; by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
-      · subst hj; simp [Configuration.write]
-      · simp [Configuration.write, hj]
-    rw [hself, htp_h]
+  obtain ⟨hph1, hhd1, htp1⟩ := bZeroRouteProgram_runConfig_step1 x z hz1 hzeros hterm
   have h2b : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
       ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val := by
     rw [hph1]; decide

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunCompose.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunCompose.lean
@@ -1,0 +1,235 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
+
+/-!
+# `bZeroRouteProgram` run-through, final compose (NP-verifier track — D2t-3 routing run-through)
+
+Glues the run-through together: after the handoff (`bZeroRouteProgram_P1_runConfig_handoff`, phase `2`,
+head on the marker `z`, tape unchanged), two P2-region steps — driven on `seq` directly via
+`runConfig_seq_succ_P2_*` and the `stepRightThenBranch` transition helpers below — read the discriminator
+cell `z + 1` and land in the composed branch target:
+
+* `bZeroRouteProgram_runConfig_decide_true` — discriminator `= 1` ⇒ after `z + 4` steps, phase `4`
+  (`B = 0` → sink);
+* `bZeroRouteProgram_runConfig_decide_false` — discriminator `= 0` ⇒ phase `5` (`B > 0` → body-entry).
+
+This completes the composed routing run-through (the P1 region + handoff + P2 region, all on the one
+`bZeroRouteProgram`).  The remaining D2t-3 pieces are `ε` (`loopUntilSink`) and `ζ` (`|U| = value(B)`).
+
+The `stepRightThenBranch.transition` field values are evaluated by isolated helpers (same discipline as
+the `gscan_*` helpers), keeping `simp [stepRightThenBranch]` out of the `seq` `runConfig` goal.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- `stepRightThenBranch` writes the scanned bit back (the write field is the input bit in every
+branch). -/
+private theorem srb_trans_write (i : Fin stepRightThenBranch.numPhases) (s : Unit) (b : Bool) :
+    (stepRightThenBranch.transition i s b).snd.snd.fst = b := by
+  simp only [stepRightThenBranch]; split <;> [skip; split] <;> simp
+
+/-- Phase `0` of `stepRightThenBranch` advances to phase `1`. -/
+private theorem srb_trans_p0_phase (i : Fin stepRightThenBranch.numPhases) (s : Unit) (b : Bool)
+    (h : i.val = 0) : (stepRightThenBranch.transition i s b).fst.val = 1 := by
+  simp [stepRightThenBranch, h]
+
+/-- Phase `0` of `stepRightThenBranch` moves right. -/
+private theorem srb_trans_p0_move (i : Fin stepRightThenBranch.numPhases) (s : Unit) (b : Bool)
+    (h : i.val = 0) : (stepRightThenBranch.transition i s b).snd.snd.snd = Move.right := by
+  simp [stepRightThenBranch, h]
+
+/-- Phase `1` of `stepRightThenBranch` reading `1` branches to phase `2`. -/
+private theorem srb_trans_p1_phase_true (i : Fin stepRightThenBranch.numPhases) (s : Unit)
+    (h : i.val = 1) : (stepRightThenBranch.transition i s true).fst.val = 2 := by
+  simp [stepRightThenBranch, h]
+
+/-- Phase `1` of `stepRightThenBranch` reading `0` branches to phase `3`. -/
+private theorem srb_trans_p1_phase_false (i : Fin stepRightThenBranch.numPhases) (s : Unit)
+    (h : i.val = 1) : (stepRightThenBranch.transition i s false).fst.val = 3 := by
+  simp [stepRightThenBranch, h]
+
+/-- Phase `1` of `stepRightThenBranch` stays put (reads in place). -/
+private theorem srb_trans_p1_move (i : Fin stepRightThenBranch.numPhases) (s : Unit) (b : Bool)
+    (h : i.val = 1) : (stepRightThenBranch.transition i s b).snd.snd.snd = Move.stay := by
+  simp [stepRightThenBranch, h]
+
+/-- **Full run-through, `B = 0` branch.**  Layout: cells `[0, z)` are `0`, cell `z` is the scan-stop `1`,
+and the discriminator cell `z + 1` is `1`.  Then `bZeroRouteProgram` runs: scan to `z` (`z + 1` steps,
+phase `1`), handoff (phase `2`), step right (phase `3`, head `z + 1`), read the discriminator `1` (phase
+`4`).  After `z + 1 + 1 + 1 + 1` steps it rests in composed phase `4` — the `B = 0` → sink target. -/
+theorem bZeroRouteProgram_runConfig_decide_true {L : Nat} (x : Boolcube.Point L) (z : Nat)
+    (hz1 : z + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) < z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+    (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) = z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true)
+    (hdisc : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) = z + 1 →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true) :
+    (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
+        (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 4 := by
+  obtain ⟨hph_h, hhd_h, htp_h⟩ := bZeroRouteProgram_P1_runConfig_handoff x z (by omega) hzeros hterm
+  -- P2 step 1 (z+1+1 → z+1+1+1): phase 2 → 3, head z → z+1, tape unchanged.
+  have h2a : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val := by
+    rw [hph_h]; decide
+  have hlt_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph_h]; decide
+  have hi0 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases = 0 := by rw [hph_h]; decide
+  have hbnd_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head : Nat) + 1
+      < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by rw [hhd_h]; omega
+  have hph1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst : Nat) = 3 := by
+    rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
+      srb_trans_p0_phase _ _ _ hi0]
+    decide
+  have hhd1 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head : Nat) = z + 1 := by
+    rw [runConfig_seq_succ_P2_head gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
+      srb_trans_p0_move _ _ _ hi0]
+    simp only [Configuration.moveHead, dif_pos hbnd_a]
+    rw [hhd_h]
+  have htp1 : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
+      = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
+    rw [runConfig_seq_succ_P2_tape gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
+      srb_trans_write]
+    have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).write
+        (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
+        ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape
+          (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head)
+        = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape := by
+      funext j; by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
+      · subst hj; simp [Configuration.write]
+      · simp [Configuration.write, hj]
+    rw [hself, htp_h]
+  -- P2 step 2 (z+1+1+1 → z+1+1+1+1): phase 3, read discriminator z+1 = 1 → phase 4.
+  have h2b : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val := by
+    rw [hph1]; decide
+  have hlt_b : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph1]; decide
+  have hi1 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases = 1 := by rw [hph1]; decide
+  have hread : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
+      (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head = true := by
+    rw [htp1]; exact hdisc _ hhd1
+  rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
+    ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1) h2b hlt_b,
+    hread, srb_trans_p1_phase_true _ _ hi1]
+  decide
+
+/-- **Full run-through, `B > 0` branch.**  Layout: cells `[0, z)` are `0`, cell `z` is the scan-stop `1`
+(the lowest set bit), and the discriminator cell `z + 1` is a `0` separator.  Then `bZeroRouteProgram`
+runs: scan to `z`, handoff, step right, read the separator `0` → composed phase `5` (the `B > 0` →
+body-entry target), after `z + 1 + 1 + 1 + 1` steps. -/
+theorem bZeroRouteProgram_runConfig_decide_false {L : Nat} (x : Boolcube.Point L) (z : Nat)
+    (hz1 : z + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) < z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+    (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) = z →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true)
+    (hdisc : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
+      (p : Nat) = z + 1 →
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false) :
+    (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
+        (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 5 := by
+  obtain ⟨hph_h, hhd_h, htp_h⟩ := bZeroRouteProgram_P1_runConfig_handoff x z (by omega) hzeros hterm
+  have h2a : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val := by
+    rw [hph_h]; decide
+  have hlt_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph_h]; decide
+  have hi0 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases = 0 := by rw [hph_h]; decide
+  have hbnd_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head : Nat) + 1
+      < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by rw [hhd_h]; omega
+  have hph1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst : Nat) = 3 := by
+    rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
+      srb_trans_p0_phase _ _ _ hi0]
+    decide
+  have hhd1 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head : Nat) = z + 1 := by
+    rw [runConfig_seq_succ_P2_head gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
+      srb_trans_p0_move _ _ _ hi0]
+    simp only [Configuration.moveHead, dif_pos hbnd_a]
+    rw [hhd_h]
+  have htp1 : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
+      = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
+    rw [runConfig_seq_succ_P2_tape gammaSelfLoopScan stepRightThenBranch
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
+      srb_trans_write]
+    have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).write
+        (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
+        ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape
+          (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head)
+        = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape := by
+      funext j; by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
+      · subst hj; simp [Configuration.write]
+      · simp [Configuration.write, hj]
+    rw [hself, htp_h]
+  have h2b : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val := by
+    rw [hph1]; decide
+  have hlt_b : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph1]; decide
+  have hi1 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val
+      - gammaSelfLoopScan.numPhases = 1 := by rw [hph1]; decide
+  have hread : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
+      (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head = false := by
+    rw [htp1]; exact hdisc _ hhd1
+  rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
+    ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1) h2b hlt_b,
+    hread, srb_trans_p1_phase_false _ _ hi1]
+  decide
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -102,6 +102,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -3834,6 +3835,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_scanning
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_terminator
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_handoff
+-- D2t-3 routing run-through, FULL compose: bZeroRouteProgram reaches phase 4 (B=0) / 5 (B>0).
+#check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_runConfig_decide_true
+#check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_runConfig_decide_false
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -92,6 +92,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -620,6 +621,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_terminator
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P1_runConfig_handoff
+-- D2t-3 routing run-through, FULL compose: bZeroRouteProgram reaches phase 4 (B=0) / 5 (B>0).
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_runConfig_decide_true
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_runConfig_decide_false
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

**Completes the composed routing run-through** — `bZeroRouteProgram` is now proven **end-to-end**. From
the handoff (#1556: phase `2`, head `z`, tape unchanged), two P2-region steps — driven on `seq` directly
via `runConfig_seq_succ_P2_*` and isolated `stepRightThenBranch` transition helpers — read the
discriminator cell `z + 1` and land in the composed branch target:

- **`bZeroRouteProgram_runConfig_decide_true`** — discriminator `1` ⇒ after `z + 4` steps, phase `4`
  (`B = 0` → sink);
- **`bZeroRouteProgram_runConfig_decide_false`** — discriminator `0` ⇒ phase `5` (`B > 0` → body-entry).

So `bZeroRouteProgram = seq gammaSelfLoopScan stepRightThenBranch`, from `initialConfig` with the
*spread + double-marker* layout (cells `[0,z)=0`, cell `z=1` the scan-stop, discriminator `z+1`), reaches
**phase `4` iff the discriminator is `1`** — the fixed-phase loop-exit decision the entire routing layer
was built for.

This ties together everything from #1547 onward: positional decision → fixed-phase distinguisher →
`stepRightThenBranch` primitive → composed program → P2 run-through → P1 scan/terminator → handoff → **this
compose**.

## Technique

The `stepRightThenBranch.transition` fields are evaluated by **isolated helpers** (`srb_trans_*`, same
discipline as the `gscan_*` helpers), keeping `simp [stepRightThenBranch]` out of the `seq` `runConfig`
goal; the P2 steps use `rw` with the `seq` P2-region step lemmas.

## Scope / remaining for D2t-3

`ε` (`loopUntilSink`, discharging `hbase` via this run-through / `hstep` via #1547) and `ζ`
(`|U| = value(B)`).

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- New module `TreeMCSPBZeroRouteRunCompose.lean`; surface tests + `AxiomsAudit` extended. **0
  `sorry`/`admit`/`native_decide`/custom axiom**; standard `[propext, Classical.choice, Quot.sound]`
  triple.

**Infrastructure** (AGENTS.md): run-behaviour toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_