### PR TITLE
transcoder(D2t-3 ε): bZeroFullScan seqP2 lift + sound loop assembly (foundation)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -340,6 +340,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -341,6 +341,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScanComposition.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScanComposition.lean
@@ -1,0 +1,196 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
+
+/-!
+# `bZeroFullScan` as a non-first `seq` phase (NP-verifier track — D2t-3 `ε`, seqP2 lift)
+
+`bZeroFullScan` (the sound width-`w` `B = 0` test, `TreeMCSPBZeroFullScan.lean`) must run **inside** the
+conversion loop, where it sits as the head component of `seq (bZeroFullScanRouteBody w) rest` — i.e. as a
+**non-first** program in a `seq` chain, started from an arbitrary configuration at composition phase
+`P1.numPhases`.  This module re-derives its run-through in that P2-region, the offset analogue of the
+standalone `bZeroFullScan_runConfig_{scanning,zero,pos}`, mirroring `gammaSelfLoopScan_seqP2_runConfig_*`
+(`TreeMCSPScanComposition.lean`).
+
+The only structural difference from `gammaSelfLoopScan`'s lift is that this scanner **advances its phase**
+each step (`p → p+1`), so the single-step lemmas are parameterised by the local phase `p` (`= i.val −
+P1.numPhases`), and the scanning invariant tracks the composition phase `P1.numPhases + j`.
+
+**Progress classification (AGENTS.md): Infrastructure** — composition lift toward the NP-membership leg;
+it builds no verifier and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]`
+triple only.  **No `P ≠ NP` claim.**
+-/
+
+universe u
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-! ### Single-step lemmas in the P2 region (parameterised by the local scan phase `p`) -/
+
+/-- **Scan step (read `0`) as a non-first phase.**  At composition phase `P1.numPhases + p` (`p < w`)
+reading `0`, advance to composition phase `P1.numPhases + p + 1`. -/
+theorem bZeroFullScan_seqP2_stepConfig_scan_phase (P1 : ConstStatePhasedProgram Unit) (w : Nat)
+    {L : Nat} (c : Configuration (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) L)
+    {i : Fin (seq P1 (bZeroFullScan w)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c).state).fst.val
+      = P1.numPhases + p + 1 := by
+  have hsub : i.val - P1.numPhases = p := by omega
+  rw [seq_stepConfig_P2_phase P1 (bZeroFullScan w) c
+      (h2 := by omega) (hlt := by rw [hsub]; show p < w + 2; omega) hstate]
+  simp [bZeroFullScan, hsub, hbit, hp, Nat.add_assoc]
+
+/-- **Scan step (read `0`) as a non-first phase.**  Advance the head by one. -/
+theorem bZeroFullScan_seqP2_stepConfig_scan_head (P1 : ConstStatePhasedProgram Unit) (w : Nat)
+    {L : Nat} (c : Configuration (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) L)
+    {i : Fin (seq P1 (bZeroFullScan w)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false)
+    (hbound : (c.head : Nat) + 1 < (seq P1 (bZeroFullScan w)).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c).head : Nat)
+      = (c.head : Nat) + 1 := by
+  have hsub : i.val - P1.numPhases = p := by omega
+  rw [seq_stepConfig_P2_head P1 (bZeroFullScan w) c
+      (h2 := by omega) (hlt := by rw [hsub]; show p < w + 2; omega) hstate]
+  have hmove : ((bZeroFullScan w).transition ⟨i.val - P1.numPhases, by rw [hsub]; show p < w + 2; omega⟩
+      s (c.tape c.head)).2.2.2 = Move.right := by
+    simp [bZeroFullScan, hsub, hbit, hp, Nat.add_assoc]
+  rw [hmove]
+  simp only [Configuration.moveHead, dif_pos hbound]
+
+/-- **Divert step (read `1`) as a non-first phase.**  At composition phase `P1.numPhases + p` (`p < w`)
+reading `1`, jump to composition phase `P1.numPhases + w + 1` (`B > 0`). -/
+theorem bZeroFullScan_seqP2_stepConfig_divert_phase (P1 : ConstStatePhasedProgram Unit) (w : Nat)
+    {L : Nat} (c : Configuration (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) L)
+    {i : Fin (seq P1 (bZeroFullScan w)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c).state).fst.val
+      = P1.numPhases + w + 1 := by
+  have hsub : i.val - P1.numPhases = p := by omega
+  rw [seq_stepConfig_P2_phase P1 (bZeroFullScan w) c
+      (h2 := by omega) (hlt := by rw [hsub]; show p < w + 2; omega) hstate]
+  simp [bZeroFullScan, hsub, hbit, hp, Nat.add_assoc]
+
+/-- **Divert step (read `1`) as a non-first phase.**  The head stays put (on the set bit). -/
+theorem bZeroFullScan_seqP2_stepConfig_divert_head (P1 : ConstStatePhasedProgram Unit) (w : Nat)
+    {L : Nat} (c : Configuration (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) L)
+    {i : Fin (seq P1 (bZeroFullScan w)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c).head = c.head := by
+  have hsub : i.val - P1.numPhases = p := by omega
+  rw [seq_stepConfig_P2_head P1 (bZeroFullScan w) c
+      (h2 := by omega) (hlt := by rw [hsub]; show p < w + 2; omega) hstate]
+  have hmove : ((bZeroFullScan w).transition ⟨i.val - P1.numPhases, by rw [hsub]; show p < w + 2; omega⟩
+      s (c.tape c.head)).2.2.2 = Move.stay := by
+    simp [bZeroFullScan, hsub, hbit, hp, Nat.add_assoc]
+  rw [hmove]
+  simp [Configuration.moveHead]
+
+/-- **Tape unchanged.**  Every P2 step writes the scanned bit back, so the tape is unchanged. -/
+theorem bZeroFullScan_seqP2_stepConfig_tape (P1 : ConstStatePhasedProgram Unit) (w : Nat)
+    {L : Nat} (c : Configuration (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) L)
+    {i : Fin (seq P1 (bZeroFullScan w)).numPhases} {s : Unit}
+    (h2 : P1.numPhases ≤ i.val) (hlt : i.val - P1.numPhases < w + 2) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c).tape
+      = c.write c.head
+          ((bZeroFullScan w).transition ⟨i.val - P1.numPhases, hlt⟩ s (c.tape c.head)).2.2.1 := by
+    rw [seq_stepConfig_P2_tape P1 (bZeroFullScan w) c (h2 := h2) (hlt := hlt) hstate]
+  rw [hwrite, bZeroFullScan_transition_bit]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-! ### Run-through in the P2 region -/
+
+/-- **Scanning invariant as a non-first phase.**  From `c0` at composition phase `P1.numPhases`, if the
+`j` cells from the head are all `0` (`j ≤ w`, in bounds), then after `j` steps the composition phase is
+`P1.numPhases + j`, the head has advanced to `c0.head + j`, and the tape is unchanged. -/
+theorem bZeroFullScan_seqP2_runConfig_scanning (P1 : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases) :
+    ∀ j : Nat, j ≤ w →
+      (c0.head : Nat) + j < (seq P1 (bZeroFullScan w)).toPhased.toTM.tapeLength L →
+      (∀ p : Fin ((seq P1 (bZeroFullScan w)).toPhased.toTM.tapeLength L),
+        (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + j → c0.tape p = false) →
+      (((TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 j).state).fst : Nat)
+          = P1.numPhases + j
+      ∧ ((TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 j).head : Nat)
+          = (c0.head : Nat) + j
+      ∧ (TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 j).tape = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _ _; exact ⟨by simpa using hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj hb h0
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (by omega) (fun p hp1 hp2 => h0 p hp1 (by omega))
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 j with hc
+      have hbnd : (c.head : Nat) + 1 < (seq P1 (bZeroFullScan w)).toPhased.toTM.tapeLength L := by
+        rw [hhd]; omega
+      have hbit : c.tape c.head = false := by
+        rw [htp]; exact h0 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hpj : j < w := by omega
+      have hiph : (c.state.fst : Nat) = P1.numPhases + j := hph
+      refine ⟨?_, ?_, ?_⟩
+      · rw [bZeroFullScan_seqP2_stepConfig_scan_phase P1 w c
+          (i := c.state.fst) (s := c.state.snd) hpj hiph rfl hbit]
+        omega
+      · rw [bZeroFullScan_seqP2_stepConfig_scan_head P1 w c
+          (i := c.state.fst) (s := c.state.snd) hpj hiph rfl hbit hbnd]
+        omega
+      · rw [bZeroFullScan_seqP2_stepConfig_tape P1 w c
+          (i := c.state.fst) (s := c.state.snd) (by omega) (by rw [hiph]; omega) rfl, htp]
+
+/-- **`B = 0` run-through as a non-first phase.**  All `w` cells `0` ⇒ after `w` steps the composition
+phase rests at `P1.numPhases + w` (the `B = 0` accept), head at `c0.head + w`, tape unchanged. -/
+theorem bZeroFullScan_seqP2_runConfig_zero (P1 : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases)
+    (hb : (c0.head : Nat) + w < (seq P1 (bZeroFullScan w)).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((seq P1 (bZeroFullScan w)).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + w → c0.tape p = false) :
+    (((TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 w).state).fst : Nat)
+        = P1.numPhases + w
+      ∧ ((TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 w).head : Nat)
+          = (c0.head : Nat) + w
+      ∧ (TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 w).tape = c0.tape :=
+  bZeroFullScan_seqP2_runConfig_scanning P1 w c0 hphase w (le_refl w) hb hzeros
+
+/-- **`B > 0` run-through as a non-first phase.**  Low `j` cells `0`, cell `j` set (`j < w`) ⇒ after
+`j + 1` steps the composition phase is `P1.numPhases + w + 1` (`B > 0`), the head rests on the set bit
+(`c0.head + j`), tape unchanged. -/
+theorem bZeroFullScan_seqP2_runConfig_pos (P1 : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases) (j : Nat) (hjw : j < w)
+    (hb : (c0.head : Nat) + j < (seq P1 (bZeroFullScan w)).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((seq P1 (bZeroFullScan w)).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + j → c0.tape p = false)
+    (hone : ∀ p : Fin ((seq P1 (bZeroFullScan w)).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + j → c0.tape p = true) :
+    (((TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 (j + 1)).state).fst : Nat)
+        = P1.numPhases + w + 1
+      ∧ ((TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 (j + 1)).head : Nat)
+          = (c0.head : Nat) + j
+      ∧ (TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 (j + 1)).tape = c0.tape := by
+  obtain ⟨hph, hhd, htp⟩ :=
+    bZeroFullScan_seqP2_runConfig_scanning P1 w c0 hphase j (le_of_lt hjw) hb hzeros
+  rw [TM.runConfig_succ]
+  set c := TM.runConfig (M := (seq P1 (bZeroFullScan w)).toPhased.toTM) c0 j with hc
+  have hbit : c.tape c.head = true := by rw [htp]; exact hone c.head (by rw [hhd])
+  have hiph : (c.state.fst : Nat) = P1.numPhases + j := hph
+  refine ⟨?_, ?_, ?_⟩
+  · rw [bZeroFullScan_seqP2_stepConfig_divert_phase P1 w c
+      (i := c.state.fst) (s := c.state.snd) hjw hiph rfl hbit]
+  · rw [bZeroFullScan_seqP2_stepConfig_divert_head P1 w c
+      (i := c.state.fst) (s := c.state.snd) hjw hiph rfl hbit]
+    exact hhd
+  · rw [bZeroFullScan_seqP2_stepConfig_tape P1 w c
+      (i := c.state.fst) (s := c.state.snd) (by omega) (by rw [hiph]; omega) rfl, htp]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScan.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScan.lean
@@ -1,0 +1,82 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome
+
+/-!
+# `binToUnaryLoopFullScan` — the binary→unary loop on the SOUND zero-test (NP-verifier track — D2t-3 `ε`)
+
+The merged `binToUnaryLoopRehome` (`TreeMCSPBinToUnaryLoopRehome.lean`) routes via the **unsound**
+`bZeroRouteProgram` (PR #1582).  This module assembles the **revised** loop on the sound width-`w`
+zero-test `bZeroFullScan` (`TreeMCSPBZeroFullScan.lean`, the δ layer):
+
+```
+binToUnaryLoopBodyFullScan w :=
+  seq stepRightOnce                       -- HOME → B's low end (HOME+1)
+    (seq (bZeroFullScanRouteBody w)        -- sound scan of the w-window; B=0 → terminal, B>0 → accept
+      (seq stepRightOnce                   -- step past the located set bit (→ HOME+j+2, the seek start)
+        (seq seekHomeAfterRoute            -- re-home to the sentinel (reuses the proven seek design)
+          binToUnaryBody)))                -- one pass: decrement B, append to U, return to HOME
+binToUnaryLoopFullScan w := loopUntilSink (binToUnaryLoopBodyFullScan w) ⟨w + 2⟩
+```
+
+* The leading `stepRightOnce` places the scan window at exactly `[HOME+1, HOME+1+w)`, matching the
+  `counterValue` measure.  `bZeroFullScanRouteBody` (the `B>0`-re-pointed accept) hands off into the body
+  legs on `B > 0` and leaves its `B = 0` phase (composition phase `w + 2`) terminal for the sink.
+* The interposed `stepRightOnce` advances the head from the located set bit (`HOME+1+j`) to `HOME+j+2`,
+  the discriminator-style position the proven `seekHomeAfterRoute` design re-homes from — so the existing
+  seek + body navigation transfers (its run-through is re-derived on this machine in the follow-up).
+* `loopUntilSink … ⟨w + 2⟩` re-enters the body on its accept (a completed `B > 0` pass) and halts at the
+  sink phase `w + 2` (`B = 0`).
+
+This brick ships the **definitions + phase-count facts** (the loop object and its shape), introduced
+**additively** so the unsound `binToUnaryLoopRehome` stays intact.  The run behaviour — `hbase`
+(`B = 0` → sink, via the δ seqP2 `zero` lift), the fresh seek + body run-through on this machine,
+`hstep` (`B > 0` → re-enter with `counterValue B` decreasing), then `loopUntilSink_reachesSink` and the
+`ζ` bridge `|U| = value B` — is the follow-up.
+
+**Progress classification (AGENTS.md): Infrastructure** — the sound loop assembly toward the
+NP-membership leg; it proves no run behaviour and no separation here.  Standard
+`[propext, Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- The revised loop body on the sound zero-test: step to `B`'s low end, run the width-`w` full scan,
+and on `B > 0` step past the located set bit, re-home, and run one pass of `binToUnaryBody`. -/
+def binToUnaryLoopBodyFullScan (w : Nat) : ConstStatePhasedProgram Unit :=
+  seq stepRightOnce
+    (seq (bZeroFullScanRouteBody w)
+      (seq stepRightOnce (seq seekHomeAfterRoute binToUnaryBody)))
+
+/-- Phase count: `stepRightOnce (2) + bZeroFullScanRouteBody (w+2) + stepRightOnce (2) +
+seekHomeAfterRoute (9) + binToUnaryBody (15) = w + 30`. -/
+@[simp] theorem binToUnaryLoopBodyFullScan_numPhases (w : Nat) :
+    (binToUnaryLoopBodyFullScan w).numPhases = w + 30 := by
+  simp only [binToUnaryLoopBodyFullScan, seq_numPhases, bZeroFullScanRouteBody_numPhases,
+    stepRightOnce_numPhases, seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases]
+  omega
+
+/-- The sound binary→unary loop: re-enter the body on its accept (a completed `B > 0` pass), halt at the
+sink phase `w + 2` (`B = 0`, the full scan's `B=0` outcome lifted past the leading `stepRightOnce`). -/
+def binToUnaryLoopFullScan (w : Nat) : ConstStatePhasedProgram Unit :=
+  loopUntilSink (binToUnaryLoopBodyFullScan w)
+    ⟨w + 2, by rw [binToUnaryLoopBodyFullScan_numPhases]; omega⟩
+
+@[simp] theorem binToUnaryLoopFullScan_numPhases (w : Nat) :
+    (binToUnaryLoopFullScan w).numPhases = w + 30 := by
+  simp [binToUnaryLoopFullScan]
+
+@[simp] theorem binToUnaryLoopFullScan_startPhase_val (w : Nat) :
+    ((binToUnaryLoopFullScan w).startPhase : Nat) = 0 := by
+  simp [binToUnaryLoopFullScan, binToUnaryLoopBodyFullScan]
+
+@[simp] theorem binToUnaryLoopFullScan_acceptPhase_val (w : Nat) :
+    ((binToUnaryLoopFullScan w).acceptPhase : Nat) = w + 2 := rfl
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScan.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScan.lean
@@ -1,5 +1,8 @@
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
-import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopRehome
+import Pnp4.Frontier.ContractExpansion.TreeMCSPLoopUntilSink
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightProgram
+import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
 
 /-!
 # `binToUnaryLoopFullScan` — the binary→unary loop on the SOUND zero-test (NP-verifier track — D2t-3 `ε`)

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -98,6 +98,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3861,6 +3862,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_acceptPhase_val
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_neverMovesLeft
+-- D2t-3 ε seqP2 lift: bZeroFullScan's run-through as a non-first seq phase (offset by P1.numPhases).
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_scanning
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_zero
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_pos
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -99,6 +99,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3866,6 +3867,11 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_scanning
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_zero
 #check @Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_pos
+-- D2t-3 ε assembly: the sound binary→unary loop on bZeroFullScan (structural skeleton).
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_numPhases
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_acceptPhase_val
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -89,6 +89,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -650,6 +651,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_zero
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_pos
+-- D2t-3 ε assembly: the sound binary→unary loop on bZeroFullScan (structural skeleton).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_numPhases
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_numPhases
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_acceptPhase_val
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -88,6 +88,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryBody
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -645,6 +646,10 @@ end Pnp4
 -- D2t-3 ε entry: the seq-composition route-body (accept re-pointed to the B>0 branch, phase w+1).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_acceptPhase_val
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_neverMovesLeft
+-- D2t-3 ε seqP2 lift: bZeroFullScan's run-through as a non-first seq phase (offset by P1.numPhases).
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_zero
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScan_seqP2_runConfig_pos
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
## Summary

Builds on the merged δ layer (#1583, the sound `bZeroFullScan` zero-test) toward closing D2t-3's ε
(the binary→unary conversion loop on the *sound* test).  Two foundation bricks:

### 1. `bZeroFullScan` seqP2 lift (`TreeMCSPBZeroFullScanComposition.lean`)
Re-derives `bZeroFullScan`'s run-through in the `seq` P2-region (from an arbitrary start at composition
phase `P1.numPhases`), the offset analogue of `gammaSelfLoopScan_seqP2_runConfig_*`.  Unlike the
self-loop `gammaSelfLoopScan`, this scanner advances its phase each step, so the single-step lemmas are
parameterised by the local phase `p` and the invariant tracks `P1.numPhases + j`:
`bZeroFullScan_seqP2_runConfig_{scanning,zero,pos}` (`B = 0` → phase `P1.numPhases + w`; `B > 0` → phase
`P1.numPhases + w + 1`).

### 2. `binToUnaryLoopFullScan` assembly (`TreeMCSPBinToUnaryLoopFullScan.lean`, structural)
The revised loop on the sound test, introduced **additively** (the unsound `binToUnaryLoopRehome` stays
intact):
```
binToUnaryLoopBodyFullScan w :=
  seq stepRightOnce (seq (bZeroFullScanRouteBody w)
    (seq stepRightOnce (seq seekHomeAfterRoute binToUnaryBody)))   -- numPhases = w + 30
binToUnaryLoopFullScan w := loopUntilSink (binToUnaryLoopBodyFullScan w) ⟨w + 2⟩
```
The leading `stepRightOnce` aligns the scan window to `[HOME+1, HOME+1+w)` (matching the `counterValue`
measure); the interposed `stepRightOnce` advances the head from the located set bit to `HOME+j+2` so the
proven `seekHomeAfterRoute` design re-homes from there; `B = 0` lands at composition phase `w + 2` = the
loop sink.  Ships definitions + phase-count facts.

## Scope

Foundation for ε.  The **run-through closure** — `hbase` (`B = 0` → sink via the seqP2 `zero` lift),
the re-derived seek + body run-through on this machine, `hstep` (`B > 0` → re-enter with `counterValue B`
decreasing, reusing the merged `binToUnaryBody_runConfig_onePass`), `loopUntilSink_reachesSink`, then the
`ζ` bridge `|U| = value B` — is the follow-up (each a mechanical mirror of an existing pattern, since the
body's one-pass engine and measure are already proven and reusable).

## Verification

`./scripts/check.sh` → **17/17 PASS**.  All new surfaces carry only the standard
`[propext, Classical.choice, Quot.sound]` triple (audited in `AxiomsAudit`, surfaced in
`AlgorithmsToLowerBoundsSurfaceTests`).

**Progress classification (AGENTS.md): Infrastructure** — composition lift + loop assembly toward the
NP-membership leg; it proves no run behaviour and no separation here.  **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_