### PR TITLE
transcoder(D2t-3 ε): sound-loop scan run-through + hbase (B=0→sink) + B>0 scan-to-divert

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -341,6 +341,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanNested,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -343,6 +343,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanNested,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -344,6 +344,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanNested,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -348,6 +348,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanStep2,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanSeek,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -347,6 +347,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanStep2,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -346,6 +346,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -345,6 +345,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScanNested.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBZeroFullScanNested.lean
@@ -1,0 +1,217 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
+
+/-!
+# `bZeroFullScanRouteBody` as a depth-2 (`P2∘P1`) `seq` phase (NP-verifier track — D2t-3 `ε`)
+
+In the sound conversion loop body `seq stepRightOnce (seq (bZeroFullScanRouteBody w) R)`
+(`TreeMCSPBinToUnaryLoopFullScan.lean`) the scan sits as **P1 of the inner `seq`, P2 of the outer** —
+i.e. at composition depth 2.  This module lifts the scan's run-through to that position, the
+doubly-nested analogue of `bZeroFullScan_seqP2_runConfig_*` (`TreeMCSPBZeroFullScanComposition.lean`),
+mirroring `gammaSelfLoopScan_seqNested_runConfig_scanning` (`TreeMCSPScanComposition.lean`).
+
+The scan **advances its phase** each step, so the single-step lemmas are parameterised by the local
+phase `p` and the scanning invariant tracks the composition phase `P1.numPhases + j`.  Because the inner
+`seq` is `seq (bZeroFullScanRouteBody w) R`, the seq handoff check is `current phase = w + 1`
+(`bZeroFullScanRouteBody`'s accept); for `p < w` this is `False`, so the inner `seq` runs
+`bZeroFullScan`'s transition (and on `B > 0` lands at `P1.numPhases + w + 1`, whence the next step hands
+off into `R`).
+
+**Progress classification (AGENTS.md): Infrastructure** — composition lift toward the NP-membership leg;
+standard `[propext, Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-! ### Single-step lemmas at depth 2 (parameterised by the local scan phase `p`) -/
+
+/-- **Scan step (read `0`) at depth 2.**  At composition phase `P1.numPhases + p` (`p < w`), advance to
+`P1.numPhases + p + 1`. -/
+theorem bZeroFullScanRouteBody_seqNested_stepConfig_scan_phase
+    (P1 R : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c : Configuration (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) L)
+    {i : Fin (seq P1 (seq (bZeroFullScanRouteBody w) R)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c).state).fst.val
+      = P1.numPhases + p + 1 := by
+  have hsub : i.val - P1.numPhases = p := by omega
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  rw [seq_stepConfig_P2_phase P1 (seq (bZeroFullScanRouteBody w) R) c
+      (h2 := by omega)
+      (hlt := by rw [hsub, seq_numPhases, bZeroFullScanRouteBody_numPhases]; omega) hstate]
+  simp [seq, bZeroFullScanRouteBody, bZeroFullScan, hsub, hbit, hp, hne, hlt2, Nat.add_assoc]
+
+/-- **Scan step (read `0`) at depth 2.**  Advance the head by one. -/
+theorem bZeroFullScanRouteBody_seqNested_stepConfig_scan_head
+    (P1 R : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c : Configuration (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) L)
+    {i : Fin (seq P1 (seq (bZeroFullScanRouteBody w) R)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false)
+    (hbound : (c.head : Nat) + 1
+      < (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c).head : Nat)
+      = (c.head : Nat) + 1 := by
+  have hsub : i.val - P1.numPhases = p := by omega
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  rw [seq_stepConfig_P2_head P1 (seq (bZeroFullScanRouteBody w) R) c
+      (h2 := by omega)
+      (hlt := by rw [hsub, seq_numPhases, bZeroFullScanRouteBody_numPhases]; omega) hstate]
+  have hmove : ((seq (bZeroFullScanRouteBody w) R).transition
+      ⟨i.val - P1.numPhases, by rw [hsub, seq_numPhases, bZeroFullScanRouteBody_numPhases]; omega⟩
+      s (c.tape c.head)).2.2.2 = Move.right := by
+    simp [seq, bZeroFullScanRouteBody, bZeroFullScan, hsub, hbit, hp, hne, hlt2]
+  rw [hmove]
+  simp only [Configuration.moveHead, dif_pos hbound]
+
+/-- **Scan step (read `0`) at depth 2.**  The tape is unchanged. -/
+theorem bZeroFullScanRouteBody_seqNested_stepConfig_scan_tape
+    (P1 R : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c : Configuration (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) L)
+    {i : Fin (seq P1 (seq (bZeroFullScanRouteBody w) R)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c).tape = c.tape := by
+  have hsub : i.val - P1.numPhases = p := by omega
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  have hwrite : (TM.stepConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c).tape
+      = c.write c.head false := by
+    rw [seq_stepConfig_P2_tape P1 (seq (bZeroFullScanRouteBody w) R) c
+        (h2 := by omega)
+        (hlt := by rw [hsub, seq_numPhases, bZeroFullScanRouteBody_numPhases]; omega) hstate]
+    simp [seq, bZeroFullScanRouteBody, bZeroFullScan, hsub, hbit, hp, hne, hlt2]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+/-- **Divert step (read `1`) at depth 2.**  At composition phase `P1.numPhases + p` (`p < w`), jump to
+`P1.numPhases + w + 1` (`bZeroFullScanRouteBody`'s accept = `B > 0`). -/
+theorem bZeroFullScanRouteBody_seqNested_stepConfig_divert_phase
+    (P1 R : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c : Configuration (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) L)
+    {i : Fin (seq P1 (seq (bZeroFullScanRouteBody w) R)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c).state).fst.val
+      = P1.numPhases + w + 1 := by
+  have hsub : i.val - P1.numPhases = p := by omega
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  rw [seq_stepConfig_P2_phase P1 (seq (bZeroFullScanRouteBody w) R) c
+      (h2 := by omega)
+      (hlt := by rw [hsub, seq_numPhases, bZeroFullScanRouteBody_numPhases]; omega) hstate]
+  simp [seq, bZeroFullScanRouteBody, bZeroFullScan, hsub, hbit, hp, hne, hlt2, Nat.add_assoc]
+
+/-- **Divert step (read `1`) at depth 2.**  The head stays put. -/
+theorem bZeroFullScanRouteBody_seqNested_stepConfig_divert_head
+    (P1 R : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c : Configuration (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) L)
+    {i : Fin (seq P1 (seq (bZeroFullScanRouteBody w) R)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c).head = c.head := by
+  have hsub : i.val - P1.numPhases = p := by omega
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  rw [seq_stepConfig_P2_head P1 (seq (bZeroFullScanRouteBody w) R) c
+      (h2 := by omega)
+      (hlt := by rw [hsub, seq_numPhases, bZeroFullScanRouteBody_numPhases]; omega) hstate]
+  have hmove : ((seq (bZeroFullScanRouteBody w) R).transition
+      ⟨i.val - P1.numPhases, by rw [hsub, seq_numPhases, bZeroFullScanRouteBody_numPhases]; omega⟩
+      s (c.tape c.head)).2.2.2 = Move.stay := by
+    simp [seq, bZeroFullScanRouteBody, bZeroFullScan, hsub, hbit, hp, hne, hlt2]
+  rw [hmove]
+  simp [Configuration.moveHead]
+
+/-- **Tape unchanged at depth 2** (any inner-scan phase `p < w`). -/
+theorem bZeroFullScanRouteBody_seqNested_stepConfig_tape
+    (P1 R : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c : Configuration (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) L)
+    {i : Fin (seq P1 (seq (bZeroFullScanRouteBody w) R)).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = P1.numPhases + p) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c).tape = c.tape := by
+  rcases Bool.eq_false_or_eq_true (c.tape c.head) with hbit | hbit
+  · have hsub : i.val - P1.numPhases = p := by omega
+    have hne : ¬ (p = w + 1) := by omega
+    have hlt2 : p < w + 2 := by omega
+    have hwrite : (TM.stepConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c).tape
+        = c.write c.head true := by
+      rw [seq_stepConfig_P2_tape P1 (seq (bZeroFullScanRouteBody w) R) c
+          (h2 := by omega)
+          (hlt := by rw [hsub, seq_numPhases, bZeroFullScanRouteBody_numPhases]; omega) hstate]
+      simp [seq, bZeroFullScanRouteBody, bZeroFullScan, hsub, hbit, hp, hne, hlt2]
+    rw [hwrite]
+    funext j
+    by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write, hbit]
+    · simp [Configuration.write, hj]
+  · exact bZeroFullScanRouteBody_seqNested_stepConfig_scan_tape P1 R w c hp hi hstate hbit
+
+/-! ### Run-through at depth 2 -/
+
+/-- **Scanning invariant at depth 2.**  From `c0` at composition phase `P1.numPhases`, if the `j` cells
+from the head are all `0` (`j ≤ w`, in bounds), then after `j` steps the composition phase is
+`P1.numPhases + j`, the head is at `c0.head + j`, and the tape is unchanged. -/
+theorem bZeroFullScanRouteBody_seqNested_runConfig_scanning
+    (P1 R : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases) :
+    ∀ j : Nat, j ≤ w →
+      (c0.head : Nat) + j < (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM.tapeLength L →
+      (∀ q : Fin ((seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM.tapeLength L),
+        (c0.head : Nat) ≤ (q : Nat) → (q : Nat) < (c0.head : Nat) + j → c0.tape q = false) →
+      (((TM.runConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c0 j).state).fst
+          : Nat) = P1.numPhases + j
+      ∧ ((TM.runConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c0 j).head : Nat)
+          = (c0.head : Nat) + j
+      ∧ (TM.runConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c0 j).tape
+          = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _ _; exact ⟨by simpa using hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj hb h0
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (by omega) (fun q hq1 hq2 => h0 q hq1 (by omega))
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c0 j with hc
+      have hbnd : (c.head : Nat) + 1
+          < (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM.tapeLength L := by rw [hhd]; omega
+      have hbit : c.tape c.head = false := by
+        rw [htp]; exact h0 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hpj : j < w := by omega
+      have hiph : (c.state.fst : Nat) = P1.numPhases + j := hph
+      refine ⟨?_, ?_, ?_⟩
+      · rw [bZeroFullScanRouteBody_seqNested_stepConfig_scan_phase P1 R w c
+          (i := c.state.fst) (s := c.state.snd) hpj hiph rfl hbit]
+        omega
+      · rw [bZeroFullScanRouteBody_seqNested_stepConfig_scan_head P1 R w c
+          (i := c.state.fst) (s := c.state.snd) hpj hiph rfl hbit hbnd]
+        omega
+      · rw [bZeroFullScanRouteBody_seqNested_stepConfig_tape P1 R w c
+          (i := c.state.fst) (s := c.state.snd) hpj hiph rfl, htp]
+
+/-- **`B = 0` run-through at depth 2.**  All `w` cells `0` ⇒ after `w` steps the composition phase rests
+at `P1.numPhases + w` (`B = 0`), head at `c0.head + w`, tape unchanged. -/
+theorem bZeroFullScanRouteBody_seqNested_runConfig_zero
+    (P1 R : ConstStatePhasedProgram Unit) (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = P1.numPhases)
+    (hb : (c0.head : Nat) + w < (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ q : Fin ((seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (q : Nat) → (q : Nat) < (c0.head : Nat) + w → c0.tape q = false) :
+    (((TM.runConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c0 w).state).fst
+        : Nat) = P1.numPhases + w
+      ∧ ((TM.runConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c0 w).head : Nat)
+          = (c0.head : Nat) + w
+      ∧ (TM.runConfig (M := (seq P1 (seq (bZeroFullScanRouteBody w) R)).toPhased.toTM) c0 w).tape
+          = c0.tape :=
+  bZeroFullScanRouteBody_seqNested_runConfig_scanning P1 R w c0 hphase w (le_refl w) hb hzeros
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanHbase.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanHbase.lean
@@ -1,0 +1,128 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan
+
+/-!
+# `binToUnaryLoopFullScan` — the `B = 0 → sink` half of `ε` (NP-verifier track — D2t-3)
+
+`loopUntilSink_reachesSink`'s `hbase` for the sound loop: from the loop start (phase `0`, head at the
+sentinel `HOME`) with the counter `B` zero (`counterValue (HOME+1) w = 0`), the loop reaches the sink
+(phase `w + 2`).  The run is the leading `stepRightOnce` (phase `0 → 2`, head `HOME → HOME+1`) followed
+by the width-`w` full scan over all-`0` cells (phase `2 → 2 + w`); `δ1`
+(`counterValue_eq_zero_imp_all_false`) turns the `counterValue = 0` hypothesis into the all-`0` window the
+scan consumes.
+
+**Progress classification (AGENTS.md): Infrastructure** — standard triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
+
+/-- **Loop step (phase `0`)** = the leading `stepRightOnce`'s move: step one cell right, reaching phase
+`1`; tape unchanged. -/
+theorem binToUnaryLoopFullScan_step0 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = 0)
+    (hstate : c.state = ⟨i, s⟩)
+    (hbound : (c.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = 1
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat)
+          = (c.head : Nat) + 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, stepRightOnce, hi]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.right := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, stepRightOnce, hi]
+    rw [hmove]
+    simp only [Configuration.moveHead, dif_pos hbound]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, stepRightOnce, hi]
+    rw [this]
+    funext j
+    by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Loop step (phase `1`)** = the `stepRightOnce → bZeroFullScanRouteBody` handoff: jump to phase `2`
+(the scan start); head and tape unchanged. -/
+theorem binToUnaryLoopFullScan_step1 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = 1)
+    (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = 2
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, stepRightOnce, hi]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, stepRightOnce, hi]
+    rw [hmove]
+    simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, stepRightOnce, hi]
+    rw [this]
+    funext j
+    by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **`B = 0` run-through (hbase).**  From the loop start (phase `0`, head `HOME`) with the width-`w`
+counter window all-`0` (`counterValue (HOME+1) w = 0`), the loop reaches the sink phase `w + 2` after
+`2 + w` steps. -/
+theorem binToUnaryLoopFullScan_runConfig_hbase (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0)
+    (hb : (c0.head : Nat) + 1 + w < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (hzero : counterValue c0 ((c0.head : Nat) + 1) w = 0) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + w)).state).fst : Nat)
+      = w + 2 := by
+  -- step 0: the leading stepRightOnce move (head HOME → HOME+1)
+  obtain ⟨h0p, h0h, h0t⟩ := binToUnaryLoopFullScan_step0 w c0 hstart rfl (by omega)
+  -- step 1: the handoff to the scan start (phase 2)
+  set c1 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 1 with hc1
+  have hc1eq : c1 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 := by
+    rw [hc1, show (1 : Nat) = 0 + 1 from rfl, TM.runConfig_succ]; rfl
+  obtain ⟨h1p, h1h, h1t⟩ := binToUnaryLoopFullScan_step1 w c1
+    (i := c1.state.fst) (s := c1.state.snd) (by rw [hc1eq]; exact h0p) rfl
+  -- after 2 steps: phase 2, head HOME+1, tape unchanged
+  set c2 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 2 with hc2
+  have hc2eq : c2 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c1 := by
+    rw [hc2, show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_succ, hc1]
+  have h2p : (c2.state.fst : Nat) = 2 := by rw [hc2eq]; exact h1p
+  have h2h : (c2.head : Nat) = (c0.head : Nat) + 1 := by
+    rw [hc2eq, h1h, hc1eq, h0h]
+  have h2t : c2.tape = c0.tape := by rw [hc2eq, h1t, hc1eq, h0t]
+  -- the scan window [HOME+1, HOME+1+w) is all 0 (from counterValue = 0)
+  have hzeros : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c2.head : Nat) ≤ (q : Nat) → (q : Nat) < (c2.head : Nat) + w → c2.tape q = false := by
+    intro q hq1 hq2
+    rw [h2t]
+    have hqlt : (q : Nat) - ((c0.head : Nat) + 1) < w := by rw [h2h] at hq2; omega
+    have hqge : (c0.head : Nat) + 1 ≤ (q : Nat) := by rw [h2h] at hq1; omega
+    have := counterValue_eq_zero_imp_all_false c0 ((c0.head : Nat) + 1) w hzero
+      ((q : Nat) - ((c0.head : Nat) + 1)) hqlt (by omega)
+    simpa [Nat.add_sub_cancel' hqge] using this
+  -- scan w zeros from phase 2 → phase 2 + w
+  obtain ⟨hsp, _, _⟩ := binToUnaryLoopFullScan_runConfig_scanning w c2 h2p w (le_refl w)
+    (by rw [h2h]; omega) hzeros
+  rw [show (2 + w : Nat) = 2 + w from rfl, ← TM.runConfig_add, ← hc2] at *
+  rw [hsp]; omega
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanPeel.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanPeel.lean
@@ -1,0 +1,46 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan
+
+/-!
+# `binToUnaryLoopFullScan` — loop-machine peel + accept-phase (NP-verifier track — D2t-3 `ε`)
+
+Foundational lemmas for running `binToUnaryLoopFullScan` (`TreeMCSPBinToUnaryLoopFullScan.lean`): the
+accept-phase index of its loop body and the body-region peel of `loopUntilSink` (away from the body
+accept `w + 29` and the sink `w + 2`, the loop runs the body verbatim).  Mirrors
+`binToUnaryLoopBodyRehome_acceptPhase_val` / `binToUnaryLoopRehome_transition_body`, with the
+`w`-parameterised indices.
+
+**Progress classification (AGENTS.md): Infrastructure** — standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- The loop body's accept phase: `stepRightOnce (2) + bZeroFullScanRouteBody (w+2) + stepRightOnce (2) +
+seekHomeAfterRoute (9) + binToUnaryBody's accept (14) = w + 29`. -/
+@[simp] theorem binToUnaryLoopBodyFullScan_acceptPhase_val (w : Nat) :
+    ((binToUnaryLoopBodyFullScan w).acceptPhase : Nat) = w + 29 := by
+  have hbody : (binToUnaryBody.acceptPhase : Nat) = 14 := by decide
+  simp only [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody_numPhases,
+    stepRightOnce_numPhases, seekHomeAfterRoute_numPhases, hbody]
+  omega
+
+/-- **Body-region peel.**  Away from the loop body's accept `w + 29` and the sink `w + 2`,
+`binToUnaryLoopFullScan` runs `binToUnaryLoopBodyFullScan` verbatim. -/
+theorem binToUnaryLoopFullScan_transition_body (w : Nat)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases}
+    (hneA : (i : Nat) ≠ w + 29) (hneS : (i : Nat) ≠ w + 2) (s : Unit) (b : Bool) :
+    (binToUnaryLoopFullScan w).transition i s b = (binToUnaryLoopBodyFullScan w).transition i () b := by
+  have h := loopUntilSink_transition_body (binToUnaryLoopBodyFullScan w)
+    ⟨w + 2, by rw [binToUnaryLoopBodyFullScan_numPhases]; omega⟩
+    (Fin.ne_of_val_ne (by rw [binToUnaryLoopBodyFullScan_acceptPhase_val]; exact hneA))
+    (Fin.ne_of_val_ne hneS) s b
+  exact h
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanPos.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanPos.lean
@@ -1,0 +1,128 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase
+
+/-!
+# `binToUnaryLoopFullScan` — the `B > 0` scan-to-divert run (NP-verifier track — D2t-3 `ε`, `hstep` core)
+
+The `B > 0` half of the loop's first leg on the loop machine: from the loop start (phase `0`, head
+`HOME`), the leading `stepRightOnce` (phase `0 → 2`, head `HOME → HOME+1`) then the width-`w` full scan
+over `B`'s low `0`-run diverts on the lowest set bit (`HOME+1+j`, `j < w`) to the route-body's accept
+(composition phase `w + 3`), head resting on that set bit.  From there `hstep`'s remaining legs (re-home,
+body one-pass, back-edge) continue — those are the next bricks.
+
+**Progress classification (AGENTS.md): Infrastructure** — standard triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- **Loop divert step (read `1`), phase.**  At composition phase `2 + p` (`p < w`) reading `1`, jump to
+phase `w + 3` (the route-body's `B > 0` accept, lifted past the leading `stepRightOnce`). -/
+theorem binToUnaryLoopFullScan_stepConfig_divert_phase (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = 2 + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 3 := by
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  have hge : ¬ (2 + p < 2) := by omega
+  rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+      binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+  simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, hi, hbit, hp, hne, hlt2,
+    hge]
+  omega
+
+/-- **Loop divert step (read `1`), head.**  The head stays put (on the set bit). -/
+theorem binToUnaryLoopFullScan_stepConfig_divert_head (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = 2 + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head := by
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  have hge : ¬ (2 + p < 2) := by omega
+  rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+  have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+    rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, hi, hbit, hp, hne,
+      hlt2, hge]
+  rw [hmove]
+  simp [Configuration.moveHead]
+
+/-- **Loop divert step (read `1`), tape.**  The tape is unchanged. -/
+theorem binToUnaryLoopFullScan_stepConfig_divert_tape (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = 2 + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  have hge : ¬ (2 + p < 2) := by omega
+  have hwrite : (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape
+      = c.write c.head true := by
+    rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, hi, hbit, hp, hne,
+      hlt2, hge]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+/-- **`B > 0` scan-to-divert run.**  From the loop start (phase `0`, head `HOME`) with `B`'s low `j`
+cells `0` and the cell at `HOME+1+j` set (`j < w`), the loop reaches phase `w + 3` after `j + 3` steps,
+with the head on the set bit (`HOME+1+j`) and the tape unchanged. -/
+theorem binToUnaryLoopFullScan_runConfig_pos (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0) (j : Nat) (hjw : j < w)
+    (hb : (c0.head : Nat) + 1 + w < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (q : Nat) → (q : Nat) < (c0.head : Nat) + 1 + j → c0.tape q = false)
+    (hone : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (q : Nat) = (c0.head : Nat) + 1 + j → c0.tape q = true) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (j + 3)).state).fst : Nat) = w + 3
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (j + 3)).head : Nat)
+          = (c0.head : Nat) + 1 + j := by
+  -- step 0 + step 1: the leading stepRightOnce (phase 0 → 2, head HOME → HOME+1)
+  obtain ⟨h0p, h0h, h0t⟩ := binToUnaryLoopFullScan_step0 w c0 hstart rfl (by omega)
+  set c1 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 1 with hc1
+  have hc1eq : c1 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 := by
+    rw [hc1, show (1 : Nat) = 0 + 1 from rfl, TM.runConfig_succ]; rfl
+  obtain ⟨h1p, h1h, h1t⟩ := binToUnaryLoopFullScan_step1 w c1
+    (i := c1.state.fst) (s := c1.state.snd) (by rw [hc1eq]; exact h0p) rfl
+  set c2 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 2 with hc2
+  have hc2eq : c2 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c1 := by
+    rw [hc2, show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_succ, hc1]
+  have h2p : (c2.state.fst : Nat) = 2 := by rw [hc2eq]; exact h1p
+  have h2h : (c2.head : Nat) = (c0.head : Nat) + 1 := by rw [hc2eq, h1h, hc1eq, h0h]
+  have h2t : c2.tape = c0.tape := by rw [hc2eq, h1t, hc1eq, h0t]
+  -- scan j zeros from phase 2 → phase 2 + j, head HOME+1+j
+  have hzeros2 : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c2.head : Nat) ≤ (q : Nat) → (q : Nat) < (c2.head : Nat) + j → c2.tape q = false := by
+    intro q hq1 hq2; rw [h2t]; rw [h2h] at hq1 hq2; exact hzeros q hq1 (by omega)
+  obtain ⟨hsp, hsh, hst⟩ := binToUnaryLoopFullScan_runConfig_scanning w c2 h2p j (le_of_lt hjw)
+    (by rw [h2h]; omega) hzeros2
+  set c2j := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c2 j with hc2j
+  -- divert on the lowest set bit (cell HOME+1+j) → phase w+3, head stays
+  have hbit : c2j.tape c2j.head = true := by
+    rw [hst, h2t]; exact hone c2j.head (by rw [hsh, h2h])
+  have hc2jp : (c2j.state.fst : Nat) = 2 + j := hsp
+  have hc2j_eq : c2j = TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + j) := by
+    rw [hc2j, hc2, ← TM.runConfig_add]
+  have hcompose : TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (j + 3)
+      = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c2j := by
+    rw [show (j + 3 : Nat) = (2 + j) + 1 from by omega, TM.runConfig_succ, ← hc2j_eq]
+  rw [hcompose]
+  refine ⟨?_, ?_⟩
+  · rw [binToUnaryLoopFullScan_stepConfig_divert_phase w c2j (i := c2j.state.fst) (s := c2j.state.snd)
+      hjw hc2jp rfl hbit]
+  · rw [binToUnaryLoopFullScan_stepConfig_divert_head w c2j (i := c2j.state.fst) (s := c2j.state.snd)
+      hjw hc2jp rfl hbit, hsh, h2h]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanScan.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanScan.lean
@@ -1,0 +1,116 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel
+
+/-!
+# `binToUnaryLoopFullScan` — loop-machine scan run (NP-verifier track — D2t-3 `ε`, `hbase` core)
+
+The `B = 0` scan on the loop machine: from composition phase `2` (the route-body start, after the
+leading `stepRightOnce`), reading `0`s, advance phase-by-phase to phase `2 + w` (the sound test's `B = 0`
+outcome = the `loopUntilSink` sink).  Each loop step peels `loopUntilSink` (`..._transition_body`, the
+phase is `< w + 2 = sink < w + 29 = accept`) to the body, then evaluates the two `seq` layers + the scan.
+
+**Progress classification (AGENTS.md): Infrastructure** — standard triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- **Loop scan step (read `0`), phase.**  At composition phase `2 + p` (`p < w`) reading `0`, advance to
+`2 + p + 1`. -/
+theorem binToUnaryLoopFullScan_stepConfig_scan_phase (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = 2 + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = 2 + p + 1 := by
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  have hge : ¬ (2 + p < 2) := by omega
+  rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+      binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+  simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, hi, hbit, hp, hne, hlt2,
+    hge, Nat.add_assoc]
+
+/-- **Loop scan step (read `0`), head.**  Advance the head by one. -/
+theorem binToUnaryLoopFullScan_stepConfig_scan_head (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = 2 + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false)
+    (hbound : (c.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat)
+      = (c.head : Nat) + 1 := by
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  have hge : ¬ (2 + p < 2) := by omega
+  rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+  have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.right := by
+    rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, hi, hbit, hp, hne,
+      hlt2, hge]
+  rw [hmove]
+  simp only [Configuration.moveHead, dif_pos hbound]
+
+/-- **Loop scan step (read `0`), tape.**  The tape is unchanged. -/
+theorem binToUnaryLoopFullScan_stepConfig_scan_tape (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} {p : Nat} (hp : p < w)
+    (hi : (i : Nat) = 2 + p) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hne : ¬ (p = w + 1) := by omega
+  have hlt2 : p < w + 2 := by omega
+  have hge : ¬ (2 + p < 2) := by omega
+  have hwrite : (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape
+      = c.write c.head false := by
+    rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, hi, hbit, hp, hne,
+      hlt2, hge]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+/-- **Loop scanning invariant.**  From `c0` at composition phase `2`, if the `j` cells from the head are
+all `0` (`j ≤ w`, in bounds), then after `j` steps the loop's composition phase is `2 + j`, the head is at
+`c0.head + j`, and the tape is unchanged. -/
+theorem binToUnaryLoopFullScan_runConfig_scanning (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 2) :
+    ∀ j : Nat, j ≤ w →
+      (c0.head : Nat) + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L →
+      (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+        (c0.head : Nat) ≤ (q : Nat) → (q : Nat) < (c0.head : Nat) + j → c0.tape q = false) →
+      (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 j).state).fst : Nat) = 2 + j
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 j).head : Nat)
+          = (c0.head : Nat) + j
+      ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 j).tape = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _ _; exact ⟨by simpa using hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj hb h0
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (by omega) (fun q hq1 hq2 => h0 q hq1 (by omega))
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 j with hc
+      have hbnd : (c.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L := by
+        rw [hhd]; omega
+      have hbit : c.tape c.head = false := by
+        rw [htp]; exact h0 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hpj : j < w := by omega
+      have hiph : (c.state.fst : Nat) = 2 + j := hph
+      refine ⟨?_, ?_, ?_⟩
+      · rw [binToUnaryLoopFullScan_stepConfig_scan_phase w c
+          (i := c.state.fst) (s := c.state.snd) hpj hiph rfl hbit]
+        omega
+      · rw [binToUnaryLoopFullScan_stepConfig_scan_head w c
+          (i := c.state.fst) (s := c.state.snd) hpj hiph rfl hbit hbnd]
+        omega
+      · rw [binToUnaryLoopFullScan_stepConfig_scan_tape w c
+          (i := c.state.fst) (s := c.state.snd) hpj hiph rfl hbit, htp]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanSeek.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanSeek.lean
@@ -155,6 +155,204 @@ theorem binToUnaryLoopFullScan_seek_w9 (w : Nat) {L : Nat}
     · subst hj; simp [Configuration.write]
     · simp [Configuration.write, hj]
 
+/-- **Seek scan step (phase `w+10`, read `0`)** = `selfLoopScanLeft` re-entry: scan one cell left, phase
+stays `w + 10`; tape unchanged. -/
+theorem binToUnaryLoopFullScan_seek_scan0 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 10)
+    (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 10
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat)
+          = (c.head : Nat) - 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 10 < 2) := by omega
+  have hge2 : ¬ (w + 8 < w + 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hbit, hge, hge2]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.left := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hbit, hge, hge2]
+    rw [hmove]
+    have hne0 : ¬ (c.head : Nat) = 0 := by omega
+    simp [Configuration.moveHead, hne0]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hbit, hge, hge2]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write, hbit]
+    · simp [Configuration.write, hj]
+
+/-- **Seek scan step (phase `w+10`, read `1`)** = `selfLoopScanLeft` stop on `U`'s seed: phase `w + 11`;
+head/tape unchanged. -/
+theorem binToUnaryLoopFullScan_seek_scan1 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 10)
+    (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 11
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 10 < 2) := by omega
+  have hge2 : ¬ (w + 8 < w + 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hbit, hge, hge2]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hbit, hge, hge2]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hbit, hge, hge2]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write, hbit]
+    · simp [Configuration.write, hj]
+
+/-- **Seek step (phase `w+11`)** = `selfLoopScanLeft` → `stepRightOnce` handoff: phase `w + 12`;
+head/tape unchanged. -/
+theorem binToUnaryLoopFullScan_seek_w11 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 11)
+    (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 12
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 11 < 2) := by omega
+  have hge2 : ¬ (w + 9 < w + 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Seek step (phase `w+12`)** = the final `stepRightOnce` move onto the sentinel: head `+1`,
+phase `w + 13`. -/
+theorem binToUnaryLoopFullScan_seek_w12 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 12)
+    (hstate : c.state = ⟨i, s⟩)
+    (hbound : (c.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 13
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat)
+          = (c.head : Nat) + 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 12 < 2) := by omega
+  have hge2 : ¬ (w + 10 < w + 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.right := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2]
+    rw [hmove]; simp only [Configuration.moveHead, dif_pos hbound]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Seek step (phase `w+13`)** = final `stepRightOnce` → seek-idle handoff: phase `w + 14`;
+head/tape unchanged. -/
+theorem binToUnaryLoopFullScan_seek_w13 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 13)
+    (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 14
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 13 < 2) := by omega
+  have hge2 : ¬ (w + 11 < w + 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Seek step (phase `w+14`)** = seek-idle → `binToUnaryBody` handoff: phase `w + 15` (body start);
+head/tape unchanged. -/
+theorem binToUnaryLoopFullScan_seek_w14 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 14)
+    (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 14 < 2) := by omega
+  have hge2 : ¬ (w + 12 < w + 2) := by omega
+  have hbs : (binToUnaryBody.startPhase : Nat) = 0 := by decide
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2, hbs]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2, hbs]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, selfLoopScanLeft, hi, hge, hge2, hbs]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanSeek.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanSeek.lean
@@ -385,6 +385,117 @@ theorem binToUnaryLoopFullScan_seek_w14 (w : Nat) {L : Nat}
     · subst hj; simp [Configuration.write]
     · simp [Configuration.write, hj]
 
+/-! ### Seek home run-through (composition) -/
+
+/-- A helper: from a config at composition phase `w + 6`, run a single loop step and read off the result
+of the named seek single-step. -/
+private theorem stepHead_eq {w : Nat} {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (n : Nat) :
+    TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (n + 1)
+      = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM)
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c n) := by
+  rw [TM.runConfig_succ]
+
+/-- **Seek home run-through.**  From the seek start (composition phase `w + 6`, head `home + 2 + j` with
+the sentinel at `home ≥ 1`), where `B`'s window + sentinel `[home, home + j]` are all `0` and `U`'s seed
+`home - 1` is `1`, the loop re-homes: after `j + 10` steps it reaches the body start (composition phase
+`w + 15`) with the head back at the sentinel `home` and the tape unchanged. -/
+theorem binToUnaryLoopFullScan_seek_home (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (home j : Nat)
+    (hphase : (c.state.fst : Nat) = w + 6) (hhome : 1 ≤ home)
+    (hhead : (c.head : Nat) = home + 2 + j)
+    (hb : home + 2 + j + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      home ≤ (q : Nat) → (q : Nat) ≤ home + j → c.tape q = false)
+    (hseed : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (q : Nat) = home - 1 → c.tape q = true) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (j + 10)).state).fst : Nat)
+      = w + 15
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (j + 10)).head : Nat) = home
+      ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (j + 10)).tape = c.tape := by
+  -- step w6 (head home+2+j -> home+1+j)
+  obtain ⟨p6, h6, t6⟩ := binToUnaryLoopFullScan_seek_w6 w c hphase rfl (by rw [hhead]; omega)
+  set c1 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 1 with hc1
+  have e1 : c1 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c := stepHead_eq c 0
+  -- step w7
+  obtain ⟨p7, h7, t7⟩ := binToUnaryLoopFullScan_seek_w7 w c1
+    (i := c1.state.fst) (s := c1.state.snd) (by rw [e1]; exact p6) rfl
+  set c2 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 2 with hc2
+  have e2 : c2 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c1 := by
+    rw [hc2, show (2:Nat) = 1+1 from rfl, TM.runConfig_succ, hc1]
+  -- step w8 (head home+1+j -> home+j)
+  have hh1 : (c1.head : Nat) = home + 1 + j := by rw [e1, h6, hhead]; omega
+  obtain ⟨p8, h8, t8⟩ := binToUnaryLoopFullScan_seek_w8 w c2
+    (i := c2.state.fst) (s := c2.state.snd) (by rw [e2]; exact p7) rfl
+    (by rw [e2, h7, hh1]; omega)
+  set c3 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 3 with hc3
+  have e3 : c3 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c2 := by
+    rw [hc3, show (3:Nat) = 2+1 from rfl, TM.runConfig_succ, hc2]
+  -- step w9
+  have hh2 : (c2.head : Nat) = home + 1 + j := by rw [e2, h7, hh1]
+  obtain ⟨p9, h9, t9⟩ := binToUnaryLoopFullScan_seek_w9 w c3
+    (i := c3.state.fst) (s := c3.state.snd) (by rw [e3]; exact p8) rfl
+  set c4 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 4 with hc4
+  have e4 : c4 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c3 := by
+    rw [hc4, show (4:Nat) = 3+1 from rfl, TM.runConfig_succ, hc3]
+  have hh3 : (c3.head : Nat) = home + j := by rw [e3, h8, hh2]; omega
+  have p4 : (c4.state.fst : Nat) = w + 10 := by rw [e4, p9]
+  have hh4 : (c4.head : Nat) = home + j := by rw [e4, h9, hh3]
+  have t4 : c4.tape = c.tape := by rw [e4, t9, e3, t8, e2, t7, e1, t6]
+  -- scanLeft over [home, home+j] (j+1 zeros): head home+j -> home-1, phase stays w+10
+  have hzeros4 : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c4.head : Nat) - (j + 1) < (q : Nat) → (q : Nat) ≤ (c4.head : Nat) → c4.tape q = false := by
+    intro q hq1 hq2; rw [t4]; rw [hh4] at hq1 hq2; exact hzeros q (by omega) (by omega)
+  obtain ⟨ps, hs, ts⟩ := binToUnaryLoopFullScan_seek_scanLeft_run w c4 p4 (j + 1)
+    (by rw [hh4]; omega) hzeros4
+  set c5 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c4 (j + 1) with hc5
+  have hh5 : (c5.head : Nat) = home - 1 := by rw [hs, hh4]; omega
+  have t5 : c5.tape = c.tape := by rw [ts, t4]
+  -- scan1 at the U-seed (home-1): phase w+11, head stays
+  have hbit5 : c5.tape c5.head = true := by rw [t5]; exact hseed c5.head (by rw [hh5])
+  obtain ⟨q1, k1, u1⟩ := binToUnaryLoopFullScan_seek_scan1 w c5
+    (i := c5.state.fst) (s := c5.state.snd) ps rfl hbit5
+  -- assemble: c (j+10) = stepConfig (c5 stepped once) then steps w11..w14
+  set c6 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (4 + (j + 1) + 1) with hc6
+  have e6 : c6 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c5 := by
+    rw [hc6, TM.runConfig_succ, hc5, hc4, ← TM.runConfig_add]
+  have p6' : (c6.state.fst : Nat) = w + 11 := by rw [e6]; exact q1
+  have hh6 : (c6.head : Nat) = home - 1 := by rw [e6, k1, hh5]
+  have t6' : c6.tape = c.tape := by rw [e6, u1, t5]
+  obtain ⟨pa, ka, ua⟩ := binToUnaryLoopFullScan_seek_w11 w c6
+    (i := c6.state.fst) (s := c6.state.snd) p6' rfl
+  set c7 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (4 + (j + 1) + 1 + 1) with hc7
+  have e7 : c7 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c6 := by
+    rw [hc7, show (4+(j+1)+1+1 : Nat) = (4+(j+1)+1)+1 from rfl, TM.runConfig_succ, hc6]
+  have p7' : (c7.state.fst : Nat) = w + 12 := by rw [e7]; exact pa
+  have hh7 : (c7.head : Nat) = home - 1 := by rw [e7, ka, hh6]
+  have t7' : c7.tape = c.tape := by rw [e7, ua, t6']
+  obtain ⟨pb, kb, ub⟩ := binToUnaryLoopFullScan_seek_w12 w c7
+    (i := c7.state.fst) (s := c7.state.snd) p7' rfl (by rw [hh7]; omega)
+  set c8 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (4 + (j + 1) + 1 + 1 + 1) with hc8
+  have e8 : c8 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c7 := by
+    rw [hc8, show (4+(j+1)+1+1+1 : Nat) = (4+(j+1)+1+1)+1 from rfl, TM.runConfig_succ, hc7]
+  have p8' : (c8.state.fst : Nat) = w + 13 := by rw [e8]; exact pb
+  have hh8 : (c8.head : Nat) = home := by rw [e8, kb, hh7]; omega
+  have t8' : c8.tape = c.tape := by rw [e8, ub, t7']
+  obtain ⟨pc, kc, uc⟩ := binToUnaryLoopFullScan_seek_w13 w c8
+    (i := c8.state.fst) (s := c8.state.snd) p8' rfl
+  set c9 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (4 + (j + 1) + 1 + 1 + 1 + 1) with hc9
+  have e9 : c9 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c8 := by
+    rw [hc9, show (4+(j+1)+1+1+1+1 : Nat) = (4+(j+1)+1+1+1)+1 from rfl, TM.runConfig_succ, hc8]
+  have p9' : (c9.state.fst : Nat) = w + 14 := by rw [e9]; exact pc
+  have hh9 : (c9.head : Nat) = home := by rw [e9, kc, hh8]
+  have t9' : c9.tape = c.tape := by rw [e9, uc, t8']
+  obtain ⟨pd, kd, ud⟩ := binToUnaryLoopFullScan_seek_w14 w c9
+    (i := c9.state.fst) (s := c9.state.snd) p9' rfl
+  have hfin : TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (j + 10)
+      = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c9 := by
+    rw [hc9, show (j + 10 : Nat) = (4 + (j + 1) + 1 + 1 + 1 + 1) + 1 from by omega, TM.runConfig_succ]
+  rw [hfin]
+  refine ⟨pd, ?_, ?_⟩
+  · rw [kd, hh9]
+  · rw [ud, t9']
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanSeek.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanSeek.lean
@@ -222,6 +222,38 @@ theorem binToUnaryLoopFullScan_seek_scan1 (w : Nat) {L : Nat}
     · subst hj; simp [Configuration.write, hbit]
     · simp [Configuration.write, hj]
 
+/-- **Leftward scanning invariant.**  From `c0` at composition phase `w + 10`, if the `k` cells
+`(c0.head - k, c0.head]` are all `0` (and `k ≤ c0.head`), then after `k` steps the loop is still at
+phase `w + 10`, the head has moved left to `c0.head - k`, and the tape is unchanged. -/
+theorem binToUnaryLoopFullScan_seek_scanLeft_run (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = w + 10) :
+    ∀ k : Nat, k ≤ (c0.head : Nat) →
+      (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+        (c0.head : Nat) - k < (q : Nat) → (q : Nat) ≤ (c0.head : Nat) → c0.tape q = false) →
+      (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).state).fst : Nat) = w + 10
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head : Nat)
+          = (c0.head : Nat) - k
+      ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).tape = c0.tape := by
+  intro k
+  induction k with
+  | zero => intro _ _; exact ⟨by simpa using hphase, by simp, rfl⟩
+  | succ k ih =>
+      intro hk h0
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (fun q hq1 hq2 => h0 q (by omega) hq2)
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k with hc
+      have hhd' : (c.head : Nat) = (c0.head : Nat) - k := hhd
+      have hheadpos : 0 < (c.head : Nat) := by rw [hhd']; omega
+      have hbit : c.tape c.head = false := by
+        rw [htp]; exact h0 c.head (by rw [hhd']; omega) (by rw [hhd']; omega)
+      have hiph : (c.state.fst : Nat) = w + 10 := hph
+      obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_seek_scan0 w c
+        (i := c.state.fst) (s := c.state.snd) hiph rfl hbit hheadpos
+      refine ⟨sp, ?_, ?_⟩
+      · rw [sh, hhd']; omega
+      · rw [st, htp]
+
 /-- **Seek step (phase `w+11`)** = `selfLoopScanLeft` → `stepRightOnce` handoff: phase `w + 12`;
 head/tape unchanged. -/
 theorem binToUnaryLoopFullScan_seek_w11 (w : Nat) {L : Nat}

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanSeek.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanSeek.lean
@@ -1,0 +1,160 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanStep2
+import Pnp4.Frontier.ContractExpansion.TreeMCSPSeekHomeAfterRoute
+
+/-!
+# `binToUnaryLoopFullScan` — the seek-HOME run on the loop machine (NP-verifier track — D2t-3 `ε`, `hstep`)
+
+After the post-divert connector reaches the seek start (phase `w + 6`, head `HOME+2+j`),
+`seekHomeAfterRoute` re-homes the head to the sentinel `HOME`: two leftward steps (`HOME+2+j → HOME+j`),
+a leftward self-loop scan over `B`'s `0`-run + the sentinel down to `U`'s seed `1` (`HOME-1`), then one
+rightward step onto `HOME`.  Each loop step peels `loopUntilSink` and evaluates the four `seq` layers +
+`seekHomeAfterRoute`'s `seqList`.
+
+This brick ships the **single-step lemmas** of the seek region; the leftward scanning invariant and the
+home run-through are the follow-up.
+
+**Progress classification (AGENTS.md): Infrastructure** — standard triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- **Seek step (phase `w+6`)** = `seekHomeAfterRoute`'s first `stepLeftOnce` move: step one cell left,
+reaching phase `w + 7`; tape unchanged. -/
+theorem binToUnaryLoopFullScan_seek_w6 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 6)
+    (hstate : c.state = ⟨i, s⟩) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 7
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat)
+          = (c.head : Nat) - 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 6 < 2) := by omega
+  have hge2 : ¬ (w + 4 < w + 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.left := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    rw [hmove]
+    have hne0 : ¬ (c.head : Nat) = 0 := by omega
+    simp [Configuration.moveHead, hne0]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Seek step (phase `w+7`)** = first→second `stepLeftOnce` handoff: phase `w + 8`; head/tape unchanged. -/
+theorem binToUnaryLoopFullScan_seek_w7 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 7)
+    (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 8
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 7 < 2) := by omega
+  have hge2 : ¬ (w + 5 < w + 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Seek step (phase `w+8`)** = second `stepLeftOnce` move: step one cell left, phase `w + 9`. -/
+theorem binToUnaryLoopFullScan_seek_w8 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 8)
+    (hstate : c.state = ⟨i, s⟩) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 9
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat)
+          = (c.head : Nat) - 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 8 < 2) := by omega
+  have hge2 : ¬ (w + 6 < w + 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.left := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    rw [hmove]
+    have hne0 : ¬ (c.head : Nat) = 0 := by omega
+    simp [Configuration.moveHead, hne0]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Seek step (phase `w+9`)** = second `stepLeftOnce` → `selfLoopScanLeft` handoff: phase `w + 10`;
+head/tape unchanged. -/
+theorem binToUnaryLoopFullScan_seek_w9 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 9)
+    (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 10
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 9 < 2) := by omega
+  have hge2 : ¬ (w + 7 < w + 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+      bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, seqList, seekHomeAfterRoute, bZeroFullScanRouteBody,
+        bZeroFullScan, stepRightOnce, stepLeftOnce, hi, hge, hge2]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanStep2.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanStep2.lean
@@ -1,0 +1,139 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
+
+/-!
+# `binToUnaryLoopFullScan` — the `B > 0` post-divert `stepRightOnce` connector (D2t-3 `ε`, `hstep`)
+
+After the scan diverts on `B`'s lowest set bit (phase `w + 3`, head `HOME+1+j`), the loop body's second
+`stepRightOnce` steps the head one cell right to `HOME+2+j` — the discriminator-style position the proven
+`seekHomeAfterRoute` re-homes from — reaching the seek start (phase `w + 6`).  Three loop steps: the
+route-body→stepRight handoff (`w+3 → w+4`), the rightward move (`w+4 → w+5`), and the
+stepRight→seek handoff (`w+5 → w+6`).
+
+**Progress classification (AGENTS.md): Infrastructure** — standard triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- **Loop handoff (phase `w+3 → w+4`)**: route-body accept hands off into the second `stepRightOnce`;
+head and tape unchanged. -/
+theorem binToUnaryLoopFullScan_step_w3 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 3)
+    (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 4
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 3 < 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, stepRightOnce, hi, hge]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, stepRightOnce, hi, hge]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, stepRightOnce, hi, hge]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Loop move (phase `w+4 → w+5`)**: the second `stepRightOnce`'s rightward move, head `+1`. -/
+theorem binToUnaryLoopFullScan_step_w4 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 4)
+    (hstate : c.state = ⟨i, s⟩)
+    (hbound : (c.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 5
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat)
+          = (c.head : Nat) + 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 4 < 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, stepRightOnce, hi, hge]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.right := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, stepRightOnce, hi, hge]
+    rw [hmove]; simp only [Configuration.moveHead, dif_pos hbound]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, stepRightOnce, hi, hge]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **Loop handoff (phase `w+5 → w+6`)**: the second `stepRightOnce` hands off into `seekHomeAfterRoute`;
+head and tape unchanged. -/
+theorem binToUnaryLoopFullScan_step_w5 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit} (hi : (i : Nat) = w + 5)
+    (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 6
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  have hge : ¬ (w + 5 < 2) := by omega
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, stepRightOnce, hi, hge]
+    omega
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+      simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, stepRightOnce, hi, hge]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head)]
+    have hb : ((binToUnaryLoopBodyFullScan w).transition i () (c.tape c.head)).2.2.1 = c.tape c.head := by
+      simp [binToUnaryLoopBodyFullScan, seq, bZeroFullScanRouteBody, bZeroFullScan, stepRightOnce, hi, hge]
+    rw [hb]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+/-- **`B > 0` post-divert connector.**  From phase `w + 3` (head at the set bit `HOME+1+j`), after `3`
+steps the loop reaches the seek start (phase `w + 6`) with the head one cell further right (`HOME+2+j`)
+and the tape unchanged. -/
+theorem binToUnaryLoopFullScan_runConfig_postDivert (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    (hstart : (c.state.fst : Nat) = w + 3)
+    (hbound : (c.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 3).state.fst : Nat) = w + 6
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 3).head : Nat)
+          = (c.head : Nat) + 1
+      ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 3).tape = c.tape := by
+  obtain ⟨p0, h0, t0⟩ := binToUnaryLoopFullScan_step_w3 w c hstart rfl
+  set c1 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 1 with hc1
+  have hc1eq : c1 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c := by
+    rw [hc1, show (1 : Nat) = 0 + 1 from rfl, TM.runConfig_succ]; rfl
+  obtain ⟨p1, h1, t1⟩ := binToUnaryLoopFullScan_step_w4 w c1 (i := c1.state.fst) (s := c1.state.snd)
+    (by rw [hc1eq]; exact p0) rfl (by rw [hc1eq, h0]; exact hbound)
+  set c2 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 2 with hc2
+  have hc2eq : c2 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c1 := by
+    rw [hc2, show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_succ, hc1]
+  obtain ⟨p2, h2, t2⟩ := binToUnaryLoopFullScan_step_w5 w c2 (i := c2.state.fst) (s := c2.state.snd)
+    (by rw [hc2eq]; exact p1) rfl
+  have hcompose : TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c 3
+      = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c2 := by
+    rw [show (3 : Nat) = 2 + 1 from rfl, TM.runConfig_succ, hc2]
+  rw [hcompose]
+  refine ⟨p2, ?_, ?_⟩
+  · rw [h2, hc2eq, h1, hc1eq, h0]
+  · rw [t2, hc2eq, t1, hc1eq, t0]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -100,6 +100,11 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanNested
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3872,6 +3877,12 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_numPhases
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_acceptPhase_val
+-- D2t-3 ε closure: sound-loop scan run-through + hbase (B=0 -> sink) + B>0 scan-to-divert.
+#check @Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_seqNested_runConfig_zero
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_transition_body
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_scanning
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_hbase
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -90,6 +90,11 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroTest
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanComposition
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanNested
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -655,6 +660,12 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_numPhases
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_numPhases
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_acceptPhase_val
+-- D2t-3 ε closure: sound-loop scan run-through + hbase (B=0 -> sink) + B>0 scan-to-divert.
+#print axioms Pnp4.Frontier.ContractExpansion.bZeroFullScanRouteBody_seqNested_runConfig_zero
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_acceptPhase_val
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_hbase
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
## Summary

Continues D2t-3's ε closure on the **sound** zero-test (`bZeroFullScan`, merged in #1583/#1584).
Five hole-free bricks; the **`B = 0` half of `ε` is now fully closed** on the loop machine, and the
`B > 0` half is driven to the divert.

* **nested-lift** (`TreeMCSPBZeroFullScanNested.lean`) — `bZeroFullScanRouteBody` run-through at composition
  depth 2 (`P2∘P1`), the position it occupies in the loop body.
* **peel + accept-phase** (`TreeMCSPBinToUnaryLoopFullScanPeel.lean`) — `binToUnaryLoopBodyFullScan_acceptPhase_val`
  (`= w + 29`) and `binToUnaryLoopFullScan_transition_body` (away from accept `w+29` / sink `w+2`, the loop
  runs the body verbatim).
* **scan run** (`TreeMCSPBinToUnaryLoopFullScanScan.lean`) — loop-machine scan single-steps + scanning
  invariant (from composition phase `2`, `j ≤ w` zeros ⇒ phase `2 + j`).
* **hbase** (`TreeMCSPBinToUnaryLoopFullScanHbase.lean`) — **`binToUnaryLoopFullScan_runConfig_hbase`**: from
  the loop start with `counterValue (HOME+1) w = 0`, the loop reaches the sink phase `w + 2` after `2 + w`
  steps (leading `stepRightOnce` + width-`w` full scan over all-`0` cells; uses δ1 for the all-`0` window).
  This is `loopUntilSink_reachesSink`'s `hbase` for the sound loop.
* **pos run** (`TreeMCSPBinToUnaryLoopFullScanPos.lean`) — `binToUnaryLoopFullScan_runConfig_pos`: from the
  loop start with `B`'s low `j` cells `0` and the cell at `HOME+1+j` set (`j < w`), after `j + 3` steps the
  loop reaches phase `w + 3` (the route-body's `B > 0` accept) with the head on the set bit.

## Scope

The `B = 0 → sink` path is complete (`hbase`).  The remaining `ε` work — `hstep`'s re-home
(`seekHomeAfterRoute` run-through on the loop machine) + `binToUnaryBody` one-pass run-through (the
`≈ 1000`-line analogues of the Rehome lifts) + the loop back-edge with `counterValue − 1`, then
`loopUntilSink_reachesSink` and the `ζ` bridge `|U| = value B` — is the follow-up.

## Verification

`./scripts/check.sh` → **17/17 PASS**; `lake build PnP3 Pnp4` green.  All new surfaces carry only the
standard `[propext, Classical.choice, Quot.sound]` triple (audited in `AxiomsAudit`, surfaced in
`AlgorithmsToLowerBoundsSurfaceTests`).

**Progress classification (AGENTS.md): Infrastructure.**  **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_