### PR TITLE
transcoder(D2t-3): seekHomeAfterRoute run-through — scan-stop + scanning invariant (depth-3)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
@@ -274,6 +274,84 @@ theorem seekHomeAfterRoute_scan_step {L : Nat}
     · subst hj; rw [hbit]; simp [seqList, seq, selfLoopScanLeft, hi, Configuration.write]
     · simp [Configuration.write, hj]
 
+set_option linter.unusedSimpArgs false in
+/-- Scan-stop (phase `4`, reading `1`): jump to phase `5` (the `selfLoopScanLeft` accept), head and tape
+unchanged. -/
+theorem seekHomeAfterRoute_scan_stop {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).state).fst.val = 5
+      ∧ (TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).head = c.head
+      ∧ (TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [seq_stepConfig_P2_phase stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate, hbit]
+    simp [seqList, seq, selfLoopScanLeft, hi]
+  · have hmove : (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).head = Configuration.moveHead (c := c) Move.stay := by
+      rw [seq_stepConfig_P2_head stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+          (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate, hbit]
+      simp [seqList, seq, selfLoopScanLeft, hi]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [seq_stepConfig_P2_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    funext j; by_cases hj : j = c.head
+    · subst hj; rw [hbit]; simp [seqList, seq, selfLoopScanLeft, hi, Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-! ### The scanning invariant (phase `4`, leftward over the `0`-block) -/
+
+/-- **Scanning invariant.**  From phase `4` with the `m` cells `(head − m, head]` all `0`, after any
+`j ≤ m` steps the program is still in phase `4`, the head has moved `j` cells left, and the tape is
+unchanged. -/
+theorem seekHomeAfterRoute_runConfig_scanning {L : Nat}
+    (c0 : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 4) (m : Nat) (hm : m ≤ (c0.head : Nat))
+    (hzeros : ∀ p : Fin ((seq stepLeftOnce
+        (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - m < (p : Nat) → (p : Nat) ≤ (c0.head : Nat) → c0.tape p = false) :
+    ∀ j, j ≤ m →
+      (((TM.runConfig (M := (seq stepLeftOnce
+            (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) c0 j).state).fst
+          : Nat) = 4
+      ∧ ((TM.runConfig (M := (seq stepLeftOnce
+            (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) c0 j).head : Nat)
+          = (c0.head : Nat) - j
+      ∧ (TM.runConfig (M := (seq stepLeftOnce
+            (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) c0 j).tape
+          = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _; exact ⟨hstart, by simp, rfl⟩
+  | succ j ih =>
+      intro hj
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega)
+      have hbit : (TM.runConfig (M := (seq stepLeftOnce
+          (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) c0 j).tape
+          (TM.runConfig (M := (seq stepLeftOnce
+            (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) c0 j).head = false := by
+        rw [htp]; exact hzeros _ (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hhead : 0 < ((TM.runConfig (M := (seq stepLeftOnce
+          (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) c0 j).head : Nat) := by
+        rw [hhd]; omega
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (seq stepLeftOnce
+        (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) c0 j with hc
+      clear_value c
+      obtain ⟨sp, sh, st⟩ := seekHomeAfterRoute_scan_step c
+        (i := c.state.fst) (s := c.state.snd) hph rfl hbit hhead
+      exact ⟨sp, by rw [sh, hhd]; omega, by rw [st, htp]⟩
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3857,6 +3857,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_head
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_tape
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_step
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_runConfig_scanning
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3857,6 +3857,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_head
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_tape
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_step
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_stop
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_runConfig_scanning
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -647,6 +647,8 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_head
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step4_tape
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_step
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_stop
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_runConfig_scanning
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases


### PR DESCRIPTION
## Summary

Completes the **hard depth-3 sub-brick** of the `seekHomeAfterRoute` run-through:

- `seekHomeAfterRoute_scan_stop` (phase 4 reading `1` → phase 5; head/tape unchanged);
- `seekHomeAfterRoute_runConfig_scanning`: from phase 4 with the `m` cells `(head − m, head]` all `0`,
  after any `j ≤ m` steps still phase 4, head moved `j` left, tape unchanged — the `runConfig` induction
  composing the scan-step (opaque-config `set`/`clear_value` pattern).

`selfLoopScanLeft`'s leftward scan is now fully characterized in the composite machine through the two
nested `seq_stepConfig_P2` levels.

## Remaining (to finish `seekHomeAfterRoute`)
- depth-4 `stepRightOnce` (phases 6/7);
- the **headline**: from the discriminator config (`head = s + j + 2`, seed-`U` non-empty) the run reaches
  the accept phase 8 with `head = s` (re-homed to the sentinel);
- then `binToUnaryLoopBody` revision + `hstep` + `ζ`.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- Extends `TreeMCSPSeekHomeAfterRouteRun.lean`; surface tests + `AxiomsAudit` extended (axiom surface
  `+2`, standard triple). **0 `sorry`/`admit`/`native_decide`/custom axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_