### PR TITLE
transcoder(D2t-3): binToUnaryLoopH — the seek-HOME loop assembly (scaffolding)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -348,7 +348,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun,
-    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopH,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -348,6 +348,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopH,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopH.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopH.lean
@@ -1,0 +1,66 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
+import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
+
+/-!
+# `binToUnaryLoopH` — the binary→unary loop with the seek-HOME bridge (NP-verifier track — D2t-3 `ε`)
+
+The merged `binToUnaryLoop = loopUntilSink (seq binToUnaryRouteBody binToUnaryBody) ⟨4⟩` (the route-only
+loop, #1559) cannot discharge `hstep`: on `B > 0` the route exits at the discriminator, `j + 2` cells
+right of the sentinel, but `binToUnaryBody` needs the head **on** the sentinel (see the `decide_false`
+navigation analysis, #1563 / `TM_VERIFIER_STRATEGY.md` §12).  The resolution (literature-grounded: a
+binary-alphabet *endmarker* realized as a permanent seed-`U` cell, #1571) is the **`seekHomeAfterRoute`**
+primitive, now proven end-to-end (`seekHomeAfterRoute_runConfig_home`).
+
+This module assembles the **revised** loop that inserts that re-homing between the route and the body:
+
+* `binToUnaryLoopBodyH := seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)` — route first;
+  on `B > 0` (route accept, phase `5`) hand off into `seekHomeAfterRoute` (re-home to the sentinel), then
+  one pass of `binToUnaryBody`;
+* `binToUnaryLoopH := loopUntilSink binToUnaryLoopBodyH ⟨4⟩` — re-enter the body on its accept and halt at
+  the sink phase `4` (`B = 0`).
+
+It is introduced **additively** (the route-only `binToUnaryLoop` and its merged `hbase`/`decide_false`
+stay intact) so nothing breaks; the route region (phases `0..5`) and sink `⟨4⟩` are unchanged, so the
+`B = 0` and `B > 0` route decisions re-derive on this machine exactly as before, and `hstep` becomes
+provable (route → seek-HOME → body one-pass → loop back-edge).  This brick ships the **definitions +
+phase-count facts**; the run behaviour (`hbase`/`decide_false`/`hstep` on `binToUnaryLoopH`, then `ζ`) is
+the follow-up.
+
+**Progress classification (AGENTS.md): Infrastructure** — the loop assembly toward the NP-membership leg;
+it proves no run behaviour here.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- The revised loop body: route, then on `B > 0` re-home (`seekHomeAfterRoute`) and run one pass of
+`binToUnaryBody`. -/
+def binToUnaryLoopBodyH : ConstStatePhasedProgram Unit :=
+  seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)
+
+/-- Phase count: route `6` + (`seekHomeAfterRoute` `9` + `binToUnaryBody` `15`) `= 30`. -/
+@[simp] theorem binToUnaryLoopBodyH_numPhases : binToUnaryLoopBodyH.numPhases = 30 := rfl
+
+/-- The seek-HOME loop: re-enter the body on its accept (a completed `B > 0` pass), halt at the sink phase
+`4` (`B = 0`). -/
+def binToUnaryLoopH : ConstStatePhasedProgram Unit :=
+  loopUntilSink binToUnaryLoopBodyH ⟨4, by decide⟩
+
+@[simp] theorem binToUnaryLoopH_numPhases : binToUnaryLoopH.numPhases = 30 := rfl
+
+@[simp] theorem binToUnaryLoopH_acceptPhase : (binToUnaryLoopH.acceptPhase : Nat) = 4 := rfl
+
+/-- The route region of `binToUnaryLoopBodyH` is `binToUnaryRouteBody` (phases `0..5`), unchanged from the
+route-only loop — so the `B = 0`/`B > 0` route decisions re-derive identically. -/
+@[simp] theorem binToUnaryLoopBodyH_startPhase_val : (binToUnaryLoopBodyH.startPhase : Nat) = 0 := rfl
+
+@[simp] theorem binToUnaryLoopH_startPhase_val : (binToUnaryLoopH.startPhase : Nat) = 0 := rfl
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehome.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehome.lean
@@ -2,7 +2,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
 
 /-!
-# `binToUnaryLoopH` — the binary→unary loop with the seek-HOME bridge (NP-verifier track — D2t-3 `ε`)
+# `binToUnaryLoopRehome` — the binary→unary loop with the seek-HOME bridge (NP-verifier track — D2t-3 `ε`)
 
 The merged `binToUnaryLoop = loopUntilSink (seq binToUnaryRouteBody binToUnaryBody) ⟨4⟩` (the route-only
 loop, #1559) cannot discharge `hstep`: on `B > 0` the route exits at the discriminator, `j + 2` cells
@@ -13,17 +13,17 @@ primitive, now proven end-to-end (`seekHomeAfterRoute_runConfig_home`).
 
 This module assembles the **revised** loop that inserts that re-homing between the route and the body:
 
-* `binToUnaryLoopBodyH := seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)` — route first;
+* `binToUnaryLoopBodyRehome := seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)` — route first;
   on `B > 0` (route accept, phase `5`) hand off into `seekHomeAfterRoute` (re-home to the sentinel), then
   one pass of `binToUnaryBody`;
-* `binToUnaryLoopH := loopUntilSink binToUnaryLoopBodyH ⟨4⟩` — re-enter the body on its accept and halt at
+* `binToUnaryLoopRehome := loopUntilSink binToUnaryLoopBodyRehome ⟨4⟩` — re-enter the body on its accept and halt at
   the sink phase `4` (`B = 0`).
 
 It is introduced **additively** (the route-only `binToUnaryLoop` and its merged `hbase`/`decide_false`
 stay intact) so nothing breaks; the route region (phases `0..5`) and sink `⟨4⟩` are unchanged, so the
 `B = 0` and `B > 0` route decisions re-derive on this machine exactly as before, and `hstep` becomes
 provable (route → seek-HOME → body one-pass → loop back-edge).  This brick ships the **definitions +
-phase-count facts**; the run behaviour (`hbase`/`decide_false`/`hstep` on `binToUnaryLoopH`, then `ζ`) is
+phase-count facts**; the run behaviour (`hbase`/`decide_false`/`hstep` on `binToUnaryLoopRehome`, then `ζ`) is
 the follow-up.
 
 **Progress classification (AGENTS.md): Infrastructure** — the loop assembly toward the NP-membership leg;
@@ -40,26 +40,26 @@ open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
 /-- The revised loop body: route, then on `B > 0` re-home (`seekHomeAfterRoute`) and run one pass of
 `binToUnaryBody`. -/
-def binToUnaryLoopBodyH : ConstStatePhasedProgram Unit :=
+def binToUnaryLoopBodyRehome : ConstStatePhasedProgram Unit :=
   seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)
 
 /-- Phase count: route `6` + (`seekHomeAfterRoute` `9` + `binToUnaryBody` `15`) `= 30`. -/
-@[simp] theorem binToUnaryLoopBodyH_numPhases : binToUnaryLoopBodyH.numPhases = 30 := rfl
+@[simp] theorem binToUnaryLoopBodyRehome_numPhases : binToUnaryLoopBodyRehome.numPhases = 30 := rfl
 
 /-- The seek-HOME loop: re-enter the body on its accept (a completed `B > 0` pass), halt at the sink phase
 `4` (`B = 0`). -/
-def binToUnaryLoopH : ConstStatePhasedProgram Unit :=
-  loopUntilSink binToUnaryLoopBodyH ⟨4, by decide⟩
+def binToUnaryLoopRehome : ConstStatePhasedProgram Unit :=
+  loopUntilSink binToUnaryLoopBodyRehome ⟨4, by decide⟩
 
-@[simp] theorem binToUnaryLoopH_numPhases : binToUnaryLoopH.numPhases = 30 := rfl
+@[simp] theorem binToUnaryLoopRehome_numPhases : binToUnaryLoopRehome.numPhases = 30 := rfl
 
-@[simp] theorem binToUnaryLoopH_acceptPhase : (binToUnaryLoopH.acceptPhase : Nat) = 4 := rfl
+@[simp] theorem binToUnaryLoopRehome_acceptPhase : (binToUnaryLoopRehome.acceptPhase : Nat) = 4 := rfl
 
-/-- The route region of `binToUnaryLoopBodyH` is `binToUnaryRouteBody` (phases `0..5`), unchanged from the
+/-- The route region of `binToUnaryLoopBodyRehome` is `binToUnaryRouteBody` (phases `0..5`), unchanged from the
 route-only loop — so the `B = 0`/`B > 0` route decisions re-derive identically. -/
-@[simp] theorem binToUnaryLoopBodyH_startPhase_val : (binToUnaryLoopBodyH.startPhase : Nat) = 0 := rfl
+@[simp] theorem binToUnaryLoopBodyRehome_startPhase_val : (binToUnaryLoopBodyRehome.startPhase : Nat) = 0 := rfl
 
-@[simp] theorem binToUnaryLoopH_startPhase_val : (binToUnaryLoopH.startPhase : Nat) = 0 := rfl
+@[simp] theorem binToUnaryLoopRehome_startPhase_val : (binToUnaryLoopRehome.startPhase : Nat) = 0 := rfl
 
 end ContractExpansion
 end Frontier

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -106,6 +106,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopH
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -3866,6 +3867,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopH_numPhases
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopH_acceptPhase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_hbase_realizable
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_decide_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -106,7 +106,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun
-import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopH
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -3867,8 +3867,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
-#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopH_numPhases
-#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopH_acceptPhase
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_numPhases
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_acceptPhase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_hbase_realizable
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_decide_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -96,7 +96,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun
-import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopH
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -659,9 +659,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
--- D2t-3 ε seek-HOME loop (revised body with re-homing): binToUnaryLoopH = loopUntilSink (route ; seekHome ; body).
-#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopH_numPhases
-#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopH_acceptPhase
+-- D2t-3 ε seek-HOME loop (revised body with re-homing): binToUnaryLoopRehome = loopUntilSink (route ; seekHome ; body).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_numPhases
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_acceptPhase
 -- D2t-3 ε `hbase`: from a B=0 HOME config the loop reaches the sink phase 4 (the clean loop-exit half).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -96,6 +96,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunCompose
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopH
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -658,6 +659,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_transition_route
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_numPhases
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
+-- D2t-3 ε seek-HOME loop (revised body with re-homing): binToUnaryLoopH = loopUntilSink (route ; seekHome ; body).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopH_numPhases
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopH_acceptPhase
 -- D2t-3 ε `hbase`: from a B=0 HOME config the loop reaches the sink phase 4 (the clean loop-exit half).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase


### PR DESCRIPTION
## Summary

Assembles the **revised** binary→unary loop that inserts the now-proven `seekHomeAfterRoute` re-homing
between the route and the body — the structural change that makes `ε`'s `hstep` provable:

```
binToUnaryLoopBodyH := seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)   -- 30 phases
binToUnaryLoopH    := loopUntilSink binToUnaryLoopBodyH ⟨4⟩
```

Introduced **additively** — the route-only `binToUnaryLoop` and its merged `hbase`/`decide_false` stay
intact, so nothing breaks. The route region (phases `0..5`) and the sink `⟨4⟩` are unchanged, so the
`B=0`/`B>0` route decisions re-derive on this machine exactly as before, and `hstep` becomes provable
(route → seek-HOME → body one-pass → loop back-edge).

Ships **defs + phase-count facts**; the run behaviour (`hbase`/`decide_false`/`hstep` on
`binToUnaryLoopH`, then `ζ`) is the follow-up.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- New module `TreeMCSPBinToUnaryLoopH.lean`; `lakefile` + surface tests + `AxiomsAudit` extended
  (axiom surface `+2`, standard triple). **0 `sorry`/`admit`/`native_decide`/custom axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_