### PR TITLE
transcoder(D2t-5a machine): pushCtrlFrame — control-stack push

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -321,6 +321,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPWriteBits,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPPushCtrlFrame,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlattenValueStack,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPushCtrlFrame.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPushCtrlFrame.lean
@@ -12,8 +12,8 @@ Because the tag is known from the dispatch branch, that frame's encoding `encode
 is a **fixed bit list**, so the push is a fixed-width write — `pushCtrlFrame tag := writeBits …`.  Its
 correctness is therefore a direct corollary of `writeBits_runConfig`: from the stack-top pointer `p`, after
 `(encodeCtrlFrame (tag, tag.arity)).length` steps the window `[p, p + …)` holds exactly the control frame's
-bits and the pointer rests just past it (so the new frame sits at the head of `encodeCtrlStack`, via the
-merged `encodeCtrlStack_cons`).
+bits and the pointer rests just past it (so the new frame sits at the head of `encodeCtrlStack`, since
+`encodeCtrlStack (f :: rest)` prepends `encodeCtrlFrame f` by definition).
 
 `pushCtrlFrame_frameLen_*` give the concrete per-tag frame widths (`not` ↦ 3, `and` ↦ 5, `or` ↦ 6 cells),
 for the driver's room bounds.

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPushCtrlFrame.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPPushCtrlFrame.lean
@@ -1,0 +1,79 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPWriteBits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCtrlFrameStack
+
+/-!
+# `pushCtrlFrame` — D2t-5a machine: push an initial control frame onto the STACK
+
+The control-stack `pushFrame` of D2t-5's driver (D2t-5b): when the preorder reader (`treeTagDispatch`)
+hits an internal node `tag`, the driver pushes the **initial frame** `(tag, tag.arity)` onto the control
+stack (`STACK_ctrl`) — `tag` and `arity` children still to process.
+
+Because the tag is known from the dispatch branch, that frame's encoding `encodeCtrlFrame (tag, tag.arity)`
+is a **fixed bit list**, so the push is a fixed-width write — `pushCtrlFrame tag := writeBits …`.  Its
+correctness is therefore a direct corollary of `writeBits_runConfig`: from the stack-top pointer `p`, after
+`(encodeCtrlFrame (tag, tag.arity)).length` steps the window `[p, p + …)` holds exactly the control frame's
+bits and the pointer rests just past it (so the new frame sits at the head of `encodeCtrlStack`, via the
+merged `encodeCtrlStack_cons`).
+
+`pushCtrlFrame_frameLen_*` give the concrete per-tag frame widths (`not` ↦ 3, `and` ↦ 5, `or` ↦ 6 cells),
+for the driver's room bounds.
+
+**Progress classification (AGENTS.md): Infrastructure** — a stack-push machine proven at the configuration
+level against the merged frame codec; builds no verifier and proves no separation.  Standard `[propext,
+Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- Push the initial frame `(tag, tag.arity)` onto the control stack: write its fixed encoding
+`encodeCtrlFrame (tag, tag.arity)` rightward from the stack-top pointer. -/
+def pushCtrlFrame (tag : ITag) : ConstStatePhasedProgram Unit :=
+  writeBits (encodeCtrlFrame (tag, tag.arity))
+
+/-- **`pushCtrlFrame` run-through.**  From the stack-top pointer `p = c.head` (phase `0`) with room for the
+frame, after `(encodeCtrlFrame (tag, tag.arity)).length` steps the machine halts at the accept phase, the
+pointer rests at `p + len`, and the window `[p, p + len)` holds exactly `encodeCtrlFrame (tag, tag.arity)`
+— the pushed control frame (tape elsewhere unchanged).  Direct corollary of `writeBits_runConfig`. -/
+theorem pushCtrlFrame_runConfig {L : Nat} (tag : ITag)
+    (c : Configuration (M := (pushCtrlFrame tag).toPhased.toTM) L)
+    (hphase : (c.state.fst : Nat) = 0)
+    (hroom : (c.head : Nat) + (encodeCtrlFrame (tag, tag.arity)).length
+        < (pushCtrlFrame tag).toPhased.toTM.tapeLength L) :
+    ((TM.runConfig (M := (pushCtrlFrame tag).toPhased.toTM) c
+          (encodeCtrlFrame (tag, tag.arity)).length).state.fst : Nat)
+        = (encodeCtrlFrame (tag, tag.arity)).length
+      ∧ ((TM.runConfig (M := (pushCtrlFrame tag).toPhased.toTM) c
+          (encodeCtrlFrame (tag, tag.arity)).length).head : Nat)
+        = (c.head : Nat) + (encodeCtrlFrame (tag, tag.arity)).length
+      ∧ ∀ q : Fin ((pushCtrlFrame tag).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (pushCtrlFrame tag).toPhased.toTM) c
+              (encodeCtrlFrame (tag, tag.arity)).length).tape q
+            = if (c.head : Nat) ≤ (q : Nat)
+                  ∧ (q : Nat) < (c.head : Nat) + (encodeCtrlFrame (tag, tag.arity)).length
+              then (encodeCtrlFrame (tag, tag.arity)).getD ((q : Nat) - (c.head : Nat)) false
+              else c.tape q :=
+  writeBits_runConfig (encodeCtrlFrame (tag, tag.arity)) c hphase hroom
+
+/-- The `not` control frame `(tnot, 1)` is 3 cells: `unaryField 0 ++ unaryField 1`. -/
+@[simp] theorem pushCtrlFrame_frameLen_not :
+    (encodeCtrlFrame (ITag.tnot, ITag.tnot.arity)).length = 3 := by
+  simp [encodeCtrlFrame, ITag.arity, ITag.tagCode, unaryField]
+
+/-- The `and` control frame `(tand, 2)` is 5 cells: `unaryField 1 ++ unaryField 2`. -/
+@[simp] theorem pushCtrlFrame_frameLen_and :
+    (encodeCtrlFrame (ITag.tand, ITag.tand.arity)).length = 5 := by
+  simp [encodeCtrlFrame, ITag.arity, ITag.tagCode, unaryField]
+
+/-- The `or` control frame `(tor, 2)` is 6 cells: `unaryField 2 ++ unaryField 2`. -/
+@[simp] theorem pushCtrlFrame_frameLen_or :
+    (encodeCtrlFrame (ITag.tor, ITag.tor.arity)).length = 6 := by
+  simp [encodeCtrlFrame, ITag.arity, ITag.tagCode, unaryField]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -77,6 +77,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPWriteBits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPushCtrlFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlattenValueStack
@@ -3934,6 +3935,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.emitConstRecord_runConfig_record
 -- D2t-5a machine: `writeBits` fixed-width tape writer — window holds `bs` after `bs.length` steps.
 #check @Pnp4.Frontier.ContractExpansion.writeBits_runConfig
+-- D2t-5a machine: `pushCtrlFrame` control-stack push — window holds the per-tag control frame.
+#check @Pnp4.Frontier.ContractExpansion.pushCtrlFrame_runConfig
 -- D2t-4b leaf emit (core): binary→unary index realised as `unaryField i` on the tape (sentinel preserved).
 #check @Pnp4.Frontier.ContractExpansion.emitInputRecord_runConfig_unaryField
 -- D2t-5 pure core: stack linearization `runSteps (toSteps c) []` = structural `flattenAt 0 c`.

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -67,6 +67,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPStepRightProgram
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordLayout
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitConstRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPWriteBits
+import Pnp4.Frontier.ContractExpansion.TreeMCSPPushCtrlFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitInputRecord
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlatten
 import Pnp4.Frontier.ContractExpansion.TreeMCSPStackFlattenValueStack
@@ -731,6 +732,9 @@ end Pnp4
 -- D2t-5a machine: `writeBits` — the fixed-width tape writer (generalizes the const-record write); after
 -- `bs.length` steps the window holds `bs`. Foundation for the control-frame `pushFrame` on-tape machine.
 #print axioms Pnp4.Frontier.ContractExpansion.writeBits_runConfig
+-- D2t-5a machine: `pushCtrlFrame` — the control-stack push (writeBits on the fixed per-tag frame); the
+-- written window holds `encodeCtrlFrame (tag, tag.arity)`.
+#print axioms Pnp4.Frontier.ContractExpansion.pushCtrlFrame_runConfig
 -- D2t-4b leaf emit (core): the loop's binary→unary of the index realises `unaryField i` on the tape
 -- window `[HOME-i, HOME]` (sentinel preserved via the strengthened reachesSink/output), the substance of
 -- an `input i` record.


### PR DESCRIPTION
## Summary

**D2t-5a machine — `pushCtrlFrame`**, the control-stack push. On an internal node `tag` (from `treeTagDispatch`), the driver pushes the initial frame `(tag, tag.arity)` onto `STACK_ctrl`. Since the tag is known, the frame encoding `encodeCtrlFrame (tag, tag.arity)` is a fixed bit list, so the push is a fixed-width write: `pushCtrlFrame tag := writeBits (encodeCtrlFrame (tag, tag.arity))` (built on the merged `writeBits` #1595 + `CtrlFrameStack` codec #1594).

## Lemmas (`TreeMCSPPushCtrlFrame.lean`)

- `pushCtrlFrame_runConfig` — from the stack-top pointer `p`, after `(encodeCtrlFrame (tag, tag.arity)).length` steps the window `[p, p + len)` holds exactly the control frame's encoding and the pointer rests at `p + len` (so the new frame sits at the head of `encodeCtrlStack`, via the merged `encodeCtrlStack_cons`). Direct corollary of `writeBits_runConfig`.
- `pushCtrlFrame_frameLen_{not,and,or}` — concrete per-tag frame widths (3 / 5 / 6 cells) for the driver's room bounds.

## Verification

`./scripts/check.sh` → **17/17 PASS**; `lake build PnP3 Pnp4` green. Standard `[propext, Classical.choice, Quot.sound]` triple (audited in `AxiomsAudit`, surfaced in `AlgorithmsToLowerBoundsSurfaceTests`).

**Progress classification (AGENTS.md): Infrastructure.** **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_