### PR TITLE
transcoder(D2t-3): binToUnaryLoop — the ε loop assembly (scaffolding)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -346,6 +346,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoop.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoop.lean
@@ -1,0 +1,66 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
+import Pnp4.Frontier.ContractExpansion.TreeMCSPLoopUntilSink
+
+/-!
+# `binToUnaryLoop` — the binary→unary loop (NP-verifier track — D2t-3 `ε`, scaffolding)
+
+The D2t-3 converter loop (`TM_VERIFIER_STRATEGY.md` §12, sub-brick `ε`): repeat the one-pass body while
+the counter `B > 0`, halting at `B = 0`.  This module assembles the loop **structure** from the pieces
+proved earlier in D2t-3, via the established combinators (no new program machinery):
+
+* `binToUnaryRouteBody` — `bZeroRouteProgram` (the proven routing decision: scan-stop → read → branch,
+  phase `4` = `B=0`, phase `5` = `B>0`) with its **`acceptPhase` set to `5`** (the `B>0` target), so that
+  `seq` redirects the `B>0` branch into the body and leaves the `B=0` branch (phase `4`) as a terminal
+  phase;
+* `binToUnaryLoopBody := seq binToUnaryRouteBody binToUnaryBody` — route first; on `B>0` (phase `5` =
+  accept) hand off into the parallel session's `binToUnaryBody` (decrement + append + return to HOME,
+  reaching its `idleCS` accept at composed phase `20`); on `B=0` rest at phase `4`;
+* `binToUnaryLoop := loopUntilSink binToUnaryLoopBody ⟨4⟩` — re-enter the body on its accept (phase `20`,
+  a completed `B>0` pass) and **halt at the sink phase `4`** (`B = 0`).
+
+This brick ships the **definitions + phase-count facts** (the loop object and its shape).  The run
+behaviour — discharging `loopUntilSink_reachesSink`'s `hbase` (`B=0` → sink, by lifting the run-through
+`bZeroRouteProgram_runConfig_decide_true` through the outer `seq`) and `hstep` (`B>0` → re-enter with
+`counterValue B` decreasing, via `binToUnaryBody`'s one-pass measure-decrease) — is the substantial
+follow-up, then the `ζ` bridge `|U| = value(B)`.
+
+**Progress classification (AGENTS.md): Infrastructure** — the loop assembly toward the NP-membership leg;
+it proves no run behaviour and no separation here.  Standard `[propext, Classical.choice, Quot.sound]`
+triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- The routing decision (`bZeroRouteProgram`) re-pointed so its **accept phase is `5`** (the `B > 0`
+target).  Under `seq` this routes `B > 0` into the body and leaves `B = 0` (phase `4`) terminal. -/
+def binToUnaryRouteBody : ConstStatePhasedProgram Unit :=
+  { bZeroRouteProgram with acceptPhase := ⟨5, by decide⟩ }
+
+@[simp] theorem binToUnaryRouteBody_numPhases : binToUnaryRouteBody.numPhases = 6 := rfl
+
+@[simp] theorem binToUnaryRouteBody_acceptPhase : (binToUnaryRouteBody.acceptPhase : Nat) = 5 := rfl
+
+/-- The loop body: route, then on `B > 0` run one pass of `binToUnaryBody`. -/
+def binToUnaryLoopBody : ConstStatePhasedProgram Unit :=
+  seq binToUnaryRouteBody binToUnaryBody
+
+@[simp] theorem binToUnaryLoopBody_numPhases : binToUnaryLoopBody.numPhases = 21 := rfl
+
+/-- The binary→unary loop: re-enter the body on its accept (a completed `B > 0` pass), halt at the sink
+phase `4` (`B = 0`). -/
+def binToUnaryLoop : ConstStatePhasedProgram Unit :=
+  loopUntilSink binToUnaryLoopBody ⟨4, by decide⟩
+
+@[simp] theorem binToUnaryLoop_numPhases : binToUnaryLoop.numPhases = 21 := rfl
+
+@[simp] theorem binToUnaryLoop_acceptPhase : (binToUnaryLoop.acceptPhase : Nat) = 4 := rfl
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -104,6 +104,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -3842,6 +3843,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3 routing run-through: realizability witnesses (the full decision is non-vacuously instantiable).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_true_realizable
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_false_realizable
+-- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -94,6 +94,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -628,6 +629,9 @@ end Pnp4
 -- D2t-3 routing run-through: realizability witnesses (the full decision is non-vacuously instantiable).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_true_realizable
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_false_realizable
+-- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

Assembles the binary→unary loop (§12 sub-brick **`ε`**) from the proven D2t-3 pieces via the established
combinators — the loop **object** and its phase structure (no new program machinery):

- **`binToUnaryRouteBody`** := `bZeroRouteProgram` with `acceptPhase := 5` (the `B>0` target), so `seq`
  redirects `B>0` into the body and leaves `B=0` (phase `4`) terminal;
- **`binToUnaryLoopBody`** := `seq binToUnaryRouteBody binToUnaryBody` — route; on `B>0` (phase `5` =
  accept) run one pass of `binToUnaryBody` (decrement + append + return to HOME, reaching its `idleCS`
  accept at composed phase `20`); on `B=0` rest at phase `4`;
- **`binToUnaryLoop`** := `loopUntilSink binToUnaryLoopBody ⟨4⟩` — re-enter on the body's accept (a
  completed `B>0` pass), halt at the **sink phase `4`** (`B=0`).

Ships the **definitions + phase-count/accept facts** (`numPhases = 21`, sink = phase `4`).

## Scope / remaining

The **run behaviour** is the substantial follow-up: `loopUntilSink_reachesSink`'s `hbase` (`B=0` → sink,
by lifting the run-through decision #1557 through the outer `seq`) and `hstep` (`B>0` → re-enter, with
`counterValue B` decreasing, via `binToUnaryBody`'s one-pass measure #1547) — then the **`ζ`** bridge
`|U| = value(B)` closes D2t-3.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` all-pass (17/17).
- New module `TreeMCSPBinToUnaryLoop.lean`; surface tests + `AxiomsAudit` extended. **0
  `sorry`/`admit`/`native_decide`/custom axiom**; standard `[propext, Classical.choice, Quot.sound]`
  triple.

**Infrastructure** (AGENTS.md): loop assembly toward the NP-membership leg. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_