### PR TITLE
transcoder(D2t-3): binToUnaryLoop hbase — B=0 drives the loop to its sink (phase 4)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -347,6 +347,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopHbase.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopHbase.lean
@@ -1,0 +1,306 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
+
+/-!
+# `binToUnaryLoop` base case `hbase` — `B = 0` drives the loop to its sink (NP-verifier track — D2t-3 `ε`)
+
+The conversion loop `binToUnaryLoop = loopUntilSink binToUnaryLoopBody ⟨4⟩` (§12 `ε`) halts at the **sink
+phase `4`** exactly when the binary counter `B = 0`.  This module proves that base case (`loopUntilSink`'s
+`hbase`): from a HOME config at the loop's start phase whose `B`-block is all `0` with the **double
+end-marker** (`1 1`) just past it, the loop's routing decision (`bZeroRouteProgram`, embedded as the outer
+`seq`'s P1) scans the zeros, reads the second marker `1`, and lands in composed phase `4` — the sink — in
+`z + 4` steps (`z` = the scan distance to the first marker).  On `B = 0` the head never enters the body
+(phase `4 ≠ 5`, the `B > 0` target), so no navigation is needed; this is the clean half of `ε`'s
+`loopUntilSink_reachesSink` (the `B > 0` `hstep` is the deferred follow-up).
+
+Because `loopUntilSink (seq … )`'s machine has a different `tapeLength` than the standalone route's, the
+route's run-through (proved generally in `TreeMCSPBZeroRouteRun*`) cannot be imported directly; it is
+**re-derived inside the loop machine** here.  The loop's transition in the route region (phases `0..3`) is
+evaluated by peeling the three layers: `bul_trans_route` discharges the `loopUntilSink` layer (its guards
+are *Fin* equalities — refuted via the accept index `20` and the sink `4`), leaving the two `seq` layers
+whose guards are *value* comparisons that `simp` resolves from the phase hypothesis.  Those `simp`s stay
+out of the `runConfig` goal (the same discipline as the route's `gscan_*`/`srb_*` helpers).
+
+**Progress classification (AGENTS.md): Infrastructure** — the `B = 0` loop-exit behaviour toward the
+NP-membership leg; it proves no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple
+only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- The loop body's accept phase (the `idleCS` of `binToUnaryBody`, embedded past the `6`-phase route) is
+`20` — distinct from the route region (`0..5`) and the sink (`4`). -/
+private theorem binToUnaryLoopBody_acceptPhase_val :
+    (binToUnaryLoopBody.acceptPhase : Nat) = 20 := by decide
+
+/-- In the route region (`i < 4`) the loop's transition is the body's transition: the head is neither at
+the loop body's accept phase (`20`) nor at the sink (`4`), so `loopUntilSink` runs `binToUnaryLoopBody`
+verbatim.  This peels the `loopUntilSink` layer (whose guards are *Fin* equalities), leaving the `seq`
+layers for `simp`. -/
+private theorem bul_trans_route {i : Fin binToUnaryLoop.numPhases} (hlt : (i : Nat) < 4)
+    (s : Unit) (b : Bool) :
+    binToUnaryLoop.transition i s b = binToUnaryLoopBody.transition i () b :=
+  loopUntilSink_transition_body binToUnaryLoopBody ⟨4, by decide⟩
+    (Fin.ne_of_val_ne (by rw [binToUnaryLoopBody_acceptPhase_val]; omega))
+    (Fin.ne_of_val_ne (show (i : Nat) ≠ 4 by omega)) s b
+
+/-! ### Single-step `stepConfig` lemmas (route region of the loop machine)
+
+Each evaluates one step of `binToUnaryLoop`'s machine via `toTM_stepConfig_{phase,head,tape}`, peels the
+`loopUntilSink` layer with `bul_trans_route`, then an isolated `simp` over the `seq` layers.  The route
+writes the scanned bit back, so every step leaves the tape unchanged. -/
+
+/-- **Scan step** (phase `0`, reading `0`): stay in phase `0`, advance the head one cell right, tape
+unchanged. -/
+theorem binToUnaryLoop_stepConfig_scan {L : Nat}
+    (c : Configuration (M := binToUnaryLoop.toPhased.toTM) L) {i : Fin binToUnaryLoop.numPhases}
+    {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false)
+    (hbnd : (c.head : Nat) + 1 < binToUnaryLoop.toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).state).fst.val = 0
+      ∧ ((TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).head : Nat) = (c.head : Nat) + 1
+      ∧ (TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase binToUnaryLoop c hstate,
+      bul_trans_route (by rw [hi]; omega) s (c.tape c.head), hbit]
+    simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+      stepRightThenBranch, hi]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head binToUnaryLoop c hstate]
+    have hmove : (binToUnaryLoop.transition i s (c.tape c.head)).2.2.2 = Move.right := by
+      rw [bul_trans_route (by rw [hi]; omega) s (c.tape c.head), hbit]
+      simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+        stepRightThenBranch, hi]
+    rw [hmove]; simp only [Configuration.moveHead, dif_pos hbnd]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape binToUnaryLoop c hstate]
+    have hbw : (binToUnaryLoop.transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [bul_trans_route (by rw [hi]; omega) s (c.tape c.head), hbit]
+      simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+        stepRightThenBranch, hi]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Scan-stop step** (phase `0`, reading `1`): jump to phase `1` (the scan's done phase), head and tape
+unchanged (rests on the marker). -/
+theorem binToUnaryLoop_stepConfig_stop {L : Nat}
+    (c : Configuration (M := binToUnaryLoop.toPhased.toTM) L) {i : Fin binToUnaryLoop.numPhases}
+    {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).state).fst.val = 1
+      ∧ (TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase binToUnaryLoop c hstate,
+      bul_trans_route (by rw [hi]; omega) s (c.tape c.head), hbit]
+    simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+      stepRightThenBranch, hi]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head binToUnaryLoop c hstate]
+    have hmove : (binToUnaryLoop.transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [bul_trans_route (by rw [hi]; omega) s (c.tape c.head), hbit]
+      simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+        stepRightThenBranch, hi]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape binToUnaryLoop c hstate]
+    have hbw : (binToUnaryLoop.transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [bul_trans_route (by rw [hi]; omega) s (c.tape c.head), hbit]
+      simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+        stepRightThenBranch, hi]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Inner handoff step** (phase `1`): jump to phase `2` (the branch fragment's start), head and tape
+unchanged. -/
+theorem binToUnaryLoop_stepConfig_handoff {L : Nat}
+    (c : Configuration (M := binToUnaryLoop.toPhased.toTM) L) {i : Fin binToUnaryLoop.numPhases}
+    {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).state).fst.val = 2
+      ∧ (TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase binToUnaryLoop c hstate,
+      bul_trans_route (by rw [hi]; omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+      stepRightThenBranch, hi]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head binToUnaryLoop c hstate]
+    have hmove : (binToUnaryLoop.transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [bul_trans_route (by rw [hi]; omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+        stepRightThenBranch, hi]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape binToUnaryLoop c hstate]
+    have hbw : (binToUnaryLoop.transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [bul_trans_route (by rw [hi]; omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+        stepRightThenBranch, hi]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Branch step-right** (phase `2`): step right to the discriminator cell, reaching phase `3`; tape
+unchanged. -/
+theorem binToUnaryLoop_stepConfig_right {L : Nat}
+    (c : Configuration (M := binToUnaryLoop.toPhased.toTM) L) {i : Fin binToUnaryLoop.numPhases}
+    {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbnd : (c.head : Nat) + 1 < binToUnaryLoop.toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).state).fst.val = 3
+      ∧ ((TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).head : Nat) = (c.head : Nat) + 1
+      ∧ (TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase binToUnaryLoop c hstate,
+      bul_trans_route (by rw [hi]; omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+      stepRightThenBranch, hi]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head binToUnaryLoop c hstate]
+    have hmove : (binToUnaryLoop.transition i s (c.tape c.head)).2.2.2 = Move.right := by
+      rw [bul_trans_route (by rw [hi]; omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+        stepRightThenBranch, hi]
+    rw [hmove]; simp only [Configuration.moveHead, dif_pos hbnd]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape binToUnaryLoop c hstate]
+    have hbw : (binToUnaryLoop.transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [bul_trans_route (by rw [hi]; omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+        stepRightThenBranch, hi]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Branch read-`1`** (phase `3`, reading `1`): jump to the composed phase `4` (the `B = 0` sink). -/
+theorem binToUnaryLoop_stepConfig_branch1 {L : Nat}
+    (c : Configuration (M := binToUnaryLoop.toPhased.toTM) L) {i : Fin binToUnaryLoop.numPhases}
+    {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := binToUnaryLoop.toPhased.toTM) c).state).fst.val = 4 := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_phase binToUnaryLoop c hstate,
+    bul_trans_route (by rw [hi]; omega) s (c.tape c.head), hbit]
+  simp [binToUnaryLoopBody, binToUnaryRouteBody, bZeroRouteProgram, seq, gammaSelfLoopScan,
+    stepRightThenBranch, hi]
+
+/-! ### Run-through: `B = 0` reaches the sink phase `4` -/
+
+/-- **Scanning invariant.**  From a HOME config `c0` at the loop's start phase (`0`) with the cells
+`[c0.head, c0.head + z)` all `0`, after any `k ≤ z` steps the loop is still in phase `0`, the head has
+advanced to `c0.head + k`, and the tape is unchanged. -/
+theorem binToUnaryLoop_runConfig_scanning {L : Nat}
+    (c0 : Configuration (M := binToUnaryLoop.toPhased.toTM) L) (hstart : (c0.state.fst : Nat) = 0)
+    (z : Nat) (hz : (c0.head : Nat) + z < binToUnaryLoop.toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false) :
+    ∀ k, k ≤ z →
+      (((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 k).state).fst : Nat) = 0
+      ∧ ((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 k).head : Nat) = (c0.head : Nat) + k
+      ∧ (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 k).tape = c0.tape := by
+  intro k
+  induction k with
+  | zero => intro _; exact ⟨hstart, rfl, rfl⟩
+  | succ k ih =>
+      intro hk
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega)
+      have hbit : (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 k).tape
+          (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 k).head = false := by
+        rw [htp]; exact hzeros _ (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hbnd : ((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 k).head : Nat) + 1
+          < binToUnaryLoop.toPhased.toTM.tapeLength L := by rw [hhd]; omega
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 k with hc
+      clear_value c
+      obtain ⟨sp, sh, st⟩ := binToUnaryLoop_stepConfig_scan c
+        (i := c.state.fst) (s := c.state.snd) hph rfl hbit hbnd
+      exact ⟨sp, by rw [sh, hhd]; omega, by rw [st, htp]⟩
+
+/-- **Terminator step.**  Adding the scan-stop marker `1` at `c0.head + z`: after `z + 1` steps the loop
+is in phase `1`, head on the marker (`c0.head + z`), tape unchanged. -/
+theorem binToUnaryLoop_runConfig_terminator {L : Nat}
+    (c0 : Configuration (M := binToUnaryLoop.toPhased.toTM) L) (hstart : (c0.state.fst : Nat) = 0)
+    (z : Nat) (hz : (c0.head : Nat) + z < binToUnaryLoop.toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false)
+    (hterm : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + z → c0.tape p = true) :
+    (((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1)).state).fst : Nat) = 1
+      ∧ ((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1)).head : Nat) = (c0.head : Nat) + z
+      ∧ (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1)).tape = c0.tape := by
+  obtain ⟨hph, hhd, htp⟩ := binToUnaryLoop_runConfig_scanning c0 hstart z hz hzeros z (le_refl z)
+  have hbit : (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 z).tape
+      (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 z).head = true := by
+    rw [htp]; exact hterm _ hhd
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 z with hc
+  clear_value c
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoop_stepConfig_stop c
+    (i := c.state.fst) (s := c.state.snd) hph rfl hbit
+  exact ⟨sp, by rw [sh]; exact hhd, by rw [st]; exact htp⟩
+
+/-- **Handoff step.**  After `z + 1 + 1` steps the loop is in phase `2` (the branch fragment's start),
+head still on the marker, tape unchanged. -/
+theorem binToUnaryLoop_runConfig_handoff {L : Nat}
+    (c0 : Configuration (M := binToUnaryLoop.toPhased.toTM) L) (hstart : (c0.state.fst : Nat) = 0)
+    (z : Nat) (hz : (c0.head : Nat) + z < binToUnaryLoop.toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false)
+    (hterm : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + z → c0.tape p = true) :
+    (((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1)).state).fst : Nat) = 2
+      ∧ ((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1)).head : Nat) = (c0.head : Nat) + z
+      ∧ (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1)).tape = c0.tape := by
+  obtain ⟨hph, hhd, htp⟩ := binToUnaryLoop_runConfig_terminator c0 hstart z hz hzeros hterm
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1) with hc
+  clear_value c
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoop_stepConfig_handoff c
+    (i := c.state.fst) (s := c.state.snd) hph rfl
+  exact ⟨sp, by rw [sh]; exact hhd, by rw [st]; exact htp⟩
+
+/-- **Branch step-right.**  After `z + 1 + 1 + 1` steps the loop has stepped right onto the discriminator
+cell, reaching phase `3`, head `c0.head + z + 1`, tape unchanged. -/
+theorem binToUnaryLoop_runConfig_step1 {L : Nat}
+    (c0 : Configuration (M := binToUnaryLoop.toPhased.toTM) L) (hstart : (c0.state.fst : Nat) = 0)
+    (z : Nat) (hz1 : (c0.head : Nat) + z + 1 < binToUnaryLoop.toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false)
+    (hterm : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + z → c0.tape p = true) :
+    (((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1 + 1)).state).fst : Nat) = 3
+      ∧ ((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1 + 1)).head : Nat)
+          = (c0.head : Nat) + z + 1
+      ∧ (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1 + 1)).tape = c0.tape := by
+  obtain ⟨hph, hhd, htp⟩ :=
+    binToUnaryLoop_runConfig_handoff c0 hstart z (by omega) hzeros hterm
+  have hbnd : ((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1)).head : Nat) + 1
+      < binToUnaryLoop.toPhased.toTM.tapeLength L := by rw [hhd]; omega
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1) with hc
+  clear_value c
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoop_stepConfig_right c
+    (i := c.state.fst) (s := c.state.snd) hph rfl hbnd
+  exact ⟨sp, by rw [sh, hhd], by rw [st, htp]⟩
+
+/-- **`hbase` headline.**  From a HOME config `c0` at the loop's start phase with the `B = 0` layout —
+cells `[c0.head, c0.head + z)` all `0`, scan-stop marker `1` at `c0.head + z`, and the **second marker**
+`1` at the discriminator `c0.head + z + 1` — the loop reaches the **sink phase `4`** after `z + 4` steps.
+This is `loopUntilSink_reachesSink`'s `hbase` for `binToUnaryLoop` (the `B = 0 → sink` half of `ε`). -/
+theorem binToUnaryLoop_runConfig_hbase {L : Nat}
+    (c0 : Configuration (M := binToUnaryLoop.toPhased.toTM) L) (hstart : (c0.state.fst : Nat) = 0)
+    (z : Nat) (hz1 : (c0.head : Nat) + z + 1 < binToUnaryLoop.toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + z → c0.tape p = false)
+    (hterm : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + z → c0.tape p = true)
+    (hdisc : ∀ p : Fin (binToUnaryLoop.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + z + 1 → c0.tape p = true) :
+    (((TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 4 := by
+  obtain ⟨hph, hhd, htp⟩ := binToUnaryLoop_runConfig_step1 c0 hstart z hz1 hzeros hterm
+  have hbit : (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1 + 1)).tape
+      (TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1 + 1)).head = true := by
+    rw [htp]; exact hdisc _ hhd
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := binToUnaryLoop.toPhased.toTM) c0 (z + 1 + 1 + 1) with hc
+  clear_value c
+  exact binToUnaryLoop_stepConfig_branch1 c
+    (i := c.state.fst) (s := c.state.snd) hph rfl hbit
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -105,6 +105,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -3846,6 +3847,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -95,6 +95,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -632,6 +633,9 @@ end Pnp4
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
+-- D2t-3 ε `hbase`: from a B=0 HOME config the loop reaches the sink phase 4 (the clean loop-exit half).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

The **clean half** of `ε`'s `loopUntilSink_reachesSink` (per the agreed *bank `hbase`, defer `hstep`*
plan): from a HOME config at `binToUnaryLoop`'s start phase with the **`B = 0` layout** — the `B`-block
all `0`, the **double end-marker** (`1 1`) just past it — the loop reaches the **sink phase `4`** after
`z + 4` steps (`z` = the scan distance to the first marker).  The routing decision (`bZeroRouteProgram`,
the outer `seq`'s P1) scans the zeros, reads the second marker `1`, and lands in phase `4`.  On `B = 0`
the head never enters the body (phase `4 ≠ 5`, the `B > 0` target), so **no navigation is needed**.

Headline: `binToUnaryLoop_runConfig_hbase`.

## How (re-derivation inside the loop machine)

`loopUntilSink (seq …)`'s machine has a different `tapeLength` than the standalone route's, so the route
run-through proved in `TreeMCSPBZeroRouteRun*` (generalized to arbitrary configs in #1560) **cannot be
imported directly** — it is re-derived here in the loop machine.  Each route-region step (phases `0..3`)
peels three layers:

- `bul_trans_route` discharges the `loopUntilSink` layer — its guards are **`Fin` equalities** (`i = ⟨20⟩`
  accept, `i = ⟨4⟩` sink), refuted via the accept index `20` and `i < 4`;
- the remaining two `seq` layers have **value** guards that `simp` resolves from the phase hypothesis.

Five single-step `stepConfig` lemmas + the run-through `scanning → terminator → handoff → step1 →
hbase`.  The opaque-config (`set` / `clear_value`) pattern keeps `whnf` off the iterated `runConfig` term
(otherwise the `Prod`-eta check on the step lemma's `hstate` blows up).

## Scope / remaining

The **`B > 0` `hstep`** — the navigation crux (the route ends *inside* `B`, but `binToUnaryBody` needs the
head at HOME) — is the deferred follow-up (seek-HOME vs guarded-decrement, to be decided).  This PR banks
the `B = 0` half on solid ground.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- New module `TreeMCSPBinToUnaryLoopHbase.lean`; `lakefile` + surface tests + `AxiomsAudit` extended
  (axiom surface `+2`, both new lemmas the standard triple).  **0 `sorry`/`admit`/`native_decide`/custom
  axiom**; `[propext, Classical.choice, Quot.sound]`.

**Infrastructure** (AGENTS.md): the `B = 0` loop-exit behaviour toward the NP-membership leg. **No
`P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_