### PR TITLE
transcoder(D2t-3): seekHomeAfterRoute — home-seek primitive for the ε hstep re-homing (scaffolding)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -346,6 +346,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRoute.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRoute.lean
@@ -24,7 +24,8 @@ This is the classic Turing-machine *return-to-home without an endmarker symbol* 
 "marking"/checking-off technique; the standard fix is a reserved boundary symbol — forbidden here by the
 binary-alphabet, all-`Unit`-state discipline, `TM_VERIFIER_STRATEGY.md` §6f).  The binary-alphabet
 realization is a **permanent unary sentinel**: keep `U` non-empty (seed one `1`), so the left scan always
-terminates on `U`'s `1`.  Under that invariant the home-seek is the deterministic 4-step composite
+terminates on `U`'s `1`.  Under that invariant the home-seek is the deterministic **four-sub-program**
+composite (four sub-programs, *not* four TM steps — see the step-count note below)
 
   `seekHomeAfterRoute := seqList [stepLeftOnce, stepLeftOnce, selfLoopScanLeft, stepRightOnce]`
 
@@ -33,6 +34,11 @@ into `B`'s `0`-block, **scan left over the contiguous `0`s** (`B`'s `j` zeros an
 first `1` (`U`'s rightmost cell at `s − 1`), then **step right** back onto the sentinel `s`.  Net head
 move `−(j + 2)`, tape unchanged; the `j = 0` edge (no interior zeros) is absorbed by the scan's
 zero-length-admitting invariant.
+
+**Step count.**  `seqList` folds into nested `seq` over a trailing `idleCS`, so the program has `9` phases
+(4 × 2-phase bricks + the `idleCS`) and its `timeBound` includes the per-`seq` handoff steps plus the
+*variable* `selfLoopScanLeft` cost — the executed run is `(j + 1) + 3` head moves plus handoffs, not a
+literal `4` TM steps.
 
 This brick ships the **definition + phase-count facts**.  The run behaviour (reaching the sentinel from
 the discriminator config), the `binToUnaryLoopBody` revision `seq route (seq seekHomeAfterRoute body)`,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRoute.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRoute.lean
@@ -1,0 +1,63 @@
+import Complexity.TMVerifier.TuringToolkit.ConstStatePhasedProgram
+import Pnp4.Frontier.ContractExpansion.BoundedLoopProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStepLeftProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftProgram
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-!
+# Home-seek after the routing decision (NP-verifier track — D2 transcoder, D2t-3 `ε`, scaffolding)
+
+The binary→unary loop's routing decision (`bZeroRouteProgram`, §12 `ε`) scans **right** over the counter
+`B` and, on `B > 0`, rests at the **discriminator** cell — index `s + (j + 2)` where `s` is the HOME
+sentinel and `B = 0^j 1` (`j` low zeros then the terminator `1`).  To run another body pass the head must
+return to `s`, but `s` is a `0` indistinguishable from `B`'s interior zeros: the only left-landmark is the
+unary output `U`'s `1`s.
+
+This is the classic Turing-machine *return-to-home without an endmarker symbol* problem (Hopcroft–Ullman
+"marking"/checking-off technique; the standard fix is a reserved boundary symbol — forbidden here by the
+binary-alphabet, all-`Unit`-state discipline, `TM_VERIFIER_STRATEGY.md` §6f).  The binary-alphabet
+realization is a **permanent unary sentinel**: keep `U` non-empty (seed one `1`), so the left scan always
+terminates on `U`'s `1`.  Under that invariant the home-seek is the deterministic 4-step composite
+
+  `seekHomeAfterRoute := seqList [stepLeftOnce, stepLeftOnce, selfLoopScanLeft, stepRightOnce]`
+
+reading, from the discriminator: step left off the discriminator (onto the terminator `1`), step left
+into `B`'s `0`-block, **scan left over the contiguous `0`s** (`B`'s `j` zeros and the sentinel) until the
+first `1` (`U`'s rightmost cell at `s − 1`), then **step right** back onto the sentinel `s`.  Net head
+move `−(j + 2)`, tape unchanged; the `j = 0` edge (no interior zeros) is absorbed by the scan's
+zero-length-admitting invariant.
+
+This brick ships the **definition + phase-count facts**.  The run behaviour (reaching the sentinel from
+the discriminator config), the `binToUnaryLoopBody` revision `seq route (seq seekHomeAfterRoute body)`,
+and the `loopUntilSink_reachesSink` `hstep` it unblocks are the follow-ups.
+
+**Progress classification (AGENTS.md): Infrastructure** — loop-navigation assembly toward the
+NP-membership leg; no run behaviour and no separation here.  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+/-- Home-seek after the routing decision: from the discriminator, return the head to the HOME sentinel by
+stepping past the discriminator and terminator, scanning left over `B`'s `0`-block, and stepping right
+onto the sentinel.  Relies on the seed-`U` invariant (`U` non-empty) so the left scan stops on `U`'s `1`. -/
+def seekHomeAfterRoute : ConstStatePhasedProgram Unit :=
+  seqList [stepLeftOnce, stepLeftOnce, selfLoopScanLeft, stepRightOnce]
+
+/-- The composite has `9` phases (four 2-phase programs plus the trailing `idleCS`). -/
+@[simp] theorem seekHomeAfterRoute_numPhases : seekHomeAfterRoute.numPhases = 9 := rfl
+
+/-- The home-seek's start phase is `0`. -/
+@[simp] theorem seekHomeAfterRoute_startPhase_val : (seekHomeAfterRoute.startPhase : Nat) = 0 := rfl
+
+/-- The home-seek's accept phase is the trailing `idleCS` at `8`. -/
+@[simp] theorem seekHomeAfterRoute_acceptPhase_val : (seekHomeAfterRoute.acceptPhase : Nat) = 8 := rfl
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -104,6 +104,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
+import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -3848,6 +3849,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_true_realizable
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_false_realizable
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -94,6 +94,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
+import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -633,6 +634,9 @@ end Pnp4
 -- D2t-3 routing run-through: realizability witnesses (the full decision is non-vacuously instantiable).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_true_realizable
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_false_realizable
+-- D2t-3 ε home-seek after the route (scaffolding): returns the head to the HOME sentinel for hstep.
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_numPhases
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_acceptPhase_val
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases


### PR DESCRIPTION
## Summary

Unblocks the `ε` `hstep` navigation crux. The blocker is the classic Turing-machine *return-to-home
without an endmarker symbol* problem (Hopcroft–Ullman marking/checking-off technique; the textbook fix is
a reserved boundary symbol — forbidden here by the binary-alphabet, all-`Unit`-state discipline, §6f). The
binary-alphabet realization is a **permanent unary sentinel** (seed `U` with one `1`), which keeps the
leftward scan well-founded even on the first iteration.

Under that invariant the home-seek is the deterministic 4-step composite:

```
seekHomeAfterRoute := seqList [stepLeftOnce, stepLeftOnce, selfLoopScanLeft, stepRightOnce]
```

From the discriminator (`s + j + 2`, where `s` is HOME and `B = 0^j 1`): step left off the discriminator
and the terminator into `B`'s `0`-block, **scan left over the contiguous zeros** (`B`'s `j` zeros + the
sentinel) to `U`'s guaranteed `1` at `s − 1`, then **step right** onto the sentinel `s`. Net head move
`−(j + 2)`, tape unchanged; the `j = 0` edge is absorbed by the scan's zero-length-admitting invariant.

This ships the **definition + phase-count facts** (`numPhases = 9`, `startPhase = 0`, `acceptPhase = 8`).

## Why this is self-contained (corrects the earlier "blocked on body session" read)

The fix lives entirely in the `ε`/`ζ` layer: `binToUnaryBody` is **reused unchanged** (always invoked with
`u ≥ 1`), and the seed's `+1` is absorbed in `ζ` (`value(B) = |U| − 1`). No change to the parallel body
session's U-boundary contract. (Searched the TM-construction literature to ground this — see the session
notes; the seed-as-sentinel is the standard "dummy element" trick.)

## Follow-ups (the `hstep` close-out)
1. `seekHomeAfterRoute` run-through (reach the sentinel from the discriminator config).
2. Revise `binToUnaryLoopBody` to `seq route (seq seekHomeAfterRoute body)`; re-establish the merged
   `hbase`/`decide_false` (phases `0..5`, route region unchanged) against the new numbering.
3. `hstep` (route → seek-HOME → body one-pass → loop back-edge, `counterValue` strictly decreasing), then
   `ζ` with the `−1` offset.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- New module `TreeMCSPSeekHomeAfterRoute.lean`; `lakefile` + surface tests + `AxiomsAudit` extended
  (axiom surface `+2`, standard triple). **0 `sorry`/`admit`/`native_decide`/custom axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_