### PR TITLE
transcoder(D2t-3): seekHomeAfterRoute run-through — depth-3 selfLoopScanLeft scan-step (phase 4)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
@@ -232,6 +232,48 @@ theorem seekHomeAfterRoute_step4_tape {L : Nat}
   · subst hj; simp [Configuration.write]
   · simp [Configuration.write, hj]
 
+/-! ### Step 5: the `selfLoopScanLeft` scan-step (depth-3, phase `4`)
+
+Phase `4` is `selfLoopScanLeft`'s phase `0`, reached through two nested `P2` descents (composed
+`P1.numPhases + P1'.numPhases = 4`).  Reading `0` it stays in phase `4` and moves the head one cell left
+(scanning over the contiguous `0`-block); reading `1` it stops at phase `5`. -/
+
+set_option linter.unusedSimpArgs false in
+/-- Scan-step (phase `4`, reading `0`): stay in phase `4`, head one cell left, tape unchanged. -/
+theorem seekHomeAfterRoute_scan_step {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false)
+    (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).state).fst.val = 4
+      ∧ ((TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).head : Nat) = (c.head : Nat) - 1
+      ∧ (TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [seq_stepConfig_P2_phase stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate, hbit]
+    simp [seqList, seq, selfLoopScanLeft, hi]
+  · have hmove : (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).head = Configuration.moveHead (c := c) Move.left := by
+      rw [seq_stepConfig_P2_head stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+          (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate, hbit]
+      simp [seqList, seq, selfLoopScanLeft, hi]
+    rw [hmove]
+    have hne : ¬ (c.head : Nat) = 0 := by omega
+    simp only [Configuration.moveHead, dif_neg hne]
+  · rw [seq_stepConfig_P2_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    funext j; by_cases hj : j = c.head
+    · subst hj; rw [hbit]; simp [seqList, seq, selfLoopScanLeft, hi, Configuration.write]
+    · simp [Configuration.write, hj]
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3856,6 +3856,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_phase
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_head
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_tape
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_step
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -646,6 +646,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_phase
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_head
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_tape
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_step
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases


### PR DESCRIPTION
## Summary

The hardest navigation piece of the `seekHomeAfterRoute` run-through: **phase 4** is `selfLoopScanLeft`'s
phase 0, reached through **two nested `seq_stepConfig_P2` descents** (composed `P1.numPhases +
P1'.numPhases = 4`). The scan-step (reading `0`) — stay in phase 4, head one cell left, tape unchanged —
is the bundled `seekHomeAfterRoute_scan_step` (phase ∧ head ∧ tape). This validates the depth-3
composite-machine navigation that the scanning induction will iterate over the `0`-block.

## Follow-ups (to finish the run-through)
- scan-stop (phase 4 reading `1` → phase 5);
- the scanning `runConfig` induction (compose the scan-step over the contiguous `0`-block);
- depth-4 `stepRightOnce` (phases 6/7) + the disc→sentinel headline;
- then `binToUnaryLoopBody` revision + `hstep` + `ζ`.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- Extends `TreeMCSPSeekHomeAfterRouteRun.lean`; surface tests + `AxiomsAudit` extended (axiom surface
  `+1`, standard triple); `unusedSimpArgs` scoped per-proof. **0 `sorry`/`admit`/`native_decide`/custom
  axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_