### PR TITLE
transcoder(D2t-5 pure): value-stack invariant + faithful stack transcoder

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -322,6 +322,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlattenValueStack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPStackFlattenValueStack.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPStackFlattenValueStack.lean
@@ -1,0 +1,129 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten
+
+/-!
+# `runStack` — D2t-5b foundation: the value-stack execution model
+
+D2t-5's on-tape driver reads the certificate in **preorder** and maintains, in tape scratch, a **value
+stack** of completed-subtree **root WORK-indices**: a leaf emits its record and pushes its index; an
+internal node, once its children are done, **pops** their indices, emits the gate record with those
+indices as operands, and pushes its own index.  This module fixes the pure semantics of that value stack
+and proves it correct against the structural `flattenAt` — the loop invariant the on-tape driver (D2t-5b)
+will be proven to maintain.
+
+It reuses D2t-5's postorder step program `toSteps` (#1589) but executes it with a **value stack** rather
+than the static carried sizes:
+
+* `runStack prog (out, S)` — threads the WORK accumulator `out` and the index stack `S`.  A leaf/`mk*`
+  step appends one gate and pushes its index `out.length`; binary `mk*` steps **pop** the two operand
+  indices off `S` (so operands are read off the stack directly — no truncating-`Nat` arithmetic, unlike
+  `runSteps`).
+* `runStack_toSteps` — the key invariant: running `c`'s program appends exactly `flattenAt out.length c`
+  to WORK and pushes its root index `out.length + c.size - 1`.
+* `flattenStackVS_eq_flatten` — `(runStack (toSteps c) ([], [])).1 = (flatten c).gates`, and the final
+  value stack is the single root index `[c.size - 1]`.
+* `flattenStackVS_eq_flattenStack` — the value-stack model agrees with the size-carrying `flattenStack`
+  (#1589): both compute the postorder flatten.
+
+**Progress classification (AGENTS.md): Infrastructure** — a pure transcoder-algorithm spec proven against
+the verified `flattenAt`; builds no machine and proves no separation.  Standard `[propext, Quot.sound]`
+only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- Execute a postorder step program against a WORK accumulator `out` **and** a value stack `S` of
+completed-subtree root indices.  A leaf / unary / binary step appends one gate at index `out.length` and
+pushes that index; binary steps first **pop** their two operand indices off `S` (so the gate's operands
+are exactly the children's indices — read off the stack, never computed by subtraction).  The size carried
+by `mkAnd`/`mkOr` is ignored here (the stack supplies the operands).  Malformed states (a `mk*` step with
+too few stacked indices) halt unchanged; they never arise from a `toSteps`-produced program run from the
+empty stack. -/
+def runStack {n : Nat} :
+    List (FlattenStep n) → List (SLGate n) × List Nat → List (SLGate n) × List Nat
+  | [], st => st
+  | FlattenStep.leaf g :: w, (out, S) => runStack w (out ++ [g], out.length :: S)
+  | FlattenStep.mkNot :: w, (out, i :: S) => runStack w (out ++ [SLGate.notGate i], out.length :: S)
+  | FlattenStep.mkAnd _ :: w, (out, i2 :: i1 :: S) =>
+      runStack w (out ++ [SLGate.andGate i1 i2], out.length :: S)
+  | FlattenStep.mkOr _ :: w, (out, i2 :: i1 :: S) =>
+      runStack w (out ++ [SLGate.orGate i1 i2], out.length :: S)
+  | _ :: _, st => st
+
+/-- **The value-stack invariant.**  Running the postorder program of `c` appends exactly
+`flattenAt out.length c` to WORK and pushes `c`'s root index `out.length + c.size - 1`.  Induction on `c`;
+the operand indices come straight off the stack (the IH's pushed root indices), so no `Nat`-subtraction
+reconciliation is needed — only the pushed root index uses `size`. -/
+theorem runStack_toSteps {n : Nat} (c : CircuitTree n) :
+    ∀ (w : List (FlattenStep n)) (out : List (SLGate n)) (S : List Nat),
+      runStack (toSteps c ++ w) (out, S)
+        = runStack w (out ++ CircuitTree.flattenAt out.length c,
+            (out.length + c.size - 1) :: S) := by
+  induction c with
+  | input i => intro w out S; simp [toSteps, runStack, CircuitTree.flattenAt, CircuitTree.size]
+  | const b => intro w out S; simp [toSteps, runStack, CircuitTree.flattenAt, CircuitTree.size]
+  | not c ih =>
+      intro w out S
+      have hcat : toSteps (CircuitTree.not c) ++ w = toSteps c ++ (FlattenStep.mkNot :: w) := by
+        simp [toSteps, List.append_assoc]
+      rw [hcat, ih (FlattenStep.mkNot :: w) out S]
+      simp only [runStack, CircuitTree.flattenAt, CircuitTree.size, List.length_append,
+        CircuitTree.flattenAt_length, List.append_assoc]
+      congr 2
+  | and a b iha ihb =>
+      intro w out S
+      have hcat : toSteps (CircuitTree.and a b) ++ w
+          = toSteps a ++ (toSteps b ++ (FlattenStep.mkAnd b.size :: w)) := by
+        simp [toSteps, List.append_assoc]
+      rw [hcat, iha (toSteps b ++ (FlattenStep.mkAnd b.size :: w)) out S,
+        ihb (FlattenStep.mkAnd b.size :: w) (out ++ CircuitTree.flattenAt out.length a)
+          ((out.length + a.size - 1) :: S)]
+      simp only [runStack, CircuitTree.flattenAt, CircuitTree.size, List.length_append,
+        CircuitTree.flattenAt_length, List.append_assoc]
+      congr 2
+  | or a b iha ihb =>
+      intro w out S
+      have hcat : toSteps (CircuitTree.or a b) ++ w
+          = toSteps a ++ (toSteps b ++ (FlattenStep.mkOr b.size :: w)) := by
+        simp [toSteps, List.append_assoc]
+      rw [hcat, iha (toSteps b ++ (FlattenStep.mkOr b.size :: w)) out S,
+        ihb (FlattenStep.mkOr b.size :: w) (out ++ CircuitTree.flattenAt out.length a)
+          ((out.length + a.size - 1) :: S)]
+      simp only [runStack, CircuitTree.flattenAt, CircuitTree.size, List.length_append,
+        CircuitTree.flattenAt_length, List.append_assoc]
+      congr 2
+
+/-- Running `c`'s program from the empty WORK/stack: the WORK is the flattened gate list and the value
+stack ends with the single root index `c.size - 1`. -/
+theorem runStack_toSteps_nil {n : Nat} (c : CircuitTree n) :
+    runStack (toSteps c) ([], []) = ((CircuitTree.flatten c).gates, [c.size - 1]) := by
+  have h := runStack_toSteps c [] [] []
+  simpa [runStack, CircuitTree.flatten] using h
+
+/-- The value-stack model's WORK output: the iterative value-stack linearization of a circuit tree. -/
+def flattenStackVS {n : Nat} (c : CircuitTree n) : List (SLGate n) :=
+  (runStack (toSteps c) ([], [])).1
+
+/-- **D2t-5b invariant (pure).**  The value-stack execution produces exactly the flattened gate list. -/
+theorem flattenStackVS_eq_flatten {n : Nat} (c : CircuitTree n) :
+    flattenStackVS c = (CircuitTree.flatten c).gates := by
+  rw [flattenStackVS, runStack_toSteps_nil]
+
+/-- The value-stack model agrees with the size-carrying `flattenStack` (#1589): both compute the postorder
+flatten. -/
+theorem flattenStackVS_eq_flattenStack {n : Nat} (c : CircuitTree n) :
+    flattenStackVS c = flattenStack c := by
+  rw [flattenStackVS_eq_flatten, flattenStack_eq_flatten]
+
+/-- The value-stack WORK record stream equals that of the flattened circuit — the D2t-5c target, reached
+through the on-tape driver's value-stack discipline. -/
+theorem encodeGateRecordStream_flattenStackVS {n : Nat} (c : CircuitTree n) :
+    encodeGateRecordStream (flattenStackVS c) = encodeGateRecordStream (CircuitTree.flatten c).gates := by
+  rw [flattenStackVS_eq_flatten]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPStackFlattenValueStack.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPStackFlattenValueStack.lean
@@ -39,9 +39,15 @@ open Pnp3.Internal.PsubsetPpoly.TM.Encoding
 completed-subtree root indices.  A leaf / unary / binary step appends one gate at index `out.length` and
 pushes that index; binary steps first **pop** their two operand indices off `S` (so the gate's operands
 are exactly the children's indices — read off the stack, never computed by subtraction).  The size carried
-by `mkAnd`/`mkOr` is ignored here (the stack supplies the operands).  Malformed states (a `mk*` step with
-too few stacked indices) halt unchanged; they never arise from a `toSteps`-produced program run from the
-empty stack. -/
+by `mkAnd`/`mkOr` is ignored here (the stack supplies the operands).
+
+This is a **propositional spec** (used only inside proofs, never executed), so the per-step `out ++ [·]`
+accumulation and the malformed-state halt are immaterial to its role: the only intended caller is
+`flattenStackVS` (`runStack (toSteps c) ([], [])`), and `runStack_toSteps` establishes that such a run is
+well-formed (the value stack never underflows) and equals `flattenAt 0 c`.  A `mk*` step with too few
+stacked indices simply halts unchanged (the catch-all) — that state never arises from a `toSteps`-produced
+program run from the empty stack, so it is unreachable on the proven path; running an arbitrary, hand-built
+program is not a supported use. -/
 def runStack {n : Nat} :
     List (FlattenStep n) → List (SLGate n) × List Nat → List (SLGate n) × List Nat
   | [], st => st
@@ -123,6 +129,35 @@ through the on-tape driver's value-stack discipline. -/
 theorem encodeGateRecordStream_flattenStackVS {n : Nat} (c : CircuitTree n) :
     encodeGateRecordStream (flattenStackVS c) = encodeGateRecordStream (CircuitTree.flatten c).gates := by
   rw [flattenStackVS_eq_flatten]
+
+/-! ### Pure D2t-5 capstone: the stack algorithm is a faithful transcoder
+
+Packaging the value-stack linearization with the self-delimiting gate-count prefix gives the full
+**stack-based transcoder output**; decoding it recovers a straight-line program computing the circuit.
+This connects the D2t-5 *algorithm* (not just `flatten` abstractly) to the §9 transcoder faithfulness
+(`transcodeWitness_faithful`), and is the pure correctness statement the on-tape driver (D2t-5b/c) must
+realise: its WORK + gate-count prefix equals this stream. -/
+
+/-- The stack-based transcoder output: the count-prefixed gate-record stream produced by the D2t-5
+value-stack linearization algorithm. -/
+def transcodeStreamViaStack {n : Nat} (c : CircuitTree n) : List Bool :=
+  encodeGateStream (flattenStackVS c)
+
+/-- The stack transcoder stream equals the self-delimiting stream of the flattened circuit. -/
+theorem transcodeStreamViaStack_eq {n : Nat} (c : CircuitTree n) :
+    transcodeStreamViaStack c = encodeGateStream (CircuitTree.flatten c).gates := by
+  rw [transcodeStreamViaStack, flattenStackVS_eq_flatten]
+
+/-- **D2t-5 algorithm faithfulness (pure).**  The value-stack transcoder of a circuit's tree yields a
+self-delimiting stream that decodes to a straight-line program computing the circuit's value — the stack
+algorithm realises the §9 transcoder spec end-to-end (cf. `transcodeWitness_faithful`, which routes
+through `flatten` directly). -/
+theorem transcodeStreamViaStack_faithful {n : Nat} (c : Pnp3.Models.Circuit n) (x : Fin n → Bool) :
+    ∃ gates : List (SLGate n),
+      decodeGateStream n (transcodeStreamViaStack (toTree c)) = some (gates, [])
+      ∧ SLProgram.eval ⟨gates⟩ x = some (Pnp3.Models.Circuit.eval c x) := by
+  rw [transcodeStreamViaStack_eq]
+  simpa using decodeGateStream_circuit_eval c x []
 
 end ContractExpansion
 end Frontier

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3936,6 +3936,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5b foundation: value-stack execution model `runStack` (driver loop invariant) = flatten.
 #check @Pnp4.Frontier.ContractExpansion.flattenStackVS_eq_flatten
 #check @Pnp4.Frontier.ContractExpansion.flattenStackVS_eq_flattenStack
+-- D2t-5 pure capstone: the stack-linearization transcoder is faithful (stream decodes to the circuit).
+#check @Pnp4.Frontier.ContractExpansion.transcodeStreamViaStack_faithful
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -78,6 +78,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlattenValueStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -3932,6 +3933,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5 pure core: stack linearization `runSteps (toSteps c) []` = structural `flattenAt 0 c`.
 #check @Pnp4.Frontier.ContractExpansion.flattenStack_eq_flattenAt
 #check @Pnp4.Frontier.ContractExpansion.encodeGateRecordStream_flattenStack
+-- D2t-5b foundation: value-stack execution model `runStack` (driver loop invariant) = flatten.
+#check @Pnp4.Frontier.ContractExpansion.flattenStackVS_eq_flatten
+#check @Pnp4.Frontier.ContractExpansion.flattenStackVS_eq_flattenStack
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -736,6 +736,9 @@ end Pnp4
 -- produces the flattened gate list; agrees with the size-carrying `flattenStack`.
 #print axioms Pnp4.Frontier.ContractExpansion.flattenStackVS_eq_flatten
 #print axioms Pnp4.Frontier.ContractExpansion.flattenStackVS_eq_flattenStack
+-- D2t-5 pure capstone: the stack-linearization transcoder is faithful — its count-prefixed stream decodes
+-- to a straight-line program computing the circuit (the §9 spec, realised via the stack algorithm).
+#print axioms Pnp4.Frontier.ContractExpansion.transcodeStreamViaStack_faithful
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -68,6 +68,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten
+import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlattenValueStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -731,6 +732,10 @@ end Pnp4
 -- structural postorder flatten `flattenAt 0 c` — the on-tape STACK machine's correctness target.
 #print axioms Pnp4.Frontier.ContractExpansion.flattenStack_eq_flattenAt
 #print axioms Pnp4.Frontier.ContractExpansion.encodeGateRecordStream_flattenStack
+-- D2t-5b foundation: the value-stack execution model (`runStack`, the on-tape driver's loop invariant)
+-- produces the flattened gate list; agrees with the size-carrying `flattenStack`.
+#print axioms Pnp4.Frontier.ContractExpansion.flattenStackVS_eq_flatten
+#print axioms Pnp4.Frontier.ContractExpansion.flattenStackVS_eq_flattenStack
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
## Summary

Completes the **pure layer of D2t-5**: the value-stack execution model that the on-tape driver realizes, plus the capstone showing the stack algorithm is a **faithful transcoder**. Builds on the D2t-5 pure core (#1589).

## Value-stack model (the D2t-5b loop invariant)

D2t-5's on-tape driver reads the certificate in **preorder** and maintains, in tape scratch, a **value stack** of completed-subtree root WORK-indices: a leaf emits its record and pushes its index; an internal node pops its children's indices, emits its gate record with those operands, and pushes its own index.

- `runStack prog (out, S)` — executes a `toSteps` program (#1589) against WORK `out` **and** a value stack `S`; binary steps **pop** their operand indices off `S` (operands come off the stack directly — no truncating-`Nat` arithmetic).
- `runStack_toSteps` — the invariant: running `c`'s program appends exactly `flattenAt out.length c` and pushes its root index `out.length + c.size − 1`.
- `flattenStackVS_eq_flatten` — `(runStack (toSteps c) ([], [])).1 = (flatten c).gates`.
- `flattenStackVS_eq_flattenStack` — agrees with the size-carrying `flattenStack` (#1589).

## Pure capstone: the stack algorithm is a faithful transcoder

- `transcodeStreamViaStack c := encodeGateStream (flattenStackVS c)` — count-prefixed record stream from the value-stack linearization.
- `transcodeStreamViaStack_faithful` — for a circuit `c`, this stream **decodes to a straight-line program computing `Circuit.eval c x`** (via `decodeGateStream_circuit_eval`). This connects the D2t-5 *algorithm* (not just `flatten` abstractly) to the §9 transcoder faithfulness — the pure statement the on-tape driver (D2t-5b/c) must realise.

## Qodo

Both findings are the same non-bug patterns Qodo raised on #1589's `runSteps` (and accepted the docstring resolution for), on this same **propositional spec layer**: "quadratic accumulation" (advisory; never executed; `++` mirrors `flattenAt` and keeps the proof clean) and "silent underflow halt" (misuse-safety; the proven `toSteps`-from-empty path never underflows). Resolved consistently via an explicit docstring spec-contract; the accumulator/Option refactors are declined (they'd obscure the clean `flattenAt` correspondence for no benefit on a never-executed spec).

## Verification

`./scripts/check.sh` → **17/17 PASS**; `lake build PnP3 Pnp4` green. Standard `[propext, Classical.choice, Quot.sound]` triple (audited in `AxiomsAudit`, surfaced in `AlgorithmsToLowerBoundsSurfaceTests`).

**Progress classification (AGENTS.md): Infrastructure.** **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_