### PR TITLE
transcoder(D2t-3): generalize the bZeroRouteProgram run-through decision to an arbitrary start config

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunCompose.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunCompose.lean
@@ -4,18 +4,23 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 # `bZeroRouteProgram` run-through, final compose (NP-verifier track — D2t-3 routing run-through)
 
 Glues the run-through together: after the handoff (`bZeroRouteProgram_P1_runConfig_handoff`, phase `2`,
-head on the marker `z`, tape unchanged), two P2-region steps — driven on `seq` directly via
+head on the marker `c0.head + z`, tape unchanged), two P2-region steps — driven on `seq` directly via
 `runConfig_seq_succ_P2_*` and the `stepRightThenBranch` transition helpers below — read the discriminator
-cell `z + 1` and land in the composed branch target:
+cell `c0.head + z + 1` and land in the composed branch target:
 
 * `bZeroRouteProgram_runConfig_decide_true` — discriminator `= 1` ⇒ after `z + 4` steps, phase `4`
   (`B = 0` → sink);
 * `bZeroRouteProgram_runConfig_decide_false` — discriminator `= 0` ⇒ phase `5` (`B > 0` → body-entry).
 
-The shared first P2 step (handoff → phase `3`, head `z + 1`, tape unchanged) is factored into the private
-`bZeroRouteProgram_runConfig_step1`; the two branch theorems differ only in the second step's read bit and
-branch lemma.  This completes the composed routing run-through (P1 region + handoff + P2 region, all on
-the one `bZeroRouteProgram`).  The remaining D2t-3 pieces are `ε` (`loopUntilSink`) and `ζ`
+Like the P1 region, the run-through is stated from an **arbitrary start config `c0`** at the route's
+start phase (`hstart`), with all positions relative to `c0.head`; `initialConfig x` is the `c0.head = 0`
+specialization (the `*_realizable` witnesses), while the conversion loop (`ε`) drives the route from
+arbitrary mid-loop HOME configs.
+
+The shared first P2 step (handoff → phase `3`, head `c0.head + z + 1`, tape unchanged) is factored into
+the private `bZeroRouteProgram_runConfig_step1`; the two branch theorems differ only in the second step's
+read bit and branch lemma.  This completes the composed routing run-through (P1 region + handoff + P2
+region, all on the one `bZeroRouteProgram`).  The remaining D2t-3 pieces are `ε` (`loopUntilSink`) and `ζ`
 (`|U| = value(B)`).
 
 The `stepRightThenBranch.transition` field values are evaluated by isolated helpers (same discipline as
@@ -58,139 +63,132 @@ private theorem srb_trans_p1_phase_false (i : Fin stepRightThenBranch.numPhases)
     (h : i.val = 1) : (stepRightThenBranch.transition i s false).fst.val = 3 := by
   simp [stepRightThenBranch, h]
 
-/-- Shared first P2 step: from the handoff (phase `2`, head `z`, tape unchanged) one step (step right)
-reaches phase `3`, head `z + 1`, tape unchanged — the common prefix of both branch run-throughs. -/
-private theorem bZeroRouteProgram_runConfig_step1 {L : Nat} (x : Boolcube.Point L) (z : Nat)
-    (hz1 : z + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+/-- Shared first P2 step: from the handoff (phase `2`, head `c0.head + z`, tape unchanged) one step (step
+right) reaches phase `3`, head `c0.head + z + 1`, tape unchanged — the common prefix of both branch
+run-throughs. -/
+private theorem bZeroRouteProgram_runConfig_step1 {L : Nat}
+    (c0 : Configuration (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0) (z : Nat)
+    (hz1 : (c0.head : Nat) + z + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
     (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) < z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false)
     (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) = z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true) :
+      (p : Nat) = (c0.head : Nat) + z → c0.tape p = true) :
     (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst : Nat) = 3
+        c0 (z + 1 + 1 + 1)).state).fst : Nat) = 3
       ∧ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head : Nat) = z + 1
+          c0 (z + 1 + 1 + 1)).head : Nat) = (c0.head : Nat) + z + 1
       ∧ (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
-          = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
-  obtain ⟨hph_h, hhd_h, htp_h⟩ := bZeroRouteProgram_P1_runConfig_handoff x z (by omega) hzeros hterm
+          c0 (z + 1 + 1 + 1)).tape = c0.tape := by
+  obtain ⟨hph_h, hhd_h, htp_h⟩ := bZeroRouteProgram_P1_runConfig_handoff c0 hstart z (by omega) hzeros hterm
   have h2a : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val := by
+      c0 (z + 1 + 1)).state).fst.val := by
     rw [hph_h]; decide
   have hlt_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
+      c0 (z + 1 + 1)).state).fst.val
       - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph_h]; decide
   have hi0 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst.val
+      c0 (z + 1 + 1)).state).fst.val
       - gammaSelfLoopScan.numPhases = 0 := by rw [hph_h]; decide
   have hbnd_a : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head : Nat) + 1
+      c0 (z + 1 + 1)).head : Nat) + 1
       < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by rw [hhd_h]; omega
   refine ⟨?_, ?_, ?_⟩
   · rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
-      srb_trans_p0_phase _ _ _ hi0]
+      c0 (z + 1 + 1) h2a hlt_a, srb_trans_p0_phase _ _ _ hi0]
     decide
   · rw [runConfig_seq_succ_P2_head gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
-      srb_trans_p0_move _ _ _ hi0]
+      c0 (z + 1 + 1) h2a hlt_a, srb_trans_p0_move _ _ _ hi0]
     simp only [Configuration.moveHead, dif_pos hbnd_a]
     rw [hhd_h]
   · rw [runConfig_seq_succ_P2_tape gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1) h2a hlt_a,
-      srb_trans_write]
+      c0 (z + 1 + 1) h2a hlt_a, srb_trans_write]
     have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).write
+        c0 (z + 1 + 1)).write
         (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
+        c0 (z + 1 + 1)).head
         ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape
+        c0 (z + 1 + 1)).tape
           (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head)
+          c0 (z + 1 + 1)).head)
         = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape := by
+        c0 (z + 1 + 1)).tape := by
       funext j; by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head
+          c0 (z + 1 + 1)).head
       · subst hj; simp [Configuration.write]
       · simp [Configuration.write, hj]
     rw [hself, htp_h]
 
-/-- **Full run-through, `B = 0` branch.**  Layout: cells `[0, z)` are `0`, cell `z` is the scan-stop `1`,
-and the discriminator cell `z + 1` is `1`.  Then `bZeroRouteProgram` runs: scan to `z` (`z + 1` steps,
-phase `1`), handoff (phase `2`), step right (phase `3`, head `z + 1`), read the discriminator `1` (phase
-`4`).  After `z + 1 + 1 + 1 + 1` steps it rests in composed phase `4` — the `B = 0` → sink target. -/
-theorem bZeroRouteProgram_runConfig_decide_true {L : Nat} (x : Boolcube.Point L) (z : Nat)
-    (hz1 : z + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+/-- **Full run-through, `B = 0` branch.**  Layout (relative to `c0.head`): cells `[c0.head, c0.head + z)`
+are `0`, cell `c0.head + z` is the scan-stop `1`, and the discriminator cell `c0.head + z + 1` is `1`.
+Then `bZeroRouteProgram` runs: scan to `c0.head + z` (`z + 1` steps, phase `1`), handoff (phase `2`), step
+right (phase `3`, head `c0.head + z + 1`), read the discriminator `1` (phase `4`).  After `z + 1 + 1 + 1 +
+1` steps it rests in composed phase `4` — the `B = 0` → sink target. -/
+theorem bZeroRouteProgram_runConfig_decide_true {L : Nat}
+    (c0 : Configuration (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0) (z : Nat)
+    (hz1 : (c0.head : Nat) + z + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
     (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) < z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false)
     (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) = z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true)
+      (p : Nat) = (c0.head : Nat) + z → c0.tape p = true)
     (hdisc : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) = z + 1 →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true) :
+      (p : Nat) = (c0.head : Nat) + z + 1 → c0.tape p = true) :
     (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
-        (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 4 := by
-  obtain ⟨hph1, hhd1, htp1⟩ := bZeroRouteProgram_runConfig_step1 x z hz1 hzeros hterm
+        c0 (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 4 := by
+  obtain ⟨hph1, hhd1, htp1⟩ := bZeroRouteProgram_runConfig_step1 c0 hstart z hz1 hzeros hterm
   have h2b : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val := by
+      c0 (z + 1 + 1 + 1)).state).fst.val := by
     rw [hph1]; decide
   have hlt_b : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val
+      c0 (z + 1 + 1 + 1)).state).fst.val
       - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph1]; decide
   have hi1 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val
+      c0 (z + 1 + 1 + 1)).state).fst.val
       - gammaSelfLoopScan.numPhases = 1 := by rw [hph1]; decide
   have hread : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
+      c0 (z + 1 + 1 + 1)).tape
       (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head = true := by
+      c0 (z + 1 + 1 + 1)).head = true := by
     rw [htp1]; exact hdisc _ hhd1
   rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
-    ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1) h2b hlt_b,
-    hread, srb_trans_p1_phase_true _ _ hi1]
+    c0 (z + 1 + 1 + 1) h2b hlt_b, hread, srb_trans_p1_phase_true _ _ hi1]
   decide
 
-/-- **Full run-through, `B > 0` branch.**  Layout: cells `[0, z)` are `0`, cell `z` is the scan-stop `1`
-(the lowest set bit), and the discriminator cell `z + 1` is a `0` separator.  Then `bZeroRouteProgram`
-runs: scan to `z`, handoff, step right, read the separator `0` → composed phase `5` (the `B > 0` →
-body-entry target), after `z + 1 + 1 + 1 + 1` steps. -/
-theorem bZeroRouteProgram_runConfig_decide_false {L : Nat} (x : Boolcube.Point L) (z : Nat)
-    (hz1 : z + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+/-- **Full run-through, `B > 0` branch.**  Layout (relative to `c0.head`): cells `[c0.head, c0.head + z)`
+are `0`, cell `c0.head + z` is the scan-stop `1` (the lowest set bit), and the discriminator cell
+`c0.head + z + 1` is a `0` separator.  Then `bZeroRouteProgram` runs: scan to `c0.head + z`, handoff, step
+right, read the separator `0` → composed phase `5` (the `B > 0` → body-entry target), after `z + 1 + 1 +
+1 + 1` steps. -/
+theorem bZeroRouteProgram_runConfig_decide_false {L : Nat}
+    (c0 : Configuration (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0) (z : Nat)
+    (hz1 : (c0.head : Nat) + z + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
     (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) < z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false)
     (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) = z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true)
+      (p : Nat) = (c0.head : Nat) + z → c0.tape p = true)
     (hdisc : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) = z + 1 →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false) :
+      (p : Nat) = (c0.head : Nat) + z + 1 → c0.tape p = false) :
     (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
-        (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 5 := by
-  obtain ⟨hph1, hhd1, htp1⟩ := bZeroRouteProgram_runConfig_step1 x z hz1 hzeros hterm
+        c0 (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 5 := by
+  obtain ⟨hph1, hhd1, htp1⟩ := bZeroRouteProgram_runConfig_step1 c0 hstart z hz1 hzeros hterm
   have h2b : gammaSelfLoopScan.numPhases ≤ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val := by
+      c0 (z + 1 + 1 + 1)).state).fst.val := by
     rw [hph1]; decide
   have hlt_b : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val
+      c0 (z + 1 + 1 + 1)).state).fst.val
       - gammaSelfLoopScan.numPhases < stepRightThenBranch.numPhases := by rw [hph1]; decide
   have hi1 : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).state).fst.val
+      c0 (z + 1 + 1 + 1)).state).fst.val
       - gammaSelfLoopScan.numPhases = 1 := by rw [hph1]; decide
   have hread : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).tape
+      c0 (z + 1 + 1 + 1)).tape
       (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1)).head = false := by
+      c0 (z + 1 + 1 + 1)).head = false := by
     rw [htp1]; exact hdisc _ hhd1
   rw [runConfig_seq_succ_P2_phase gammaSelfLoopScan stepRightThenBranch
-    ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1 + 1) h2b hlt_b,
-    hread, srb_trans_p1_phase_false _ _ hi1]
+    c0 (z + 1 + 1 + 1) h2b hlt_b, hread, srb_trans_p1_phase_false _ _ hi1]
   decide
 
 end ContractExpansion

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunP1.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunP1.lean
@@ -9,8 +9,14 @@ then hands off into `stepRightThenBranch`.  This module lifts the scan's behavio
 P1-region simulation (`runConfig_seq_succ_P1_normal_*`): replicating `gammaSelfLoopScan`'s scanning loop
 inside `seq`.
 
-* `bZeroRouteProgram_P1_scanning` — while the leading cells are `0`, the scan stays in phase `0`,
-  advancing the head one cell per step, tape unchanged (the back-edge loop, in `seq`'s P1 region).
+The run-through is stated from an **arbitrary start config `c0`** at the route's start phase (`hstart`),
+with all positions taken **relative to `c0.head`** (the scan's HOME).  `initialConfig x` is the
+`c0.head = 0`, `hstart := rfl` specialization (used by the `*_realizable` witnesses); the conversion loop
+(`ε`) instead drives the route from arbitrary mid-loop HOME configs, which is exactly this general form.
+
+* `bZeroRouteProgram_P1_scanning` — while the cells `[c0.head, c0.head + z)` are `0`, the scan stays in
+  phase `0`, advancing the head one cell per step (to `c0.head + k`), tape unchanged (the back-edge loop,
+  in `seq`'s P1 region).
 
 `seq`'s P1-accept (phase `1`) is where the handoff fires (`runConfig_seq_succ_P1_boundary`), landing in
 `stepRightThenBranch` (phase `2`) = the input to the P2-region run-through
@@ -47,63 +53,60 @@ private theorem gscan_trans_move0 (i : Fin gammaSelfLoopScan.numPhases) (s : Uni
     (gammaSelfLoopScan.transition i s false).snd.snd.snd = Move.right := by
   simp [gammaSelfLoopScan, h]
 
-/-- Scan back-edge loop inside `seq`'s P1 region: if the first `z` cells are `0` (and `z` is within the
-tape), then for every `k ≤ z` running `k` steps from the start leaves the program in phase `0` with the
-head advanced to `k` and the tape unchanged. -/
-theorem bZeroRouteProgram_P1_scanning {L : Nat} (x : Boolcube.Point L) (z : Nat)
-    (hz : z < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+/-- Scan back-edge loop inside `seq`'s P1 region, from an arbitrary start config `c0` (at phase `0`): if
+the cells `[c0.head, c0.head + z)` are `0` (and `c0.head + z` is within the tape), then for every `k ≤ z`
+running `k` steps from `c0` leaves the program in phase `0` with the head advanced to `c0.head + k` and
+the tape unchanged. -/
+theorem bZeroRouteProgram_P1_scanning {L : Nat}
+    (c0 : Configuration (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0) (z : Nat)
+    (hz : (c0.head : Nat) + z < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
     (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) < z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false) :
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false) :
     ∀ k, k ≤ z →
       (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).state).fst : Nat) = 0
+          c0 k).state).fst : Nat) = 0
       ∧ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head : Nat) = k
+          c0 k).head : Nat) = (c0.head : Nat) + k
       ∧ (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).tape
-          = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
+          c0 k).tape = c0.tape := by
   intro k
   induction k with
-  | zero => intro _; exact ⟨rfl, rfl, rfl⟩
+  | zero => intro _; exact ⟨hstart, rfl, rfl⟩
   | succ k ih =>
       intro hk
       obtain ⟨hph, hhd, htp⟩ := ih (by omega)
       have hbit : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).tape
+          c0 k).tape
           (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head = false := by
-        rw [htp]; exact hzeros _ (by rw [hhd]; omega)
+          c0 k).head = false := by
+        rw [htp]; exact hzeros _ (by rw [hhd]; omega) (by rw [hhd]; omega)
       have h1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).state).fst : Nat)
-          < gammaSelfLoopScan.numPhases := by rw [hph]; decide
+          c0 k).state).fst : Nat) < gammaSelfLoopScan.numPhases := by rw [hph]; decide
       have hne : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).state).fst : Nat)
-          ≠ gammaSelfLoopScan.acceptPhase.val := by rw [hph]; decide
+          c0 k).state).fst : Nat) ≠ gammaSelfLoopScan.acceptPhase.val := by rw [hph]; decide
       have hbnd : ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head : Nat) + 1
+          c0 k).head : Nat) + 1
           < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by rw [hhd]; omega
       refine ⟨?_, ?_, ?_⟩
       · rw [runConfig_seq_succ_P1_normal_phase gammaSelfLoopScan stepRightThenBranch
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k h1 hne, hbit]
+          c0 k h1 hne, hbit]
         exact gscan_trans_phase0 _ _ hph
       · rw [runConfig_seq_succ_P1_normal_head gammaSelfLoopScan stepRightThenBranch
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k h1 hne, hbit,
-          gscan_trans_move0 _ _ hph]
+          c0 k h1 hne, hbit, gscan_trans_move0 _ _ hph]
         simp only [Configuration.moveHead, dif_pos hbnd]
         omega
       · rw [runConfig_seq_succ_P1_normal_tape gammaSelfLoopScan stepRightThenBranch
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k h1 hne, hbit,
-          gscan_trans_write]
+          c0 k h1 hne, hbit, gscan_trans_write]
         have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-            ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).write
+            c0 k).write
             (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-            ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head false
+            c0 k).head false
             = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-            ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).tape := by
+            c0 k).tape := by
           funext j
           by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-              ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) k).head
+              c0 k).head
           · subst hj; simp [Configuration.write, hbit]
           · simp [Configuration.write, hj]
         rw [hself, htp]
@@ -118,92 +121,85 @@ private theorem gscan_trans_movestay (i : Fin gammaSelfLoopScan.numPhases) (s : 
     (gammaSelfLoopScan.transition i s true).snd.snd.snd = Move.stay := by
   simp [gammaSelfLoopScan, h]
 
-/-- Terminator step inside `seq`'s P1 region: with the first `z` cells `0` and cell `z` a `1`, after
-`z + 1` steps the scan rests in phase `1` (`gammaSelfLoopScan`'s accept = `seq`'s P1-accept), head on the
-marker (`= z`), tape unchanged.  Applies `bZeroRouteProgram_P1_scanning` at `k = z`, then one terminator
-step (reading the `1` → phase `1`, stay).  Phase `1` is where `runConfig_seq_succ_P1_boundary` then hands
-off into `stepRightThenBranch` (phase `2`). -/
-theorem bZeroRouteProgram_P1_runConfig_terminator {L : Nat} (x : Boolcube.Point L) (z : Nat)
-    (hz : z < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+/-- Terminator step inside `seq`'s P1 region, from an arbitrary start config `c0` (at phase `0`): with the
+cells `[c0.head, c0.head + z)` all `0` and cell `c0.head + z` a `1`, after `z + 1` steps the scan rests in
+phase `1` (`gammaSelfLoopScan`'s accept = `seq`'s P1-accept), head on the marker (`= c0.head + z`), tape
+unchanged.  Applies `bZeroRouteProgram_P1_scanning` at `k = z`, then one terminator step (reading the `1`
+→ phase `1`, stay).  Phase `1` is where `runConfig_seq_succ_P1_boundary` then hands off into
+`stepRightThenBranch` (phase `2`). -/
+theorem bZeroRouteProgram_P1_runConfig_terminator {L : Nat}
+    (c0 : Configuration (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0) (z : Nat)
+    (hz : (c0.head : Nat) + z < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
     (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) < z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false)
     (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) = z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true) :
+      (p : Nat) = (c0.head : Nat) + z → c0.tape p = true) :
     (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).state).fst : Nat) = 1
+        c0 (z + 1)).state).fst : Nat) = 1
       ∧ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).head : Nat) = z
+          c0 (z + 1)).head : Nat) = (c0.head : Nat) + z
       ∧ (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).tape
-          = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
-  obtain ⟨hph, hhd, htp⟩ := bZeroRouteProgram_P1_scanning x z hz hzeros z (le_refl z)
+          c0 (z + 1)).tape = c0.tape := by
+  obtain ⟨hph, hhd, htp⟩ := bZeroRouteProgram_P1_scanning c0 hstart z hz hzeros z (le_refl z)
   have hbit : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).tape
+      c0 z).tape
       (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).head = true := by
+      c0 z).head = true := by
     rw [htp]; exact hterm _ hhd
   have h1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).state).fst : Nat)
-      < gammaSelfLoopScan.numPhases := by rw [hph]; decide
+      c0 z).state).fst : Nat) < gammaSelfLoopScan.numPhases := by rw [hph]; decide
   have hne : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).state).fst : Nat)
-      ≠ gammaSelfLoopScan.acceptPhase.val := by rw [hph]; decide
+      c0 z).state).fst : Nat) ≠ gammaSelfLoopScan.acceptPhase.val := by rw [hph]; decide
   refine ⟨?_, ?_, ?_⟩
   · rw [runConfig_seq_succ_P1_normal_phase gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z h1 hne, hbit]
+      c0 z h1 hne, hbit]
     exact gscan_trans_phase1 _ _ hph
   · rw [runConfig_seq_succ_P1_normal_head gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z h1 hne, hbit,
-      gscan_trans_movestay _ _ hph]
+      c0 z h1 hne, hbit, gscan_trans_movestay _ _ hph]
     simp only [Configuration.moveHead]
     exact hhd
   · rw [runConfig_seq_succ_P1_normal_tape gammaSelfLoopScan stepRightThenBranch
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z h1 hne, hbit,
-      gscan_trans_write]
+      c0 z h1 hne, hbit, gscan_trans_write]
     have hself : (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).write
+        c0 z).write
         (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).head true
+        c0 z).head true
         = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).tape := by
+        c0 z).tape := by
       funext j
       by_cases hj : j = (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) z).head
+          c0 z).head
       · subst hj; simp [Configuration.write, hbit]
       · simp [Configuration.write, hj]
     rw [hself, htp]
 
-/-- Handoff step: from the P1-accept (phase `1`, reached by the terminator after `z + 1` steps), one
-more step hands off into `stepRightThenBranch`'s start (composed phase `2`), head and tape preserved.
-So after `z + 1 + 1` steps the routing program is in phase `2`, head on the marker (`= z`), tape
-unchanged — exactly the entry point for the P2-region run-through (`bZeroRouteProgram_P2_*`).  Uses the
-terminator plus `runConfig_seq_succ_P1_boundary`. -/
-theorem bZeroRouteProgram_P1_runConfig_handoff {L : Nat} (x : Boolcube.Point L) (z : Nat)
-    (hz : z < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
+/-- Handoff step, from an arbitrary start config `c0` (at phase `0`): from the P1-accept (phase `1`,
+reached by the terminator after `z + 1` steps), one more step hands off into `stepRightThenBranch`'s start
+(composed phase `2`), head and tape preserved.  So after `z + 1 + 1` steps the routing program is in phase
+`2`, head on the marker (`= c0.head + z`), tape unchanged — exactly the entry point for the P2-region
+run-through (`bZeroRouteProgram_P2_*`).  Uses the terminator plus `runConfig_seq_succ_P1_boundary`. -/
+theorem bZeroRouteProgram_P1_runConfig_handoff {L : Nat}
+    (c0 : Configuration (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0) (z : Nat)
+    (hz : (c0.head : Nat) + z < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L)
     (hzeros : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) < z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = false)
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false)
     (hterm : ∀ p : Fin ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L),
-      (p : Nat) = z →
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape p = true) :
+      (p : Nat) = (c0.head : Nat) + z → c0.tape p = true) :
     (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-        ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).state).fst : Nat) = 2
+        c0 (z + 1 + 1)).state).fst : Nat) = 2
       ∧ ((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).head : Nat) = z
+          c0 (z + 1 + 1)).head : Nat) = (c0.head : Nat) + z
       ∧ (TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-          ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1 + 1)).tape
-          = ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).tape := by
-  obtain ⟨hph, hhd, htp⟩ := bZeroRouteProgram_P1_runConfig_terminator x z hz hzeros hterm
+          c0 (z + 1 + 1)).tape = c0.tape := by
+  obtain ⟨hph, hhd, htp⟩ := bZeroRouteProgram_P1_runConfig_terminator c0 hstart z hz hzeros hterm
   have h1 : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).state).fst : Nat)
-      < gammaSelfLoopScan.numPhases := by rw [hph]; decide
+      c0 (z + 1)).state).fst : Nat) < gammaSelfLoopScan.numPhases := by rw [hph]; decide
   have heq : (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
-      ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1)).state).fst : Nat)
-      = gammaSelfLoopScan.acceptPhase.val := by rw [hph]; decide
+      c0 (z + 1)).state).fst : Nat) = gammaSelfLoopScan.acceptPhase.val := by rw [hph]; decide
   obtain ⟨hph2, _, hhd2, htp2⟩ := runConfig_seq_succ_P1_boundary gammaSelfLoopScan stepRightThenBranch
-    ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x) (z + 1) h1 heq
+    c0 (z + 1) h1 heq
   refine ⟨?_, ?_, ?_⟩
   · rw [hph2]; decide
   · rw [hhd2]; exact hhd

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunRealizable.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroRouteRunRealizable.lean
@@ -3,10 +3,11 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 /-!
 # Realizability of the `bZeroRouteProgram` run-through decision (NP-verifier track — D2t-3 routing)
 
-`TreeMCSPBZeroRouteRunCompose.lean` proves the composed run-through *routing-agnostically* (the
-`spread + double marker` layout enters as hypotheses).  This module exhibits **concrete inputs** that
-satisfy those hypotheses, so the end-to-end decision is **non-vacuously instantiable** (the analogue of
-`bZeroRoute_*_realizable` for the full run-through):
+`TreeMCSPBZeroRouteRunCompose.lean` proves the composed run-through *routing-agnostically*, from an
+**arbitrary start config `c0`** (the `spread + double marker` layout enters as hypotheses relative to
+`c0.head`).  This module exhibits **concrete inputs** that satisfy those hypotheses with
+`c0 := initialConfig x` (so `c0.head = 0`), so the end-to-end decision is **non-vacuously instantiable**
+(the analogue of `bZeroRoute_*_realizable` for the full run-through):
 
 * `bZeroRouteProgram_decide_true_realizable` — the input with the double marker at cells `w`, `w + 1`
   (all else `0`) drives `bZeroRouteProgram` to composed phase `4` after `w + 4` steps (`B = 0` → sink);
@@ -28,25 +29,33 @@ namespace ContractExpansion
 open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
 open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
+/-- `initialConfig` places the head at cell `0`; the run-through decision (stated relative to `c0.head`)
+specializes to absolute positions through this. -/
+private theorem initialConfig_head_val {L : Nat} (x : Boolcube.Point L) :
+    (((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x).head : Nat) = 0 := rfl
+
 /-- The composed `B = 0` decision is realizable: a concrete double-marker input reaches phase `4`. -/
 theorem bZeroRouteProgram_decide_true_realizable {L : Nat} (w : Nat) (hwL : w + 1 < L) :
     ∃ x : Boolcube.Point L,
       (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
           ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
           (w + 1 + 1 + 1 + 1)).state).fst : Nat) = 4 := by
-  have hwt : w + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by
+  refine ⟨fun j => decide ((j : Nat) = w ∨ (j : Nat) = w + 1), ?_⟩
+  apply bZeroRouteProgram_runConfig_decide_true _ rfl w
+  · rw [initialConfig_head_val]
     have hLe : L ≤ (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by
       simp only [TM.tapeLength]; omega
     omega
-  refine ⟨fun j => decide ((j : Nat) = w ∨ (j : Nat) = w + 1), ?_⟩
-  apply bZeroRouteProgram_runConfig_decide_true _ w hwt
-  · intro p hp
+  · intro p hp1 hp2
+    rw [initialConfig_head_val] at hp2
     have hpL : (p : Nat) < L := by omega
     simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_false_iff_not]; omega
   · intro p hp
+    rw [initialConfig_head_val] at hp
     have hpL : (p : Nat) < L := by omega
     simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_true_eq]; omega
   · intro p hp
+    rw [initialConfig_head_val] at hp
     have hpL : (p : Nat) < L := by omega
     simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_true_eq]; omega
 
@@ -56,19 +65,22 @@ theorem bZeroRouteProgram_decide_false_realizable {L : Nat} (j : Nat) (hjL : j +
       (((TM.runConfig (M := (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM)
           ((seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.initialConfig x)
           (j + 1 + 1 + 1 + 1)).state).fst : Nat) = 5 := by
-  have hjt : j + 1 < (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by
+  refine ⟨fun q => decide ((q : Nat) = j), ?_⟩
+  apply bZeroRouteProgram_runConfig_decide_false _ rfl j
+  · rw [initialConfig_head_val]
     have hLe : L ≤ (seq gammaSelfLoopScan stepRightThenBranch).toPhased.toTM.tapeLength L := by
       simp only [TM.tapeLength]; omega
     omega
-  refine ⟨fun q => decide ((q : Nat) = j), ?_⟩
-  apply bZeroRouteProgram_runConfig_decide_false _ j hjt
-  · intro p hp
+  · intro p hp1 hp2
+    rw [initialConfig_head_val] at hp2
     have hpL : (p : Nat) < L := by omega
     simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_false_iff_not]; omega
   · intro p hp
+    rw [initialConfig_head_val] at hp
     have hpL : (p : Nat) < L := by omega
     simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_true_eq]; omega
   · intro p hp
+    rw [initialConfig_head_val] at hp
     have hpL : (p : Nat) < L := by omega
     simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_false_iff_not]; omega
 


### PR DESCRIPTION
## Summary

Foundation step toward D2t-3 `ε`'s **`hbase`** (the clean `B = 0 → sink` half, per the agreed
"bank `hbase`, defer `hstep`" plan).

The route's decision run-through — P1 region (`bZeroRouteProgram_P1_scanning` / `_terminator` /
`_handoff`) and the compose (`bZeroRouteProgram_runConfig_decide_true` / `_decide_false`) — was stated
only from `initialConfig x`, i.e. with the head fixed at cell `0`.  The conversion loop drives the route
from **arbitrary mid-loop HOME configs**, not `initialConfig`, so this generalizes those lemmas to an
arbitrary start config `c0` at the route's start phase, with **every position relative to `c0.head`**:

- layout hypotheses become `[c0.head, c0.head + z)` zeros, scan-stop `c0.head + z`, discriminator
  `c0.head + z + 1`;
- the head conclusions advance to `c0.head + k`;
- step counts are unchanged (they depend on the relative scan distance `z`, not on HOME).

`initialConfig x` is now exactly the `c0.head = 0` specialization: the `bZeroRoute*_realizable`
witnesses pass `c0 := initialConfig x` (head `= 0` via a one-line `rfl` helper), so **their public
statements are unchanged**.  This arbitrary-config form is the template the loop's `hbase` (and the
deferred `hstep`) run-throughs mirror one layer up (`seq binToUnaryRouteBody binToUnaryBody`).

## Verification

- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- Diff is a balanced in-place generalization of 3 modules (P1 / compose / realizable); **no new module,
  no `lakefile`/test changes** (the `#print axioms` / `#check @` targets are name-based and unchanged).
- pnp4 axiom surface unchanged (`Quot.sound` occurrences `527`); same `induction / rw / simp / omega /
  decide`, so **0 `sorry`/`admit`/`native_decide`/custom axiom**; standard
  `[propext, Classical.choice, Quot.sound]` triple.

**Infrastructure** (AGENTS.md): routing-decision generalization toward the NP-membership leg. **No
`P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_