### PR TITLE
transcoder(D2t-3): seekHomeAfterRoute run-through — steps 6–8 (all single-steps complete)

### DIFF
--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPSeekHomeAfterRouteRun.lean
@@ -352,6 +352,112 @@ theorem seekHomeAfterRoute_runConfig_scanning {L : Nat}
         (i := c.state.fst) (s := c.state.snd) hph rfl hbit hhead
       exact ⟨sp, by rw [sh, hhd]; omega, by rw [st, htp]⟩
 
+/-! ### Steps 6–8: scan-accept handoff, the rightward step, and the final handoff -/
+
+set_option linter.unusedSimpArgs false in
+/-- Step 6 (phase `5` = `selfLoopScanLeft`'s accept): handoff to phase `6` (the `stepRightOnce` start),
+head and tape unchanged. -/
+theorem seekHomeAfterRoute_step6 {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 5) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).state).fst.val = 6
+      ∧ (TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).head = c.head
+      ∧ (TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [seq_stepConfig_P2_phase stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    simp [seqList, seq, selfLoopScanLeft, stepRightOnce, hi]
+  · have hmove : (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).head = Configuration.moveHead (c := c) Move.stay := by
+      rw [seq_stepConfig_P2_head stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+          (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+      simp [seqList, seq, selfLoopScanLeft, stepRightOnce, hi]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [seq_stepConfig_P2_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    funext j; by_cases hj : j = c.head
+    · subst hj; simp [seqList, seq, selfLoopScanLeft, stepRightOnce, hi, Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+/-- Step 7 (phase `6` = `stepRightOnce`'s move): step one cell right (back onto the sentinel), reaching
+phase `7`; tape unchanged. -/
+theorem seekHomeAfterRoute_step7 {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 6) (hstate : c.state = ⟨i, s⟩)
+    (hbnd : (c.head : Nat) + 1 < (seq stepLeftOnce
+      (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).state).fst.val = 7
+      ∧ ((TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).head : Nat) = (c.head : Nat) + 1
+      ∧ (TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [seq_stepConfig_P2_phase stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    simp [seqList, seq, selfLoopScanLeft, stepRightOnce, hi]
+  · have hmove : (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).head = Configuration.moveHead (c := c) Move.right := by
+      rw [seq_stepConfig_P2_head stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+          (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+      simp [seqList, seq, selfLoopScanLeft, stepRightOnce, hi]
+    rw [hmove]; simp only [Configuration.moveHead, dif_pos hbnd]
+  · rw [seq_stepConfig_P2_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    funext j; by_cases hj : j = c.head
+    · subst hj; simp [seqList, seq, selfLoopScanLeft, stepRightOnce, hi, Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+/-- Step 8 (phase `7` = `stepRightOnce`'s accept): handoff to the trailing `idleCS` (phase `8`, the
+accept), head and tape unchanged. -/
+theorem seekHomeAfterRoute_step8 {L : Nat}
+    (c : Configuration
+      (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM) L)
+    {i : Fin (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).numPhases}
+    {s : Unit} (hi : i.val = 7) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).state).fst.val = 8
+      ∧ (TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).head = c.head
+      ∧ (TM.stepConfig
+          (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+          c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [seq_stepConfig_P2_phase stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    simp [seqList, seq, selfLoopScanLeft, stepRightOnce, hi]
+  · have hmove : (TM.stepConfig
+        (M := (seq stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce])).toPhased.toTM)
+        c).head = Configuration.moveHead (c := c) Move.stay := by
+      rw [seq_stepConfig_P2_head stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+          (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+      simp [seqList, seq, selfLoopScanLeft, stepRightOnce, hi]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [seq_stepConfig_P2_tape stepLeftOnce (seqList [stepLeftOnce, selfLoopScanLeft, stepRightOnce]) c
+        (h2 := by rw [hi]; decide) (hlt := by rw [hi]; decide) hstate]
+    funext j; by_cases hj : j = c.head
+    · subst hj; simp [seqList, seq, selfLoopScanLeft, stepRightOnce, hi, Configuration.write]
+    · simp [Configuration.write, hj]
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3859,6 +3859,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_step
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_stop
 #check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_runConfig_scanning
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step6
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step7
+#check @Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step8
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -649,6 +649,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_step
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_scan_stop
 #print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_runConfig_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step6
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step7
+#print axioms Pnp4.Frontier.ContractExpansion.seekHomeAfterRoute_step8
 -- D2t-3 ε (loop scaffolding): binToUnaryLoop = loopUntilSink (route ; binToUnaryBody), sink phase 4.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases


### PR DESCRIPTION
## Summary

Completes **all single-step lemmas** of the `seekHomeAfterRoute` run-through (phases 0–7):

- `step6` (phase 5 = `selfLoopScanLeft` accept → phase 6, the `stepRightOnce` start; handoff);
- `step7` (phase 6 = `stepRightOnce` move → phase 7, head + 1; **depth-4** — three nested
  `seq_stepConfig_P2`);
- `step8` (phase 7 = `stepRightOnce` accept → phase 8 = `idleCS` accept; handoff).

Together with the leading steps (#1565), depth-2 (#1566), phase-3 handoff (#1567), and the depth-3
scanning (#1568/#1569), **every phase 0→7 transition of `seekHomeAfterRoute` is now characterized.**

## Remaining
- the disc→sentinel **headline** composing all steps + the scanning invariant (the capstone);
- then `binToUnaryLoopBody` revision (`seq route (seq seekHomeAfterRoute body)`) + `hstep` + `ζ`.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- Extends `TreeMCSPSeekHomeAfterRouteRun.lean`; surface tests + `AxiomsAudit` extended (axiom surface
  `+3`, standard triple). **0 `sorry`/`admit`/`native_decide`/custom axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_