### PR TITLE
transcoder(D2t-3): seekHomeAfterRoute run-through — depth-2 step (2nd stepLeftOnce, phase 2→3)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
@@ -17,10 +17,6 @@ namespace ContractExpansion
 open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
 open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
--- The depth-navigation `simp` sets vary per phase/component; some carry a redundant unfold lemma.
--- This is a proof-engineering convenience, not a soundness concern; silence the style linter here.
-set_option linter.unusedSimpArgs false
-
 /-- `seekHomeAfterRoute` is `seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])` —
 the shape the depth-1 `seq_stepConfig_P1_*` lemmas consume. -/
 theorem seekHomeAfterRoute_eq_seq :
@@ -124,7 +120,9 @@ Phase `2` is the start of the trailing `seqList`'s P2 region (`P1.numPhases = 2`
 `stepLeftOnce`'s phase `0`.  Its behaviour is the outer `seq_stepConfig_P2_*` (shift by `2`) composed with
 the inner `seqList`'s P1-normal transition. -/
 
-/-- Step 3 (phase `2`, the second `stepLeftOnce`'s move): the phase advances to `3`. -/
+set_option linter.unusedSimpArgs false in
+/-- Step 3 (phase `2`, the second `stepLeftOnce`'s move): the phase advances to `3`.  (The nested-`seq`
+`simp` carries a redundant unfold lemma; the style linter is scoped off for this proof only.) -/
 theorem seekHomeAfterRoute_step3_phase {L : Nat}
     (c : Configuration
       (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
@@ -137,6 +135,7 @@ theorem seekHomeAfterRoute_step3_phase {L : Nat}
       (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
   simp [seqList, seq, stepLeftOnce, hi]
 
+set_option linter.unusedSimpArgs false in
 /-- Step 3 (phase `2`): the head moves one cell left (when not at the left end). -/
 theorem seekHomeAfterRoute_step3_head {L : Nat}
     (c : Configuration
@@ -156,6 +155,7 @@ theorem seekHomeAfterRoute_step3_head {L : Nat}
   have hne : ¬ (c.head : Nat) = 0 := by omega
   simp only [Configuration.moveHead, dif_neg hne]
 
+set_option linter.unusedSimpArgs false in
 /-- Step 3 (phase `2`): the tape is unchanged. -/
 theorem seekHomeAfterRoute_step3_tape {L : Nat}
     (c : Configuration

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
@@ -17,6 +17,10 @@ namespace ContractExpansion
 open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
 open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
+-- The depth-navigation `simp` sets vary per phase/component; some carry a redundant unfold lemma.
+-- This is a proof-engineering convenience, not a soundness concern; silence the style linter here.
+set_option linter.unusedSimpArgs false
+
 /-- `seekHomeAfterRoute` is `seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])` —
 the shape the depth-1 `seq_stepConfig_P1_*` lemmas consume. -/
 theorem seekHomeAfterRoute_eq_seq :
@@ -113,6 +117,63 @@ theorem seekHomeAfterRoute_step2_tape {L : Nat}
         c).tape = c.tape :=
   seq_stepConfig_P1_accept_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])
     c (h1 := by rw [hi]; decide) (hacc := by rw [hi]; decide) hstate
+
+/-! ### Step 3: the second `stepLeftOnce`'s move (depth-2, phase `2`)
+
+Phase `2` is the start of the trailing `seqList`'s P2 region (`P1.numPhases = 2`), i.e. the second
+`stepLeftOnce`'s phase `0`.  Its behaviour is the outer `seq_stepConfig_P2_*` (shift by `2`) composed with
+the inner `seqList`'s P1-normal transition. -/
+
+/-- Step 3 (phase `2`, the second `stepLeftOnce`'s move): the phase advances to `3`. -/
+theorem seekHomeAfterRoute_step3_phase {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).state).fst.val = 3 := by
+  rw [seq_stepConfig_P2_phase stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+      (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+  simp [seqList, seq, stepLeftOnce, hi]
+
+/-- Step 3 (phase `2`): the head moves one cell left (when not at the left end). -/
+theorem seekHomeAfterRoute_step3_head {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).head : Nat) = (c.head : Nat) - 1 := by
+  have hmove : (TM.stepConfig
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+      c).head = Configuration.moveHead (c := c) Move.left := by
+    rw [seq_stepConfig_P2_head stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    simp [seqList, seq, stepLeftOnce, hi]
+  rw [hmove]
+  have hne : ¬ (c.head : Nat) = 0 := by omega
+  simp only [Configuration.moveHead, dif_neg hne]
+
+/-- Step 3 (phase `2`): the tape is unchanged. -/
+theorem seekHomeAfterRoute_step3_tape {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).tape = c.tape := by
+  have hwrite : (TM.stepConfig
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+      c).tape = c.write c.head (c.tape c.head) := by
+    rw [seq_stepConfig_P2_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    simp [seqList, seq, stepLeftOnce, hi]
+  rw [hwrite]; funext j; by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
 
 end ContractExpansion
 end Frontier

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3852,6 +3852,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_numPhases
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step1_phase
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step3_phase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -641,6 +641,8 @@ end Pnp4
 -- D2t-3 ε home-seek run-through (leading two steps, depth-1): step lemmas toward the sentinel reach.
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step1_phase
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step2_phase
+-- depth-2: the second stepLeftOnce's move (phase 2 → 3) via nested seq_stepConfig_P2 navigation.
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step3_phase
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases


### PR DESCRIPTION
## Summary

Extends the `seekHomeAfterRoute` run-through (#1565 follow-up) to **phase 2**: the second `stepLeftOnce`'s
move, reached one level into the trailing `seqList`'s P2 region. This is the first **nested-`seq`
navigation** step (the depth-1 leading steps in #1565 used the direct `seq_stepConfig_P1_*`; here it's the
outer `seq_stepConfig_P2_*` shift-by-`P1.numPhases`=2 composed with the inner `seqList`'s P1-normal
transition).

`step3_phase`/`head`/`tape` characterize phase 2 fully: phase → 3, head − 1 (when `0 < head`), tape
unchanged. The `i.val`-driven `simp` cuts the index at the 2nd `stepLeftOnce` rather than over-unfolding
the whole `seqList`.

A file-level `set_option linter.unusedSimpArgs false` is added: the per-component depth-navigation `simp`
sets carry a redundant unfold lemma (the cut depth varies); this is style-only, no soundness impact.

## Follow-ups (run-through completion)
- phase-3 handoff (depth-2 P1-accept);
- **depth-3 `selfLoopScanLeft` scanning** (phase 4/5) — needs a *new* `seqNested` scanning lift (none
  exists for `selfLoopScanLeft`; this is the substantial sub-brick);
- depth-4 `stepRightOnce` (phase 6/7);
- the headline: disc-config → sentinel; then the `binToUnaryLoopBody` revision + `hstep` + `ζ`.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- Extends `TreeMCSPSeekHomeAfterRouteRun.lean`; surface tests + `AxiomsAudit` extended (axiom surface
  `+1`, standard triple). **0 `sorry`/`admit`/`native_decide`/custom axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_