### PR TITLE
transcoder(D2t-4b core): binary→unary index as a unary field `unaryField i` on the tape

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -320,6 +320,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanCorrect.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanCorrect.lean
@@ -43,7 +43,7 @@ theorem binToUnaryLoopFullScan_transcoder_correct (w : Nat) {L : Nat}
           (c.head : Nat) - (u + i.val) ≤ (q : Nat) → (q : Nat) < (c.head : Nat) →
           (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape q = true) := by
   have hlt : counterValue c ((c.head : Nat) + 1) w < 2 ^ w := counterValue_lt_two_pow c _ w
-  obtain ⟨t, hsink, hU⟩ :=
+  obtain ⟨t, hsink, hU, _⟩ :=
     binToUnaryLoopFullScan_reachesSink_output w (counterValue c ((c.head : Nat) + 1) w) c u hL rfl
   refine ⟨t, ⟨counterValue c ((c.head : Nat) + 1) w, hlt⟩, hsink,
     decodeFin_tapeBits c ((c.head : Nat) + 1) w hlt, ?_⟩

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanOutput.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPBinToUnaryLoopFullScanOutput.lean
@@ -69,45 +69,54 @@ theorem binToUnaryLoopFullScan_runConfig_hbase_tape (w : Nat) {L : Nat}
   rw [this, hst, h2t]
 
 
-/-- **ζ core — the produced unary block.**  From a `LoopLayout w c u` config, the loop reaches its sink
-and the cells `[HOME - (u + counterValue B), HOME)` are all `1`: the unary block of length
-`u + counterValue B = u₀ + value(B)`.  (With the seed `u₀`, the produced answer block has length
-`value(B)`.)  Bespoke strong induction on `counterValue B`, base `B = 0` (head scans to the sink, `U`
-untouched, length `u`), step `B > 0` (one pass appends a `1`, `u ↦ u+1`, `counterValue ↦ counterValue-1`,
-the block length `u + counterValue` preserved). -/
+/-- **ζ core — the produced unary block (+ sentinel).**  From a `LoopLayout w c u` config, the loop
+reaches its sink and the cells `[HOME - (u + counterValue B), HOME)` are all `1`: the unary block of
+length `u + counterValue B = u₀ + value(B)`.  (With the seed `u₀`, the produced answer block has length
+`value(B)`.)  The **sentinel** cell `HOME` still holds `0` at the sink — it is part of the `LoopLayout`
+invariant, preserved by every `B > 0` iteration (`oneIteration` re-establishes the layout) and by the
+`B = 0` base path (`hbase_tape` leaves the tape unchanged); downstream `unaryField`/record framing reads
+it as the field terminator.  Bespoke strong induction on `counterValue B`, base `B = 0` (head scans to the
+sink, `U` untouched, length `u`), step `B > 0` (one pass appends a `1`, `u ↦ u+1`,
+`counterValue ↦ counterValue-1`, the block length `u + counterValue` preserved). -/
 theorem binToUnaryLoopFullScan_reachesSink_output (w : Nat) {L : Nat} :
     ∀ (m : Nat) (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat),
       LoopLayout w c u → counterValue c ((c.head : Nat) + 1) w = m →
       ∃ t, ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).state.fst : Nat) = w + 2
         ∧ (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
             (c.head : Nat) - (u + m) ≤ (q : Nat) → (q : Nat) < (c.head : Nat) →
-            (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape q = true) := by
+            (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape q = true)
+        ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape c.head = false := by
   intro m
   induction m using Nat.strong_induction_on with
   | _ m ih =>
     intro c u hL hm
     obtain ⟨hph0, hu1, hHOME1, hbound, hsent, hUlay, hblank, hroom⟩ := hL
     rcases Nat.eq_zero_or_pos m with hm0 | hmpos
-    · refine ⟨2 + w, binToUnaryLoopFullScan_runConfig_hbase w c hph0 (by omega) (by rw [hm]; exact hm0), ?_⟩
-      intro q hq1 hq2
-      rw [binToUnaryLoopFullScan_runConfig_hbase_tape w c hph0 (by omega) (by rw [hm]; exact hm0)]
-      exact hUlay q (by omega) hq2
+    · refine ⟨2 + w, binToUnaryLoopFullScan_runConfig_hbase w c hph0 (by omega) (by rw [hm]; exact hm0),
+        ?_, ?_⟩
+      · intro q hq1 hq2
+        rw [binToUnaryLoopFullScan_runConfig_hbase_tape w c hph0 (by omega) (by rw [hm]; exact hm0)]
+        exact hUlay q (by omega) hq2
+      · rw [binToUnaryLoopFullScan_runConfig_hbase_tape w c hph0 (by omega) (by rw [hm]; exact hm0)]
+        exact hsent
     · obtain ⟨sB, _, hhd, hLnext, hdec⟩ :=
         binToUnaryLoopFullScan_oneIteration w c u
           ⟨hph0, hu1, hHOME1, hbound, hsent, hUlay, hblank, hroom⟩ (by rw [hm]; omega)
       set d := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1) with hddef
       have hmlt : counterValue d ((d.head : Nat) + 1) w < m := by
         rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
-      obtain ⟨t, htsink, htU⟩ :=
+      obtain ⟨t, htsink, htU, htsent⟩ :=
         ih (counterValue d ((d.head : Nat) + 1) w) hmlt d (u + 1) hLnext rfl
-      refine ⟨(sB + 1) + t, by rw [TM.runConfig_add, ← hddef]; exact htsink, ?_⟩
-      intro q hq1 hq2
-      rw [TM.runConfig_add, ← hddef]
-      have hdc : counterValue d ((d.head : Nat) + 1) w + 1 = m := by
-        rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
-      apply htU q
-      · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
-      · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+      refine ⟨(sB + 1) + t, by rw [TM.runConfig_add, ← hddef]; exact htsink, ?_, ?_⟩
+      · intro q hq1 hq2
+        rw [TM.runConfig_add, ← hddef]
+        have hdc : counterValue d ((d.head : Nat) + 1) w + 1 = m := by
+          rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+        apply htU q
+        · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+        · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+      · rw [TM.runConfig_add, ← hddef, show c.head = d.head from Fin.ext (by rw [hhd])]
+        exact htsent
 
 end ContractExpansion
 end Frontier

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEmitInputRecord.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEmitInputRecord.lean
@@ -7,12 +7,11 @@ The second **leaf-emit** brick (D2t-4b).  An `input i` gate encodes (`encodeGate
 `unaryField 0 ++ unaryField i = [false] ++ 1^i ++ [false]` (`0 1^i 0`) — the tag `0`, the index in unary,
 the field terminator `0`.  The `1^i` is exactly the **binary→unary of the index** produced by D2t-3's
 `binToUnaryLoopFullScan`: from a `LoopLayout w c u` config the loop halts with the unary block
-`[HOME - (u + i), HOME)` all `1` (`transcoder_correct`), and — proved here — the **sentinel `HOME` stays
-`0`**, so the window `[HOME - i, HOME]` realises `unaryField i = 1^i 0` directly on the tape.
+`[HOME - (u + i), HOME)` all `1` and the **sentinel `HOME` still `0`**
+(`binToUnaryLoopFullScan_reachesSink_output`, sentinel conjunct), so the window `[HOME - i, HOME]` realises
+`unaryField i = 1^i 0` directly on the tape.
 
 This module ships the layout-reconciliation core of D2t-4b:
-* `binToUnaryLoopFullScan_reachesSink_output_framed` — strengthens `reachesSink_output` with sentinel
-  preservation (`LoopLayout`'s sentinel is preserved by every iteration and the `B=0` base path).
 * `emitInputRecord_runConfig_unaryField` — from `LoopLayout`, the loop halts, the width-`w` window decodes
   to `i`, and the window `[HOME - i, HOME]` holds `unaryField i` (the `i` value-ones + the terminator `0`).
 
@@ -32,56 +31,13 @@ open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
 open Pnp3.Internal.PsubsetPpoly.TM.Encoding
 
-/-- **Sentinel-framed reachesSink/output.**  Strengthens `binToUnaryLoopFullScan_reachesSink_output` with
-the fact that the sentinel cell `HOME` still holds `0` at the sink: it is part of the `LoopLayout`
-invariant, preserved by every `B > 0` iteration (`oneIteration` re-establishes the layout) and by the
-`B = 0` base path (`hbase_tape` leaves the tape unchanged). -/
-theorem binToUnaryLoopFullScan_reachesSink_output_framed (w : Nat) {L : Nat} :
-    ∀ (m : Nat) (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat),
-      LoopLayout w c u → counterValue c ((c.head : Nat) + 1) w = m →
-      ∃ t, ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).state.fst : Nat) = w + 2
-        ∧ (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
-            (c.head : Nat) - (u + m) ≤ (q : Nat) → (q : Nat) < (c.head : Nat) →
-            (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape q = true)
-        ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape c.head = false := by
-  intro m
-  induction m using Nat.strong_induction_on with
-  | _ m ih =>
-    intro c u hL hm
-    obtain ⟨hph0, hu1, hHOME1, hbound, hsent, hUlay, hblank, hroom⟩ := hL
-    rcases Nat.eq_zero_or_pos m with hm0 | hmpos
-    · refine ⟨2 + w, binToUnaryLoopFullScan_runConfig_hbase w c hph0 (by omega) (by rw [hm]; exact hm0),
-        ?_, ?_⟩
-      · intro q hq1 hq2
-        rw [binToUnaryLoopFullScan_runConfig_hbase_tape w c hph0 (by omega) (by rw [hm]; exact hm0)]
-        exact hUlay q (by omega) hq2
-      · rw [binToUnaryLoopFullScan_runConfig_hbase_tape w c hph0 (by omega) (by rw [hm]; exact hm0)]
-        exact hsent
-    · obtain ⟨sB, _, hhd, hLnext, hdec⟩ :=
-        binToUnaryLoopFullScan_oneIteration w c u
-          ⟨hph0, hu1, hHOME1, hbound, hsent, hUlay, hblank, hroom⟩ (by rw [hm]; omega)
-      set d := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1) with hddef
-      have hmlt : counterValue d ((d.head : Nat) + 1) w < m := by
-        rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
-      obtain ⟨t, htsink, htU, htsent⟩ :=
-        ih (counterValue d ((d.head : Nat) + 1) w) hmlt d (u + 1) hLnext rfl
-      refine ⟨(sB + 1) + t, by rw [TM.runConfig_add, ← hddef]; exact htsink, ?_, ?_⟩
-      · intro q hq1 hq2
-        rw [TM.runConfig_add, ← hddef]
-        have hdc : counterValue d ((d.head : Nat) + 1) w + 1 = m := by
-          rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
-        apply htU q
-        · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
-        · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
-      · rw [TM.runConfig_add, ← hddef, show c.head = d.head from Fin.ext (by rw [hhd])]
-        exact htsent
-
 /-- **D2t-4b core — the index as a unary field.**  From a valid `LoopLayout`, the sound loop halts, the
 width-`w` input window decodes to `i = decodeFin …`, and the tape window `[HOME - i, HOME]` holds
 `unaryField i = 1^i 0`: the `i` value-ones (`[HOME - i, HOME)`) and the terminator `0` at `HOME`.  This is
 the binary→unary of the index, framed as a self-delimiting unary field — the substance of an `input i`
 record (`encodeGateRecord (.input i) = unaryField 0 ++ unaryField i`); the leading tag-`0` is the next
-brick. -/
+brick.  The `1`-block and the sentinel `0` both come from the (sentinel-strengthened)
+`binToUnaryLoopFullScan_reachesSink_output`. -/
 theorem emitInputRecord_runConfig_unaryField (w : Nat) {L : Nat}
     (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat)
     (hL : LoopLayout w c u) :
@@ -94,7 +50,7 @@ theorem emitInputRecord_runConfig_unaryField (w : Nat) {L : Nat}
       ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape c.head = false := by
   have hlt : counterValue c ((c.head : Nat) + 1) w < 2 ^ w := counterValue_lt_two_pow c _ w
   obtain ⟨t, hsink, hU, hsent⟩ :=
-    binToUnaryLoopFullScan_reachesSink_output_framed w (counterValue c ((c.head : Nat) + 1) w) c u hL rfl
+    binToUnaryLoopFullScan_reachesSink_output w (counterValue c ((c.head : Nat) + 1) w) c u hL rfl
   refine ⟨t, ⟨counterValue c ((c.head : Nat) + 1) w, hlt⟩, hsink,
     decodeFin_tapeBits c ((c.head : Nat) + 1) w hlt, ?_, hsent⟩
   intro q hq1 hq2

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEmitInputRecord.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEmitInputRecord.lean
@@ -1,0 +1,107 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPBinToUnaryLoopFullScanCorrect
+
+/-!
+# `emitInputRecord` — D2t-4b: emit an `input i` gate record `0 1^i 0` (NP-verifier leaf emit)
+
+The second **leaf-emit** brick (D2t-4b).  An `input i` gate encodes (`encodeGateRecord`, D0) as
+`unaryField 0 ++ unaryField i = [false] ++ 1^i ++ [false]` (`0 1^i 0`) — the tag `0`, the index in unary,
+the field terminator `0`.  The `1^i` is exactly the **binary→unary of the index** produced by D2t-3's
+`binToUnaryLoopFullScan`: from a `LoopLayout w c u` config the loop halts with the unary block
+`[HOME - (u + i), HOME)` all `1` (`transcoder_correct`), and — proved here — the **sentinel `HOME` stays
+`0`**, so the window `[HOME - i, HOME]` realises `unaryField i = 1^i 0` directly on the tape.
+
+This module ships the layout-reconciliation core of D2t-4b:
+* `binToUnaryLoopFullScan_reachesSink_output_framed` — strengthens `reachesSink_output` with sentinel
+  preservation (`LoopLayout`'s sentinel is preserved by every iteration and the `B=0` base path).
+* `emitInputRecord_runConfig_unaryField` — from `LoopLayout`, the loop halts, the width-`w` window decodes
+  to `i`, and the window `[HOME - i, HOME]` holds `unaryField i` (the `i` value-ones + the terminator `0`).
+
+The tag-`0` framing into the full `encodeGateRecord (.input i)` record is the next brick.
+
+**Progress classification (AGENTS.md): Infrastructure** — a verifier emit-component proven against the
+pure record codec; builds no verifier and proves no separation.  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.BinaryCounter
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- **Sentinel-framed reachesSink/output.**  Strengthens `binToUnaryLoopFullScan_reachesSink_output` with
+the fact that the sentinel cell `HOME` still holds `0` at the sink: it is part of the `LoopLayout`
+invariant, preserved by every `B > 0` iteration (`oneIteration` re-establishes the layout) and by the
+`B = 0` base path (`hbase_tape` leaves the tape unchanged). -/
+theorem binToUnaryLoopFullScan_reachesSink_output_framed (w : Nat) {L : Nat} :
+    ∀ (m : Nat) (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat),
+      LoopLayout w c u → counterValue c ((c.head : Nat) + 1) w = m →
+      ∃ t, ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).state.fst : Nat) = w + 2
+        ∧ (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+            (c.head : Nat) - (u + m) ≤ (q : Nat) → (q : Nat) < (c.head : Nat) →
+            (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape q = true)
+        ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape c.head = false := by
+  intro m
+  induction m using Nat.strong_induction_on with
+  | _ m ih =>
+    intro c u hL hm
+    obtain ⟨hph0, hu1, hHOME1, hbound, hsent, hUlay, hblank, hroom⟩ := hL
+    rcases Nat.eq_zero_or_pos m with hm0 | hmpos
+    · refine ⟨2 + w, binToUnaryLoopFullScan_runConfig_hbase w c hph0 (by omega) (by rw [hm]; exact hm0),
+        ?_, ?_⟩
+      · intro q hq1 hq2
+        rw [binToUnaryLoopFullScan_runConfig_hbase_tape w c hph0 (by omega) (by rw [hm]; exact hm0)]
+        exact hUlay q (by omega) hq2
+      · rw [binToUnaryLoopFullScan_runConfig_hbase_tape w c hph0 (by omega) (by rw [hm]; exact hm0)]
+        exact hsent
+    · obtain ⟨sB, _, hhd, hLnext, hdec⟩ :=
+        binToUnaryLoopFullScan_oneIteration w c u
+          ⟨hph0, hu1, hHOME1, hbound, hsent, hUlay, hblank, hroom⟩ (by rw [hm]; omega)
+      set d := TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c (sB + 1) with hddef
+      have hmlt : counterValue d ((d.head : Nat) + 1) w < m := by
+        rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+      obtain ⟨t, htsink, htU, htsent⟩ :=
+        ih (counterValue d ((d.head : Nat) + 1) w) hmlt d (u + 1) hLnext rfl
+      refine ⟨(sB + 1) + t, by rw [TM.runConfig_add, ← hddef]; exact htsink, ?_, ?_⟩
+      · intro q hq1 hq2
+        rw [TM.runConfig_add, ← hddef]
+        have hdc : counterValue d ((d.head : Nat) + 1) w + 1 = m := by
+          rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+        apply htU q
+        · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+        · rw [show (d.head : Nat) = (c.head : Nat) from hhd]; omega
+      · rw [TM.runConfig_add, ← hddef, show c.head = d.head from Fin.ext (by rw [hhd])]
+        exact htsent
+
+/-- **D2t-4b core — the index as a unary field.**  From a valid `LoopLayout`, the sound loop halts, the
+width-`w` input window decodes to `i = decodeFin …`, and the tape window `[HOME - i, HOME]` holds
+`unaryField i = 1^i 0`: the `i` value-ones (`[HOME - i, HOME)`) and the terminator `0` at `HOME`.  This is
+the binary→unary of the index, framed as a self-delimiting unary field — the substance of an `input i`
+record (`encodeGateRecord (.input i) = unaryField 0 ++ unaryField i`); the leading tag-`0` is the next
+brick. -/
+theorem emitInputRecord_runConfig_unaryField (w : Nat) {L : Nat}
+    (c : Configuration (M := (binToUnaryLoopFullScan w).toPhased.toTM) L) (u : Nat)
+    (hL : LoopLayout w c u) :
+    ∃ (t : Nat) (i : Fin (2 ^ w)),
+      ((TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).state.fst : Nat) = w + 2
+      ∧ decodeFin w (tapeBits c ((c.head : Nat) + 1) w) = some i
+      ∧ (∀ q : Fin ((binToUnaryLoopFullScan w).toPhased.toTM.tapeLength L),
+          (c.head : Nat) - i.val ≤ (q : Nat) → (q : Nat) < (c.head : Nat) →
+          (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape q = true)
+      ∧ (TM.runConfig (M := (binToUnaryLoopFullScan w).toPhased.toTM) c t).tape c.head = false := by
+  have hlt : counterValue c ((c.head : Nat) + 1) w < 2 ^ w := counterValue_lt_two_pow c _ w
+  obtain ⟨t, hsink, hU, hsent⟩ :=
+    binToUnaryLoopFullScan_reachesSink_output_framed w (counterValue c ((c.head : Nat) + 1) w) c u hL rfl
+  refine ⟨t, ⟨counterValue c ((c.head : Nat) + 1) w, hlt⟩, hsink,
+    decodeFin_tapeBits c ((c.head : Nat) + 1) w hlt, ?_, hsent⟩
+  intro q hq1 hq2
+  simp only [Fin.val_mk] at hq1
+  -- the `i` value-ones sit inside the `u + i`-wide block, so they are all `1`
+  exact hU q (by omega) hq2
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3927,7 +3927,6 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.emitConstRecord_runConfig_three
 #check @Pnp4.Frontier.ContractExpansion.emitConstRecord_runConfig_record
 -- D2t-4b leaf emit (core): binary→unary index realised as `unaryField i` on the tape (sentinel preserved).
-#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output_framed
 #check @Pnp4.Frontier.ContractExpansion.emitInputRecord_runConfig_unaryField
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -76,6 +76,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord
+import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -3925,6 +3926,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.emitConstRecord_stepConfig_done
 #check @Pnp4.Frontier.ContractExpansion.emitConstRecord_runConfig_three
 #check @Pnp4.Frontier.ContractExpansion.emitConstRecord_runConfig_record
+-- D2t-4b leaf emit (core): binary→unary index realised as `unaryField i` on the tape (sentinel preserved).
+#check @Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output_framed
+#check @Pnp4.Frontier.ContractExpansion.emitInputRecord_runConfig_unaryField
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -723,8 +723,8 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.emitConstRecord_runConfig_three
 #print axioms Pnp4.Frontier.ContractExpansion.emitConstRecord_runConfig_record
 -- D2t-4b leaf emit (core): the loop's binary→unary of the index realises `unaryField i` on the tape
--- window `[HOME-i, HOME]` (sentinel preserved), the substance of an `input i` record.
-#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output_framed
+-- window `[HOME-i, HOME]` (sentinel preserved via the strengthened reachesSink/output), the substance of
+-- an `input i` record.
 #print axioms Pnp4.Frontier.ContractExpansion.emitInputRecord_runConfig_unaryField
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -66,6 +66,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPScanRightOneProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord
+import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -721,6 +722,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.emitConstRecord_stepConfig_done
 #print axioms Pnp4.Frontier.ContractExpansion.emitConstRecord_runConfig_three
 #print axioms Pnp4.Frontier.ContractExpansion.emitConstRecord_runConfig_record
+-- D2t-4b leaf emit (core): the loop's binary→unary of the index realises `unaryField i` on the tape
+-- window `[HOME-i, HOME]` (sentinel preserved), the substance of an `input i` record.
+#print axioms Pnp4.Frontier.ContractExpansion.binToUnaryLoopFullScan_reachesSink_output_framed
+#print axioms Pnp4.Frontier.ContractExpansion.emitInputRecord_runConfig_unaryField
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
## Summary

The substantive **core** of D2t-4b (`emitInputRecord`), the second leaf-emit brick. An `input i` gate encodes (`encodeGateRecord`, D0) as `unaryField 0 ++ unaryField i = 0 1^i 0` — tag `0`, the index in unary, terminator `0`. The `1^i` is exactly the **binary→unary of the index** produced by D2t-3's `binToUnaryLoopFullScan`. This PR lands the layout-reconciliation core proving the loop realises `unaryField i` on the tape.

## Lemmas (`TreeMCSPEmitInputRecord.lean`)

- `binToUnaryLoopFullScan_reachesSink_output_framed` — strengthens `reachesSink_output` with **sentinel preservation**: `tape[HOME] = 0` still holds at the sink. The sentinel is part of the `LoopLayout` invariant, preserved by every `B > 0` iteration (`oneIteration` re-establishes the layout) and by the `B = 0` base path (`hbase_tape` leaves the tape unchanged).
- `emitInputRecord_runConfig_unaryField` — from a valid `LoopLayout`, the loop halts (sink `w + 2`), the width-`w` window decodes to `i = decodeFin …`, and the tape window `[HOME − i, HOME]` holds `unaryField i = 1^i 0` (the `i` value-ones plus the terminator `0`).

## Scope / next

This is the binary→unary index framed as a self-delimiting unary field — the substance of D2t-4b. The leading **tag-`0`** framing into the full `encodeGateRecord (.input i) = 0 1^i 0` record hits a real layout tension: D2t-3's loop grows the `1`-block **leftward** (seed + value), so the tag cell isn't naturally `0`; placing it cleanly interplays with the WORK-stream layout established in **D2t-5**, where each leaf's WORK index is pushed onto STACK. So the tag-framing is most naturally completed alongside D2t-5.

## Verification

`./scripts/check.sh` → **17/17 PASS**; `lake build PnP3 Pnp4` green. New surfaces carry only the standard `[propext, Classical.choice, Quot.sound]` triple (audited in `AxiomsAudit`, surfaced in `AlgorithmsToLowerBoundsSurfaceTests`).

**Progress classification (AGENTS.md): Infrastructure.** **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_