### PR TITLE
transcoder(D2t-3): realizability of the bZeroRouteProgram run-through decision

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -345,6 +345,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunRealizable.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunRealizable.lean
@@ -29,12 +29,15 @@ open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
 open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
 /-- The composed `B = 0` decision is realizable: a concrete double-marker input reaches phase `4`. -/
-theorem bZeroRouteProgram_decide_true_realizable {L : Nat} (w : Nat) (hwL : w + 1 < L)
-    (hwt : w + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L) :
+theorem bZeroRouteProgram_decide_true_realizable {L : Nat} (w : Nat) (hwL : w + 1 < L) :
     ∃ x : Boolcube.Point L,
       (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
           ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
           (w + 1 + 1 + 1 + 1)).state).fst : Nat) = 4 := by
+  have hwt : w + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by
+    have hLe : L ≤ (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by
+      simp only [TM.tapeLength]; omega
+    omega
   refine ⟨fun j => decide ((j : Nat) = w ∨ (j : Nat) = w + 1), ?_⟩
   apply bZeroRouteProgram_runConfig_decide_true _ w hwt
   · intro p hp
@@ -48,12 +51,15 @@ theorem bZeroRouteProgram_decide_true_realizable {L : Nat} (w : Nat) (hwL : w + 
     simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_true_eq]; omega
 
 /-- The composed `B > 0` decision is realizable: a concrete single-set-bit input reaches phase `5`. -/
-theorem bZeroRouteProgram_decide_false_realizable {L : Nat} (j : Nat) (hjL : j + 1 < L)
-    (hjt : j + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L) :
+theorem bZeroRouteProgram_decide_false_realizable {L : Nat} (j : Nat) (hjL : j + 1 < L) :
     ∃ x : Boolcube.Point L,
       (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
           ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
           (j + 1 + 1 + 1 + 1)).state).fst : Nat) = 5 := by
+  have hjt : j + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by
+    have hLe : L ≤ (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by
+      simp only [TM.tapeLength]; omega
+    omega
   refine ⟨fun q => decide ((q : Nat) = j), ?_⟩
   apply bZeroRouteProgram_runConfig_decide_false _ j hjt
   · intro p hp

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunRealizable.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunRealizable.lean
@@ -1,0 +1,71 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
+
+/-!
+# Realizability of the `bZeroRouteProgram` run-through decision (NP-verifier track — D2t-3 routing)
+
+`TreeMCSPBZeroRouteRunCompose.lean` proves the composed run-through *routing-agnostically* (the
+`spread + double marker` layout enters as hypotheses).  This module exhibits **concrete inputs** that
+satisfy those hypotheses, so the end-to-end decision is **non-vacuously instantiable** (the analogue of
+`bZeroRoute_*_realizable` for the full run-through):
+
+* `bZeroRouteProgram_decide_true_realizable` — the input with the double marker at cells `w`, `w + 1`
+  (all else `0`) drives `bZeroRouteProgram` to composed phase `4` after `w + 4` steps (`B = 0` → sink);
+* `bZeroRouteProgram_decide_false_realizable` — the input with a single set bit at `j` (all else `0`, so
+  cell `j + 1` is its own `0` separator) drives it to composed phase `5` after `j + 4` steps
+  (`B > 0` → body-entry).
+
+These are existence witnesses (validation), not the converter's real layout.  They confirm the run-through
+decision proved in `decide_true`/`decide_false` is realizable from `initialConfig`.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- The composed `B = 0` decision is realizable: a concrete double-marker input reaches phase `4`. -/
+theorem bZeroRouteProgram_decide_true_realizable {L : Nat} (w : Nat) (hwL : w + 1 < L)
+    (hwt : w + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L) :
+    ∃ x : Boolcube.Point L,
+      (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
+          (w + 1 + 1 + 1 + 1)).state).fst : Nat) = 4 := by
+  refine ⟨fun j => decide ((j : Nat) = w ∨ (j : Nat) = w + 1), ?_⟩
+  apply bZeroRouteProgram_runConfig_decide_true _ w hwt
+  · intro p hp
+    have hpL : (p : Nat) < L := by omega
+    simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_false_iff_not]; omega
+  · intro p hp
+    have hpL : (p : Nat) < L := by omega
+    simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_true_eq]; omega
+  · intro p hp
+    have hpL : (p : Nat) < L := by omega
+    simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_true_eq]; omega
+
+/-- The composed `B > 0` decision is realizable: a concrete single-set-bit input reaches phase `5`. -/
+theorem bZeroRouteProgram_decide_false_realizable {L : Nat} (j : Nat) (hjL : j + 1 < L)
+    (hjt : j + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L) :
+    ∃ x : Boolcube.Point L,
+      (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
+          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
+          (j + 1 + 1 + 1 + 1)).state).fst : Nat) = 5 := by
+  refine ⟨fun q => decide ((q : Nat) = j), ?_⟩
+  apply bZeroRouteProgram_runConfig_decide_false _ j hjt
+  · intro p hp
+    have hpL : (p : Nat) < L := by omega
+    simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_false_iff_not]; omega
+  · intro p hp
+    have hpL : (p : Nat) < L := by omega
+    simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_true_eq]; omega
+  · intro p hp
+    have hpL : (p : Nat) < L := by omega
+    simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_false_iff_not]; omega
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -103,6 +103,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -3838,6 +3839,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3 routing run-through, FULL compose: bZeroRouteProgram reaches phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_runConfig_decide_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_runConfig_decide_false
+-- D2t-3 routing run-through: realizability witnesses (the full decision is non-vacuously instantiable).
+#check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_true_realizable
+#check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_false_realizable
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -93,6 +93,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -624,6 +625,9 @@ end Pnp4
 -- D2t-3 routing run-through, FULL compose: bZeroRouteProgram reaches phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_runConfig_decide_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_runConfig_decide_false
+-- D2t-3 routing run-through: realizability witnesses (the full decision is non-vacuously instantiable).
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_true_realizable
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_false_realizable
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

Exhibits **concrete inputs** satisfying the composed run-through hypotheses (`decide_true`/`decide_false`,
#1557), so the end-to-end routing decision is **non-vacuously instantiable** — the analogue of
`bZeroRoute_*_realizable` (#1551) for the full run-through:

- **`bZeroRouteProgram_decide_true_realizable`** — the input with the double marker at cells `w`, `w+1`
  (all else `0`) drives `bZeroRouteProgram` to composed phase `4` after `w+4` steps (`B=0` → sink);
- **`bZeroRouteProgram_decide_false_realizable`** — the input with a single set bit at `j` (all else `0`,
  so cell `j+1` is its own `0` separator) drives it to phase `5` after `j+4` steps (`B>0` → body-entry).

These are existence witnesses (validation that the run-through decision isn't vacuous), via the same
`decide`-based / `dif_pos` discharge technique as #1551 — *not* the converter's real layout construction.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- New module `TreeMCSPBZeroRouteRunRealizable.lean`; surface tests + `AxiomsAudit` extended. **0
  `sorry`/`admit`/`native_decide`/custom axiom**; standard `[propext, Classical.choice, Quot.sound]`
  triple.

**Infrastructure** (AGENTS.md): validation toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_