### PR TITLE
transcoder(D2t-5a): on-tape control-stack format (pending (tag,remaining) frames)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -324,6 +324,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlattenValueStack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPNatStack,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCtrlFrameStack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCtrlFrameStack.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCtrlFrameStack.lean
@@ -1,0 +1,110 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack
+
+/-!
+# `encodeCtrlStack` — D2t-5a: the on-tape control-stack format
+
+The second tape stack of D2t-5's driver (D2t-5b, `drive`/`TreeMCSPDriveStack`): the **control stack** of
+pending internal nodes, each a frame `(tag, remaining)` — the gate tag and how many children are still to
+be processed.  On tape it is stored, like the value stack (`NatStack`) and the WORK records, as a run of
+**self-delimiting unary fields**: a frame is `unaryField tag.tagCode ++ unaryField remaining` (tag code,
+then the remaining-children count), and the stack is the frames concatenated **top-first**.
+
+This module fixes that format and proves the stack operations against the abstract `List (ITag × Nat)`:
+
+* `encodeCtrlStack S` — the control stack `S` (top at the head) as concatenated frames; `push` (cons)
+  prepends one frame.
+* `decodeCtrlFrame_encodeCtrlStack_cons` — **pop**: reading one frame off the top recovers `(tag, rem)`
+  and the encoded tail (two `unaryField` reads + a 3-way tag decode).
+* `decodeCtrlStack_encodeCtrlStack` — full **round-trip**: `S.length` frame-pops recover `S` and leave the
+  suffix untouched.
+
+Together with `TreeMCSPNatStack` (the value-stack format), this completes the **D2t-5a tape formats**; the
+on-tape `pushFrame`/`popFrame` machines realise these codecs, and the D2t-5b loop relates the two tape
+stacks to `drive`'s abstract `(control, value)` stacks.
+
+**Progress classification (AGENTS.md): Infrastructure** — a tape-format codec proven against the abstract
+stack; builds no machine and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]`
+triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- A small code per internal tag, stored on tape as a unary field. -/
+def ITag.tagCode : ITag → Nat
+  | .tnot => 0
+  | .tand => 1
+  | .tor => 2
+
+/-- Recover a tag from its code (the inverse of `tagCode` on `{0,1,2}`). -/
+def ITag.ofCode : Nat → Option ITag
+  | 0 => some .tnot
+  | 1 => some .tand
+  | 2 => some .tor
+  | _ => none
+
+@[simp] theorem ITag.ofCode_tagCode (t : ITag) : ITag.ofCode t.tagCode = some t := by
+  cases t <;> rfl
+
+/-- A control frame `(tag, remaining)` as two self-delimiting unary fields: the tag code, then the
+remaining-children count. -/
+def encodeCtrlFrame : ITag × Nat → List Bool
+  | (tag, rem) => unaryField tag.tagCode ++ unaryField rem
+
+/-- The control stack `S` (top at the head) as concatenated frames; `push f` (cons) prepends `f`. -/
+def encodeCtrlStack : List (ITag × Nat) → List Bool
+  | [] => []
+  | f :: rest => encodeCtrlFrame f ++ encodeCtrlStack rest
+
+@[simp] theorem encodeCtrlStack_nil : encodeCtrlStack [] = [] := rfl
+
+/-- Decode one control frame off the front: the tag-code field, the 3-way tag decode, then the
+remaining-count field. -/
+def decodeCtrlFrame (bs : List Bool) : Option ((ITag × Nat) × List Bool) :=
+  match decodeUnaryField bs with
+  | none => none
+  | some (code, rest) =>
+    match ITag.ofCode code with
+    | none => none
+    | some tag =>
+      match decodeUnaryField rest with
+      | none => none
+      | some (rem, rest') => some ((tag, rem), rest')
+
+/-- **Pop.**  Reading one frame off the top of the encoded stack recovers the top `(tag, rem)` and the
+encoded tail. -/
+@[simp] theorem decodeCtrlFrame_encodeCtrlStack_cons (tag : ITag) (rem : Nat)
+    (rest : List (ITag × Nat)) :
+    decodeCtrlFrame (encodeCtrlStack ((tag, rem) :: rest)) = some ((tag, rem), encodeCtrlStack rest) := by
+  simp [encodeCtrlStack, encodeCtrlFrame, decodeCtrlFrame, List.append_assoc]
+
+/-- Decode `count` consecutive control frames off the front of a bit stream (the control-stack reader). -/
+def decodeCtrlStack : Nat → List Bool → Option (List (ITag × Nat) × List Bool)
+  | 0, bs => some ([], bs)
+  | (k + 1), bs =>
+    match decodeCtrlFrame bs with
+    | none => none
+    | some (f, rest) =>
+      match decodeCtrlStack k rest with
+      | none => none
+      | some (fs, rest') => some (f :: fs, rest')
+
+@[simp] theorem decodeCtrlStack_zero (bs : List Bool) : decodeCtrlStack 0 bs = some ([], bs) := rfl
+
+/-- **Stack round-trip**: popping `S.length` frames off `encodeCtrlStack S ++ suffix` recovers `S` exactly
+and leaves the suffix untouched (induction on `S`, via the one-frame pop). -/
+theorem decodeCtrlStack_encodeCtrlStack (S : List (ITag × Nat)) (suffix : List Bool) :
+    decodeCtrlStack S.length (encodeCtrlStack S ++ suffix) = some (S, suffix) := by
+  induction S generalizing suffix with
+  | nil => simp
+  | cons f tail ih =>
+      obtain ⟨tag, rem⟩ := f
+      simp only [encodeCtrlStack, encodeCtrlFrame, List.length_cons, List.append_assoc, decodeCtrlStack,
+        decodeCtrlFrame, decodeUnaryField_unaryField, ITag.ofCode_tagCode, ih]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCtrlFrameStack.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCtrlFrameStack.lean
@@ -1,4 +1,5 @@
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 
 /-!
 # `encodeCtrlStack` — D2t-5a: the on-tape control-stack format

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -80,6 +80,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlattenValueStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPNatStack
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCtrlFrameStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
@@ -3942,6 +3943,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.transcodeStreamViaStack_faithful
 -- D2t-5a: on-tape value-stack format (unary-field stack) round-trip against the abstract `List Nat`.
 #check @Pnp4.Frontier.ContractExpansion.decodeNatStack_encodeNatStack
+-- D2t-5a: on-tape control-stack format (pending `(tag, remaining)` frames) round-trip.
+#check @Pnp4.Frontier.ContractExpansion.decodeCtrlStack_encodeCtrlStack
 -- D2t-5b: preorder-streaming driver (control + value stacks) produces the postorder flatten.
 #check @Pnp4.Frontier.ContractExpansion.driveWORK_eq_flatten
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -70,6 +70,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlattenValueStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPNatStack
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCtrlFrameStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
@@ -744,6 +745,9 @@ end Pnp4
 -- D2t-5a: the on-tape value-stack format — child indices as self-delimiting unary fields; pop = field
 -- read, round-trip against the abstract `List Nat`.
 #print axioms Pnp4.Frontier.ContractExpansion.decodeNatStack_encodeNatStack
+-- D2t-5a: the on-tape control-stack format — pending `(tag, remaining)` frames as unary fields; round-trip
+-- against the abstract `List (ITag × Nat)` (completes the D2t-5a tape formats with the value stack).
+#print axioms Pnp4.Frontier.ContractExpansion.decodeCtrlStack_encodeCtrlStack
 -- D2t-5b: the preorder-streaming driver (control + value stacks, settle cascade) produces the postorder
 -- flatten — the pure spec the on-tape D2t-5b loop realises.
 #print axioms Pnp4.Frontier.ContractExpansion.driveWORK_eq_flatten


### PR DESCRIPTION
## Summary

**D2t-5a — the on-tape control-stack format**, completing the two D2t-5a tape formats (value stack `NatStack` #1591 + control stack here).

D2t-5's driver (#1592 `drive`) keeps a **control stack** of pending internal nodes, each a frame `(tag, remaining)` — the gate tag and how many children remain. On tape it's stored, like the value stack and the WORK records, as self-delimiting unary fields: a frame is `unaryField tag.tagCode ++ unaryField remaining`, the stack is frames concatenated **top-first**.

## Lemmas (`TreeMCSPCtrlFrameStack.lean`)

- `ITag.tagCode` / `ITag.ofCode` (+ `ofCode_tagCode`) — the 3-way tag ↔ code map.
- `encodeCtrlStack S` — control stack (top at head) as concatenated frames; `push` (cons) prepends one frame.
- `decodeCtrlFrame_encodeCtrlStack_cons` — **pop**: one frame read recovers the top `(tag, rem)` and the encoded tail.
- `decodeCtrlStack_encodeCtrlStack` — full **round-trip**: `S.length` frame-pops recover `S` and leave the suffix.

The on-tape `pushFrame`/`popFrame` machines (D2t-5a) realize these codecs; the D2t-5b loop relates the two tape stacks to `drive`'s abstract `(control, value)` stacks.

## Verification

`./scripts/check.sh` → **17/17 PASS**; `lake build PnP3 Pnp4` green. Minimal `[propext]` axiom, within the standard triple (audited in `AxiomsAudit`, surfaced in `AlgorithmsToLowerBoundsSurfaceTests`).

**Progress classification (AGENTS.md): Infrastructure.** **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_