### PR TITLE
transcoder(D2t-3): binToUnaryLoopRehome hstep — the seq-handoff single steps (5→6, 14→15)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -352,6 +352,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeRoutePeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeDecideFalse,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeHstep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeHstep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeHstep.lean
@@ -25,19 +25,17 @@ namespace ContractExpansion
 open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
 open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
-/-- The rehome loop body's accept phase is `29`; the sink is `4`. -/
-private theorem accV : (binToUnaryLoopBodyRehome.acceptPhase : Nat) = 29 := by decide
-
 /-- Away from the loop body's accept (`29`) and the sink (`4`), the loop's transition is the body's
-transition (here for the route-accept phase `5`, outside the route region `i < 4`). -/
+transition (here for the route-accept phase `5`, outside the route region `i < 4`).  Reuses the shared
+`binToUnaryLoopBodyRehome_acceptPhase_val` (from the route peel module) for the accept-index disequality. -/
 private theorem peel5 {L : Nat}
     (c : Configuration (M := binToUnaryLoopRehome.toPhased.toTM) L) {i : Fin binToUnaryLoopRehome.numPhases}
     (s : Unit) (hi : i.val = 5) :
     binToUnaryLoopRehome.transition i s (c.tape c.head)
       = binToUnaryLoopBodyRehome.transition i () (c.tape c.head) :=
   loopUntilSink_transition_body binToUnaryLoopBodyRehome ⟨4, by decide⟩
-    (Fin.ne_of_val_ne (by rw [accV]; omega)) (Fin.ne_of_val_ne (show (i : Nat) ≠ 4 by omega))
-    s (c.tape c.head)
+    (Fin.ne_of_val_ne (by rw [binToUnaryLoopBodyRehome_acceptPhase_val]; omega))
+    (Fin.ne_of_val_ne (show (i : Nat) ≠ 4 by omega)) s (c.tape c.head)
 
 /-- **Handoff `5 → 6`** (route accept → `seekHomeAfterRoute` start): the outer `seq`'s P1-accept handoff.
 Phase advances to `6`; head and tape unchanged. -/
@@ -80,8 +78,8 @@ private theorem peel14 {L : Nat}
     binToUnaryLoopRehome.transition i s (c.tape c.head)
       = binToUnaryLoopBodyRehome.transition i () (c.tape c.head) :=
   loopUntilSink_transition_body binToUnaryLoopBodyRehome ⟨4, by decide⟩
-    (Fin.ne_of_val_ne (by rw [accV]; omega)) (Fin.ne_of_val_ne (show (i : Nat) ≠ 4 by omega))
-    s (c.tape c.head)
+    (Fin.ne_of_val_ne (by rw [binToUnaryLoopBodyRehome_acceptPhase_val]; omega))
+    (Fin.ne_of_val_ne (show (i : Nat) ≠ 4 by omega)) s (c.tape c.head)
 
 /-- **Handoff `14 → 15`** (`seekHomeAfterRoute` accept → `binToUnaryBody` start): the inner `seq`'s
 P1-accept handoff, reached through the outer `seq`'s P2.  Phase advances to `15`; head and tape

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeHstep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeHstep.lean
@@ -1,0 +1,129 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeRoutePeel
+
+/-!
+# `binToUnaryLoopRehome` `hstep` — the `B > 0` re-entry pass (NP-verifier track — D2t-3 `ε`)
+
+`loopUntilSink_reachesSink`'s `hstep` for `binToUnaryLoopRehome`: from a `B > 0` HOME config at phase `0`,
+one loop pass returns to phase `0` with `counterValue` strictly decreased.  The pass chains, on
+`binToUnaryLoopRehome = loopUntilSink (seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)) ⟨4⟩`:
+
+  `decide_false` (phase `0 → 5`) → **handoff (`5 → 6`)** → `seekHomeAfterRoute` lift (`6 → 14`, re-home) →
+  **handoff (`14 → 15`)** → `binToUnaryBody` lift (`15 → 29`, one pass) → `loopUntilSink` back-edge (`29 → 0`).
+
+This module builds the **bounded `seq`-handoff / loop-back-edge single steps** first; the two run-through
+*lifts* (`seekHomeAfterRoute` and `binToUnaryBody` re-derived at their phase offsets inside this loop
+machine) and the `counterValue` measure are the substantial follow-ups.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- The rehome loop body's accept phase is `29`; the sink is `4`. -/
+private theorem accV : (binToUnaryLoopBodyRehome.acceptPhase : Nat) = 29 := by decide
+
+/-- Away from the loop body's accept (`29`) and the sink (`4`), the loop's transition is the body's
+transition (here for the route-accept phase `5`, outside the route region `i < 4`). -/
+private theorem peel5 {L : Nat}
+    (c : Configuration (M := binToUnaryLoopRehome.toPhased.toTM) L) {i : Fin binToUnaryLoopRehome.numPhases}
+    (s : Unit) (hi : i.val = 5) :
+    binToUnaryLoopRehome.transition i s (c.tape c.head)
+      = binToUnaryLoopBodyRehome.transition i () (c.tape c.head) :=
+  loopUntilSink_transition_body binToUnaryLoopBodyRehome ⟨4, by decide⟩
+    (Fin.ne_of_val_ne (by rw [accV]; omega)) (Fin.ne_of_val_ne (show (i : Nat) ≠ 4 by omega))
+    s (c.tape c.head)
+
+/-- **Handoff `5 → 6`** (route accept → `seekHomeAfterRoute` start): the outer `seq`'s P1-accept handoff.
+Phase advances to `6`; head and tape unchanged. -/
+theorem binToUnaryLoopRehome_stepConfig_handoff5 {L : Nat}
+    (c : Configuration (M := binToUnaryLoopRehome.toPhased.toTM) L) {i : Fin binToUnaryLoopRehome.numPhases}
+    {s : Unit} (hi : i.val = 5) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := binToUnaryLoopRehome.toPhased.toTM) c).state).fst.val = 6
+      ∧ (TM.stepConfig (M := binToUnaryLoopRehome.toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := binToUnaryLoopRehome.toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase binToUnaryLoopRehome c hstate, peel5 c s hi]
+    show ((seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)).transition i ()
+        (c.tape c.head)).fst.val = 6
+    rw [seq_transition_P1_accept_phase binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)
+        (by simp only [hi]; decide) (by simp only [hi]; decide) () (c.tape c.head)]
+    decide
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head binToUnaryLoopRehome c hstate]
+    have hmove : (binToUnaryLoopRehome.transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [peel5 c s hi]
+      show ((seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)).transition i ()
+          (c.tape c.head)).2.2.2 = Move.stay
+      exact seq_transition_P1_accept_move binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)
+        (by simp only [hi]; decide) (by simp only [hi]; decide) () (c.tape c.head)
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape binToUnaryLoopRehome c hstate]
+    have hbit : (binToUnaryLoopRehome.transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [peel5 c s hi]
+      show ((seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)).transition i ()
+          (c.tape c.head)).2.2.1 = c.tape c.head
+      exact seq_transition_P1_accept_bit binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)
+        (by simp only [hi]; decide) (by simp only [hi]; decide) () (c.tape c.head)
+    rw [hbit]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- Peel for phase `14` (the `seekHomeAfterRoute`-accept phase, `∉ {29, 4}`). -/
+private theorem peel14 {L : Nat}
+    (c : Configuration (M := binToUnaryLoopRehome.toPhased.toTM) L) {i : Fin binToUnaryLoopRehome.numPhases}
+    (s : Unit) (hi : i.val = 14) :
+    binToUnaryLoopRehome.transition i s (c.tape c.head)
+      = binToUnaryLoopBodyRehome.transition i () (c.tape c.head) :=
+  loopUntilSink_transition_body binToUnaryLoopBodyRehome ⟨4, by decide⟩
+    (Fin.ne_of_val_ne (by rw [accV]; omega)) (Fin.ne_of_val_ne (show (i : Nat) ≠ 4 by omega))
+    s (c.tape c.head)
+
+/-- **Handoff `14 → 15`** (`seekHomeAfterRoute` accept → `binToUnaryBody` start): the inner `seq`'s
+P1-accept handoff, reached through the outer `seq`'s P2.  Phase advances to `15`; head and tape
+unchanged. -/
+theorem binToUnaryLoopRehome_stepConfig_handoff14 {L : Nat}
+    (c : Configuration (M := binToUnaryLoopRehome.toPhased.toTM) L) {i : Fin binToUnaryLoopRehome.numPhases}
+    {s : Unit} (hi : i.val = 14) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := binToUnaryLoopRehome.toPhased.toTM) c).state).fst.val = 15
+      ∧ (TM.stepConfig (M := binToUnaryLoopRehome.toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := binToUnaryLoopRehome.toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase binToUnaryLoopRehome c hstate, peel14 c s hi]
+    show ((seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)).transition i ()
+        (c.tape c.head)).fst.val = 15
+    rw [seq_transition_P2_phase binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)
+        (by simp only [hi]; decide) (by simp only [hi]; decide) () (c.tape c.head),
+      seq_transition_P1_accept_phase seekHomeAfterRoute binToUnaryBody
+        (by simp only [hi]; decide) (by simp only [hi]; decide) () (c.tape c.head)]
+    decide
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head binToUnaryLoopRehome c hstate]
+    have hmove : (binToUnaryLoopRehome.transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [peel14 c s hi]
+      show ((seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)).transition i ()
+          (c.tape c.head)).2.2.2 = Move.stay
+      rw [seq_transition_P2_move binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)
+          (by simp only [hi]; decide) (by simp only [hi]; decide) () (c.tape c.head)]
+      exact seq_transition_P1_accept_move seekHomeAfterRoute binToUnaryBody
+        (by simp only [hi]; decide) (by simp only [hi]; decide) () (c.tape c.head)
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape binToUnaryLoopRehome c hstate]
+    have hbit : (binToUnaryLoopRehome.transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [peel14 c s hi]
+      show ((seq binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)).transition i ()
+          (c.tape c.head)).2.2.1 = c.tape c.head
+      rw [seq_transition_P2_bit binToUnaryRouteBody (seq seekHomeAfterRoute binToUnaryBody)
+          (by simp only [hi]; decide) (by simp only [hi]; decide) () (c.tape c.head)]
+      exact seq_transition_P1_accept_bit seekHomeAfterRoute binToUnaryBody
+        (by simp only [hi]; decide) (by simp only [hi]; decide) () (c.tape c.head)
+    rw [hbit]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeRoutePeel.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopRehomeRoutePeel.lean
@@ -26,7 +26,7 @@ open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
 /-- The rehome loop body's accept phase: route `6` + seek-HOME `9` + `binToUnaryBody`'s `idleCS` accept
 `14` `= 29` — well past the peel's route region (`i < 4`) and the sink (`4`), so neither equals it. -/
-private theorem binToUnaryLoopBodyRehome_acceptPhase_val :
+theorem binToUnaryLoopBodyRehome_acceptPhase_val :
     (binToUnaryLoopBodyRehome.acceptPhase : Nat) = 29 := by decide
 
 /-- In the route region (`i < 4`) the rehome loop's transition is the body's transition (head at neither

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -110,6 +110,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeDecideFalse
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -3876,6 +3877,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_runConfig_hbase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_runConfig_decide_false
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_decide_false_realizable
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_stepConfig_handoff5
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_stepConfig_handoff14
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_hbase_realizable
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_decide_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3874,6 +3874,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_acceptPhase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_transition_route
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyRehome_acceptPhase_val
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_runConfig_hbase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_runConfig_decide_false
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_decide_false_realizable

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -667,6 +667,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_numPhases
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_acceptPhase
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_transition_route
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyRehome_acceptPhase_val
 -- D2t-3 ε hbase on the rehome machine (B=0 → sink phase 4), mirroring the merged binToUnaryLoop hbase.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_runConfig_hbase

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -100,6 +100,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeDecideFalse
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehomeHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoop
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRoutePeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopHbase
@@ -672,6 +673,9 @@ end Pnp4
 -- D2t-3 ε decide_false on the rehome machine (B>0 → phase 5, the seekHomeAfterRoute handoff) + realizable.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_runConfig_decide_false
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_decide_false_realizable
+-- D2t-3 ε hstep seq-handoffs (rehome machine): route→seekHome (5→6) and seekHome→body (14→15).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_stepConfig_handoff5
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopRehome_stepConfig_handoff14
 -- D2t-3 ε `hbase`: from a B=0 HOME config the loop reaches the sink phase 4 (the clean loop-exit half).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoop_runConfig_hbase


### PR DESCRIPTION
## Summary

The bounded glue of `hstep` on `binToUnaryLoopRehome`: the two **seq-handoff single steps** between the
legs of a `B>0` pass —

- `handoff5` (phase 5 → 6): route accept → `seekHomeAfterRoute` start (outer `seq` P1-accept);
- `handoff14` (phase 14 → 15): `seekHomeAfterRoute` accept → `binToUnaryBody` start (inner `seq` P1-accept,
  reached through the outer `seq`'s P2).

Each via the `loopUntilSink` peel + `seq_transition_P1_accept_{phase,move,bit}` (handoff14 through the
two-level outer-P2 → inner-P1-accept navigation); phase advances, head/tape unchanged.

The loop **back-edge** (29 → 0) is already covered by `loopUntilSink_runConfig_oneIter`. The remaining
hstep legs — the `seekHomeAfterRoute` lift (6→14) and `binToUnaryBody` lift (15→29), re-derived at their
phase offsets in this loop machine — plus the `counterValue` measure are the substantial follow-ups.

## Verification
- `lake build PnP3 Pnp4` green; `./scripts/check.sh` **all-pass (17/17)**.
- New module `TreeMCSPBinToUnaryLoopRehomeHstep.lean`; `lakefile` + surface tests + `AxiomsAudit` extended
  (axiom surface `+2`, standard triple). **0 `sorry`/`admit`/`native_decide`/custom axiom**.

**Infrastructure** (AGENTS.md). **No `P ≠ NP` claim.**

https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaaQoAWTAUorGj3X6QNaBD)_