### PR TITLE
transcoder(D2t-3): seekHomeAfterRoute run-through — leading two steps (depth-1)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -347,6 +347,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
@@ -1,0 +1,119 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
+
+/-!
+# `seekHomeAfterRoute` run-through — single-step lemmas (NP-verifier track — D2t-3 `ε`)
+
+Per-step `stepConfig` lemmas for `seekHomeAfterRoute = seqList [stepLeftOnce, stepLeftOnce,
+selfLoopScanLeft, stepRightOnce]`, built bottom-up before the scanning run-through (the toolkit's
+single-step-first discipline).  Phase layout: `0` = first `stepLeftOnce` move, `1` = its handoff, `2` =
+second `stepLeftOnce` move, `3` = handoff, `4` = `selfLoopScanLeft` scan, `5` = handoff, `6` =
+`stepRightOnce` move, `7` = handoff, `8` = `idleCS` (accept).
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- `seekHomeAfterRoute` is `seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])` —
+the shape the depth-1 `seq_stepConfig_P1_*` lemmas consume. -/
+theorem seekHomeAfterRoute_eq_seq :
+    seekHomeAfterRoute
+      = seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) := rfl
+
+/-- Step 1 (phase `0`, the first `stepLeftOnce`'s move): the phase advances to `1`.  Stated over the
+`seq`-head form (defeq to `seekHomeAfterRoute` by `seekHomeAfterRoute_eq_seq`), so the depth-1
+`seq_stepConfig` lemmas match syntactically. -/
+theorem seekHomeAfterRoute_step1_phase {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).state).fst.val = 1 := by
+  rw [seq_stepConfig_P1_normal_phase stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])
+      c (h1 := by rw [hi]; decide) (hne := by rw [hi]; decide) hstate]
+  simp [stepLeftOnce, hi]
+
+/-- Step 1 (phase `0`): the head moves one cell left (when not at the left end). -/
+theorem seekHomeAfterRoute_step1_head {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).head : Nat) = (c.head : Nat) - 1 := by
+  have hmove : (TM.stepConfig
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+      c).head = Configuration.moveHead (c := c) Move.left := by
+    rw [seq_stepConfig_P1_normal_head stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])
+        c (h1 := by rw [hi]; decide) (hne := by rw [hi]; decide) hstate]
+    simp [stepLeftOnce, hi]
+  rw [hmove]
+  have hne : ¬ (c.head : Nat) = 0 := by omega
+  simp only [Configuration.moveHead, dif_neg hne]
+
+/-- Step 1 (phase `0`): the tape is unchanged (the scanned bit is written back). -/
+theorem seekHomeAfterRoute_step1_tape {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).tape = c.tape := by
+  have hwrite : (TM.stepConfig
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+      c).tape = c.write c.head (c.tape c.head) := by
+    rw [seq_stepConfig_P1_normal_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])
+        c (h1 := by rw [hi]; decide) (hne := by rw [hi]; decide) hstate]
+    simp [stepLeftOnce, hi]
+  rw [hwrite]; funext j; by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- Step 2 (phase `1` = first `stepLeftOnce`'s accept): the `seq` handoff jumps to the shifted start of
+the trailing `seqList` (the second `stepLeftOnce`), i.e. phase `2`. -/
+theorem seekHomeAfterRoute_step2_phase {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).state).fst.val = 2 := by
+  rw [seq_stepConfig_P1_accept_phase stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])
+      c (h1 := by rw [hi]; decide) (hacc := by rw [hi]; decide) hstate]
+  decide
+
+/-- Step 2 (handoff): the head stays put. -/
+theorem seekHomeAfterRoute_step2_head {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).head = c.head :=
+  seq_stepConfig_P1_accept_head stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])
+    c (h1 := by rw [hi]; decide) (hacc := by rw [hi]; decide) hstate
+
+/-- Step 2 (handoff): the tape is unchanged. -/
+theorem seekHomeAfterRoute_step2_tape {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).tape = c.tape :=
+  seq_stepConfig_P1_accept_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])
+    c (h1 := by rw [hi]; decide) (hacc := by rw [hi]; decide) hstate
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -105,6 +105,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
+import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -3850,6 +3851,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_decide_false_realizable
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_numPhases
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step1_phase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -95,6 +95,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunP1
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
+import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -637,6 +638,9 @@ end Pnp4
 -- D2t-3 ε home-seek after the route (scaffolding): returns the head to the HOME sentinel for hstep.
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_numPhases
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_acceptPhase_val
+-- D2t-3 ε home-seek run-through (leading two steps, depth-1): step lemmas toward the sentinel reach.
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step1_phase
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step2_phase
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases


### PR DESCRIPTION
## Summary

First increment of the `seekHomeAfterRoute` run-through (toward the `ε` `hstep` re-homing, #1564's
follow-up). Establishes:

- **The `seq`-head bridge**: `seekHomeAfterRoute_eq_seq : seekHomeAfterRoute = seq stepLeftOnce (seqList
  [stepLeftOnce, selfLoopScanLeft, stepRightOnce])` (`rfl`), so the run lemmas are stated over the `seq`-head
  form and the depth-1 `seq_stepConfig_P1_*` lemmas match syntactically (stating them over the named
  `seekHomeAfterRoute` fails — the machine appears in `c`/`i`'s types, so a `rw` hits a dependent-motive
  error; the `seq` form sidesteps it, exactly as `seekHomeAfterDecrement` does).
- **The leading two steps, fully characterized** (phase/head/tape):
  - `step1` (phase 0, first `stepLeftOnce` move): phase → 1, head − 1 (when `0 < head`), tape unchanged;
  - `step2` (phase 1, `seq` P1-accept handoff): phase → 2, head/tape unchanged.

Mirrors the proven `seekHomeAfterDecrement` leading-step structure exactly.

## Follow-up increments (the rest of the run-through)
- depth-2 `stepLeftOnce` (phase 2/3), depth-3 `selfLoopScanLeft` scanning invariant (phase 4/5), depth-4
  `stepRightOnce` (phase 6/7) — via the `seq_stepConfig_P2_*` navigation;
- the headline: from the discriminator config (head `s + j + 2`, seed-`U` non-empty), reach the sentinel
  `s` with tape unchanged;
- then the `binToUnaryLoopBody` revision + `hstep` + `ζ`.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- New module `TreeMCSPSeekHomeAfterRouteRun.lean`; `lakefile` + surface tests + `AxiomsAudit` extended
  (axiom surface `+2`, standard triple). **0 `sorry`/`admit`/`native_decide`/custom axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_