### PR TITLE
NP-verifier infrastructure: composition lemmas and loop combinators

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -351,6 +351,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -344,6 +344,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroFullScanNested,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -347,6 +347,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -346,6 +346,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyStep,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -348,6 +348,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -350,6 +350,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterDecodeFin,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -345,6 +345,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -349,6 +349,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -353,6 +353,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterDecodeFin,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanCorrect,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -350,6 +350,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanBodyBridge.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanBodyBridge.lean
@@ -1,0 +1,144 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel
+
+/-!
+# `binToUnaryLoopFullScan` body bridge — collapsing the depth-4 nesting (NP-verifier track — D2t-3 `ε`)
+
+`hstep`'s body leg, foundational tool.  The sound loop body
+`binToUnaryLoopBodyFullScan w = seq stepRightOnce (seq (bZeroFullScanRouteBody w)
+  (seq stepRightOnce (seq seekHomeAfterRoute binToUnaryBody)))`
+buries `binToUnaryBody` at **`seq`-depth 4**, occupying composition phases `w + 15 .. w + 29` (its
+local phases `0 .. 14` shifted up by `stepRightOnce (2) + bZeroFullScanRouteBody (w+2) + stepRightOnce (2)
++ seekHomeAfterRoute (9) = w + 15`).
+
+On the **Rehome** loop the body sits at depth 2 with *concrete* phases `15 .. 29`, so each single step is
+re-derived by one `simp [seq, seqList, …]` that evaluates the nested routing by computation
+(`TreeMCSPBinToUnaryLoopRehomeBodyStep.lean`).  Here the phase `w + 15 + k` is **symbolic in `w`**, so
+that `simp` cannot decide `i.val < P1.numPhases` (e.g. `P1.numPhases = w + 2`) and whnf-blows up.
+
+This module supplies the missing tool: a **bridge** that, via four `seq_transition_P2_*` lifts (each with
+`omega`-discharged region/bound side-conditions that tolerate the symbolic `w`), rewrites the loop body's
+transition at composition phase `w + 15 + k` (`k < 15`) to `binToUnaryBody`'s transition at its local
+phase `k` — the phase shifted up by `w + 15`, the local state / written bit / head move inherited
+verbatim.  Composed with the loop peel (`binToUnaryLoopFullScan_transition_body`) and `binToUnaryBody`'s
+*concrete*-phase transition (which `decide`/`simp` then evaluate), it turns each body single step into the
+short, symbolic-`w`-robust form — the FullScan analogue of the Rehome body's per-step `simp`.
+
+**Progress classification (AGENTS.md): Infrastructure** — a transition-rewrite lemma toward the
+NP-membership leg; it proves no run behaviour and builds no verifier.  Standard
+`[propext, Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+set_option linter.unusedSimpArgs false in
+/-- **Body bridge — phase.**  At composition phase `w + 15 + k` (`k < 15`) the loop body's transition
+advances to phase `w + 15 + (binToUnaryBody.transition ⟨k⟩ s b).fst` — `binToUnaryBody`'s local next
+phase shifted up by `w + 15`. -/
+theorem binToUnaryLoopBodyFullScan_atBody_phase (w k : Nat) (hk : k < 15)
+    {i : Fin (binToUnaryLoopBodyFullScan w).numPhases}
+    (hi : (i : Nat) = w + 15 + k) (s : Unit) (b : Bool) :
+    ((binToUnaryLoopBodyFullScan w).transition i s b).fst.val
+      = w + 15 + (binToUnaryBody.transition ⟨k, by rw [binToUnaryBody_numPhases]; exact hk⟩ s b).fst.val := by
+  unfold binToUnaryLoopBodyFullScan
+  rw [seq_transition_P2_phase stepRightOnce
+        (seq (bZeroFullScanRouteBody w) (seq stepRightOnce (seq seekHomeAfterRoute binToUnaryBody)))
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  rw [seq_transition_P2_phase (bZeroFullScanRouteBody w)
+        (seq stepRightOnce (seq seekHomeAfterRoute binToUnaryBody))
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  rw [seq_transition_P2_phase stepRightOnce (seq seekHomeAfterRoute binToUnaryBody)
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  rw [seq_transition_P2_phase seekHomeAfterRoute binToUnaryBody
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  simp only [stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases, seekHomeAfterRoute_numPhases]
+  simp only [show (↑i - 2 - (w + 2) - 2 - 9 : Nat) = k from by omega]
+  omega
+
+set_option linter.unusedSimpArgs false in
+/-- **Body bridge — written bit.**  At composition phase `w + 15 + k` (`k < 15`) the loop body writes the
+bit `binToUnaryBody`'s transition would write at local phase `k`. -/
+theorem binToUnaryLoopBodyFullScan_atBody_bit (w k : Nat) (hk : k < 15)
+    {i : Fin (binToUnaryLoopBodyFullScan w).numPhases}
+    (hi : (i : Nat) = w + 15 + k) (s : Unit) (b : Bool) :
+    ((binToUnaryLoopBodyFullScan w).transition i s b).snd.snd.fst
+      = (binToUnaryBody.transition ⟨k, by rw [binToUnaryBody_numPhases]; exact hk⟩ s b).snd.snd.fst := by
+  unfold binToUnaryLoopBodyFullScan
+  rw [seq_transition_P2_bit stepRightOnce
+        (seq (bZeroFullScanRouteBody w) (seq stepRightOnce (seq seekHomeAfterRoute binToUnaryBody)))
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  rw [seq_transition_P2_bit (bZeroFullScanRouteBody w)
+        (seq stepRightOnce (seq seekHomeAfterRoute binToUnaryBody))
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  rw [seq_transition_P2_bit stepRightOnce (seq seekHomeAfterRoute binToUnaryBody)
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  rw [seq_transition_P2_bit seekHomeAfterRoute binToUnaryBody
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  simp only [stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases, seekHomeAfterRoute_numPhases]
+  simp only [show (↑i - 2 - (w + 2) - 2 - 9 : Nat) = k from by omega]
+
+set_option linter.unusedSimpArgs false in
+/-- **Body bridge — head move.**  At composition phase `w + 15 + k` (`k < 15`) the loop body moves the
+head as `binToUnaryBody`'s transition would at local phase `k`. -/
+theorem binToUnaryLoopBodyFullScan_atBody_move (w k : Nat) (hk : k < 15)
+    {i : Fin (binToUnaryLoopBodyFullScan w).numPhases}
+    (hi : (i : Nat) = w + 15 + k) (s : Unit) (b : Bool) :
+    ((binToUnaryLoopBodyFullScan w).transition i s b).snd.snd.snd
+      = (binToUnaryBody.transition ⟨k, by rw [binToUnaryBody_numPhases]; exact hk⟩ s b).snd.snd.snd := by
+  unfold binToUnaryLoopBodyFullScan
+  rw [seq_transition_P2_move stepRightOnce
+        (seq (bZeroFullScanRouteBody w) (seq stepRightOnce (seq seekHomeAfterRoute binToUnaryBody)))
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  rw [seq_transition_P2_move (bZeroFullScanRouteBody w)
+        (seq stepRightOnce (seq seekHomeAfterRoute binToUnaryBody))
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  rw [seq_transition_P2_move stepRightOnce (seq seekHomeAfterRoute binToUnaryBody)
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  rw [seq_transition_P2_move seekHomeAfterRoute binToUnaryBody
+        (h2 := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega)
+        (hi_lt := by simp only [Fin.val_mk, stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases,
+          seekHomeAfterRoute_numPhases, binToUnaryBody_numPhases, seq_numPhases]; omega) s b]
+  simp only [stepRightOnce_numPhases, bZeroFullScanRouteBody_numPhases, seekHomeAfterRoute_numPhases]
+  simp only [show (↑i - 2 - (w + 2) - 2 - 9 : Nat) = k from by omega]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanBodyRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanBodyRun.lean
@@ -1,0 +1,623 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyStep
+
+/-!
+# `(binToUnaryLoopFullScan w)` body lift — run-through, the `onePass` HOME→HOME engine (NP-verifier track — D2t-3 `ε`)
+
+`hstep`'s body leg.  Building on the single steps (`TreeMCSPBinToUnaryLoopFullScanBodyStep.lean`), this
+module composes all seven `binToUnaryBody` elements into the full one-pass engine **directly on the loop
+machine** at offset `+15`, mirroring `binToUnaryBody`'s `lead2 → afterDecrement → … → afterScanRight7 →
+onePass` segments (identical tape predicates — they depend only on head positions, which are unchanged —
+and step counts; only the phases shift `+15` and the machine becomes `(binToUnaryLoopFullScan w)`).
+
+From HOME (phase `15`, head on the sentinel) with `B`'s lowest set bit at offset `j` and `U = 1^u` to the
+left, one pass: `stepRight` onto `b₀`, **decrement** `B` (borrow-flip the `j` low zeros to `1`, clear bit
+`j`), `stepLeft`, **scanLeft** back over the flipped run to the sentinel, `stepLeft` onto `U`'s right end,
+**append** a fresh `1` at `U`'s left boundary `head−u−1`, **scanRight** back over the now-`u+1`-long `U`
+to the sentinel — reaching the loop body's **accept phase `29`** (the `loopUntilSink` back-edge target)
+with the head **back at HOME** and the tape holding `(B − 1, 1^(u+1))`.
+
+The four scan inductions (`binToUnaryLoopFullScan_body_{decrement,scanLeft,append,scanRight}_scanning`) are
+re-derived from this module's bit-conditional single steps; the segment lemmas chain them with the
+moves/handoffs up to the headline `binToUnaryLoopFullScan_body_runConfig_onePass`.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-! ### Lead-in: `stepRight` onto `B`'s low cell (phases `15 → 17`) -/
+
+/-- From HOME (phase `15`, head on the sentinel), after `2` steps the loop is at phase `17` (the decrement
+start), head advanced one cell right onto `B`'s low cell `b₀`, tape unchanged. -/
+theorem binToUnaryLoopFullScan_body_runConfig_lead2 (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (hbnd : (c0.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 2).state).fst : Nat) = w + 17
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 2).head : Nat) = (c0.head : Nat) + 1
+      ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 2).tape = c0.tape := by
+  rw [show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_add, TM.runConfig_one, TM.runConfig_one]
+  obtain ⟨h1p, h1h, h1t⟩ := binToUnaryLoopFullScan_body_w15 w c0 (i := c0.state.fst) (s := c0.state.snd)
+    hphase rfl hbnd
+  set c1 := TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 with hc1
+  clear_value c1
+  obtain ⟨h2p, h2h, h2t⟩ := binToUnaryLoopFullScan_body_w16 w c1 (i := c1.state.fst) (s := c1.state.snd)
+    h1p rfl
+  exact ⟨h2p, by rw [h2h, h1h], by rw [h2t, h1t]⟩
+
+/-! ### Element 1 — decrement: the borrow scan (phase `17`) -/
+
+/-- **Decrement borrow scan.**  From phase `17` with the `k` cells `[head, head + k)` all `0`, after any
+`m ≤ k` borrow steps the loop is still in phase `17`, the head has advanced `m` cells right, and those `m`
+cells are flipped to `1` (tape elsewhere unchanged).  Re-derived from `step17_zero`. -/
+theorem binToUnaryLoopFullScan_body_decrement_scanning (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hstart : (c0.state.fst : Nat) = w + 17)
+    (k : Nat) (hbnd : (c0.head : Nat) + k < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + k → c0.tape p = false) :
+    ∀ m, m ≤ k →
+      (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 m).state).fst : Nat) = w + 17
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 m).head : Nat) = (c0.head : Nat) + m
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 m).tape p
+            = (if (c0.head : Nat) ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + m then true
+                else c0.tape p) := by
+  intro m
+  induction m with
+  | zero => intro _; refine ⟨hstart, by simp, ?_⟩; intro p; simp
+  | succ m ih =>
+      intro hm
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega)
+      have hbit : (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 m).tape
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 m).head = false := by
+        rw [htp, hhd]
+        rw [if_neg (by omega)]
+        exact hzeros _ (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hbnd' : ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 m).head : Nat) + 1
+          < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L := by rw [hhd]; omega
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 m with hc
+      clear_value c
+      obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w17_zero w c
+        (i := c.state.fst) (s := c.state.snd) hph rfl hbit hbnd'
+      refine ⟨sp, by rw [sh, hhd]; omega, ?_⟩
+      intro p
+      rw [st]
+      by_cases hjp : p = c.head
+      · subst hjp; rw [Configuration.write, dif_pos rfl, hhd, if_pos ⟨by omega, by omega⟩]
+      · rw [Configuration.write, dif_neg hjp, htp p]
+        by_cases hlo : (c0.head : Nat) ≤ (p : Nat)
+        · by_cases hhi : (p : Nat) < (c0.head : Nat) + m
+          · rw [if_pos ⟨hlo, hhi⟩, if_pos ⟨hlo, by omega⟩]
+          · rw [if_neg (by tauto), if_neg ?_]
+            have : (p : Nat) ≠ (c0.head : Nat) + m := by
+              intro he; apply hjp; apply Fin.ext; rw [hhd]; omega
+            rintro ⟨_, hcontra⟩; omega
+        · rw [if_neg (by tauto), if_neg (by tauto)]
+
+/-- **After the decrement** (phases `15 → 18`).  From HOME with `B`'s low cells `[head+1, head+1+j)` all
+`0` and cell `head+1+j` set (`j` = lowest set bit), after `2 + (j + 1)` steps the loop is at phase `18`
+(decrement accept), head on the cleared cell `head+1+j`, and `B`'s low `j` cells flipped to `1` with cell
+`head+1+j` cleared.  Composes `lead2` + the borrow scan + the read-`1` stop step. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterDecrement (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1))).state).fst : Nat) = w + 18
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1))).head : Nat)
+          = (c0.head : Nat) + 1 + j
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1))).tape p
+            = (if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hLp, hLh, hLt⟩ := binToUnaryLoopFullScan_body_runConfig_lead2 w c0 hphase (by omega)
+  rw [show (2 + (j + 1)) = 2 + j + 1 from by omega, TM.runConfig_succ, TM.runConfig_add]
+  -- Scan the j zeros from `runConfig c0 2` (phase 17, head c0.head+1).
+  obtain ⟨hSp, hSh, hSt⟩ := binToUnaryLoopFullScan_body_decrement_scanning w
+    (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 2) hLp j
+    (by rw [hLh]; omega)
+    (by
+      intro p hp1 hp2; rw [hLt]
+      exact h_zeros p (by rw [hLh] at hp1; omega) (by rw [hLh] at hp2; omega)) j (le_refl j)
+  set cS := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM)
+      (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 2) j with hcS
+  have hSp' : (cS.state.fst : Nat) = w + 17 := hSp
+  have hSh' : (cS.head : Nat) = (c0.head : Nat) + 1 + j := by rw [hcS, hSh, hLh]
+  have hSt' : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L), cS.tape p
+      = (if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+          else c0.tape p) := by
+    intro p; rw [hcS, hSt p, hLh, hLt]
+  clear_value cS
+  have hbitS : cS.tape cS.head = true := by
+    rw [hSt', if_neg (by rw [hSh']; omega)]; exact h_one cS.head hSh'
+  obtain ⟨q1p, q1h, q1t⟩ := binToUnaryLoopFullScan_body_w17_one w cS
+    (i := cS.state.fst) (s := cS.state.snd) hSp' rfl hbitS
+  refine ⟨q1p, by rw [q1h, hSh'], ?_⟩
+  intro p
+  rw [q1t]
+  by_cases hjp : p = cS.head
+  · subst hjp; rw [Configuration.write, dif_pos rfl, hSh', if_neg (by omega), if_pos rfl]
+  · rw [Configuration.write, dif_neg hjp, hSt' p]
+    by_cases hlo : (c0.head : Nat) + 1 ≤ (p : Nat)
+    · by_cases hhi : (p : Nat) < (c0.head : Nat) + 1 + j
+      · rw [if_pos ⟨hlo, hhi⟩, if_pos ⟨hlo, hhi⟩]
+      · rw [if_neg (by tauto), if_neg (by tauto), if_neg ?_]
+        have : (p : Nat) ≠ (c0.head : Nat) + 1 + j := by
+          intro he; apply hjp; apply Fin.ext; rw [hSh']; omega
+        omega
+    · rw [if_neg (by tauto), if_neg (by tauto), if_neg (by omega)]
+
+/-- **After the decrement handoff** (phases `15 → 19`): one more step hands off out of the decrement to
+`stepLeft` (element 2, phase `19`); head still on the cleared cell, tape the decremented pattern. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterDecrHandoff (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1)).state).fst : Nat) = w + 19
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1)).head : Nat)
+          = (c0.head : Nat) + 1 + j
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1)).tape p
+            = (if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hAp, hAh, hAt⟩ := binToUnaryLoopFullScan_body_runConfig_afterDecrement w c0 hphase j hj h_zeros h_one
+  rw [TM.runConfig_succ]
+  set cA := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1)) with hcA
+  clear_value cA
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w18 w cA (i := cA.state.fst) (s := cA.state.snd) hAp rfl
+  exact ⟨sp, by rw [sh, hAh], by intro p; rw [st]; exact hAt p⟩
+
+/-- **After `stepLeft` (element 2)** (phases `15 → 20`): one left step off the cleared cell, reaching phase
+`20`; head `head + j` (on `B`'s flipped run), tape unchanged. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterStepLeft3 (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1)).state).fst : Nat) = w + 20
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1)).head : Nat)
+          = (c0.head : Nat) + j
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1)).tape p
+            = (if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ :=
+    binToUnaryLoopFullScan_body_runConfig_afterDecrHandoff w c0 hphase j hj h_zeros h_one
+  rw [TM.runConfig_succ]
+  set cH := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1) with hcH
+  clear_value cH
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w19 w cH (i := cH.state.fst) (s := cH.state.snd)
+    hHp rfl (by rw [hHh]; omega)
+  exact ⟨sp, by rw [sh, hHh]; omega, by intro p; rw [st]; exact hHt p⟩
+
+/-- **After the `stepLeft`→scanLeft handoff** (phases `15 → 21`): hands off into `selfLoopScanLeftOne`
+(element 3, phase `21`); head `head + j`, tape unchanged. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterStepLeft3Handoff (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1)).state).fst : Nat) = w + 21
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1)).head : Nat)
+          = (c0.head : Nat) + j
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1)).tape p
+            = (if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ := binToUnaryLoopFullScan_body_runConfig_afterStepLeft3 w c0 hphase j hj h_zeros h_one
+  rw [TM.runConfig_succ]
+  set cH := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1) with hcH
+  clear_value cH
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w20 w cH (i := cH.state.fst) (s := cH.state.snd) hHp rfl
+  exact ⟨sp, by rw [sh, hHh], by intro p; rw [st]; exact hHt p⟩
+
+/-! ### Element 3 — scanLeft: the leftward scan back to the sentinel (phase `21`) -/
+
+/-- **ScanLeft scan.**  From phase `21` with the `m` cells `(head − m, head]` all `1`, after any `k ≤ m`
+steps the loop is still in phase `21`, the head has retreated `k` cells left, and the tape is unchanged
+(a scan writes the `1` back).  Re-derived from `step21_one`. -/
+theorem binToUnaryLoopFullScan_body_scanLeft_scanning (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hstart : (c0.state.fst : Nat) = w + 21)
+    (m : Nat) (hm : m ≤ (c0.head : Nat))
+    (hones : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - m < (p : Nat) → (p : Nat) ≤ (c0.head : Nat) → c0.tape p = true) :
+    ∀ k, k ≤ m →
+      (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).state).fst : Nat) = w + 21
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head : Nat) = (c0.head : Nat) - k
+      ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).tape = c0.tape := by
+  intro k
+  induction k with
+  | zero => intro _; exact ⟨hstart, by simp, rfl⟩
+  | succ k ih =>
+      intro hk
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega)
+      have hbit : (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).tape
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head = true := by
+        rw [htp]; exact hones _ (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hhead : 0 < ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head : Nat) := by
+        rw [hhd]; omega
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k with hc
+      clear_value c
+      obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w21_one w c
+        (i := c.state.fst) (s := c.state.snd) hph rfl hbit hhead
+      exact ⟨sp, by rw [sh, hhd]; omega, by rw [st, htp]⟩
+
+/-- **After scanLeft (element 3)** (phases `15 → 22`).  From HOME the leftward scan retraces `B`'s flipped
+`1`-run (`j` cells) and stops on the sentinel, reaching phase `22` with the head **back at HOME**; tape
+the decremented pattern.  Composes `afterStepLeft3Handoff` + the scanLeft scan (`j` steps) + the read-`0`
+stop on the sentinel. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterScanLeft4 (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true)
+    (h_sentinel : c0.tape c0.head = false) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1))).state).fst : Nat) = w + 22
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1))).head : Nat)
+          = (c0.head : Nat)
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1))).tape p
+            = (if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ := binToUnaryLoopFullScan_body_runConfig_afterStepLeft3Handoff w c0 hphase j hj h_zeros h_one
+  rw [show (2 + (j + 1) + 1 + 1 + 1 + (j + 1)) = (2 + (j + 1) + 1 + 1 + 1) + j + 1 from by omega,
+    TM.runConfig_succ, TM.runConfig_add]
+  obtain ⟨hSp, hSh, hSt⟩ := binToUnaryLoopFullScan_body_scanLeft_scanning w
+    (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1)) hHp j
+    (by rw [hHh]; omega)
+    (by
+      intro p hp1 hp2
+      rw [hHt p, if_pos ⟨by rw [hHh] at hp1; omega, by rw [hHh] at hp2; omega⟩]) j (le_refl j)
+  set cS := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM)
+      (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1)) j with hcS
+  have hSp' : (cS.state.fst : Nat) = w + 21 := hSp
+  have hSh' : (cS.head : Nat) = (c0.head : Nat) := by rw [hSh, hHh]; omega
+  clear_value cS
+  have hbitS : cS.tape cS.head = false := by
+    have hfeq : cS.head = c0.head := Fin.ext hSh'
+    rw [hSt, hfeq, hHt c0.head, if_neg (by omega), if_neg (by omega)]; exact h_sentinel
+  obtain ⟨q0p, q0h, q0t⟩ := binToUnaryLoopFullScan_body_w21_zero w cS
+    (i := cS.state.fst) (s := cS.state.snd) hSp' rfl hbitS
+  refine ⟨q0p, by rw [q0h, hSh'], ?_⟩
+  intro p; rw [q0t, hSt]; exact hHt p
+
+/-- **After the scanLeft → stepLeft handoff** (phases `15 → 23`): hands off into the second home-seek
+`stepLeft` (element 4, phase `23`); head at HOME, tape the decremented pattern. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterScanLeft4Handoff (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true)
+    (h_sentinel : c0.tape c0.head = false) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1)).state).fst : Nat) = w + 23
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1)).head : Nat)
+          = (c0.head : Nat)
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1)).tape p
+            = (if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ :=
+    binToUnaryLoopFullScan_body_runConfig_afterScanLeft4 w c0 hphase j hj h_zeros h_one h_sentinel
+  rw [TM.runConfig_succ]
+  set cH := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1)) with hcH
+  clear_value cH
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w22 w cH (i := cH.state.fst) (s := cH.state.snd) hHp rfl
+  exact ⟨sp, by rw [sh, hHh], by intro p; rw [st]; exact hHt p⟩
+
+/-- **After `stepLeft` (element 4)** (phases `15 → 24`): one left step off the sentinel onto `U`'s right
+end, reaching phase `24`; head `head − 1`, tape unchanged.  Requires `0 < head` (the U-left layout
+invariant: HOME has at least a blank to its left). -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterStepLeft5 (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat)) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1)).state).fst : Nat) = w + 24
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1)).head : Nat)
+          = (c0.head : Nat) - 1
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1)).tape p
+            = (if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ :=
+    binToUnaryLoopFullScan_body_runConfig_afterScanLeft4Handoff w c0 hphase j hj h_zeros h_one h_sentinel
+  rw [TM.runConfig_succ]
+  set cH := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1) with hcH
+  clear_value cH
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w23 w cH (i := cH.state.fst) (s := cH.state.snd)
+    hHp rfl (by rw [hHh]; omega)
+  exact ⟨sp, by rw [sh, hHh], by intro p; rw [st]; exact hHt p⟩
+
+/-- **After the `stepLeft` → append handoff** (phases `15 → 25`): hands off into `selfLoopAppendLeftOne`
+(element 5, phase `25`, the append start); head at `U`'s right end `head − 1`, tape the decremented
+pattern.  This is the headline of the `B`-decrement half — `B` is decremented, the head is positioned to
+append a `1` to `U`. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterStepLeft5Handoff (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat)) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1)).state).fst : Nat) = w + 25
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1)).head : Nat)
+          = (c0.head : Nat) - 1
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1)).tape p
+            = (if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ :=
+    binToUnaryLoopFullScan_body_runConfig_afterStepLeft5 w c0 hphase j hj h_zeros h_one h_sentinel hHOME
+  rw [TM.runConfig_succ]
+  set cH := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1) with hcH
+  clear_value cH
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w24 w cH (i := cH.state.fst) (s := cH.state.snd) hHp rfl
+  exact ⟨sp, by rw [sh, hHh], by intro p; rw [st]; exact hHt p⟩
+
+/-! ### Element 5 — append: the leftward scan over `U` + the appended `1` (phase `25`) -/
+
+/-- **Append scan.**  From phase `25` with the `m` cells `(head − m, head]` all `1`, after any `k ≤ m`
+steps the loop is still in phase `25`, the head has retreated `k` cells left, and the tape is unchanged
+(the append writes each scanned `1` back unchanged).  Re-derived from `step25_one`. -/
+theorem binToUnaryLoopFullScan_body_append_scanning (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hstart : (c0.state.fst : Nat) = w + 25)
+    (m : Nat) (hm : m ≤ (c0.head : Nat))
+    (hones : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - m < (p : Nat) → (p : Nat) ≤ (c0.head : Nat) → c0.tape p = true) :
+    ∀ k, k ≤ m →
+      (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).state).fst : Nat) = w + 25
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head : Nat) = (c0.head : Nat) - k
+      ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).tape = c0.tape := by
+  intro k
+  induction k with
+  | zero => intro _; exact ⟨hstart, by simp, rfl⟩
+  | succ k ih =>
+      intro hk
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega)
+      have hbit : (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).tape
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head = true := by
+        rw [htp]; exact hones _ (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hhead : 0 < ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head : Nat) := by
+        rw [hhd]; omega
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k with hc
+      clear_value c
+      obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w25_one w c
+        (i := c.state.fst) (s := c.state.snd) hph rfl hbit hhead
+      exact ⟨sp, by rw [sh, hhd]; omega, by rw [st, htp]⟩
+
+/-- **After append (element 5)** (phases `15 → 26`).  From `U`'s right end the leftward append scans over
+`U`'s `u` `1`s and writes a fresh `1` at `U`'s left `0`-boundary `head − u − 1`, extending `U` to `u + 1`.
+After `2 + (j+1) + 1 + 1 + 1 + (j+1) + 1 + 1 + 1 + (u + 1)` steps the loop is at phase `26` (append accept),
+head on the new cell `head − u − 1`, tape the decremented `B` pattern **plus** the appended `1`. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterAppend6 (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat))
+    (u : Nat) (hUfit : u + 1 ≤ (c0.head : Nat))
+    (hU : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - u ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) → c0.tape p = true)
+    (hUboundary : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) - u - 1 → c0.tape p = false) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1))).state).fst : Nat) = w + 26
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1))).head : Nat)
+          = (c0.head : Nat) - u - 1
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1))).tape p
+            = (if (p : Nat) = (c0.head : Nat) - u - 1 then true
+                else if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ :=
+    binToUnaryLoopFullScan_body_runConfig_afterStepLeft5Handoff w c0 hphase j hj h_zeros h_one h_sentinel hHOME
+  rw [show (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1))
+        = (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1) + u + 1 from by omega,
+    TM.runConfig_succ, TM.runConfig_add]
+  obtain ⟨hSp, hSh, hSt⟩ := binToUnaryLoopFullScan_body_append_scanning w
+    (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1)) hHp u
+    (by rw [hHh]; omega)
+    (by
+      intro p hp1 hp2
+      rw [hHt p, if_neg (by rw [hHh] at hp2; omega), if_neg (by rw [hHh] at hp2; omega)]
+      exact hU p (by rw [hHh] at hp1; omega) (by rw [hHh] at hp2; omega)) u (le_refl u)
+  set cS := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM)
+      (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1)) u with hcS
+  have hSp' : (cS.state.fst : Nat) = w + 25 := hSp
+  have hSh' : (cS.head : Nat) = (c0.head : Nat) - u - 1 := by rw [hSh, hHh]; omega
+  clear_value cS
+  have hbitS : cS.tape cS.head = false := by
+    rw [hSt, hHt cS.head, if_neg (by rw [hSh']; omega), if_neg (by rw [hSh']; omega)]
+    exact hUboundary cS.head hSh'
+  obtain ⟨q0p, q0h, q0t⟩ := binToUnaryLoopFullScan_body_w25_zero w cS
+    (i := cS.state.fst) (s := cS.state.snd) hSp' rfl hbitS
+  refine ⟨q0p, by rw [q0h, hSh'], ?_⟩
+  intro p
+  rw [q0t]
+  by_cases hjp : p = cS.head
+  · subst hjp; rw [Configuration.write, dif_pos rfl, if_pos hSh']
+  · rw [Configuration.write, dif_neg hjp, hSt]
+    have hpn : (p : Nat) ≠ (c0.head : Nat) - u - 1 := by
+      intro he; apply hjp; apply Fin.ext; rw [hSh']; omega
+    rw [if_neg hpn]; exact hHt p
+
+/-- **After the append → scanRight handoff** (phases `15 → 27`): hands off into `selfLoopScanRightOne`
+(element 6, phase `27`); head on `U`'s new left end `head − u − 1`, tape the `U`-extended pattern. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterAppend6Handoff (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat))
+    (u : Nat) (hUfit : u + 1 ≤ (c0.head : Nat))
+    (hU : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - u ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) → c0.tape p = true)
+    (hUboundary : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) - u - 1 → c0.tape p = false) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1)).state).fst : Nat) = w + 27
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1)).head : Nat)
+          = (c0.head : Nat) - u - 1
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1)).tape p
+            = (if (p : Nat) = (c0.head : Nat) - u - 1 then true
+                else if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ :=
+    binToUnaryLoopFullScan_body_runConfig_afterAppend6 w c0 hphase j hj h_zeros h_one h_sentinel hHOME u hUfit hU hUboundary
+  rw [TM.runConfig_succ]
+  set cH := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1)) with hcH
+  clear_value cH
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w26 w cH (i := cH.state.fst) (s := cH.state.snd) hHp rfl
+  exact ⟨sp, by rw [sh, hHh], by intro p; rw [st]; exact hHt p⟩
+
+/-! ### Element 6 — scanRight: the rightward scan back to the sentinel (phase `27`) -/
+
+/-- **ScanRight scan.**  From phase `27` with the `m` cells `[head, head + m)` all `1`, after any `k ≤ m`
+steps the loop is still in phase `27`, the head has advanced `k` cells right, and the tape is unchanged.
+Re-derived from `step27_one`. -/
+theorem binToUnaryLoopFullScan_body_scanRight_scanning (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hstart : (c0.state.fst : Nat) = w + 27)
+    (m : Nat) (hbnd : (c0.head : Nat) + m < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (hones : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + m → c0.tape p = true) :
+    ∀ k, k ≤ m →
+      (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).state).fst : Nat) = w + 27
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head : Nat) = (c0.head : Nat) + k
+      ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).tape = c0.tape := by
+  intro k
+  induction k with
+  | zero => intro _; exact ⟨hstart, by simp, rfl⟩
+  | succ k ih =>
+      intro hk
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega)
+      have hbit : (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).tape
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head = true := by
+        rw [htp]; exact hones _ (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hbnd' : ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k).head : Nat) + 1
+          < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L := by rw [hhd]; omega
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 k with hc
+      clear_value c
+      obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w27_one w c
+        (i := c.state.fst) (s := c.state.snd) hph rfl hbit hbnd'
+      exact ⟨sp, by rw [sh, hhd]; omega, by rw [st, htp]⟩
+
+/-- **After scanRight (element 6)** (phases `15 → 28`).  From `U`'s new left end the rightward scan
+retraces the now-`u+1`-long unary block and stops back on the sentinel, reaching phase `28` with the head
+**back at HOME**; tape the `U`-extended / `B`-decremented pattern. -/
+theorem binToUnaryLoopFullScan_body_runConfig_afterScanRight7 (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat))
+    (u : Nat) (hUfit : u + 1 ≤ (c0.head : Nat))
+    (hU : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - u ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) → c0.tape p = true)
+    (hUboundary : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) - u - 1 → c0.tape p = false) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1))).state).fst : Nat) = w + 28
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1))).head : Nat)
+          = (c0.head : Nat)
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1))).tape p
+            = (if (p : Nat) = (c0.head : Nat) - u - 1 then true
+                else if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ :=
+    binToUnaryLoopFullScan_body_runConfig_afterAppend6Handoff w c0 hphase j hj h_zeros h_one h_sentinel hHOME u hUfit hU hUboundary
+  rw [show (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1))
+        = (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1) + (u + 1) + 1 from by omega,
+    TM.runConfig_succ, TM.runConfig_add]
+  obtain ⟨hSp, hSh, hSt⟩ := binToUnaryLoopFullScan_body_scanRight_scanning w
+    (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1)) hHp (u + 1)
+    (by rw [hHh]; omega)
+    (by
+      intro p hp1 hp2
+      rw [hHt p]
+      by_cases hpe : (p : Nat) = (c0.head : Nat) - u - 1
+      · rw [if_pos hpe]
+      · rw [if_neg hpe, if_neg (by rw [hHh] at hp1 hp2; omega), if_neg (by rw [hHh] at hp1 hp2; omega)]
+        exact hU p (by rw [hHh] at hp1; omega) (by rw [hHh] at hp2; omega)) (u + 1) (le_refl (u + 1))
+  set cS := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM)
+      (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1)) (u + 1) with hcS
+  have hSp' : (cS.state.fst : Nat) = w + 27 := hSp
+  have hSh' : (cS.head : Nat) = (c0.head : Nat) := by rw [hSh, hHh]; omega
+  clear_value cS
+  have hbitS : cS.tape cS.head = false := by
+    have hfeq : cS.head = c0.head := Fin.ext hSh'
+    rw [hSt, hfeq, hHt c0.head, if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+    exact h_sentinel
+  obtain ⟨q0p, q0h, q0t⟩ := binToUnaryLoopFullScan_body_w27_zero w cS
+    (i := cS.state.fst) (s := cS.state.snd) hSp' rfl hbitS
+  refine ⟨q0p, by rw [q0h, hSh'], ?_⟩
+  intro p; rw [q0t, hSt]; exact hHt p
+
+/-- **`onePass` headline** (phases `15 → 29`).  From HOME (phase `15`, head on the sentinel) with `B`'s
+lowest set bit at offset `j`, the `B`-zeros / lowest-bit / sentinel layout, and `U = 1^u` to the left
+(`hU` / `hUboundary`), one body pass — `decrement B`, re-home, `append 1` to `U`, re-home — reaches the
+loop body's **accept phase `29`** (the `loopUntilSink` back-edge target) after the body's step count, with
+the head **back at HOME** and the tape holding `(B − 1, 1^(u+1))`: the appended `1` at `head − u − 1`,
+`B`'s low `j` cells set, bit `j` cleared.  This is the per-iteration engine `hstep` iterates. -/
+theorem binToUnaryLoopFullScan_body_runConfig_onePass (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat))
+    (u : Nat) (hUfit : u + 1 ≤ (c0.head : Nat))
+    (hU : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - u ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) → c0.tape p = true)
+    (hUboundary : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) - u - 1 → c0.tape p = false) :
+    (((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1)).state).fst : Nat) = w + 29
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1)).head : Nat)
+          = (c0.head : Nat)
+      ∧ ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1)).tape p
+            = (if (p : Nat) = (c0.head : Nat) - u - 1 then true
+                else if (c0.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c0.head : Nat) + 1 + j then true
+                else if (p : Nat) = (c0.head : Nat) + 1 + j then false else c0.tape p) := by
+  obtain ⟨hHp, hHh, hHt⟩ :=
+    binToUnaryLoopFullScan_body_runConfig_afterScanRight7 w c0 hphase j hj h_zeros h_one h_sentinel hHOME u hUfit hU hUboundary
+  rw [TM.runConfig_succ]
+  set cH := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1)) with hcH
+  clear_value cH
+  obtain ⟨sp, sh, st⟩ := binToUnaryLoopFullScan_body_w28 w cH (i := cH.state.fst) (s := cH.state.snd) hHp rfl
+  exact ⟨sp, by rw [sh, hHh], by intro p; rw [st]; exact hHt p⟩
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanBodyStep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanBodyStep.lean
@@ -1,0 +1,574 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
+
+/-!
+# `binToUnaryLoopFullScan` body single-steps (NP-verifier track — D2t-3 `ε`, `hstep` body leg)
+
+The `binToUnaryBody` one-pass engine, re-derived **directly on the sound loop machine** at composition
+offset `+ (w + 15)`, via the body bridge (`TreeMCSPBinToUnaryLoopFullScanBodyBridge.lean`): each step is
+the loop peel (`binToUnaryLoopFullScan_transition_body`) + the bridge (collapse the depth-4 nesting to
+`binToUnaryBody`'s local transition at phase `k`) + an evaluation of that concrete-phase transition.
+This is the symbolic-`w` FullScan analogue of `TreeMCSPBinToUnaryLoopRehomeBodyStep.lean`.
+
+Phase map (loop ↔ `binToUnaryBody` ↔ element): `w+15↔0` stepRight move, `w+16↔1` handoff, `w+17↔2`
+decrement, `w+18↔3` handoff, `w+19↔4` stepLeft, `w+20↔5` handoff, `w+21↔6` scanLeft, `w+22↔7` handoff,
+`w+23↔8` stepLeft, `w+24↔9` handoff, `w+25↔10` appendLeft, `w+26↔11` handoff, `w+27↔12` scanRight,
+`w+28↔13` handoff (into the `idleCS` accept at `w+29 ↔ 14` = the loop body's accept / back-edge target).
+The four scan work-phases (`w+17` decrement, `w+21` scanLeft, `w+25` appendLeft, `w+27` scanRight) are
+bit-conditional, so each splits into a read-`1` and a read-`0` lemma.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 0 on the sound loop (composition phase `w + 15 + 0`). -/
+theorem binToUnaryLoopFullScan_body_w15 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 0) (hstate : c.state = ⟨i, s⟩) (hbnd : (c.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 1
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat) = (c.head : Nat) + 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 0 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.right := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 0 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]; simp only [Configuration.moveHead, dif_pos hbnd]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 0 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 1 on the sound loop (composition phase `w + 15 + 1`). -/
+theorem binToUnaryLoopFullScan_body_w16 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 1) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 2
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 1 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 1 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 1 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 2 on the sound loop (composition phase `w + 15 + 2`). -/
+theorem binToUnaryLoopFullScan_body_w17_one (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 2) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 3
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.write c.head false := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 2 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 2 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = false := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 2 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hbw]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 2 on the sound loop (composition phase `w + 15 + 2`). -/
+theorem binToUnaryLoopFullScan_body_w17_zero (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 2) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) (hbnd : (c.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 2
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat) = (c.head : Nat) + 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.write c.head true := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 2 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.right := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 2 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hmove]; simp only [Configuration.moveHead, dif_pos hbnd]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = true := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 2 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hbw]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 3 on the sound loop (composition phase `w + 15 + 3`). -/
+theorem binToUnaryLoopFullScan_body_w18 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 3) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 4
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 3 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 3 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 3 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 4 on the sound loop (composition phase `w + 15 + 4`). -/
+theorem binToUnaryLoopFullScan_body_w19 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 4) (hstate : c.state = ⟨i, s⟩) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 5
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat) = (c.head : Nat) - 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 4 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.left := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 4 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]
+    have hne : ¬ (c.head : Nat) = 0 := by omega
+    simp only [Configuration.moveHead, dif_neg hne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 4 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 5 on the sound loop (composition phase `w + 15 + 5`). -/
+theorem binToUnaryLoopFullScan_body_w20 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 5) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 6
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 5 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 5 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 5 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 6 on the sound loop (composition phase `w + 15 + 6`). -/
+theorem binToUnaryLoopFullScan_body_w21_one (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 6) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 6
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat) = (c.head : Nat) - 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 6 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.left := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 6 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hmove]
+    have hne : ¬ (c.head : Nat) = 0 := by omega
+    simp only [Configuration.moveHead, dif_neg hne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 6 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 6 on the sound loop (composition phase `w + 15 + 6`). -/
+theorem binToUnaryLoopFullScan_body_w21_zero (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 6) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 7
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 6 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 6 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 6 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 7 on the sound loop (composition phase `w + 15 + 7`). -/
+theorem binToUnaryLoopFullScan_body_w22 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 7) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 8
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 7 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 7 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 7 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 8 on the sound loop (composition phase `w + 15 + 8`). -/
+theorem binToUnaryLoopFullScan_body_w23 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 8) (hstate : c.state = ⟨i, s⟩) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 9
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat) = (c.head : Nat) - 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 8 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.left := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 8 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]
+    have hne : ¬ (c.head : Nat) = 0 := by omega
+    simp only [Configuration.moveHead, dif_neg hne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 8 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 9 on the sound loop (composition phase `w + 15 + 9`). -/
+theorem binToUnaryLoopFullScan_body_w24 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 9) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 10
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 9 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 9 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 9 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 10 on the sound loop (composition phase `w + 15 + 10`). -/
+theorem binToUnaryLoopFullScan_body_w25_one (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 10) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) (hhead : 0 < (c.head : Nat)) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 10
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat) = (c.head : Nat) - 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 10 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.left := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 10 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hmove]
+    have hne : ¬ (c.head : Nat) = 0 := by omega
+    simp only [Configuration.moveHead, dif_neg hne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 10 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 10 on the sound loop (composition phase `w + 15 + 10`). -/
+theorem binToUnaryLoopFullScan_body_w25_zero (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 10) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 11
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.write c.head true := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 10 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 10 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = true := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 10 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hbw]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 11 on the sound loop (composition phase `w + 15 + 11`). -/
+theorem binToUnaryLoopFullScan_body_w26 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 11) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 12
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 11 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 11 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 11 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 12 on the sound loop (composition phase `w + 15 + 12`). -/
+theorem binToUnaryLoopFullScan_body_w27_one (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 12) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = true) (hbnd : (c.head : Nat) + 1 < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 12
+      ∧ ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head : Nat) = (c.head : Nat) + 1
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 12 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.right := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 12 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hmove]; simp only [Configuration.moveHead, dif_pos hbnd]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 12 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 12 on the sound loop (composition phase `w + 15 + 12`). -/
+theorem binToUnaryLoopFullScan_body_w27_zero (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 12) (hstate : c.state = ⟨i, s⟩) (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 13
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 12 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 12 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 12 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne, hbit]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+set_option linter.unusedSimpArgs false in
+set_option maxHeartbeats 1000000 in
+/-- `binToUnaryBody` local phase 13 on the sound loop (composition phase `w + 15 + 13`). -/
+theorem binToUnaryLoopFullScan_body_w28 (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 15 + 13) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).state).fst.val = w + 15 + 14
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).head = c.head
+      ∧ (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c).tape = c.tape := by
+  refine ⟨?_, ?_, ?_⟩
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) c hstate,
+        binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+        binToUnaryLoopBodyFullScan_atBody_phase w 13 (by omega) hi () (c.tape c.head)]
+    simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) c hstate]
+    have hmove : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.2 = Move.stay := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_move w 13 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hmove]; simp [Configuration.moveHead]
+  · rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) c hstate]
+    have hbw : ((binToUnaryLoopFullScan w).transition i s (c.tape c.head)).2.2.1 = c.tape c.head := by
+      rw [binToUnaryLoopFullScan_transition_body w (by omega) (by omega) s (c.tape c.head),
+          binToUnaryLoopBodyFullScan_atBody_bit w 13 (by omega) hi () (c.tape c.head)]
+      simp [binToUnaryBody, seqList, seq, stepRightOnce, selfLoopDecrement, stepLeftOnce, selfLoopScanLeftOne, selfLoopAppendLeftOne, selfLoopScanRightOne]
+    rw [hbw]; funext j; by_cases hj : j = c.head
+    · subst hj; simp [Configuration.write]
+    · simp [Configuration.write, hj]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanCorrect.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanCorrect.lean
@@ -1,0 +1,55 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterDecodeFin
+
+/-!
+# `binToUnaryLoopFullScan` — D2t-3 transcoder correctness capstone (NP-verifier track — `ζ`)
+
+The headline tying D2t-3's sound binary→unary transcoder together.  Composing
+`binToUnaryLoopFullScan_reachesSink_output` (the loop halts and the produced unary block has length
+`u + counterValue B`) with the `counterValue ↔ decodeFin` bridge (`decodeFin_tapeBits`), this states the
+full `ζ` correctness: from a valid `LoopLayout`, the loop reaches its sink, the width-`w` input window
+decodes to some `i : Fin (2^w)`, and the produced unary block has length `u₀ + i.val` — i.e.
+`|U| = value(B) = (decodeFin w …).val`, the seed `u₀` plus exactly `value(B)` fresh `1`s.
+
+This settles the sound full-scan transcoder end-to-end: **δ** (sound zero-test `bZeroFullScan`), **ε** (the
+loop — `hbase`, `hstep`/`oneIteration`, `reachesSink`), and **ζ** (output length against `decodeFin`).
+
+**Progress classification (AGENTS.md): Infrastructure** — a verifier-component correctness statement; it
+proves no separation and makes no `P ≠ NP` claim.  Standard `[propext, Classical.choice, Quot.sound]`
+triple only.
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- **D2t-3 transcoder correctness (the `ζ` headline).**  From a valid `LoopLayout` config, the sound
+binary→unary loop halts (reaches its sink `w + 2`), the width-`w` input window decodes to `i`
+(`decodeFin w (tapeBits …) = some i`), and the produced unary block `[HOME - (u + i.val), HOME)` is all
+`1` — length `u₀ + i.val`, the seed plus exactly `value(B) = i.val` fresh `1`s.  This is
+`|U| = value(B) = (decodeFin w …).val`. -/
+theorem binToUnaryLoopFullScan_transcoder_correct (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat)
+    (hL : LoopLayout w c u) :
+    ∃ (t : Nat) (i : Fin (2 ^ w)),
+      ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).state.fst : Nat) = w + 2
+      ∧ decodeFin w (tapeBits c ((c.head : Nat) + 1) w) = some i
+      ∧ (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (c.head : Nat) - (u + i.val) ≤ (q : Nat) → (q : Nat) < (c.head : Nat) →
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape q = true) := by
+  have hlt : counterValue c ((c.head : Nat) + 1) w < 2 ^ w := counterValue_lt_two_pow c _ w
+  obtain ⟨t, hsink, hU⟩ :=
+    binToUnaryLoopFullScan_reachesSink_output w (counterValue c ((c.head : Nat) + 1) w) c u hL rfl
+  refine ⟨t, ⟨counterValue c ((c.head : Nat) + 1) w, hlt⟩, hsink,
+    decodeFin_tapeBits c ((c.head : Nat) + 1) w hlt, ?_⟩
+  intro q hq1 hq2
+  exact hU q hq1 hq2
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanHstep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanHstep.lean
@@ -1,0 +1,148 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanSeek
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanStep2
+
+/-!
+# `binToUnaryLoopFullScan` `hstep` core — one `B > 0` body pass (NP-verifier track — D2t-3 `ε`)
+
+The `B > 0` re-entry pass on the sound loop, composed end-to-end. From a HOME config at the loop start
+(phase `0`) with the U-LEFT layout and `B`'s lowest set bit at offset `j`, one pass chains the four proven
+legs — `pos` (scan-to-divert, phase `0 → w+3`), `postDivert` (the connector, `w+3 → w+6`),
+`seekHomeAfterRoute` (re-home, `w+6 → w+15`), and the `binToUnaryBody` one-pass engine (`w+15 → w+29`,
+decrement `B` / append `1` to `U`) — into a single run reaching the loop body's accept phase `w+29` with
+the head back at HOME and the width-`w` counter value `counterValue B` strictly decreased by one.
+
+`binToUnaryLoopFullScan_runConfig_pos_tape` strengthens `pos` with the tape preservation the chain needs
+(every leg before the body engine leaves the tape unchanged), so the body engine's preconditions reduce to
+the original layout. The headline `binToUnaryLoopFullScan_runConfig_bodyPass` is the per-iteration work
+`loopUntilSink_reachesSink`'s `hstep` consumes (with `μ := counterValue B`); the back-edge re-entry and the
+`reachesSink` assembly are the follow-up.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
+
+/-- `pos` with tape preservation: the B>0 scan-to-divert run leaves the tape unchanged. -/
+theorem binToUnaryLoopFullScan_runConfig_pos_tape (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0) (j : Nat) (hjw : j < w)
+    (hb : (c0.head : Nat) + 1 + w < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (q : Nat) → (q : Nat) < (c0.head : Nat) + 1 + j → c0.tape q = false)
+    (hone : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (q : Nat) = (c0.head : Nat) + 1 + j → c0.tape q = true) :
+    (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (j + 3)).tape = c0.tape := by
+  obtain ⟨h0p, h0h, h0t⟩ := binToUnaryLoopFullScan_step0 w c0 hstart rfl (by omega)
+  set c1 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 1 with hc1
+  have hc1eq : c1 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 := by
+    rw [hc1, show (1 : Nat) = 0 + 1 from rfl, TM.runConfig_succ]; rfl
+  obtain ⟨h1p, h1h, h1t⟩ := binToUnaryLoopFullScan_step1 w c1
+    (i := c1.state.fst) (s := c1.state.snd) (by rw [hc1eq]; exact h0p) rfl
+  set c2 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 2 with hc2
+  have hc2eq : c2 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c1 := by
+    rw [hc2, show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_succ, hc1]
+  have h2p : (c2.state.fst : Nat) = 2 := by rw [hc2eq]; exact h1p
+  have h2h : (c2.head : Nat) = (c0.head : Nat) + 1 := by rw [hc2eq, h1h, hc1eq, h0h]
+  have h2t : c2.tape = c0.tape := by rw [hc2eq, h1t, hc1eq, h0t]
+  have hzeros2 : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c2.head : Nat) ≤ (q : Nat) → (q : Nat) < (c2.head : Nat) + j → c2.tape q = false := by
+    intro q hq1 hq2; rw [h2t]; rw [h2h] at hq1 hq2; exact hzeros q hq1 (by omega)
+  obtain ⟨hsp, hsh, hst⟩ := binToUnaryLoopFullScan_runConfig_scanning w c2 h2p j (le_of_lt hjw)
+    (by rw [h2h]; omega) hzeros2
+  set c2j := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c2 j with hc2j
+  have hbit : c2j.tape c2j.head = true := by
+    rw [hst, h2t]; exact hone c2j.head (by rw [hsh, h2h])
+  have hc2jp : (c2j.state.fst : Nat) = 2 + j := hsp
+  have hc2j_eq : c2j = TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + j) := by
+    rw [hc2j, hc2, ← TM.runConfig_add]
+  have hcompose : TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (j + 3)
+      = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c2j := by
+    rw [show (j + 3 : Nat) = (2 + j) + 1 from by omega, TM.runConfig_succ, ← hc2j_eq]
+  rw [hcompose, binToUnaryLoopFullScan_stepConfig_divert_tape w c2j (i := c2j.state.fst) (s := c2j.state.snd)
+    hjw hc2jp rfl hbit, hst, h2t]
+
+set_option maxHeartbeats 1000000 in
+theorem binToUnaryLoopFullScan_runConfig_bodyPass (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0) (j : Nat) (hjw : j < w)
+    (hb : (c0.head : Nat) + 3 + w < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (hzeros : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (q : Nat) → (q : Nat) < (c0.head : Nat) + 1 + j → c0.tape q = false)
+    (hone : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (q : Nat) = (c0.head : Nat) + 1 + j → c0.tape q = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat))
+    (u : Nat) (hUfit : u + 1 ≤ (c0.head : Nat))
+    (hU : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - u ≤ (q : Nat) → (q : Nat) < (c0.head : Nat) → c0.tape q = true)
+    (hUboundary : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (q : Nat) = (c0.head : Nat) - u - 1 → c0.tape q = false)
+    (hseed : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (q : Nat) = (c0.head : Nat) - 1 → c0.tape q = true) :
+    ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0
+        ((j + 3) + 3 + (j + 10) + onePassSteps j u)).state.fst : Nat) = w + 29
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0
+        ((j + 3) + 3 + (j + 10) + onePassSteps j u)).head : Nat) = (c0.head : Nat)
+      ∧ counterValue (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0
+            ((j + 3) + 3 + (j + 10) + onePassSteps j u)) ((c0.head : Nat) + 1) w + 1
+          = counterValue c0 ((c0.head : Nat) + 1) w := by
+  obtain ⟨hPp, hPh⟩ := binToUnaryLoopFullScan_runConfig_pos w c0 hstart j hjw (by omega) hzeros hone
+  have hPt := binToUnaryLoopFullScan_runConfig_pos_tape w c0 hstart j hjw (by omega) hzeros hone
+  set cP := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (j + 3) with hcPdef
+  obtain ⟨hQp, hQh, hQt⟩ := binToUnaryLoopFullScan_runConfig_postDivert w cP hPp (by rw [hPh]; omega)
+  set cQ := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) cP 3 with hcQdef
+  have hQt' : cQ.tape = c0.tape := hQt.trans hPt
+  have hQh' : (cQ.head : Nat) = (c0.head : Nat) + 2 + j := by omega
+  obtain ⟨hRp, hRh, hRt⟩ := binToUnaryLoopFullScan_seek_home w cQ (c0.head : Nat) j hQp hHOME hQh'
+    (by omega)
+    (by intro q hq1 hq2; rw [hQt']
+        rcases Nat.lt_or_ge (q : Nat) ((c0.head : Nat) + 1) with hlt | hge
+        · have heq : (q : Nat) = (c0.head : Nat) := by omega
+          rw [show q = c0.head from Fin.ext heq]; exact h_sentinel
+        · exact hzeros q hge (by omega))
+    (by intro q hq; rw [hQt']; exact hseed q hq)
+  set cR := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) cQ (j + 10) with hcRdef
+  have hRt' : cR.tape = c0.tape := hRt.trans hQt'
+  have hRh' : (cR.head : Nat) = (c0.head : Nat) := hRh
+  have hcF : TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0
+        ((j + 3) + 3 + (j + 10) + onePassSteps j u)
+      = TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) cR (onePassSteps j u) := by
+    rw [hcRdef, hcQdef, hcPdef, ← TM.runConfig_add, ← TM.runConfig_add, ← TM.runConfig_add]
+    congr 1; omega
+  have hRsent : cR.tape cR.head = false := by
+    rw [hRt']; rw [show cR.head = c0.head from Fin.ext hRh']; exact h_sentinel
+  have hZ : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (cR.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (cR.head : Nat) + 1 + j → cR.tape p = false := by
+    intro p hp1 hp2; rw [hRt']; exact hzeros p (by rw [hRh'] at hp1; omega) (by rw [hRh'] at hp2; omega)
+  have hO : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (cR.head : Nat) + 1 + j → cR.tape p = true := by
+    intro p hp; rw [hRt']; exact hone p (by rw [hRh'] at hp; omega)
+  have hUU : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (cR.head : Nat) - u ≤ (p : Nat) → (p : Nat) < (cR.head : Nat) → cR.tape p = true := by
+    intro p hp1 hp2; rw [hRt']; exact hU p (by rw [hRh'] at hp1; omega) (by rw [hRh'] at hp2; omega)
+  have hUb : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (cR.head : Nat) - u - 1 → cR.tape p = false := by
+    intro p hp; rw [hRt']; exact hUboundary p (by rw [hRh'] at hp; omega)
+  obtain ⟨hFp, hFh, _⟩ := binToUnaryLoopFullScan_body_runConfig_onePass w cR hRp j
+    (by rw [hRh']; omega) hZ hO hRsent (by rw [hRh']; exact hHOME) u (by rw [hRh']; exact hUfit) hUU hUb
+  have hMeasure := binToUnaryLoopFullScan_body_onePass_counterValue w cR hRp j
+    (by rw [hRh']; omega) hZ hO hRsent (by rw [hRh']; exact hHOME) u (by rw [hRh']; exact hUfit) hUU hUb
+    hjw (by rw [hRh']; omega)
+  refine ⟨?_, ?_, ?_⟩
+  · rw [hcF]; exact hFp
+  · rw [hcF, hFh, hRh']
+  · rw [hcF]
+    rw [show ((cR.head : Nat) + 1) = ((c0.head : Nat) + 1) from by rw [hRh']] at hMeasure
+    rw [hMeasure]
+    exact counterValue_eq_of_tape_eq cR c0 ((c0.head : Nat) + 1) w (fun p _ _ => by rw [hRt'])
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanMeasure.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanMeasure.lean
@@ -1,0 +1,95 @@
+import Complexity.TMVerifier.TuringToolkit.BinaryCounter
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryMeasure
+
+/-!
+# `(binToUnaryLoopFullScan w)` one-pass measure decrease (NP-verifier track — D2t-3 `ε`)
+
+`hstep`'s measure ingredient.  The body run-through `binToUnaryLoopFullScan_body_runConfig_onePass` returns
+its post-tape explicitly: `B`'s low block `[head+1, head+1+j)` flips `0 → 1`, its lowest set bit
+`head+1+j` flips `1 → 0` (a borrow), and `U` gains one `1` at `head−u−1`.  This module reads the **net
+arithmetic effect** off that post-tape — the borrow drops `counterValue B` by exactly one — directly on
+the loop machine `(binToUnaryLoopFullScan w)` (offset `+15`, phase `15`).
+
+This is the strict measure decrease `loopUntilSink_reachesSink`'s `hstep` consumes (with `μ :=
+counterValue B`).  It mirrors the standalone `binToUnaryBody_onePass_counterValue`
+(`TreeMCSPBinToUnaryMeasure.lean`): the post-tape matches `counterValue_first_zero_diff`'s hypotheses with
+`c := after`, `c' := c0`, `start := head+1`; `U`'s new bit at `head−u−1 < head+1` sits strictly left of
+the `counterValue` window `[head+1, head+1+w)`, so it leaves the counter value untouched.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
+
+/-- **One-pass measure-decrease (loop machine).**  From a HOME config at the body-start phase `15` with
+`B > 0` (lowest set bit at `head+1+j`) and `U = 1^u` to the left, one body pass drops the little-endian
+counter value of the width-`w` block `[head+1, head+1+w)` by exactly one:
+`counterValue (after) + 1 = counterValue (before)`.  The strict measure decrease for
+`loopUntilSink_reachesSink`'s `hstep` with `μ := counterValue B`.  Hypotheses match
+`binToUnaryLoopFullScan_body_runConfig_onePass`; `w` (with `j < w`) is the counter window's width. -/
+theorem binToUnaryLoopFullScan_body_onePass_counterValue (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (hphase : (c0.state.fst : Nat) = w + 15)
+    (j : Nat) (hj : (c0.head : Nat) + 1 + j < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (h_zeros : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + 1 + j → c0.tape p = false)
+    (h_one : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 + j → c0.tape p = true)
+    (h_sentinel : c0.tape c0.head = false) (hHOME : 0 < (c0.head : Nat))
+    (u : Nat) (hUfit : u + 1 ≤ (c0.head : Nat))
+    (hU : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - u ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) → c0.tape p = true)
+    (hUboundary : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) - u - 1 → c0.tape p = false)
+    (hjw : j < w)
+    (hwfit : (c0.head : Nat) + 1 + w ≤ (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L) :
+    counterValue (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (onePassSteps j u))
+          ((c0.head : Nat) + 1) w + 1
+      = counterValue c0 ((c0.head : Nat) + 1) w := by
+  unfold onePassSteps
+  obtain ⟨_, _, hTape⟩ :=
+    binToUnaryLoopFullScan_body_runConfig_onePass w c0 hphase j hj h_zeros h_one h_sentinel hHOME u hUfit hU
+      hUboundary
+  set cF := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0
+    (2 + (j + 1) + 1 + 1 + 1 + (j + 1) + 1 + 1 + 1 + (u + 1) + 1 + (u + 1 + 1) + 1)
+  refine (counterValue_first_zero_diff cF c0 ((c0.head : Nat) + 1) j w hjw hwfit
+    ?_ ?_ ?_ ?_ ?_).symm
+  · -- after: low block `[head+1, head+1+j)` is all `1` (the borrow filled it in).
+    intro i hi hb
+    rw [hTape ⟨(c0.head : Nat) + 1 + i, hb⟩,
+      if_neg (by show ¬((c0.head : Nat) + 1 + i = (c0.head : Nat) - u - 1); omega),
+      if_pos (by show (c0.head : Nat) + 1 ≤ (c0.head : Nat) + 1 + i
+        ∧ (c0.head : Nat) + 1 + i < (c0.head : Nat) + 1 + j; omega)]
+  · -- after: the lowest set bit `head+1+j` was cleared to `0`.
+    intro hb
+    rw [hTape ⟨(c0.head : Nat) + 1 + j, hb⟩,
+      if_neg (by show ¬((c0.head : Nat) + 1 + j = (c0.head : Nat) - u - 1); omega),
+      if_neg (by show ¬((c0.head : Nat) + 1 ≤ (c0.head : Nat) + 1 + j
+        ∧ (c0.head : Nat) + 1 + j < (c0.head : Nat) + 1 + j); omega),
+      if_pos rfl]
+  · -- before: low block was all `0` (input hypothesis `h_zeros`).
+    intro i hi hb
+    exact h_zeros ⟨(c0.head : Nat) + 1 + i, hb⟩
+      (by show (c0.head : Nat) + 1 ≤ (c0.head : Nat) + 1 + i; omega)
+      (by show (c0.head : Nat) + 1 + i < (c0.head : Nat) + 1 + j; omega)
+  · -- before: the lowest set bit `head+1+j` was `1` (input hypothesis `h_one`).
+    intro hb
+    exact h_one ⟨(c0.head : Nat) + 1 + j, hb⟩ rfl
+  · -- beyond `j`, the counter cells are untouched by the pass.
+    intro i hij hiw hb
+    rw [hTape ⟨(c0.head : Nat) + 1 + i, hb⟩,
+      if_neg (by show ¬((c0.head : Nat) + 1 + i = (c0.head : Nat) - u - 1); omega),
+      if_neg (by show ¬((c0.head : Nat) + 1 ≤ (c0.head : Nat) + 1 + i
+        ∧ (c0.head : Nat) + 1 + i < (c0.head : Nat) + 1 + j); omega),
+      if_neg (by show ¬((c0.head : Nat) + 1 + i = (c0.head : Nat) + 1 + j); omega)]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanOutput.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanOutput.lean
@@ -1,0 +1,114 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink
+
+/-!
+# `binToUnaryLoopFullScan` — ζ core: the produced unary block has length `value(B)` (D2t-3 `ε`)
+
+The output-correctness core of `ε`.  `reachesSink` (the prior brick) shows the sound loop halts; this
+module shows **what it produced**: from a `LoopLayout w c u` config the loop reaches its sink with the
+cells `[HOME - (u + counterValue B), HOME)` all `1` — a unary block of length `u + counterValue B =
+u₀ + value(B)` (the seed `u₀` plus one `1` per decrement of `B`).  So the produced answer block has length
+`value(B)` — the `ζ` bridge `|U| = value(B)`.
+
+* `binToUnaryLoopFullScan_runConfig_hbase_tape` — the `B = 0` path to the sink leaves the tape unchanged
+  (it only scans the all-`0` `B` block, never touching `U`), so the base case keeps `U` intact.
+* `binToUnaryLoopFullScan_reachesSink_output` — bespoke strong induction on `counterValue B`: each `B > 0`
+  pass (`oneIteration`) appends one `1` (`u ↦ u+1`, `counterValue ↦ counterValue-1`), so the invariant
+  `u + counterValue B` — the block length — is preserved to the sink.
+
+This settles `ε`'s run behaviour **and** its output length against `counterValue`.  The only remaining
+formality is the pure spec identity `counterValue (little-endian B) = (decodeFin w …).val` connecting the
+on-tape counter to the `Encoding.decodeFin` reference — a `BinaryCounter`/`Encoding` arithmetic lemma with
+no run content.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
+
+/-- `hbase` with tape preservation: the `B = 0` path to the sink leaves the tape unchanged (it only scans
+the all-`0` `B` block; it never touches `U`). -/
+theorem binToUnaryLoopFullScan_runConfig_hbase_tape (w : Nat) {L : Nat}
+    (c0 : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    (hstart : (c0.state.fst : Nat) = 0)
+    (hb : (c0.head : Nat) + 1 + w < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L)
+    (hzero : counterValue c0 ((c0.head : Nat) + 1) w = 0) :
+    (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + w)).tape = c0.tape := by
+  obtain ⟨h0p, h0h, h0t⟩ := binToUnaryLoopFullScan_step0 w c0 hstart rfl (by omega)
+  set c1 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 1 with hc1
+  have hc1eq : c1 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 := by
+    rw [hc1, show (1 : Nat) = 0 + 1 from rfl, TM.runConfig_succ]; rfl
+  obtain ⟨h1p, h1h, h1t⟩ := binToUnaryLoopFullScan_step1 w c1
+    (i := c1.state.fst) (s := c1.state.snd) (by rw [hc1eq]; exact h0p) rfl
+  set c2 := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 2 with hc2
+  have hc2eq : c2 = TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c1 := by
+    rw [hc2, show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_succ, hc1]
+  have h2p : (c2.state.fst : Nat) = 2 := by rw [hc2eq]; exact h1p
+  have h2h : (c2.head : Nat) = (c0.head : Nat) + 1 := by rw [hc2eq, h1h, hc1eq, h0h]
+  have h2t : c2.tape = c0.tape := by rw [hc2eq, h1t, hc1eq, h0t]
+  have hzeros : ∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c2.head : Nat) ≤ (q : Nat) → (q : Nat) < (c2.head : Nat) + w → c2.tape q = false := by
+    intro q hq1 hq2
+    rw [h2t]
+    have hqlt : (q : Nat) - ((c0.head : Nat) + 1) < w := by rw [h2h] at hq2; omega
+    have hqge : (c0.head : Nat) + 1 ≤ (q : Nat) := by rw [h2h] at hq1; omega
+    have := counterValue_eq_zero_imp_all_false c0 ((c0.head : Nat) + 1) w hzero
+      ((q : Nat) - ((c0.head : Nat) + 1)) hqlt (by omega)
+    simpa [Nat.add_sub_cancel' hqge] using this
+  obtain ⟨_, _, hst⟩ := binToUnaryLoopFullScan_runConfig_scanning w c2 h2p w (le_refl w)
+    (by rw [h2h]; omega) hzeros
+  have : TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c0 (2 + w)
+      = TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c2 w := by
+    rw [hc2, ← TM.runConfig_add]
+  rw [this, hst, h2t]
+
+
+/-- **ζ core — the produced unary block.**  From a `LoopLayout w c u` config, the loop reaches its sink
+and the cells `[HOME - (u + counterValue B), HOME)` are all `1`: the unary block of length
+`u + counterValue B = u₀ + value(B)`.  (With the seed `u₀`, the produced answer block has length
+`value(B)`.)  Bespoke strong induction on `counterValue B`, base `B = 0` (head scans to the sink, `U`
+untouched, length `u`), step `B > 0` (one pass appends a `1`, `u ↦ u+1`, `counterValue ↦ counterValue-1`,
+the block length `u + counterValue` preserved). -/
+theorem binToUnaryLoopFullScan_reachesSink_output (w : Nat) {L : Nat} :
+    ∀ (m : Nat) (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat),
+      LoopLayout w c u → counterValue c ((c.head : Nat) + 1) w = m →
+      ∃ t, ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).state.fst : Nat) = w + 2
+        ∧ (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+            (c.head : Nat) - (u + m) ≤ (q : Nat) → (q : Nat) < (c.head : Nat) →
+            (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape q = true) := by
+  intro m
+  induction m using Nat.strong_induction_on with
+  | _ m ih =>
+    intro c u hL hm
+    obtain ⟨hph0, hu1, hHOME1, hbound, hsent, hUlay, hblank, hroom⟩ := hL
+    rcases Nat.eq_zero_or_pos m with hm0 | hmpos
+    · refine ⟨2 + w, binToUnaryLoopFullScan_runConfig_hbase w c hph0 (by omega) (by rw [hm]; exact hm0), ?_⟩
+      intro q hq1 hq2
+      rw [binToUnaryLoopFullScan_runConfig_hbase_tape w c hph0 (by omega) (by rw [hm]; exact hm0)]
+      exact hUlay q (by omega) hq2
+    · obtain ⟨sB, _, hhd, hLnext, hdec⟩ :=
+        binToUnaryLoopFullScan_oneIteration w c u
+          ⟨hph0, hu1, hHOME1, hbound, hsent, hUlay, hblank, hroom⟩ (by rw [hm]; omega)
+      set d := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1) with hddef
+      have hmlt : counterValue d ((d.head : Nat) + 1) w < m := by
+        rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+      obtain ⟨t, htsink, htU⟩ :=
+        ih (counterValue d ((d.head : Nat) + 1) w) hmlt d (u + 1) hLnext rfl
+      refine ⟨(sB + 1) + t, by rw [TM.runConfig_add, ← hddef]; exact htsink, ?_⟩
+      intro q hq1 hq2
+      rw [TM.runConfig_add, ← hddef]
+      have hdc : counterValue d ((d.head : Nat) + 1) w + 1 = m := by
+        rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+      apply htU q
+      · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+      · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanReachesSink.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanReachesSink.lean
@@ -24,7 +24,7 @@ combinator `loopUntilSink_reachesSink` cannot be applied directly — it quantif
 strong induction on `counterValue B`** carrying `LoopLayout`, discharging the `B = 0` base from
 `binToUnaryLoopFullScan_runConfig_hbase` and the `B > 0` step from `…_bodyPass` + the back-edge tools here.
 
-This brick ships the tools + the invariant (everything below is `sorry`-free and axiom-clean); the
+This brick ships the tools + the invariant (everything below is hole-free and axiom-clean); the
 termination induction and the `ζ` correctness bridge (`|U| = value B`) are the remaining follow-ups.
 
 **Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanReachesSink.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanReachesSink.lean
@@ -1,0 +1,76 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
+
+/-!
+# `binToUnaryLoopFullScan` — `reachesSink` scaffolding (NP-verifier track — D2t-3 `ε`)
+
+The final assembly of `ε`: the sound binary→unary loop reaches its sink (halts) on every valid input.
+This module fixes the two reusable tools the assembly needs and the **loop layout invariant** it inducts
+over; the bespoke termination proof itself is the documented follow-up.
+
+`loopUntilSink_stepConfig_loop_tape` — the loop's back-edge (`B`'s accept → `B`'s start) **preserves the
+tape** (the re-entry writes the scanned bit back). With `loopUntilSink_stepConfig_loop_{phase,head}` this
+characterises the back-edge fully (phase → start, head/tape unchanged), so the per-iteration counter value
+after re-entry equals the body pass's output.
+
+`LoopLayout w c u` — the **U-LEFT layout invariant**: the loop is at the start phase with the head on the
+sentinel `HOME`, `U = 1^u` occupies `[HOME-u, HOME)`, everything strictly left of `U` is blank, and the
+**room invariant** `u + counterValue B ≤ HOME - 1` holds (so `U` can keep growing left as `B` shrinks).
+One body pass (`binToUnaryLoopFullScan_runConfig_bodyPass`) maps `LoopLayout w c u` with `B > 0` to
+`LoopLayout w c' (u+1)` with `counterValue B' = counterValue B - 1` (the borrow decrements `B`, the append
+extends `U`; `u + counterValue` is preserved, so the room invariant survives). The standard library
+combinator `loopUntilSink_reachesSink` cannot be applied directly — it quantifies its `hstep`/`hbase` over
+*all* start-phase configs, but the run behaviour holds only on layouts — so termination is a **bespoke
+strong induction on `counterValue B`** carrying `LoopLayout`, discharging the `B = 0` base from
+`binToUnaryLoopFullScan_runConfig_hbase` and the `B > 0` step from `…_bodyPass` + the back-edge tools here.
+
+This brick ships the tools + the invariant (everything below is `sorry`-free and axiom-clean); the
+termination induction and the `ζ` correctness bridge (`|U| = value B`) are the remaining follow-ups.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
+
+/-- **Back-edge tape preservation.**  A step from `B`'s accept phase (the `loopUntilSink` re-entry) leaves
+the tape unchanged — it writes the scanned bit back.  Completes the back-edge characterisation alongside
+`loopUntilSink_stepConfig_loop_{phase,head}`. -/
+theorem loopUntilSink_stepConfig_loop_tape (B : ConstStatePhasedProgram Unit) (sink : Fin B.numPhases)
+    {L : Nat} (c : Configuration (M := (loopUntilSink B sink).toPhased.toTM) L) {s : Unit}
+    (hstate : c.state = ⟨B.acceptPhase, s⟩) :
+    (TM.stepConfig (M := (loopUntilSink B sink).toPhased.toTM) c).tape = c.tape := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_tape (loopUntilSink B sink) c hstate]
+  have hbit : ((loopUntilSink B sink).transition B.acceptPhase s (c.tape c.head)).2.2.1
+      = c.tape c.head := by rw [loopUntilSink_transition_loop]
+  rw [hbit]; funext j; by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- **The loop layout invariant.**  At the loop start phase `0` with the head on the sentinel `HOME`,
+`U = 1^u` occupying `[HOME-u, HOME)` (`u ≥ 1`, the permanent endmarker seed is the rightmost `U` cell),
+everything strictly left of `U` blank, the width-`w` counter window fitting, and the **room invariant**
+`u + counterValue B ≤ HOME - 1` (so `U` keeps room to grow as `B` shrinks).  One body pass maps this to the
+same invariant with `u ↦ u+1` and `counterValue B ↦ counterValue B - 1`. -/
+def LoopLayout (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat) : Prop :=
+  (c.state.fst : Nat) = 0
+  ∧ 1 ≤ u
+  ∧ 1 ≤ (c.head : Nat)
+  ∧ (c.head : Nat) + 3 + w < (binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L
+  ∧ c.tape c.head = false
+  ∧ (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (c.head : Nat) - u ≤ (q : Nat) → (q : Nat) < (c.head : Nat) → c.tape q = true)
+  ∧ (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (q : Nat) < (c.head : Nat) - u → c.tape q = false)
+  ∧ u + counterValue c ((c.head : Nat) + 1) w ≤ (c.head : Nat) - 1
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanReachesSink.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanReachesSink.lean
@@ -53,6 +53,62 @@ theorem loopUntilSink_stepConfig_loop_tape (B : ConstStatePhasedProgram Unit) (s
   · subst hj; simp [Configuration.write]
   · simp [Configuration.write, hj]
 
+/-! ### The back-edge on the sound loop machine, directly (avoiding the expensive `loopUntilSink` defeq)
+
+The generic `loopUntilSink_stepConfig_loop_*` lemmas can be applied to a `binToUnaryLoopFullScan` config
+only through the `binToUnaryLoopFullScan ≡ loopUntilSink …` defeq, whose `whnf` blows up (it unfolds the
+loop's transition, which contains `bZeroFullScan`'s `2^i`).  These FullScan-specific versions instead use
+the cheap one-`delta` unfold at the *transition* level (`binToUnaryLoopFullScan_transition_backedge`) plus
+the `binToUnaryLoopFullScan`-stated `toTM_stepConfig_*`, exactly the device of
+`binToUnaryLoopFullScan_transition_body`. -/
+
+/-- **Transition-level back-edge.**  At the loop body's accept phase `w + 29`, the loop jumps to the body's
+start phase (writing the scanned bit back, head stay). -/
+theorem binToUnaryLoopFullScan_transition_backedge (w : Nat)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} (hi : (i : Nat) = w + 29) (s : Unit) (b : Bool) :
+    (binToUnaryLoopFullScan w).transition i s b
+      = ((binToUnaryLoopBodyFullScan w).startPhase, (), b, Move.stay) := by
+  have hacc : i = (binToUnaryLoopBodyFullScan w).acceptPhase :=
+    Fin.ext (by rw [hi, binToUnaryLoopBodyFullScan_acceptPhase_val])
+  rw [hacc]
+  exact loopUntilSink_transition_loop (binToUnaryLoopBodyFullScan w)
+    ⟨w + 2, by rw [binToUnaryLoopBodyFullScan_numPhases]; omega⟩ s b
+
+/-- **Back-edge step, phase.**  From phase `w + 29` the loop re-enters at the start phase `0`. -/
+theorem binToUnaryLoopFullScan_backedge_phase (w : Nat) {L : Nat}
+    (cF : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 29) (hstate : cF.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) cF).state).fst.val = 0 := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_phase (binToUnaryLoopFullScan w) cF hstate,
+      binToUnaryLoopFullScan_transition_backedge w hi s (cF.tape cF.head)]
+  show ((binToUnaryLoopBodyFullScan w).startPhase : Nat) = 0
+  exact binToUnaryLoopFullScan_startPhase_val w
+
+/-- **Back-edge step, head.**  The re-entry leaves the head where the body finished (a `Move.stay`). -/
+theorem binToUnaryLoopFullScan_backedge_head (w : Nat) {L : Nat}
+    (cF : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 29) (hstate : cF.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) cF).head = cF.head := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_head (binToUnaryLoopFullScan w) cF hstate]
+  have hmove : ((binToUnaryLoopFullScan w).transition i s (cF.tape cF.head)).2.2.2 = Move.stay := by
+    rw [binToUnaryLoopFullScan_transition_backedge w hi s (cF.tape cF.head)]
+  rw [hmove]; simp [Configuration.moveHead]
+
+/-- **Back-edge step, tape.**  The re-entry writes the scanned bit back, leaving the tape unchanged. -/
+theorem binToUnaryLoopFullScan_backedge_tape (w : Nat) {L : Nat}
+    (cF : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L)
+    {i : Fin (binToUnaryLoopFullScan w).numPhases} {s : Unit}
+    (hi : (i : Nat) = w + 29) (hstate : cF.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) cF).tape = cF.tape := by
+  rw [ConstStatePhasedProgram.toTM_stepConfig_tape (binToUnaryLoopFullScan w) cF hstate]
+  have hbit : ((binToUnaryLoopFullScan w).transition i s (cF.tape cF.head)).2.2.1 = cF.tape cF.head := by
+    rw [binToUnaryLoopFullScan_transition_backedge w hi s (cF.tape cF.head)]
+  rw [hbit]; funext j; by_cases hj : j = cF.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
 /-- **The loop layout invariant.**  At the loop start phase `0` with the head on the sentinel `HOME`,
 `U = 1^u` occupying `[HOME-u, HOME)` (`u ≥ 1`, the permanent endmarker seed is the rightmost `U` cell),
 everything strictly left of `U` blank, the width-`w` counter window fitting, and the **room invariant**

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanReachesSink.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanReachesSink.lean
@@ -2,11 +2,12 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
 
 /-!
-# `binToUnaryLoopFullScan` — `reachesSink` scaffolding (NP-verifier track — D2t-3 `ε`)
+# `binToUnaryLoopFullScan` — `reachesSink`: the sound loop halts (NP-verifier track — D2t-3 `ε`)
 
-The final assembly of `ε`: the sound binary→unary loop reaches its sink (halts) on every valid input.
-This module fixes the two reusable tools the assembly needs and the **loop layout invariant** it inducts
-over; the bespoke termination proof itself is the documented follow-up.
+The loop-termination half of `ε`, **proven**: the sound binary→unary loop reaches its sink (halts) on
+every valid layout.  This module fixes the back-edge tools + the **loop layout invariant**, the
+per-iteration lemma `binToUnaryLoopFullScan_oneIteration`, and the headline
+`binToUnaryLoopFullScan_reachesSink`.
 
 `loopUntilSink_stepConfig_loop_tape` — the loop's back-edge (`B`'s accept → `B`'s start) **preserves the
 tape** (the re-entry writes the scanned bit back). With `loopUntilSink_stepConfig_loop_{phase,head}` this
@@ -24,8 +25,10 @@ combinator `loopUntilSink_reachesSink` cannot be applied directly — it quantif
 strong induction on `counterValue B`** carrying `LoopLayout`, discharging the `B = 0` base from
 `binToUnaryLoopFullScan_runConfig_hbase` and the `B > 0` step from `…_bodyPass` + the back-edge tools here.
 
-This brick ships the tools + the invariant (everything below is hole-free and axiom-clean); the
-termination induction and the `ζ` correctness bridge (`|U| = value B`) are the remaining follow-ups.
+Everything below is hole-free and axiom-clean.  With this, the loop's run behaviour is fully settled
+(`B = 0 → sink` via `hbase`; `B > 0 →` decrement-and-loop via `oneIteration`; termination via
+`reachesSink`).  The `ζ` correctness bridge (`|U| = value B = (decodeFin …).val`) is the remaining
+follow-up before `ε` is fully closed.
 
 **Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
 Quot.sound]` triple only.  **No `P ≠ NP` claim.**
@@ -126,6 +129,145 @@ def LoopLayout (w : Nat) {L : Nat}
   ∧ (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
       (q : Nat) < (c.head : Nat) - u → c.tape q = false)
   ∧ u + counterValue c ((c.head : Nat) + 1) w ≤ (c.head : Nat) - 1
+
+/-! ### One layout-preserving loop iteration, and the loop-termination proof -/
+
+set_option maxHeartbeats 1600000 in
+theorem binToUnaryLoopFullScan_oneIteration (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat)
+    (hL : LoopLayout w c u)
+    (hpos : counterValue c ((c.head : Nat) + 1) w ≠ 0) :
+    ∃ sB, ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1)).state.fst : Nat) = 0
+      ∧ ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1)).head : Nat) = (c.head : Nat)
+      ∧ LoopLayout w (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1)) (u + 1)
+      ∧ counterValue (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1))
+            ((c.head : Nat) + 1) w + 1 = counterValue c ((c.head : Nat) + 1) w := by
+  obtain ⟨hph0, hu1, hHOME1, hbound, hsent, hUlay, hblank, hroom⟩ := hL
+  obtain ⟨j, hjw, hzeros, hone⟩ := counterValue_pos_imp_lowestBit c ((c.head : Nat) + 1) w hpos
+  obtain ⟨hPp, hPh⟩ := binToUnaryLoopFullScan_runConfig_pos w c hph0 j hjw (by omega) hzeros hone
+  have hPt := binToUnaryLoopFullScan_runConfig_pos_tape w c hph0 j hjw (by omega) hzeros hone
+  set cP := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (j + 3) with hcPdef
+  obtain ⟨hQp, hQh, hQt⟩ := binToUnaryLoopFullScan_runConfig_postDivert w cP hPp (by rw [hPh]; omega)
+  set cQ := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) cP 3 with hcQdef
+  have hQt' : cQ.tape = c.tape := hQt.trans hPt
+  have hQh' : (cQ.head : Nat) = (c.head : Nat) + 2 + j := by omega
+  obtain ⟨hRp, hRh, hRt⟩ := binToUnaryLoopFullScan_seek_home w cQ (c.head : Nat) j hQp hHOME1 hQh'
+    (by omega)
+    (by intro q hq1 hq2; rw [hQt']
+        rcases Nat.lt_or_ge (q : Nat) ((c.head : Nat) + 1) with hlt | hge
+        · have heq : (q : Nat) = (c.head : Nat) := by omega
+          rw [show q = c.head from Fin.ext heq]; exact hsent
+        · exact hzeros q hge (by omega))
+    (by intro q hq; rw [hQt']; exact hUlay q (by omega) (by omega))
+  set cR := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) cQ (j + 10) with hcRdef
+  have hRt' : cR.tape = c.tape := hRt.trans hQt'
+  have hRh' : (cR.head : Nat) = (c.head : Nat) := hRh
+  have hRsent : cR.tape cR.head = false := by
+    rw [hRt']; rw [show cR.head = c.head from Fin.ext hRh']; exact hsent
+  have hZ : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (cR.head : Nat) + 1 ≤ (p : Nat) → (p : Nat) < (cR.head : Nat) + 1 + j → cR.tape p = false := by
+    intro p hp1 hp2; rw [hRt']; exact hzeros p (by rw [hRh'] at hp1; omega) (by rw [hRh'] at hp2; omega)
+  have hO : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (cR.head : Nat) + 1 + j → cR.tape p = true := by
+    intro p hp; rw [hRt']; exact hone p (by rw [hRh'] at hp; omega)
+  have hUU : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (cR.head : Nat) - u ≤ (p : Nat) → (p : Nat) < (cR.head : Nat) → cR.tape p = true := by
+    intro p hp1 hp2; rw [hRt']; exact hUlay p (by rw [hRh'] at hp1; omega) (by rw [hRh'] at hp2; omega)
+  have hUb : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (p : Nat) = (cR.head : Nat) - u - 1 → cR.tape p = false := by
+    intro p hp; rw [hRt']; exact hblank p (by rw [hRh'] at hp; omega)
+  have hUfitR : u + 1 ≤ (cR.head : Nat) := by rw [hRh']; omega
+  obtain ⟨hFp, hFh, hFt⟩ := binToUnaryLoopFullScan_body_runConfig_onePass w cR hRp j
+    (by rw [hRh']; omega) hZ hO hRsent (by rw [hRh']; omega) u hUfitR hUU hUb
+  have hMeasure := binToUnaryLoopFullScan_body_onePass_counterValue w cR hRp j
+    (by rw [hRh']; omega) hZ hO hRsent (by rw [hRh']; omega) u hUfitR hUU hUb hjw (by rw [hRh']; omega)
+  set sB := (j + 3) + 3 + (j + 10) + onePassSteps j u with hsBdef
+  have hcF : TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB
+      = TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) cR (onePassSteps j u) := by
+    rw [hsBdef, hcRdef, hcQdef, hcPdef, ← TM.runConfig_add, ← TM.runConfig_add, ← TM.runConfig_add]
+    congr 1; omega
+  have hFp' : ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB).state.fst : Nat) = w + 29 := by
+    rw [hcF]; exact hFp
+  have hFh' : ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB).head : Nat) = (c.head : Nat) := by
+    rw [hcF]; exact hFh.trans hRh'
+  have hFtape : ∀ p : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+      (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB).tape p
+        = (if (p : Nat) = (c.head : Nat) - u - 1 then true
+          else if (c.head : Nat) + 1 ≤ (p : Nat) ∧ (p : Nat) < (c.head : Nat) + 1 + j then true
+          else if (p : Nat) = (c.head : Nat) + 1 + j then false else c.tape p) := by
+    intro p; rw [hcF, hFt p, hRt', hRh']
+  have hcounterF : counterValue (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB)
+        ((c.head : Nat) + 1) w + 1 = counterValue c ((c.head : Nat) + 1) w := by
+    rw [show ((cR.head : Nat) + 1) = ((c.head : Nat) + 1) from by rw [hRh']] at hMeasure
+    rw [hcF, hMeasure]
+    exact counterValue_eq_of_tape_eq cR c ((c.head : Nat) + 1) w (fun p _ _ => by rw [hRt'])
+  -- back-edge facts on runConfig c (sB+1) = stepConfig (runConfig c sB)
+  have hbe_phase : ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1)).state.fst : Nat) = 0 := by
+    rw [TM.runConfig_succ]
+    exact binToUnaryLoopFullScan_backedge_phase w (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB)
+      (i := _) (s := _) hFp' rfl
+  have hbe_head : ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1)).head : Nat) = (c.head : Nat) := by
+    rw [TM.runConfig_succ,
+      binToUnaryLoopFullScan_backedge_head w (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB)
+        (i := _) (s := _) hFp' rfl]
+    exact hFh'
+  have hbe_tape : (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1)).tape
+      = (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB).tape := by
+    rw [TM.runConfig_succ]
+    exact binToUnaryLoopFullScan_backedge_tape w (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB)
+      (i := _) (s := _) hFp' rfl
+  have hbe_hfin : (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1)).head = c.head :=
+    Fin.ext hbe_head
+  refine ⟨sB, hbe_phase, hbe_head, ⟨hbe_phase, by omega, by rw [hbe_head]; omega, by rw [hbe_head]; omega, ?_, ?_, ?_, ?_⟩, ?_⟩
+  · -- sentinel
+    rw [hbe_tape, hbe_hfin, hFtape c.head]
+    rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]; exact hsent
+  · -- U' = 1^(u+1)
+    intro q hq1 hq2; rw [hbe_head] at hq1 hq2
+    rw [hbe_tape, hFtape q]
+    by_cases hqe : (q : Nat) = (c.head : Nat) - u - 1
+    · rw [if_pos hqe]
+    · rw [if_neg hqe, if_neg (by omega), if_neg (by omega)]; exact hUlay q (by omega) (by omega)
+  · -- blank'
+    intro q hq; rw [hbe_head] at hq
+    rw [hbe_tape, hFtape q, if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+    exact hblank q (by omega)
+  · -- room invariant
+    rw [hbe_head]
+    have hcD : counterValue (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1))
+        ((c.head : Nat) + 1) w = counterValue (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB)
+          ((c.head : Nat) + 1) w :=
+      counterValue_eq_of_tape_eq _ _ ((c.head : Nat) + 1) w (fun p _ _ => by rw [hbe_tape])
+    rw [hcD]; omega
+  · -- counter decrease
+    have hcD : counterValue (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1))
+        ((c.head : Nat) + 1) w = counterValue (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c sB)
+          ((c.head : Nat) + 1) w :=
+      counterValue_eq_of_tape_eq _ _ ((c.head : Nat) + 1) w (fun p _ _ => by rw [hbe_tape])
+    rw [hcD]; exact hcounterF
+
+
+/-- **The sound binary→unary loop halts.**  From any `LoopLayout` config, the loop reaches its sink phase
+`w + 2` (the `B = 0` outcome): bespoke strong induction on `counterValue B`, base `B = 0` from `hbase`,
+step `B > 0` from `oneIteration` (one pass drops the counter and re-establishes the layout). -/
+theorem binToUnaryLoopFullScan_reachesSink (w : Nat) {L : Nat} :
+    ∀ (m : Nat) (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat),
+      LoopLayout w c u → counterValue c ((c.head : Nat) + 1) w = m →
+      ∃ t, ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).state.fst : Nat) = w + 2 := by
+  intro m
+  induction m using Nat.strong_induction_on with
+  | _ m ih =>
+    intro c u hL hm
+    rcases Nat.eq_zero_or_pos m with hm0 | hmpos
+    · obtain ⟨hph0, _, _, hbound, _, _, _, _⟩ := hL
+      exact ⟨2 + w, binToUnaryLoopFullScan_runConfig_hbase w c hph0 (by omega) (by rw [hm]; exact hm0)⟩
+    · obtain ⟨sB, _, hhd, hLnext, hdec⟩ :=
+        binToUnaryLoopFullScan_oneIteration w c u hL (by rw [hm]; omega)
+      set d := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1) with hddef
+      have hmlt : counterValue d ((d.head : Nat) + 1) w < m := by
+        rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+      obtain ⟨t, ht⟩ := ih (counterValue d ((d.head : Nat) + 1) w) hmlt d (u + 1) hLnext rfl
+      exact ⟨(sB + 1) + t, by rw [TM.runConfig_add, ← hddef]; exact ht⟩
 
 end ContractExpansion
 end Frontier

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterDecodeFin.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterDecodeFin.lean
@@ -1,0 +1,81 @@
+import Complexity.TMVerifier.TuringToolkit.Encoding
+import Mathlib.Tactic.Ring
+
+/-!
+# `counterValue` ↔ `decodeFin` bridge (NP-verifier track — D2t-3 `ζ`)
+
+The pure-spec identity closing `ζ`: the on-tape little-endian counter value `counterValue` agrees with the
+formal decoder `Encoding.decodeFin`.  `tapeBits` reads the width-`w` window as a little-endian bit list,
+and `decodeFin_tapeBits` shows `decodeFin w (tapeBits …) = some ⟨counterValue …, _⟩` — i.e.
+`counterValue = (decodeFin w …).val`.  `counterValue_lsb_shift` is the supporting little-endian shift
+(`value (w+1) = lowbit + 2 · value w` on the shifted window).
+
+Combined with `binToUnaryLoopFullScan_reachesSink_output` (`|U| = u₀ + counterValue B`), this gives the
+`ζ` bridge `|U| = value(B) = (decodeFin w …).val`.  Pure `BinaryCounter`/`Encoding` arithmetic — no
+machine/run content.
+
+**Progress classification (AGENTS.md): Infrastructure.**  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp3
+namespace Internal
+namespace PsubsetPpoly
+namespace TM
+namespace BinaryCounter
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- Little-endian LSB-shift for `counterValue`: the value of the width-`w+1` window at `start` is the low
+bit at `start` plus twice the value of the width-`w` window at `start+1`. -/
+theorem counterValue_lsb_shift {M : TM.{u}} {n : Nat}
+    (c : Configuration (M := M) n) (start : Nat) :
+    ∀ w, counterValue c start (w + 1)
+      = (if h : start < M.tapeLength n then (if c.tape ⟨start, h⟩ then 1 else 0) else 0)
+        + 2 * counterValue c (start + 1) w := by
+  intro w
+  induction w with
+  | zero =>
+      rw [counterValue_succ, counterValue_zero, counterValue_zero]
+      simp only [Nat.add_zero, pow_zero, Nat.mul_zero, Nat.zero_add]
+  | succ w ih =>
+      rw [counterValue_succ, ih, counterValue_succ]
+      have hfe : start + 1 + w = start + (w + 1) := by omega
+      rw [hfe]
+      by_cases hd : start + (w + 1) < M.tapeLength n
+      · rw [dif_pos hd, dif_pos hd, pow_succ]; split_ifs <;> ring
+      · rw [dif_neg hd, dif_neg hd]; ring
+
+/-- Tape bit list (little-endian, LSB first): the width-`w` window at `start`. -/
+def tapeBits {M : TM.{u}} {n : Nat} (c : Configuration (M := M) n) (start : Nat) : Nat → List Bool
+  | 0 => []
+  | w + 1 => (if h : start < M.tapeLength n then c.tape ⟨start, h⟩ else false) :: tapeBits c (start + 1) w
+
+set_option linter.unusedSimpArgs false in
+/-- **ζ decode bridge.**  Decoding the tape's width-`w` window (as a little-endian bit list) recovers the
+counter value: `decodeFin w (tapeBits …) = some ⟨counterValue …, _⟩`, i.e. `counterValue` agrees with the
+formal `Encoding.decodeFin`. -/
+theorem decodeFin_tapeBits {M : TM.{u}} {n : Nat}
+    (c : Configuration (M := M) n) (start : Nat) :
+    ∀ w, (h : counterValue c start w < 2 ^ w) →
+      decodeFin w (tapeBits c start w) = some ⟨counterValue c start w, h⟩ := by
+  intro w
+  induction w generalizing start with
+  | zero => intro h; simp [tapeBits, decodeFin, counterValue_zero]
+  | succ w ih =>
+      intro h
+      have hcvw : counterValue c (start + 1) w < 2 ^ w := counterValue_lt_two_pow c (start + 1) w
+      rw [tapeBits, decodeFin, ih (start + 1) hcvw]
+      apply Option.some_inj.mpr
+      apply Fin.ext
+      simp only [Fin.val_mk]
+      rw [counterValue_lsb_shift c start w]
+      by_cases hd : start < M.tapeLength n
+      · rw [dif_pos hd, dif_pos hd]
+      · rw [dif_neg hd, dif_neg hd]; simp
+
+end BinaryCounter
+end TM
+end PsubsetPpoly
+end Internal
+end Pnp3

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterDecodeFin.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterDecodeFin.lean
@@ -18,13 +18,12 @@ machine/run content.
 Quot.sound]` triple only.  **No `P ≠ NP` claim.**
 -/
 
-namespace Pnp3
-namespace Internal
-namespace PsubsetPpoly
-namespace TM
-namespace BinaryCounter
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
 
 open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM Pnp3.Internal.PsubsetPpoly.TM.Encoding
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
 
 /-- Little-endian LSB-shift for `counterValue`: the value of the width-`w+1` window at `start` is the low
 bit at `start` plus twice the value of the width-`w` window at `start+1`. -/
@@ -74,8 +73,6 @@ theorem decodeFin_tapeBits {M : TM.{u}} {n : Nat}
       · rw [dif_pos hd, dif_pos hd]
       · rw [dif_neg hd, dif_neg hd]; simp
 
-end BinaryCounter
-end TM
-end PsubsetPpoly
-end Internal
-end Pnp3
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterLowestBit.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterLowestBit.lean
@@ -15,13 +15,12 @@ forces every counted cell to `0`), proved by the same per-bit induction.
 no run behaviour.  Standard `[propext, Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
 -/
 
-namespace Pnp3
-namespace Internal
-namespace PsubsetPpoly
-namespace TM
-namespace BinaryCounter
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
 
 open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
 
 /-- `counterValue = 0` forces every counted cell to be `false` (the converse of
 `counterValue_of_all_false`). -/
@@ -81,8 +80,6 @@ theorem counterValue_pos_imp_lowestBit {M : TM.{u}} {n : Nat}
       · obtain ⟨j, hj, hz, ho⟩ := ih hcw
         exact ⟨j, Nat.lt_succ_of_lt hj, hz, ho⟩
 
-end BinaryCounter
-end TM
-end PsubsetPpoly
-end Internal
-end Pnp3
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterLowestBit.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCounterLowestBit.lean
@@ -1,0 +1,88 @@
+import Complexity.TMVerifier.TuringToolkit.BinaryCounter
+
+/-!
+# `counterValue` lowest-set-bit existence (NP-verifier track — D2t-3 `ε`, `hstep` support)
+
+The arithmetic ingredient `hstep` needs to invoke the `B > 0` body pass: a nonzero little-endian counter
+has a **lowest set bit**.  Given `counterValue c start w ≠ 0`, there is a `j < w` with cells
+`[start, start+j)` all `0` and cell `start+j` set — exactly the `hzeros`/`hone` hypotheses of
+`binToUnaryLoopFullScan_runConfig_bodyPass` (with `start := head + 1`).
+
+`counterValue_eq_zero_imp_false` is the supporting converse of `counterValue_of_all_false` (a zero counter
+forces every counted cell to `0`), proved by the same per-bit induction.
+
+**Progress classification (AGENTS.md): Infrastructure** — a `BinaryCounter` arithmetic lemma; no verifier,
+no run behaviour.  Standard `[propext, Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp3
+namespace Internal
+namespace PsubsetPpoly
+namespace TM
+namespace BinaryCounter
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+
+/-- `counterValue = 0` forces every counted cell to be `false` (the converse of
+`counterValue_of_all_false`). -/
+theorem counterValue_eq_zero_imp_false {M : TM.{u}} {n : Nat}
+    (c : Configuration (M := M) n) (start : Nat) :
+    ∀ k, counterValue c start k = 0 →
+      ∀ i, i < k → (h : start + i < M.tapeLength n) → c.tape ⟨start + i, h⟩ = false := by
+  intro k
+  induction k with
+  | zero => intro _ i hi _; omega
+  | succ k ih =>
+      intro h0 i hi h
+      rw [counterValue_succ] at h0
+      have hlo : counterValue c start k = 0 := by omega
+      have hbit : (if hh : start + k < M.tapeLength n then
+            (if c.tape ⟨start + k, hh⟩ then 2 ^ k else 0) else 0) = 0 := by omega
+      rcases Nat.lt_succ_iff_lt_or_eq.mp hi with hlt | heq
+      · exact ih hlo i hlt h
+      · subst heq
+        rw [dif_pos h] at hbit
+        by_contra hc
+        rw [Bool.not_eq_false] at hc
+        rw [hc] at hbit
+        simp at hbit
+
+/-- **Lowest set bit.**  If the width-`w` little-endian counter at `start` is nonzero, there is a lowest
+set bit `j < w`: cells `[start, start+j)` are all `0` and cell `start+j` is `1`.  Matches the
+`hzeros`/`hone` hypotheses of `binToUnaryLoopFullScan_runConfig_bodyPass` (with `start := head + 1`). -/
+theorem counterValue_pos_imp_lowestBit {M : TM.{u}} {n : Nat}
+    (c : Configuration (M := M) n) (start : Nat) :
+    ∀ w, counterValue c start w ≠ 0 →
+      ∃ j, j < w
+        ∧ (∀ q : Fin (M.tapeLength n), start ≤ (q : Nat) → (q : Nat) < start + j → c.tape q = false)
+        ∧ (∀ q : Fin (M.tapeLength n), (q : Nat) = start + j → c.tape q = true) := by
+  intro w
+  induction w with
+  | zero => intro h; simp [counterValue] at h
+  | succ w ih =>
+      intro hpos
+      by_cases hcw : counterValue c start w = 0
+      · refine ⟨w, Nat.lt_succ_self w, ?_, ?_⟩
+        · intro q hq1 hq2
+          have hi := counterValue_eq_zero_imp_false c start w hcw ((q : Nat) - start) (by omega)
+            (by omega)
+          simp only [show start + ((q : Nat) - start) = (q : Nat) from by omega, Fin.eta] at hi
+          exact hi
+        · intro q hq
+          rw [counterValue_succ, hcw, Nat.zero_add] at hpos
+          have hfit : start + w < M.tapeLength n := by
+            by_contra hnf; rw [dif_neg hnf] at hpos; exact hpos rfl
+          rw [dif_pos hfit] at hpos
+          have hqeq : q = ⟨start + w, hfit⟩ := Fin.ext (by rw [hq])
+          rw [hqeq]
+          by_contra hc
+          rw [Bool.not_eq_true] at hc
+          rw [hc] at hpos; simp at hpos
+      · obtain ⟨j, hj, hz, ho⟩ := ih hcw
+        exact ⟨j, Nat.lt_succ_of_lt hj, hz, ho⟩
+
+end BinaryCounter
+end TM
+end PsubsetPpoly
+end Internal
+end Pnp3

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -110,6 +110,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterDecodeFin
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
@@ -3914,6 +3915,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink
 -- D2t-3 ζ core: the produced unary block has length value(B).
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output
+-- D2t-3 ζ bridge: counterValue = (decodeFin w …).val.
+#check @Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.decodeFin_tapeBits
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3908,7 +3908,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos_tape
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_bodyPass
 -- D2t-3 ε hstep support: lowest-set-bit existence for a nonzero little-endian counter.
-#check @Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.counterValue_pos_imp_lowestBit
+#check @Pnp4.Frontier.ContractExpansion.counterValue_pos_imp_lowestBit
 -- D2t-3 ε loop-termination (PROVEN): back-edge + LoopLayout invariant, one iteration, reachesSink.
 #check @Pnp4.Frontier.ContractExpansion.loopUntilSink_stepConfig_loop_tape
 #check @Pnp4.Frontier.ContractExpansion.LoopLayout
@@ -3917,7 +3917,7 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3 ζ core: the produced unary block has length value(B).
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output
 -- D2t-3 ζ bridge: counterValue = (decodeFin w …).val.
-#check @Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.decodeFin_tapeBits
+#check @Pnp4.Frontier.ContractExpansion.decodeFin_tapeBits
 -- D2t-3 capstone: transcoder correctness (|U| = value(B) = (decodeFin …).val).
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_transcoder_correct
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -112,6 +112,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterDecodeFin
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
@@ -3917,6 +3918,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output
 -- D2t-3 ζ bridge: counterValue = (decodeFin w …).val.
 #check @Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.decodeFin_tapeBits
+-- D2t-3 capstone: transcoder correctness (|U| = value(B) = (decodeFin …).val).
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_transcoder_correct
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3906,9 +3906,11 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_bodyPass
 -- D2t-3 ε hstep support: lowest-set-bit existence for a nonzero little-endian counter.
 #check @Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.counterValue_pos_imp_lowestBit
--- D2t-3 ε reachesSink scaffolding: back-edge tape preservation + the LoopLayout invariant.
+-- D2t-3 ε loop-termination (PROVEN): back-edge + LoopLayout invariant, one iteration, reachesSink.
 #check @Pnp4.Frontier.ContractExpansion.loopUntilSink_stepConfig_loop_tape
 #check @Pnp4.Frontier.ContractExpansion.LoopLayout
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_oneIteration
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -109,6 +109,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3902,6 +3903,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-3 ε hstep core: one B>0 body pass reaches the body accept w+29, head at HOME, counterValue B − 1.
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos_tape
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_bodyPass
+-- D2t-3 ε hstep support: lowest-set-bit existence for a nonzero little-endian counter.
+#check @Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.counterValue_pos_imp_lowestBit
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -111,6 +111,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3911,6 +3912,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.LoopLayout
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_oneIteration
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink
+-- D2t-3 ζ core: the produced unary block has length value(B).
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -105,6 +105,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3883,6 +3884,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_scanning
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_hbase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos
+-- D2t-3 ε body bridge: loop body transition at phase w+15+k = binToUnaryBody transition at phase k.
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_phase
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_bit
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_move
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -107,6 +107,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3895,6 +3896,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_append_scanning
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_scanRight_scanning
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_runConfig_onePass
+-- D2t-3 ε measure: one body pass drops counterValue B by exactly one.
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_onePass_counterValue
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -108,6 +108,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3898,6 +3899,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_runConfig_onePass
 -- D2t-3 ε measure: one body pass drops counterValue B by exactly one.
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_onePass_counterValue
+-- D2t-3 ε hstep core: one B>0 body pass reaches the body accept w+29, head at HOME, counterValue B − 1.
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos_tape
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_bodyPass
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -106,6 +106,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3888,6 +3889,12 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_phase
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_bit
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_move
+-- D2t-3 ε body one-pass on the sound loop (phases w+15..w+29): the four scan inductions + onePass.
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_decrement_scanning
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_scanLeft_scanning
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_append_scanning
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_scanRight_scanning
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_runConfig_onePass
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -110,6 +110,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -3905,6 +3906,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_bodyPass
 -- D2t-3 ε hstep support: lowest-set-bit existence for a nonzero little-endian counter.
 #check @Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.counterValue_pos_imp_lowestBit
+-- D2t-3 ε reachesSink scaffolding: back-edge tape preservation + the LoopLayout invariant.
+#check @Pnp4.Frontier.ContractExpansion.loopUntilSink_stepConfig_loop_tape
+#check @Pnp4.Frontier.ContractExpansion.LoopLayout
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -100,6 +100,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterDecodeFin
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
@@ -709,6 +710,8 @@ end Pnp4
 -- D2t-3 ζ core: the loop produces a unary block of length u₀ + value(B) at the sink (|U| = value B).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_hbase_tape
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output
+-- D2t-3 ζ bridge: counterValue agrees with the formal decoder — counterValue = (decodeFin w …).val.
+#print axioms Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.decodeFin_tapeBits
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -102,6 +102,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterDecodeFin
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanCorrect
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
@@ -712,6 +713,8 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output
 -- D2t-3 ζ bridge: counterValue agrees with the formal decoder — counterValue = (decodeFin w …).val.
 #print axioms Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.decodeFin_tapeBits
+-- D2t-3 capstone: the sound transcoder halts and emits a unary block of length value(B) = (decodeFin …).val.
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_transcoder_correct
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -701,6 +701,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.loopUntilSink_stepConfig_loop_tape
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_transition_backedge
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_backedge_phase
+-- D2t-3 ε loop-termination, PROVEN: one layout-preserving iteration (counterValue B − 1), and the loop
+-- reaches its sink w+2 on every valid layout (bespoke strong induction on counterValue B).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_oneIteration
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -696,8 +696,11 @@ end Pnp4
 -- D2t-3 ε hstep support: a nonzero little-endian counter has a lowest set bit (the j the body pass needs).
 #print axioms Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.counterValue_pos_imp_lowestBit
 -- D2t-3 ε reachesSink scaffolding: the loop back-edge preserves the tape (per-iteration counter is the
--- body pass's output); the LoopLayout invariant the bespoke termination induction carries.
+-- body pass's output); the LoopLayout invariant the bespoke termination induction carries; the
+-- FullScan-specific back-edge (phase w+29 → start 0) avoiding the expensive loopUntilSink defeq.
 #print axioms Pnp4.Frontier.ContractExpansion.loopUntilSink_stepConfig_loop_tape
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_transition_backedge
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_backedge_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -97,6 +97,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -682,6 +683,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_append_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_scanRight_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_runConfig_onePass
+-- D2t-3 ε measure: one body pass drops counterValue B by exactly one (the strict decrease
+-- `loopUntilSink_reachesSink`'s hstep consumes, with μ := counterValue B).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_onePass_counterValue
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -96,6 +96,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -673,6 +674,14 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_phase
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_bit
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_move
+-- D2t-3 ε body one-pass: `binToUnaryBody`'s HOME→HOME engine re-derived on the sound loop (phases
+-- w+15..w+29) via the body bridge — decrement B, re-home, append 1 to U, re-home, reach the body accept
+-- w+29.  The four scan inductions + the `onePass` headline (per-iteration engine `hstep` iterates).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_decrement_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_scanLeft_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_append_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_scanRight_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_runConfig_onePass
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -100,6 +100,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -694,6 +695,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_bodyPass
 -- D2t-3 ε hstep support: a nonzero little-endian counter has a lowest set bit (the j the body pass needs).
 #print axioms Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.counterValue_pos_imp_lowestBit
+-- D2t-3 ε reachesSink scaffolding: the loop back-edge preserves the tape (per-iteration counter is the
+-- body pass's output); the LoopLayout invariant the bespoke termination induction carries.
+#print axioms Pnp4.Frontier.ContractExpansion.loopUntilSink_stepConfig_loop_tape
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -101,6 +101,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanReachesSink
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanOutput
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -705,6 +706,9 @@ end Pnp4
 -- reaches its sink w+2 on every valid layout (bespoke strong induction on counterValue B).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_oneIteration
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink
+-- D2t-3 ζ core: the loop produces a unary block of length u₀ + value(B) at the sink (|U| = value B).
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_hbase_tape
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -98,6 +98,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -686,6 +687,10 @@ end Pnp4
 -- D2t-3 ε measure: one body pass drops counterValue B by exactly one (the strict decrease
 -- `loopUntilSink_reachesSink`'s hstep consumes, with μ := counterValue B).
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_body_onePass_counterValue
+-- D2t-3 ε hstep core: one B>0 body pass (pos→postDivert→seek→onePass) reaches the body accept w+29 with
+-- the head back at HOME and counterValue B strictly decreased — the per-iteration work hstep iterates.
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos_tape
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_bodyPass
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -95,6 +95,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPeel
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanScan
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHbase
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanPos
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -666,6 +667,12 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_scanning
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_hbase
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos
+-- D2t-3 ε body bridge: collapse the depth-4 nesting of binToUnaryBody (phases w+15..w+29) to its
+-- local transition at phase k (phase shifted by w+15; bit/move inherited) — the symbolic-w analogue of
+-- the Rehome body's per-step simp, the foundation for the FullScan body one-pass run-through.
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_phase
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_bit
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopBodyFullScan_atBody_move
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -697,7 +697,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos_tape
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_bodyPass
 -- D2t-3 ε hstep support: a nonzero little-endian counter has a lowest set bit (the j the body pass needs).
-#print axioms Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.counterValue_pos_imp_lowestBit
+#print axioms Pnp4.Frontier.ContractExpansion.counterValue_pos_imp_lowestBit
 -- D2t-3 ε reachesSink scaffolding: the loop back-edge preserves the tape (per-iteration counter is the
 -- body pass's output); the LoopLayout invariant the bespoke termination induction carries; the
 -- FullScan-specific back-edge (phase w+29 → start 0) avoiding the expensive loopUntilSink defeq.
@@ -712,7 +712,7 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_hbase_tape
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output
 -- D2t-3 ζ bridge: counterValue agrees with the formal decoder — counterValue = (decodeFin w …).val.
-#print axioms Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.decodeFin_tapeBits
+#print axioms Pnp4.Frontier.ContractExpansion.decodeFin_tapeBits
 -- D2t-3 capstone: the sound transcoder halts and emits a unary block of length value(B) = (decodeFin …).val.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_transcoder_correct
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -99,6 +99,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyBridge
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanBodyRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanMeasure
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanHstep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCounterLowestBit
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightBranch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRouteRealizable
 import Pnp4.Frontier.ContractExpansion.TreeMCSPBZeroRoute
@@ -691,6 +692,8 @@ end Pnp4
 -- the head back at HOME and counterValue B strictly decreased — the per-iteration work hstep iterates.
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_pos_tape
 #print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_runConfig_bodyPass
+-- D2t-3 ε hstep support: a nonzero little-endian counter has a lowest set bit (the j the body pass needs).
+#print axioms Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter.counterValue_pos_imp_lowestBit
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
## Summary

This PR adds foundational infrastructure for the NP-verifier track of the tree-MCSP lower bound project. It introduces composition-survival lemmas for proven Turing machine primitives, loop combinators for iterative control flow, and a suite of decoder/transcoder modules that build toward the full verifier machine.

## Key Changes

### Core Infrastructure
- **`BoundedLoopProgram.lean`**: Introduces `repeatProgram` for symbolic loop iteration via `seqList` repetition, enabling row-iteration loops without back-edge machinery
- **`TreeMCSPLoopUntilSink.lean`**: Implements `loopUntilSink`, a self-terminating loop combinator that re-enters a body until reaching a designated sink phase
- **`TreeMCSPCounterComposition.lean`**: Re-derives single-step carry/stop lemmas and carry-ripple invariants for `selfLoopIncrement` when composed as the first component of `seq selfLoopIncrement P2`, establishing composition-survival for proven primitives

### Decoder Bricks (D0–D2)
- **`TreeMCSPGateRecordLayout.lean`**: Specifies the on-tape gate-record format (unary tag + operands)
- **`TreeMCSPGateTagDispatch.lean`**: Implements the tag dispatcher (D1b part 1) — reads self-delimiting unary tag `1^t 0`
- **`TreeMCSPGateRecordDecoder.lean`**: Monolithic one-gate-record decoder (D1b part 2) with 14 phases: tag scanning, per-tag operand reads as internal self-loop phases, common accept phase
- **`TreeMCSPGateStreamDecoder.lean`** & **`TreeMCSPGateStreamReachesSink.lean`**: Stream decoder (D2) looping the record decoder until end-of-stream marker

### Binary→Unary Transcoder (D2t-3)
- **`TreeMCSPBinToUnaryBody.lean`**: Defines the 7-element one-pass body (step right, decrement, step left, scan left, step left, append left, scan right)
- **`TreeMCSPBinToUnaryLoop.lean`** & **`TreeMCSPBinToUnaryLoopRehome.lean`**: Two loop variants with different seek-home strategies
- **`TreeMCSPBZeroRoute.lean`** & **`TreeMCSPBZeroFullScan.lean`**: Sound `B = 0` test implementations (routing and full-scan variants)
- **Loop body lemmas** (`TreeMCSPBinToUnaryLoopFullScanBodyStep.lean`, `TreeMCSPBinToUnaryLoopFullScanBodyRun.lean`, etc.): Re-derive body behavior directly on composed loop machines at offset `+15` or `+w+15`
- **Loop termination** (`TreeMCSPBinToUnaryLoopFullScanReachesSink.lean`, `TreeMCSPBinToUnaryLoopHbase.lean`): Prove loop halts when `B = 0`

### Gamma Decoder (D1a)
- **`TreeMCSPGammaScanProgram.lean`**: Head-carried scan for Elias-gamma leading zeros
- **`TreeMCSPGammaFillProgram.lean`** & **`TreeMCSPGammaFillComposition.lean`**: Materialize loop counter by filling zeros with ones
- **`TreeMCSPCountdownLeft.lean`**: Unary countdown self-loop for bounded counter iteration

### Supporting Modules
- **`TreeMCSPUnaryFieldReader.lean`**: Unary field reader (D1a part 2)
- **`TreeMCSPBidirHeadBounds.lean`**: Head-movement bounds for bidirectional programs
- **`TreeMCSPCounterLowestBit.lean`**: Lowest-set-bit existence for binary counters
- **`TreeMCSPCounterDecodeFin.lean`**: Bridge between `counterValue

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj