### PR TITLE
transcoder(D2t-3 δ): sound full-width-scan B=0 test (bZeroFullScan) + run-through

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -339,6 +339,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TM_VERIFIER_STRATEGY.md
@@ -1110,6 +1110,48 @@ under the corrected design: seek-HOME lift (#1577), body single-steps (#1578), b
 (`hbase`/`decide_false` as `B=0`/`B>0` branches) are **superseded** by the full-scan and must not be wired
 into the final `reachesSink`.
 
+##### δ BUILT — `bZeroFullScan` (the sound width-`w` zero-test), with run-through
+
+The corrected design is now realised in `TreeMCSPBZeroFullScan.lean` (`bZeroFullScan w :
+ConstStatePhasedProgram Unit`, `numPhases = w + 2`): phases `0 .. w-1` read each cell of the `w`-window
+(`0` → step right, next phase; `1` → phase `w+1` = `B > 0`); phase `w` is the accept (`B = 0`), phase
+`w+1` the `B > 0` branch.  Proven this stack:
+* **Structural** — `numPhases`/`startPhase`/`acceptPhase`/`timeBound`, `neverMovesLeft`,
+  `transition_move`/`transition_bit` (so it composes under `seq`/`loopUntilSink`).
+* **Spec foundation** — `counterValue_eq_zero_imp_all_false`: a zero counter value forces every cell of
+  the width-`w` window to `false` (the converse of the toolkit's `counterValue_of_all_false`).  This is
+  the fact the `B = 0` path consumes (the loop's `hbase` hypothesis is `μ = counterValue B = 0`).
+* **Run-through** (mirroring `gateTagDispatch`'s phase-scanner template) — `..._runConfig_scanning`
+  (induction on step count: `j ≤ w` leading `0`s ⇒ after `j` steps phase `j`, head `+ j`, tape
+  unchanged), `..._runConfig_zero` (all `w` cells `0` ⇒ after `w` steps the accept phase `w` = `B = 0`),
+  `..._runConfig_pos` (low `j` cells `0`, cell `j` set, `j < w` ⇒ after `j + 1` steps phase `w+1` =
+  `B > 0`, head on the set bit).
+
+All surfaces carry the standard `[propext, Classical.choice, Quot.sound]` triple (or fewer); audited in
+`AxiomsAudit`, surfaced in `AlgorithmsToLowerBoundsSurfaceTests`.
+
+**Remaining for ε/ζ (the focused next milestone, on the new sound test).**  Because `bZeroFullScan` is
+`w`-parameterised, its loop assembly is `w`-parameterised too, so the route-leg phase arithmetic must be
+re-expressed with `w`-dependent indices (this is the bulk of the redo `≈` #1564–#1581, now against a
+*sound* decider):
+1. **ε-seqP2** — lift `bZeroFullScan`'s run-through into the `seq` P2-region (re-derive `_runConfig_zero`
+   / `_runConfig_pos` from an arbitrary start `c0` at phase `P1.numPhases`), the analogue of
+   `gammaSelfLoopScan_seqP2_runConfig_*`, so the scan composes as a non-first phase.
+2. **ε-assembly** — `binToUnaryLoopFullScan w := loopUntilSink (seq stepRightOnce (seq (bZeroFullScan w
+   re-pointed to the `B>0` phase) (seq seekHome binToUnaryBody))) ⟨sink = the `B=0` accept⟩`; ship the
+   phase-count facts.  (`stepRightOnce` moves HOME→`B`'s low end so the scan window is exactly
+   `[HOME+1, HOME+1+w)`, matching the `counterValue` measure.)
+3. **ε-hbase** — `B = 0` ⇒ sink: `counterValue = 0` →(δ1)→ all-`0` window →(ε-seqP2 `zero`)→ the scan
+   reaches the sink phase.  (Does **not** need the re-home.)
+4. **ε-rehome** — a fresh seek-HOME matching `bZeroFullScan`'s `B>0` exit (head on the lowest set bit at
+   `HOME+1+j`, left of it all `0` to the sentinel, then the seed-`U` `1`): a fixed-phase
+   scan-left-over-`0`s + step-right, the analogue of `seekHomeAfterRoute` at the new offset.
+5. **ε-hstep** — `B > 0` ⇒ one pass: scan `pos` → re-home → `binToUnaryBody_runConfig_onePass` →
+   loop back-edge, with `counterValue B` dropping by one (reuse `binToUnaryBody_onePass_counterValue`).
+6. **ε-reachesSink** — feed `hstep`/`hbase` to `loopUntilSink_reachesSink` with `μ := counterValue B`.
+7. **ζ** — the output bridge `|U| = value B = (decodeFin width …).val` (induction on `counterValue`,
+   each pass `|U| + 1` via `binToUnaryBody_onePass_appendedBit`), closing D2t-3 against `unaryField`.
+
 #### Composition-toolkit status (the loop-body vocabulary is complete; γ is the remaining assembly)
 
 **Done — the per-primitive run-behaviour + composition lifts the loop body needs are all merged:**

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScan.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScan.lean
@@ -129,6 +129,139 @@ theorem bZeroFullScan_transition_bit (w : Nat) (i : Fin (w + 2)) (s : Unit) (b :
   dsimp only
   split_ifs <;> rfl
 
+/-! ## Single-step behaviour -/
+
+/-- Every step writes the scanned bit back, so the tape is unchanged after one step. -/
+theorem bZeroFullScan_stepConfig_tape (w : Nat) {L : Nat}
+    (c : Configuration (M := (bZeroFullScan w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (bZeroFullScan w).toPhased.toTM) c).tape = c.tape := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_tape (bZeroFullScan w) c hstate,
+    bZeroFullScan_transition_bit]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- **Scan step (read `0`).**  At a scan phase `i < w` reading `0`, advance to phase `i + 1`. -/
+theorem bZeroFullScan_stepConfig_scan_phase (w : Nat) {L : Nat}
+    (c : Configuration (M := (bZeroFullScan w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi : (i : Nat) < w) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := (bZeroFullScan w).toPhased.toTM) c).state).fst.val = (i : Nat) + 1 := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_phase (bZeroFullScan w) c hstate]
+  simp [bZeroFullScan, dif_pos hi, hbit]
+
+/-- **Scan step (read `0`).**  At a scan phase `i < w` reading `0`, advance the head by one. -/
+theorem bZeroFullScan_stepConfig_scan_head (w : Nat) {L : Nat}
+    (c : Configuration (M := (bZeroFullScan w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi : (i : Nat) < w) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false)
+    (hbound : (c.head : Nat) + 1 < (bZeroFullScan w).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (bZeroFullScan w).toPhased.toTM) c).head : Nat) = (c.head : Nat) + 1 := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_head (bZeroFullScan w) c hstate]
+  have hmove : ((bZeroFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.right := by
+    simp [bZeroFullScan, dif_pos hi, hbit]
+  rw [hmove]
+  simp only [Configuration.moveHead, dif_pos hbound]
+
+/-- **Divert step (read `1`).**  At a scan phase `i < w` reading `1`, jump to phase `w + 1` (`B > 0`). -/
+theorem bZeroFullScan_stepConfig_divert_phase (w : Nat) {L : Nat}
+    (c : Configuration (M := (bZeroFullScan w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi : (i : Nat) < w) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := (bZeroFullScan w).toPhased.toTM) c).state).fst.val = w + 1 := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_phase (bZeroFullScan w) c hstate]
+  simp [bZeroFullScan, dif_pos hi, hbit]
+
+/-- **Divert step (read `1`).**  At a scan phase `i < w` reading `1`, the head stays put (on the set
+bit). -/
+theorem bZeroFullScan_stepConfig_divert_head (w : Nat) {L : Nat}
+    (c : Configuration (M := (bZeroFullScan w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi : (i : Nat) < w) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := (bZeroFullScan w).toPhased.toTM) c).head = c.head := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_head (bZeroFullScan w) c hstate]
+  have hmove : ((bZeroFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+    simp [bZeroFullScan, dif_pos hi, hbit]
+  rw [hmove]
+  simp [Configuration.moveHead]
+
+/-! ## Run-through: the scan reaches the `B = 0` accept phase / the `B > 0` branch -/
+
+/-- **Scanning invariant.**  From a start `c0` in phase `0`, if the `j` cells from the head are all `0`
+(`j ≤ w`, in bounds), then after `j` steps the phase is `j`, the head has advanced to `c0.head + j`, and
+the tape is unchanged. -/
+theorem bZeroFullScan_runConfig_scanning (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (bZeroFullScan w).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) :
+    ∀ j : Nat, j ≤ w → (c0.head : Nat) + j < (bZeroFullScan w).toPhased.toTM.tapeLength L →
+      (∀ p : Fin ((bZeroFullScan w).toPhased.toTM.tapeLength L),
+        (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + j → c0.tape p = false) →
+      (((TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 j).state).fst : Nat) = j
+      ∧ ((TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 j).head : Nat) = (c0.head : Nat) + j
+      ∧ (TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 j).tape = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _ _; exact ⟨hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj hb h0
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (by omega) (fun p hp1 hp2 => h0 p hp1 (by omega))
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 j with hc
+      have hiw : (c.state.fst : Nat) < w := by rw [hph]; omega
+      have hbit : c.tape c.head = false := by
+        rw [htp]; exact h0 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hbnd : (c.head : Nat) + 1 < (bZeroFullScan w).toPhased.toTM.tapeLength L := by
+        rw [hhd]; omega
+      refine ⟨?_, ?_, ?_⟩
+      · rw [bZeroFullScan_stepConfig_scan_phase w c (i := c.state.fst) (s := c.state.snd) hiw rfl hbit,
+          hph]
+      · rw [bZeroFullScan_stepConfig_scan_head w c (i := c.state.fst) (s := c.state.snd) hiw rfl hbit
+          hbnd]
+        omega
+      · rw [bZeroFullScan_stepConfig_tape w c (i := c.state.fst) (s := c.state.snd) rfl, htp]
+
+/-- **`B = 0` run-through.**  If all `w` cells of `B` (from the head) are `0`, after `w` steps the scan
+rests at the accept phase `w` (`B = 0`), with the head at `c0.head + w` and the tape unchanged. -/
+theorem bZeroFullScan_runConfig_zero (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (bZeroFullScan w).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hb : (c0.head : Nat) + w < (bZeroFullScan w).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((bZeroFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + w → c0.tape p = false) :
+    (((TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 w).state).fst : Nat) = w
+      ∧ ((TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 w).head : Nat) = (c0.head : Nat) + w
+      ∧ (TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 w).tape = c0.tape :=
+  bZeroFullScan_runConfig_scanning w c0 hphase w (le_refl w) hb hzeros
+
+/-- **`B > 0` run-through.**  If `B`'s low `j` cells are `0` and cell `c0.head + j` is `1` (`j < w`),
+after `j + 1` steps the scan has diverted to phase `w + 1` (`B > 0`), with the head on the set bit
+(`c0.head + j`) and the tape unchanged. -/
+theorem bZeroFullScan_runConfig_pos (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (bZeroFullScan w).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (j : Nat) (hjw : j < w)
+    (hb : (c0.head : Nat) + j < (bZeroFullScan w).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((bZeroFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + j → c0.tape p = false)
+    (hone : ∀ p : Fin ((bZeroFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + j → c0.tape p = true) :
+    (((TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 (j + 1)).state).fst : Nat) = w + 1
+      ∧ ((TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 (j + 1)).head : Nat)
+          = (c0.head : Nat) + j
+      ∧ (TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 (j + 1)).tape = c0.tape := by
+  obtain ⟨hph, hhd, htp⟩ :=
+    bZeroFullScan_runConfig_scanning w c0 hphase j (le_of_lt hjw) hb hzeros
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := (bZeroFullScan w).toPhased.toTM) c0 j with hc
+  have hiw : (c.state.fst : Nat) < w := by rw [hph]; exact hjw
+  have hbit : c.tape c.head = true := by rw [htp]; exact hone c.head (by rw [hhd])
+  refine ⟨?_, ?_, ?_⟩
+  · rw [bZeroFullScan_stepConfig_divert_phase w c (i := c.state.fst) (s := c.state.snd) hiw rfl hbit]
+  · rw [bZeroFullScan_stepConfig_divert_head w c (i := c.state.fst) (s := c.state.snd) hiw rfl hbit]
+    exact hhd
+  · rw [bZeroFullScan_stepConfig_tape w c (i := c.state.fst) (s := c.state.snd) rfl, htp]
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScan.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScan.lean
@@ -262,6 +262,40 @@ theorem bZeroFullScan_runConfig_pos (w : Nat) {L : Nat}
     exact hhd
   · rw [bZeroFullScan_stepConfig_tape w c (i := c.state.fst) (s := c.state.snd) rfl, htp]
 
+/-! ## Composition wrapper — the route-body (re-pointed accept for `seq`)
+
+`bZeroFullScan`'s standalone accept phase is `w` (the `B = 0` outcome), which is the right *meaning*
+("accept iff `B = 0`") but the wrong wiring for `seq`: `ConstStatePhasedProgram.seq` performs the
+P1→P2 handoff only at `P1.acceptPhase`, so `seq (bZeroFullScan w) rest` would hand off on `B = 0`
+(phase `w`) rather than on `B > 0` (phase `w+1`).  For the conversion loop we want the opposite: on
+`B > 0` flow into the body, and leave `B = 0` (phase `w`) terminal for the `loopUntilSink` sink.
+
+`bZeroFullScanRouteBody` re-points the accept phase to `w + 1` (the `B > 0` branch) — exactly mirroring
+`binToUnaryRouteBody := { bZeroRouteProgram with acceptPhase := ⟨5⟩ }`.  The transition is unchanged, so
+the run-through lemmas above transfer verbatim; only the `seq` handoff target moves.  This is the
+ε-assembly entry point. -/
+def bZeroFullScanRouteBody (w : Nat) : ConstStatePhasedProgram Unit :=
+  { bZeroFullScan w with acceptPhase := ⟨w + 1, by show w + 1 < w + 2; omega⟩ }
+
+@[simp] theorem bZeroFullScanRouteBody_numPhases (w : Nat) :
+    (bZeroFullScanRouteBody w).numPhases = w + 2 := rfl
+
+@[simp] theorem bZeroFullScanRouteBody_startPhase_val (w : Nat) :
+    ((bZeroFullScanRouteBody w).startPhase : Nat) = 0 := rfl
+
+/-- The route-body's accept phase is `w + 1` (the `B > 0` branch), so `seq` hands off into the body on
+`B > 0` and leaves `B = 0` (phase `w`) terminal for the loop sink. -/
+@[simp] theorem bZeroFullScanRouteBody_acceptPhase_val (w : Nat) :
+    ((bZeroFullScanRouteBody w).acceptPhase : Nat) = w + 1 := rfl
+
+/-- The route-body shares `bZeroFullScan`'s transition (only the accept phase moved), so it too never
+moves the head left — it composes under `seq`/`loopUntilSink`. -/
+theorem bZeroFullScanRouteBody_neverMovesLeft (w : Nat) :
+    TMNeverMovesLeft ((bZeroFullScanRouteBody w).toPhased.toTM) := by
+  intro st b
+  obtain ⟨i, s⟩ := st
+  exact bZeroFullScan_transition_move w i s b
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScan.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScan.lean
@@ -1,0 +1,134 @@
+import Complexity.TMVerifier.TuringToolkit.ConstStatePhasedProgram
+import Complexity.TMVerifier.TuringToolkit.BinaryCounter
+import Pnp4.Frontier.ContractExpansion.BoundedLoopProgram
+
+/-!
+# `bZeroFullScan` — the **sound** width-`w` `B = 0` test (NP-verifier track — D2t-3 `δ`)
+
+`TM_VERIFIER_STRATEGY.md` §12 records that the merged routing test
+`bZeroRouteProgram = seq gammaSelfLoopScan stepRightThenBranch` (scan to the first `1`, read the next
+cell, branch) is **not a sound `B = 0` test** on a raw little-endian binary counter: for `B > 0` it
+silently requires the cell *after* the lowest set bit to be `0`, which binary decrement does not
+preserve (counterexample `B = 3 = "11"`).  Literature confirms a correct binary-counter zero-test
+inspects **all** counter bits at the counter's fixed bit-length (Seiferas & Vitányi, *Counting Is Easy*,
+arXiv `cs/0110038`; counter-machine constructions); the first-`1`+next-cell shortcut is unsound.
+
+This module ships the corrected design: a **width-`w` full scan**.  As a `w`-parameterised program
+(`numPhases = w + 2`, phase count growing with `w`, like `gammaZeroScanProgram`'s `maxIters`) it uses the
+**known width `w`** as the scan bound — sidestepping the binary-alphabet delimiting wall (§6).
+
+```
+bZeroFullScan w :  scan B's window cell-by-cell using the known width w
+  phases 0 .. w-1 :  read the cell  —  `0` → step right, next phase  /  `1` → phase w+1 (B > 0)
+  phase  w        :  B = 0  (every one of the w cells was `0`)   — the accept phase
+  phase  w+1      :  B > 0  (a set bit was found)                — the body-entry branch
+```
+
+So the head, started on `B`'s low end, accepts at phase `w` iff all `w` cells are `0` (`B = 0`), and
+diverts to phase `w+1` on the first `1` it meets (`B > 0`).  Following the structural-first discipline
+(`bZeroRouteProgram`, `loopUntilSink` shipped def + structural lemmas before run-invariants), this brick
+ships the **program definition + structural lemmas** plus the **pure-spec foundation**
+(`counterValue_eq_zero_imp_all_false`: a zero counter value forces every windowed cell to `false` — the
+fact the `B = 0` run-through consumes).  The run-through and the `loopUntilSink` `hbase`/`hstep` discharge
+are the follow-up bricks.
+
+**Progress classification (AGENTS.md): Infrastructure** — control program toward the NP-membership leg;
+it builds no verifier and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]`
+triple only.  **No `P ≠ NP` claim.**
+-/
+
+universe u
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
+
+/-! ## Pure-spec foundation: a zero counter value forces every windowed cell to `false` -/
+
+/-- **Converse of `counterValue_of_all_false`.**  If the little-endian counter value of the width-`k`
+window `[start, start + k)` is `0`, then every cell in that window reads `false`.  (Each set bit at
+offset `i < k` contributes `2 ^ i ≥ 1`, so any set bit makes the value positive.)  This is the spec
+fact the `bZeroFullScan` `B = 0` run-through consumes: `counterValue = 0` (the loop's `hbase`
+hypothesis) ⇒ the scan reads `0` at every one of the `w` cells, so it reaches the accept phase. -/
+theorem counterValue_eq_zero_imp_all_false {M : TM.{u}} {n : Nat}
+    (c : Configuration (M := M) n) (start : Nat) :
+    ∀ k, counterValue c start k = 0 →
+      ∀ i, i < k → ∀ (hb : start + i < M.tapeLength n),
+        c.tape ⟨start + i, hb⟩ = false := by
+  intro k
+  induction k with
+  | zero => intro _ i hi; exact absurd hi (Nat.not_lt_zero i)
+  | succ k ih =>
+    intro h0 i hi hb
+    rw [counterValue_succ] at h0
+    obtain ⟨hck, hadd⟩ := Nat.add_eq_zero.mp h0
+    rcases lt_or_eq_of_le (Nat.lt_succ_iff.mp hi) with hlt | rfl
+    · exact ih hck i hlt hb
+    · rw [dif_pos hb] at hadd
+      by_cases ht : c.tape ⟨start + i, hb⟩ = true
+      · rw [if_pos ht] at hadd
+        have hpos := Nat.one_le_pow i 2 (by decide)
+        omega
+      · simpa using ht
+
+/-! ## The `bZeroFullScan` program -/
+
+/-- The sound width-`w` `B = 0` test (see the module docstring).  Started on `B`'s low end, the scan
+reads each of the `w` cells: on `0` it steps right to the next cell, on `1` it diverts to phase `w + 1`
+(`B > 0`); having read all `w` cells as `0` it rests at the accept phase `w` (`B = 0`). -/
+def bZeroFullScan (w : Nat) : ConstStatePhasedProgram Unit where
+  numPhases := w + 2
+  startPhase := ⟨0, by omega⟩
+  startState := ()
+  acceptPhase := ⟨w, by omega⟩
+  acceptState := ()
+  transition := fun i _ b =>
+    if h : (i : Nat) < w then
+      if b then
+        (⟨w + 1, by omega⟩, (), b, Move.stay)
+      else
+        (⟨(i : Nat) + 1, by omega⟩, (), b, Move.right)
+    else
+      (i, (), b, Move.stay)
+  timeBound := fun _ => w + 1
+
+@[simp] theorem bZeroFullScan_numPhases (w : Nat) :
+    (bZeroFullScan w).numPhases = w + 2 := rfl
+
+@[simp] theorem bZeroFullScan_startPhase_val (w : Nat) :
+    ((bZeroFullScan w).startPhase : Nat) = 0 := rfl
+
+@[simp] theorem bZeroFullScan_acceptPhase_val (w : Nat) :
+    ((bZeroFullScan w).acceptPhase : Nat) = w := rfl
+
+@[simp] theorem bZeroFullScan_timeBound (w n : Nat) :
+    (bZeroFullScan w).timeBound n = w + 1 := rfl
+
+/-- The scan only ever steps right or stays, so it never moves its head left — it therefore composes
+further under `seq`/`loopUntilSink`. -/
+theorem bZeroFullScan_transition_move (w : Nat) (i : Fin (w + 2)) (s : Unit) (b : Bool) :
+    ((bZeroFullScan w).transition i s b).2.2.2 ≠ Move.left := by
+  unfold bZeroFullScan
+  dsimp only
+  split_ifs <;> simp
+
+theorem bZeroFullScan_neverMovesLeft (w : Nat) :
+    TMNeverMovesLeft ((bZeroFullScan w).toPhased.toTM) := by
+  intro st b
+  obtain ⟨i, s⟩ := st
+  exact bZeroFullScan_transition_move w i s b
+
+/-- Every step writes back the scanned bit, so the scan leaves the tape unchanged. -/
+theorem bZeroFullScan_transition_bit (w : Nat) (i : Fin (w + 2)) (s : Unit) (b : Bool) :
+    ((bZeroFullScan w).transition i s b).2.2.1 = b := by
+  unfold bZeroFullScan
+  dsimp only
+  split_ifs <;> rfl
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3857,6 +3857,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_scanning
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_zero
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_pos
+-- D2t-3 ε entry: the seq-composition route-body (accept re-pointed to the B>0 branch, phase w+1).
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_acceptPhase_val
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_neverMovesLeft
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -97,6 +97,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3846,6 +3847,12 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.bZeroRoute_pos_realizable
 -- D2t-3 routing: the composed routing program (seq scan ; stepRightThenBranch) — structural layer.
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_neverMovesLeft
+-- D2t-3 δ: the corrected SOUND width-`w` B=0 test (full-width scan).
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_neverMovesLeft
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_transition_move
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_transition_bit
+#check @Pnp4.Frontier.ContractExpansion.counterValue_eq_zero_imp_all_false
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3853,6 +3853,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_transition_move
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_transition_bit
 #check @Pnp4.Frontier.ContractExpansion.counterValue_eq_zero_imp_all_false
+-- D2t-3 δ run-through: the scan reaches the B=0 accept phase (w) / diverts to the B>0 branch (w+1).
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_scanning
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_zero
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_pos
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -87,6 +87,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -632,6 +633,11 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRoute_pos_realizable
 -- D2t-3 routing: the composed routing program (seq scan ; stepRightThenBranch) — structural layer.
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_neverMovesLeft
+-- D2t-3 δ: the corrected SOUND width-`w` B=0 test (full-width scan) — structural layer + spec foundation.
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_neverMovesLeft
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_transition_move
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_transition_bit
+#print axioms Pnp4.Frontier.ContractExpansion.counterValue_eq_zero_imp_all_false
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -642,6 +642,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_zero
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_pos
+-- D2t-3 ε entry: the seq-composition route-body (accept re-pointed to the B>0 branch, phase w+1).
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_acceptPhase_val
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_neverMovesLeft
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -638,6 +638,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_transition_move
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_transition_bit
 #print axioms Pnp4.Frontier.ContractExpansion.counterValue_eq_zero_imp_all_false
+-- D2t-3 δ run-through: the scan reaches the B=0 accept phase (w) / diverts to the B>0 branch (w+1).
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_zero
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_runConfig_pos
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
## Summary

PR #1582 recorded that the merged ε `B = 0` test `bZeroRouteProgram` (scan to the first `1`, read the
next cell, branch) is **unsound** on a raw binary counter (counterexample `B = 3 = "11"` misroutes to the
sink), and chose the corrected design: a **width-`w` full scan** using the known width as the scan bound.
This PR **builds that corrected, sound zero-test** — the δ layer of D2t-3 — fully proven, hole-free.

New module `pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScan.lean`:

* **`bZeroFullScan w : ConstStatePhasedProgram Unit`** (`numPhases = w + 2`): phases `0..w-1` read each
  cell of the `w`-window (`0` → step right, next phase; `1` → phase `w+1` = `B > 0`); phase `w` is the
  accept (`B = 0`), phase `w+1` the `B > 0` branch. It uses the **known width `w`** as the scan bound,
  sidestepping the binary-alphabet delimiting wall (§6) — the literature-confirmed sound zero-test
  (a binary-counter zero-test inspects **all** bits; Seiferas & Vitányi, *Counting Is Easy*, arXiv
  `cs/0110038`).
* **Structural** — `numPhases`/`startPhase`/`acceptPhase`/`timeBound`, `neverMovesLeft`,
  `transition_move`/`transition_bit` (so it composes under `seq`/`loopUntilSink`).
* **Spec foundation** — `counterValue_eq_zero_imp_all_false`: a zero counter value forces every cell of
  the width-`w` window to `false` (the converse of the toolkit's `counterValue_of_all_false`); this is
  the fact the `B = 0` path consumes (the loop's `hbase` hypothesis is `μ = counterValue B = 0`).
* **Run-through** (mirroring `gateTagDispatch`'s phase-scanner template) — `..._runConfig_scanning`
  (`j ≤ w` leading `0`s ⇒ after `j` steps phase `j`, head `+ j`, tape unchanged), `..._runConfig_zero`
  (all `w` cells `0` ⇒ after `w` steps the accept phase `w` = `B = 0`), `..._runConfig_pos`
  (low `j` cells `0`, cell `j` set, `j < w` ⇒ after `j + 1` steps phase `w+1` = `B > 0`, head on the
  set bit).

`TM_VERIFIER_STRATEGY.md` §12 is updated to record δ as **built** and to lay out the remaining ε/ζ
sub-bricks (seqP2 lift, assembly, `hbase`, a fresh re-home matching the new exit, `hstep`,
`reachesSink`, the `|U| = value B` bridge) against this sound decider.

## Scope

This is the **δ installment** of D2t-3 (the sound zero-test). The ε loop closure (`reachesSink` on the
new assembly) and the ζ output bridge are the documented follow-up — they are `w`-parameterised
re-derivations of the route-leg stack (`≈` #1564–#1581) against the *sound* decider.

## Verification

`./scripts/check.sh` → **17/17 PASS**. All new surfaces carry only the standard
`[propext, Classical.choice, Quot.sound]` triple (audited in `AxiomsAudit`, surfaced in
`AlgorithmsToLowerBoundsSurfaceTests`).

**Progress classification (AGENTS.md): Infrastructure** — control program toward the NP-membership leg;
it builds no verifier and proves no separation. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_