### PR TITLE
transcoder(D2t-3): realizability of binToUnaryLoop's hbase (B=0 → sink) from initialConfig

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -348,6 +348,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbaseRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopHbaseRealizable.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopHbaseRealizable.lean
@@ -1,0 +1,60 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
+
+/-!
+# Realizability of `binToUnaryLoop`'s base case (`hbase`) (NP-verifier track — D2t-3 `ε`)
+
+`TreeMCSPBinToUnaryLoopHbase.lean` proves the `B = 0 → sink` run-through *layout-agnostically* (the
+`zeros + double marker` layout enters as hypotheses relative to `c0.head`).  This module exhibits a
+**concrete input** that satisfies those hypotheses with `c0 := initialConfig x` (so `c0.head = 0`), so the
+base case is **non-vacuously instantiable** in the loop machine — the analogue of the route's
+`bZeroRouteProgram_decide_true_realizable`:
+
+* `binToUnaryLoop_hbase_realizable` — the input with the double marker at cells `z`, `z + 1` (all else
+  `0`) drives `binToUnaryLoop` to the sink phase `4` after `z + 4` steps.
+
+This is an existence witness (validation), not the converter's mid-loop layout; it confirms the layout the
+`hbase` run-through consumes does fit the loop machine's tape (`tapeLength L = 2·L + 1`) and is reachable
+from `initialConfig`.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- `initialConfig` places the loop machine's head at cell `0`; the `hbase` run-through (stated relative
+to `c0.head`) specializes to absolute positions through this. -/
+private theorem binToUnaryLoop_initialConfig_head_val {L : Nat} (x : Boolcube.Point L) :
+    ((binToUnaryLoop.toPhased.toTM.initialConfig x).head : Nat) = 0 := rfl
+
+/-- The loop's `B = 0` base case is realizable: a concrete double-marker input reaches the sink phase
+`4`. -/
+theorem binToUnaryLoop_hbase_realizable {L : Nat} (z : Nat) (hzL : z + 1 < L) :
+    ∃ x : Boolcube.Point L,
+      (((TM.runConfig (M := binToUnaryLoop.toPhased.toTM)
+          (binToUnaryLoop.toPhased.toTM.initialConfig x) (z + 1 + 1 + 1 + 1)).state).fst : Nat) = 4 := by
+  refine ⟨fun j => decide ((j : Nat) = z ∨ (j : Nat) = z + 1), ?_⟩
+  apply binToUnaryLoop_runConfig_hbase _ rfl z
+  · rw [binToUnaryLoop_initialConfig_head_val]
+    simp only [TM.tapeLength]; omega
+  · intro p hp1 hp2
+    rw [binToUnaryLoop_initialConfig_head_val] at hp2
+    have hpL : (p : Nat) < L := by omega
+    simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_false_iff_not]; omega
+  · intro p hp
+    rw [binToUnaryLoop_initialConfig_head_val] at hp
+    have hpL : (p : Nat) < L := by omega
+    simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_true_eq]; omega
+  · intro p hp
+    rw [binToUnaryLoop_initialConfig_head_val] at hp
+    have hpL : (p : Nat) < L := by omega
+    simp only [initialConfig]; rw [dif_pos hpL]; simp only [decide_eq_true_eq]; omega
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -106,6 +106,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbaseRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -3848,6 +3849,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_hbase_realizable
 #check @Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #check @Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -96,6 +96,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbaseRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPTagCheckComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPLeadingPhasesChain
@@ -636,6 +637,8 @@ end Pnp4
 -- D2t-3 ε `hbase`: from a B=0 HOME config the loop reaches the sink phase 4 (the clean loop-exit half).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase
+-- D2t-3 ε `hbase` realizability: a concrete B=0 input reaches the sink phase 4 from initialConfig.
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_hbase_realizable
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopScanLeftOne_seqNested3_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.stepLeftOnce_seqNested4_stepConfig_handoff_phase
 #print axioms Pnp4.Frontier.ContractExpansion.selfLoopAppendLeftOne_seqNested5_stepConfig_handoff_phase


### PR DESCRIPTION
## Summary

A concrete **non-vacuous instantiation** of the loop's `B = 0` base case (#1561's
`binToUnaryLoop_runConfig_hbase`): the double-marker input — cells `z` and `z + 1` set, all else `0` —
drives `binToUnaryLoop` from `initialConfig` to the **sink phase `4`** after `z + 4` steps.

Headline: `binToUnaryLoop_hbase_realizable` (hypothesis `z + 1 < L`).

This confirms the `zeros + double marker` layout the `hbase` run-through consumes **fits the loop
machine's tape** (`tapeLength L = 2·L + 1`) and is reachable from `initialConfig` — the analogue of the
route's `bZeroRouteProgram_decide_true_realizable`, completing the "every decision gets a realizable
witness" discipline for the loop-exit half of `ε`.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- New module `TreeMCSPBinToUnaryLoopHbaseRealizable.lean`; `lakefile` + surface tests + `AxiomsAudit`
  extended (axiom surface `+1`, standard triple).  **0 `sorry`/`admit`/`native_decide`/custom axiom**;
  `[propext, Classical.choice, Quot.sound]`.

**Infrastructure** (AGENTS.md): validation of the `B = 0` loop-exit toward the NP-membership leg. **No
`P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_