### PR TITLE
transcoder(D2t-3): seekHomeAfterRoute run-through — phase-3 handoff (→ phase 4)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
@@ -175,6 +175,63 @@ theorem seekHomeAfterRoute_step3_tape {L : Nat}
   · subst hj; simp [Configuration.write]
   · simp [Configuration.write, hj]
 
+/-! ### Step 4: the second `stepLeftOnce`'s accept handoff (depth-2, phase `3`)
+
+Phase `3` is the second `stepLeftOnce`'s accept (composed `P1.numPhases + stepLeftOnce.acceptPhase = 3`);
+the inner `seqList`'s P1-accept handoff jumps to the start of `selfLoopScanLeft` (phase `4`). -/
+
+set_option linter.unusedSimpArgs false in
+/-- Step 4 (phase `3`, handoff): jump to phase `4` (the `selfLoopScanLeft` start). -/
+theorem seekHomeAfterRoute_step4_phase {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).state).fst.val = 4 := by
+  rw [seq_stepConfig_P2_phase stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+      (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+  simp [seqList, seq, stepLeftOnce, hi]
+
+set_option linter.unusedSimpArgs false in
+/-- Step 4 (phase `3`, handoff): the head stays put. -/
+theorem seekHomeAfterRoute_step4_head {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).head = c.head := by
+  have hmove : (TM.stepConfig
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+      c).head = Configuration.moveHead (c := c) Move.stay := by
+    rw [seq_stepConfig_P2_head stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    simp [seqList, seq, stepLeftOnce, hi]
+  rw [hmove]; simp [Configuration.moveHead]
+
+set_option linter.unusedSimpArgs false in
+/-- Step 4 (phase `3`, handoff): the tape is unchanged. -/
+theorem seekHomeAfterRoute_step4_tape {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).tape = c.tape := by
+  have hwrite : (TM.stepConfig
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+      c).tape = c.write c.head (c.tape c.head) := by
+    rw [seq_stepConfig_P2_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    simp [seqList, seq, stepLeftOnce, hi]
+  rw [hwrite]; funext j; by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3853,6 +3853,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_numPhases
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step1_phase
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step3_phase
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_phase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3854,6 +3854,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step1_phase
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step3_phase
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_phase
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_head
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_tape
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -643,6 +643,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step2_phase
 -- depth-2: the second stepLeftOnce's move (phase 2 → 3) via nested seq_stepConfig_P2 navigation.
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step3_phase
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_phase
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -644,6 +644,8 @@ end Pnp4
 -- depth-2: the second stepLeftOnce's move (phase 2 → 3) via nested seq_stepConfig_P2 navigation.
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step3_phase
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_phase
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_head
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_tape
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases


### PR DESCRIPTION
## Summary

Extends the `seekHomeAfterRoute` run-through to **phase 3**: the second `stepLeftOnce`'s accept, whose
inner-`seqList` P1-accept handoff jumps to **phase 4** (the `selfLoopScanLeft` start). `step4_phase`/`head`/
`tape` (phase → 4, head/tape unchanged) via the outer `seq_stepConfig_P2_*` composed with the inner
`seqList` P1-accept. The run-through now covers **phases 0–3**.

## Next (the substantial remaining sub-brick)
- **depth-3 `selfLoopScanLeft` scanning invariant** (phase 4): a composite-machine induction reached via
  *two* nested `seq_stepConfig_P2` levels (no `seqNested` lift exists for `selfLoopScanLeft`);
- depth-4 `stepRightOnce` (phases 6/7) + the disc→sentinel headline;
- then the `binToUnaryLoopBody` revision + `hstep` + `ζ`.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- Extends `TreeMCSPSeekHomeAfterRouteRun.lean`; surface tests + `AxiomsAudit` extended (axiom surface
  `+1`, standard triple); the `unusedSimpArgs` linter is scoped per-proof via `set_option ... in`. **0
  `sorry`/`admit`/`native_decide`/custom axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_