### PR TITLE
transcoder(D2t-5a): on-tape value-stack format (unary-field stack) + round-trip

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -322,6 +322,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPNatStack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPNatStack.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPNatStack.lean
@@ -10,8 +10,8 @@ operands, so a popped index copies straight into a record's operand field with n
 
 This module fixes that format and proves the stack operations against the abstract `List Nat`:
 
-* `encodeNatStack S` — the bottom-to-top stack `S` as `unaryField`s concatenated left-to-right; `push`
-  (cons) is prepending one field.
+* `encodeNatStack S` — the stack `S` listed **top-first** (the head is the top) as `unaryField`s
+  concatenated left-to-right, so the top field is leftmost; `push` (cons) prepends one field.
 * `decodeUnaryField_encodeNatStack_cons` — **pop**: reading one unary field off the encoded stack returns
   the top index and the encoded tail (so the on-tape `selfLoopScanRightOne`/field-read realises a pop).
 * `decodeNatStack_encodeNatStack` — full round-trip: `S.length` pops recover `S` and leave the suffix.
@@ -31,8 +31,8 @@ namespace ContractExpansion
 
 open Pnp3.Internal.PsubsetPpoly.TM.Encoding
 
-/-- The value stack `S` (bottom-to-top) encoded as concatenated self-delimiting unary fields `1^v 0`.
-`push v` is prepending `unaryField v` (the top sits at the front). -/
+/-- The value stack `S` listed **top-first** (the head is the top of the stack) encoded as concatenated
+self-delimiting unary fields `1^v 0`, the top field leftmost.  `push v` prepends `unaryField v`. -/
 def encodeNatStack : List Nat → List Bool
   | [] => []
   | v :: rest => unaryField v ++ encodeNatStack rest
@@ -74,7 +74,7 @@ theorem decodeNatStack_encodeNatStack (S : List Nat) (rest : List Bool) :
     decodeNatStack S.length (encodeNatStack S ++ rest) = some (S, rest) := by
   induction S generalizing rest with
   | nil => simp
-  | cons v rest ih =>
+  | cons v tail ih =>
       simp only [encodeNatStack, List.length_cons, List.append_assoc, decodeNatStack,
         decodeUnaryField_unaryField, ih]
 

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPNatStack.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPNatStack.lean
@@ -1,0 +1,83 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
+
+/-!
+# `encodeNatStack` — D2t-5a: the on-tape value-stack format
+
+D2t-5's on-tape driver maintains a **value stack** of completed-subtree root WORK-indices (the abstract
+`List Nat` threaded by `runStack`, D2t-5b).  On tape that stack is stored as a contiguous run of
+**self-delimiting unary fields** `1^v 0` — the *same* `unaryField` encoding the WORK gate records use for
+operands, so a popped index copies straight into a record's operand field with no re-encoding.
+
+This module fixes that format and proves the stack operations against the abstract `List Nat`:
+
+* `encodeNatStack S` — the bottom-to-top stack `S` as `unaryField`s concatenated left-to-right; `push`
+  (cons) is prepending one field.
+* `decodeUnaryField_encodeNatStack_cons` — **pop**: reading one unary field off the encoded stack returns
+  the top index and the encoded tail (so the on-tape `selfLoopScanRightOne`/field-read realises a pop).
+* `decodeNatStack_encodeNatStack` — full round-trip: `S.length` pops recover `S` and leave the suffix.
+
+These are the value-stack analogue of the WORK record-stream codec (`encodeGateRecordStream` /
+`decodeGateRecordStream`), and the bridge D2t-5b uses to relate the tape STACK region to the abstract
+stack `runStack` threads.
+
+**Progress classification (AGENTS.md): Infrastructure** — a tape-format codec proven against the abstract
+stack; builds no machine and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]`
+triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- The value stack `S` (bottom-to-top) encoded as concatenated self-delimiting unary fields `1^v 0`.
+`push v` is prepending `unaryField v` (the top sits at the front). -/
+def encodeNatStack : List Nat → List Bool
+  | [] => []
+  | v :: rest => unaryField v ++ encodeNatStack rest
+
+@[simp] theorem encodeNatStack_nil : encodeNatStack [] = [] := rfl
+
+@[simp] theorem encodeNatStack_cons (v : Nat) (rest : List Nat) :
+    encodeNatStack (v :: rest) = unaryField v ++ encodeNatStack rest := rfl
+
+/-- **Pop.**  Reading one unary field off the encoded stack returns the top index `v` and the encoded
+tail — the on-tape field-read realises an abstract `List Nat` head/tail. -/
+@[simp] theorem decodeUnaryField_encodeNatStack_cons (v : Nat) (rest : List Nat) :
+    decodeUnaryField (encodeNatStack (v :: rest)) = some (v, encodeNatStack rest) := by
+  simp [encodeNatStack]
+
+/-- Exact length of the encoded stack: the sum of `(vᵢ + 1)` (each field is `1^vᵢ 0`). -/
+@[simp] theorem encodeNatStack_length (S : List Nat) :
+    (encodeNatStack S).length = (S.map (· + 1)).sum := by
+  induction S with
+  | nil => simp
+  | cons v rest ih => simp [encodeNatStack, ih]
+
+/-- Decode `count` consecutive indices off the front of a bit stream (the value stack reader). -/
+def decodeNatStack : Nat → List Bool → Option (List Nat × List Bool)
+  | 0, bs => some ([], bs)
+  | (k + 1), bs =>
+    match decodeUnaryField bs with
+    | none => none
+    | some (v, rest) =>
+      match decodeNatStack k rest with
+      | none => none
+      | some (vs, rest') => some (v :: vs, rest')
+
+@[simp] theorem decodeNatStack_zero (bs : List Bool) : decodeNatStack 0 bs = some ([], bs) := rfl
+
+/-- **Stack round-trip**: popping `S.length` indices off `encodeNatStack S ++ rest` recovers `S` exactly
+and leaves the suffix untouched (induction on `S`, via the one-field pop). -/
+theorem decodeNatStack_encodeNatStack (S : List Nat) (rest : List Bool) :
+    decodeNatStack S.length (encodeNatStack S ++ rest) = some (S, rest) := by
+  induction S generalizing rest with
+  | nil => simp
+  | cons v rest ih =>
+      simp only [encodeNatStack, List.length_cons, List.append_assoc, decodeNatStack,
+        decodeUnaryField_unaryField, ih]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -78,6 +78,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten
+import Pnp4.Frontier.ContractExpansion.TreeMCSPNatStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -3932,6 +3933,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5 pure core: stack linearization `runSteps (toSteps c) []` = structural `flattenAt 0 c`.
 #check @Pnp4.Frontier.ContractExpansion.flattenStack_eq_flattenAt
 #check @Pnp4.Frontier.ContractExpansion.encodeGateRecordStream_flattenStack
+-- D2t-5a: on-tape value-stack format (unary-field stack) round-trip against the abstract `List Nat`.
+#check @Pnp4.Frontier.ContractExpansion.decodeNatStack_encodeNatStack
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -68,6 +68,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten
+import Pnp4.Frontier.ContractExpansion.TreeMCSPNatStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -731,6 +732,9 @@ end Pnp4
 -- structural postorder flatten `flattenAt 0 c` — the on-tape STACK machine's correctness target.
 #print axioms Pnp4.Frontier.ContractExpansion.flattenStack_eq_flattenAt
 #print axioms Pnp4.Frontier.ContractExpansion.encodeGateRecordStream_flattenStack
+-- D2t-5a: the on-tape value-stack format — child indices as self-delimiting unary fields; pop = field
+-- read, round-trip against the abstract `List Nat`.
+#print axioms Pnp4.Frontier.ContractExpansion.decodeNatStack_encodeNatStack
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
## Summary

**D2t-5a — the on-tape value-stack format.** D2t-5's driver maintains a **value stack** of completed-subtree root WORK-indices (the abstract `List Nat` threaded by `runStack`, #1590). On tape that stack is stored as a contiguous run of **self-delimiting unary fields** `1^v 0` — the *same* `unaryField` encoding the WORK gate records use for operands, so a popped index copies straight into a record's operand field with no re-encoding. This PR fixes that format and proves the stack operations against the abstract `List Nat`.

## Lemmas (`TreeMCSPNatStack.lean`)

- `encodeNatStack S` — the bottom-to-top stack as `unaryField`s concatenated left-to-right; `push v` (cons) prepends one field.
- `decodeUnaryField_encodeNatStack_cons` — **pop**: one unary-field read returns the top index and the encoded tail (the on-tape field read realises an abstract head/tail).
- `encodeNatStack_length` — exact size `Σ (vᵢ + 1)`.
- `decodeNatStack_encodeNatStack` — full **round-trip**: `S.length` pops recover `S` and leave the suffix.

This is the value-stack analogue of the WORK record-stream codec (`encodeGateRecordStream` / `decodeGateRecordStream`), and the bridge D2t-5b uses to relate the tape STACK region to the abstract stack `runStack` threads.

## Verification

`./scripts/check.sh` → **17/17 PASS**; `lake build PnP3 Pnp4` green. Minimal `[propext]` axiom (pure list/codec reasoning), within the standard triple (audited in `AxiomsAudit`, surfaced in `AlgorithmsToLowerBoundsSurfaceTests`).

**Progress classification (AGENTS.md): Infrastructure.** **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_