### PR TITLE
transcoder(D2t-3): binToUnaryLoopRehome route-region transition peel

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -349,6 +349,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeRoutePeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeRoutePeel.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeRoutePeel.lean
@@ -1,0 +1,44 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome
+
+/-!
+# `binToUnaryLoopRehome` route-region transition peel (NP-verifier track — D2t-3 `ε`)
+
+The seek-HOME loop `binToUnaryLoopRehome = loopUntilSink binToUnaryLoopBodyRehome ⟨4⟩` evaluates, in its
+**route region** (phases `0..3`, none equal to the loop body's accept `29` or the sink `4`), to
+`binToUnaryLoopBodyRehome`'s own transition — and since `binToUnaryRouteBody` is the outer `seq`'s P1 in
+*both* the route-only `binToUnaryLoopBody` and the rehome `binToUnaryLoopBodyRehome`, that route region is
+**identical** to the route-only loop's.  So the `B = 0`/`B > 0` route decisions re-derive on this machine
+exactly as the merged `hbase`/`decide_false` did, modulo this peel (whose only difference from
+`binToUnaryLoop_transition_route` is the loop body's accept index, `29` here vs `20` there).
+
+This is the foundation for the `binToUnaryLoopRehome` run-through (`hbase`/`decide_false`, then `hstep`).
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- The rehome loop body's accept phase: route `6` + seek-HOME `9` + `binToUnaryBody`'s `idleCS` accept
+`14` `= 29` — distinct from the route region (`0..5`) and the sink (`4`). -/
+private theorem binToUnaryLoopBodyRehome_acceptPhase_val :
+    (binToUnaryLoopBodyRehome.acceptPhase : Nat) = 29 := by decide
+
+/-- In the route region (`i < 4`) the rehome loop's transition is the body's transition (head at neither
+the loop body's accept `29` nor the sink `4`), so `loopUntilSink` runs `binToUnaryLoopBodyRehome`
+verbatim — peeling the `loopUntilSink` layer and leaving the `seq` layers for `simp`. -/
+theorem binToUnaryLoopRehome_transition_route {i : Fin binToUnaryLoopRehome.numPhases}
+    (hlt : (i : Nat) < 4) (s : Unit) (b : Bool) :
+    binToUnaryLoopRehome.transition i s b = binToUnaryLoopBodyRehome.transition i () b :=
+  loopUntilSink_transition_body binToUnaryLoopBodyRehome ⟨4, by decide⟩
+    (Fin.ne_of_val_ne (by rw [binToUnaryLoopBodyRehome_acceptPhase_val]; omega))
+    (Fin.ne_of_val_ne (show (i : Nat) ≠ 4 by omega)) s b
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeRoutePeel.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeRoutePeel.lean
@@ -25,7 +25,7 @@ open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
 open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
 /-- The rehome loop body's accept phase: route `6` + seek-HOME `9` + `binToUnaryBody`'s `idleCS` accept
-`14` `= 29` — distinct from the route region (`0..5`) and the sink (`4`). -/
+`14` `= 29` — well past the peel's route region (`i < 4`) and the sink (`4`), so neither equals it. -/
 private theorem binToUnaryLoopBodyRehome_acceptPhase_val :
     (binToUnaryLoopBodyRehome.acceptPhase : Nat) = 29 := by decide
 

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -107,6 +107,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -3869,6 +3870,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_acceptPhase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_acceptPhase
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_transition_route
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_hbase_realizable
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_decide_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -97,6 +97,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRunRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
 import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRouteRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -662,6 +663,7 @@ end Pnp4
 -- D2t-3 ε seek-HOME loop (revised body with re-homing): binToUnaryLoopRehome = loopUntilSink (route ; seekHome ; body).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_numPhases
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_acceptPhase
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_transition_route
 -- D2t-3 ε `hbase`: from a B=0 HOME config the loop reaches the sink phase 4 (the clean loop-exit half).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase


### PR DESCRIPTION
## Summary

`binToUnaryLoopRehome_transition_route`: in the route region (`i < 4`) the rehome loop's transition is
`binToUnaryLoopBodyRehome`'s (head at neither the body accept `29` nor the sink `4`), via
`loopUntilSink_transition_body`. Mirrors the merged `binToUnaryLoop_transition_route`; the **only**
difference is the loop body's accept index (`29` vs `20`), since `binToUnaryRouteBody` is the outer
`seq`'s P1 in *both* bodies — so the route region is identical and the `B=0`/`B>0` route decisions
re-derive on this machine as before.

Foundation for the `binToUnaryLoopRehome` run-through (`hbase`/`decide_false` re-derivation on the new
machine, then `hstep`).

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- New module `TreeMCSPBinToUnaryLoopRehomeRoutePeel.lean`; `lakefile` + surface tests + `AxiomsAudit`
  extended (axiom surface `+1`, standard triple). **0 `sorry`/`admit`/`native_decide`/custom axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_