### PR TITLE
transcoder(D2t-5b): small-step driver termination + explicit 3·c.size step-count bound

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -332,6 +332,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCtrlFrameStack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStep,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStepTerminates,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriveStep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriveStep.lean
@@ -216,8 +216,13 @@ theorem driveStep_out_eq_flatten {n : Nat} (c : CircuitTree n) :
 
 /-! ### Termination measure (the `μ` for the on-tape `loopUntilSink` driver) -/
 
-/-- A state is **terminal** when the tokens are exhausted and we are not settling — the loop's halt
-condition (the certificate has been fully transcoded). -/
+/-- A state is **terminal** when the tokens are exhausted and we are not settling — the loop's
+**halt/idle** condition: `step` fixes exactly these states (`step_terminal`).  This is the *raw control*
+condition and deliberately does **not** constrain `ctrl`/`val`, so a malformed-input "stuck" state with
+pending frames (the `settle` underflow arm of `TreeMCSPDriveStack`, unreachable on real certificates)
+also counts as terminal.  On states reachable from `⟨preorder c, [], [], [], false⟩` it coincides with
+**full transcoding** — the control/value stacks are resolved and WORK holds the postorder flatten
+(`driveStep_halts_with_flatten`). -/
 def DriveState.terminal {n : Nat} (s : DriveState n) : Prop :=
   s.settling = false ∧ s.toks = []
 

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriveStepTerminates.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriveStepTerminates.lean
@@ -59,6 +59,87 @@ theorem driveStep_halts_with_flatten {n : Nat} (c : CircuitTree n) :
   · rw [hk]; exact ⟨rfl, rfl⟩
   · rw [hk]; show driveWORK c = (CircuitTree.flatten c).gates; exact driveWORK_eq_flatten c
 
+/-! ### Explicit step-count bound (the polynomial runtime witness for the on-tape driver) -/
+
+/-- Terminal states are **fixed by iteration**: once the certificate is consumed the loop idles for any
+number of further steps. -/
+theorem DriveState.step_terminal_state_stays {n : Nat} (s : DriveState n) (h : s.terminal) :
+    ∀ j, DriveState.step^[j] s = s := by
+  intro j
+  induction j with
+  | zero => rfl
+  | succ j ih => rw [Function.iterate_succ_apply, DriveState.step_terminal s h]; exact ih
+
+/-- Once a prefix of the run reaches a terminal state, every longer prefix lands on the **same** state
+(terminal is absorbing). -/
+theorem DriveState.step_after_terminal {n : Nat} (s : DriveState n) {a : Nat}
+    (h : (DriveState.step^[a] s).terminal) {b : Nat} (hab : a ≤ b) :
+    DriveState.step^[b] s = DriveState.step^[a] s := by
+  obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hab
+  rw [Nat.add_comm a d, Function.iterate_add_apply, DriveState.step_terminal_state_stays _ h d]
+
+/-- **Termination within `mu` steps.**  After exactly `mu s` iterations the driver is terminal — the
+explicit step-count bound (strong induction on `mu`: the non-terminal step drops `mu`, and
+`step_after_terminal` absorbs the slack). -/
+theorem DriveState.step_terminal_at_mu {n : Nat} (s : DriveState n) :
+    (DriveState.step^[s.mu] s).terminal := by
+  suffices H : ∀ m (s : DriveState n), s.mu = m → (DriveState.step^[s.mu] s).terminal by
+    exact H s.mu s rfl
+  intro m
+  induction m using Nat.strong_induction_on with
+  | _ m ih =>
+    intro s hm
+    by_cases hterm : s.terminal
+    · rw [DriveState.step_terminal_state_stays s hterm]; exact hterm
+    · have hlt : s.step.mu < s.mu := DriveState.mu_step_lt s hterm
+      have key : (DriveState.step^[s.step.mu] s.step).terminal := ih s.step.mu (by omega) s.step rfl
+      have key' : (DriveState.step^[s.step.mu + 1] s).terminal := by
+        rw [Function.iterate_succ_apply]; exact key
+      have hb1 : s.step.mu + 1 ≤ s.mu := by omega
+      rw [DriveState.step_after_terminal s key' hb1]
+      exact key'
+
+/-- The preorder token stream has exactly one token per tree node: `|preorder c| = c.size`. -/
+theorem preorder_length {n : Nat} (c : CircuitTree n) : (preorder c).length = c.size := by
+  induction c with
+  | input i => rfl
+  | const b => rfl
+  | not c ih => simp only [preorder, List.length_cons, ih, CircuitTree.size]
+  | and a b iha ihb =>
+      simp only [preorder, List.length_cons, List.length_append, iha, ihb, CircuitTree.size]
+  | or a b iha ihb =>
+      simp only [preorder, List.length_cons, List.length_append, iha, ihb, CircuitTree.size]
+
+/-- The measure of the empty initial state is `3 · c.size` — the driver's explicit step budget. -/
+theorem mu_init {n : Nat} (c : CircuitTree n) :
+    (⟨preorder c, [], [], [], false⟩ : DriveState n).mu = 3 * c.size := by
+  simp [DriveState.mu, preorder_length]
+
+/-- **D2t-5b driver step-count bound.**  Within `3 · c.size` micro-steps the driver has halted (terminal)
+with WORK exactly `(flatten c).gates` — the explicit polynomial runtime witness the on-tape `loopUntilSink`
+driver inherits (each micro-step = one bounded body pass). -/
+theorem driveStep_halts_bound {n : Nat} (c : CircuitTree n) :
+    (DriveState.step^[3 * c.size] (⟨preorder c, [], [], [], false⟩ : DriveState n)).terminal
+    ∧ (DriveState.step^[3 * c.size] (⟨preorder c, [], [], [], false⟩ : DriveState n)).out
+        = (CircuitTree.flatten c).gates := by
+  obtain ⟨k, hk⟩ := driveStep_drive c
+  have hkterm : (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).terminal := by
+    rw [hk]; exact ⟨rfl, rfl⟩
+  have hbterm : (DriveState.step^[3 * c.size]
+      (⟨preorder c, [], [], [], false⟩ : DriveState n)).terminal := by
+    have h := DriveState.step_terminal_at_mu (⟨preorder c, [], [], [], false⟩ : DriveState n)
+    rwa [mu_init c] at h
+  have e1 := DriveState.step_after_terminal (⟨preorder c, [], [], [], false⟩ : DriveState n) hkterm
+    (le_max_left k (3 * c.size))
+  have e2 := DriveState.step_after_terminal (⟨preorder c, [], [], [], false⟩ : DriveState n) hbterm
+    (le_max_right k (3 * c.size))
+  have heq : DriveState.step^[3 * c.size] (⟨preorder c, [], [], [], false⟩ : DriveState n)
+      = DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n) := by rw [← e2, e1]
+  refine ⟨hbterm, ?_⟩
+  rw [heq, hk]
+  show driveWORK c = (CircuitTree.flatten c).gates
+  exact driveWORK_eq_flatten c
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriveStepTerminates.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriveStepTerminates.lean
@@ -1,0 +1,64 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStep
+
+/-!
+# `step_reachesTerminal` — D2t-5b: the small-step driver terminates (the pure mirror of `reachesSink`)
+
+`TreeMCSPDriveStep` ships the one-micro-step driver `DriveState.step`, its measure `mu`, and the two
+facts the on-tape loop needs: `mu_step_lt` (off a terminal state `mu` strictly drops) and `step_terminal`
+(a terminal state is fixed).  This module closes the loop on the **pure** side: iterating `step` always
+**reaches a terminal state**, in at most `mu` steps — the exact pure analogue of the on-tape
+`loopUntilSink_reachesSink` (strong induction on the measure, the same shape the machine discharge will
+transcribe).
+
+* `step_reachesTerminal` — from any micro-state, `∃ k, (step^[k] s).terminal`.
+* `driveStep_halts_with_flatten` — **the headline**: run from `⟨preorder c, [], [], [], false⟩`, the
+  small-step driver halts (reaches a terminal state — the loop's sink) with WORK exactly
+  `(flatten c).gates`, the postorder flatten.
+
+Together with `driveStep_out_eq_flatten` this gives the full pure correctness-and-termination statement the
+on-tape D2t-5b `loopUntilSink` driver realises.
+
+**Progress classification (AGENTS.md): Infrastructure** — a pure termination proof for the small-step
+driver spec; builds no machine and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]`
+triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- **The small-step driver terminates.**  From any micro-state, iterating `step` reaches a terminal state
+(tokens exhausted, not settling) — in at most `mu s` steps.  Strong induction on the measure `mu` via
+`mu_step_lt` (non-terminal ⇒ strictly smaller measure) and `step_terminal` (terminal ⇒ fixed). -/
+theorem step_reachesTerminal {n : Nat} (s : DriveState n) :
+    ∃ k, (DriveState.step^[k] s).terminal := by
+  suffices H : ∀ m (s : DriveState n), s.mu = m → ∃ k, (DriveState.step^[k] s).terminal by
+    exact H s.mu s rfl
+  intro m
+  induction m using Nat.strong_induction_on with
+  | _ m ih =>
+    intro s hm
+    by_cases hterm : s.terminal
+    · exact ⟨0, hterm⟩
+    · have hlt : s.step.mu < m := hm ▸ DriveState.mu_step_lt s hterm
+      obtain ⟨k, hk⟩ := ih s.step.mu hlt s.step rfl
+      refine ⟨k + 1, ?_⟩
+      rw [Function.iterate_succ_apply]
+      exact hk
+
+/-- **The small-step driver halts with the flatten.**  Run from the empty initial state, iterating `step`
+reaches a terminal state (the loop's halt condition) whose WORK is exactly `(flatten c).gates` — the full
+pure correctness-and-termination statement realised by the on-tape D2t-5b driver loop. -/
+theorem driveStep_halts_with_flatten {n : Nat} (c : CircuitTree n) :
+    ∃ k, (DriveState.step^[k] ⟨preorder c, [], [], [], false⟩).terminal
+      ∧ (DriveState.step^[k] ⟨preorder c, [], [], [], false⟩).out = (CircuitTree.flatten c).gates := by
+  obtain ⟨k, hk⟩ := driveStep_drive c
+  refine ⟨k, ?_, ?_⟩
+  · rw [hk]; exact ⟨rfl, rfl⟩
+  · rw [hk]; show driveWORK c = (CircuitTree.flatten c).gates; exact driveWORK_eq_flatten c
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3978,6 +3978,13 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- postorder flatten in WORK.
 #check @Pnp4.Frontier.ContractExpansion.step_reachesTerminal
 #check @Pnp4.Frontier.ContractExpansion.driveStep_halts_with_flatten
+-- D2t-5b: explicit step-count bound — driver halts within `3 · c.size` steps with the flatten in WORK.
+#check @Pnp4.Frontier.ContractExpansion.DriveState.step_terminal_state_stays
+#check @Pnp4.Frontier.ContractExpansion.DriveState.step_after_terminal
+#check @Pnp4.Frontier.ContractExpansion.DriveState.step_terminal_at_mu
+#check @Pnp4.Frontier.ContractExpansion.preorder_length
+#check @Pnp4.Frontier.ContractExpansion.mu_init
+#check @Pnp4.Frontier.ContractExpansion.driveStep_halts_bound
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -88,6 +88,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPNatStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCtrlFrameStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStepTerminates
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -3973,6 +3974,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.driveStep_out_eq_flatten
 #check @Pnp4.Frontier.ContractExpansion.DriveState.step_terminal
 #check @Pnp4.Frontier.ContractExpansion.DriveState.mu_step_lt
+-- D2t-5b: the small-step driver terminates (pure mirror of `loopUntilSink_reachesSink`) — halts with the
+-- postorder flatten in WORK.
+#check @Pnp4.Frontier.ContractExpansion.step_reachesTerminal
+#check @Pnp4.Frontier.ContractExpansion.driveStep_halts_with_flatten
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -787,6 +787,14 @@ end Pnp4
 -- of `loopUntilSink_reachesSink`), halting with the postorder flatten in WORK.
 #print axioms Pnp4.Frontier.ContractExpansion.step_reachesTerminal
 #print axioms Pnp4.Frontier.ContractExpansion.driveStep_halts_with_flatten
+-- D2t-5b: explicit step-count bound — the driver halts within `3 · c.size` micro-steps with the postorder
+-- flatten in WORK (the polynomial runtime witness the on-tape `loopUntilSink` driver inherits).
+#print axioms Pnp4.Frontier.ContractExpansion.DriveState.step_terminal_state_stays
+#print axioms Pnp4.Frontier.ContractExpansion.DriveState.step_after_terminal
+#print axioms Pnp4.Frontier.ContractExpansion.DriveState.step_terminal_at_mu
+#print axioms Pnp4.Frontier.ContractExpansion.preorder_length
+#print axioms Pnp4.Frontier.ContractExpansion.mu_init
+#print axioms Pnp4.Frontier.ContractExpansion.driveStep_halts_bound
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -78,6 +78,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPNatStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCtrlFrameStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStepTerminates
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -782,6 +783,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.driveStep_out_eq_flatten
 #print axioms Pnp4.Frontier.ContractExpansion.DriveState.step_terminal
 #print axioms Pnp4.Frontier.ContractExpansion.DriveState.mu_step_lt
+-- D2t-5b: the small-step driver terminates — iterating `step` reaches a terminal state (the pure mirror
+-- of `loopUntilSink_reachesSink`), halting with the postorder flatten in WORK.
+#print axioms Pnp4.Frontier.ContractExpansion.step_reachesTerminal
+#print axioms Pnp4.Frontier.ContractExpansion.driveStep_halts_with_flatten
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
## Summary

**D2t-5b — small-step driver termination + step-count bound.** Closes the small-step story (semantics + measure landed in #1602) on the **pure** side: iterating `DriveState.step` always reaches a terminal state — the exact pure analogue of the on-tape `loopUntilSink_reachesSink`, by the *same* strong-induction-on-the-measure argument the machine discharge will transcribe — and does so within an **explicit `3·c.size` step budget**.

_(Rebased onto the merged #1602; now a standalone brick.)_

## Lemmas (`TreeMCSPDriveStepTerminates.lean`)

- `step_reachesTerminal` — from any micro-state, `∃ k, (step^[k] s).terminal` (strong induction on `mu` via `mu_step_lt` + `step_terminal`).
- **`driveStep_halts_with_flatten`** — run from `⟨preorder c, [], [], [], false⟩`, the driver halts (terminal) with WORK exactly `(flatten c).gates`, the postorder flatten.
- `step_terminal_state_stays` / `step_after_terminal` — terminal states are absorbing.
- `step_terminal_at_mu` — after exactly `mu s` steps the driver is terminal (the bound).
- `preorder_length` (`|preorder c| = c.size`) + `mu_init` (`mu` of the empty init `= 3·c.size`).
- **`driveStep_halts_bound`** — within `3·c.size` micro-steps the driver has halted with WORK `= (flatten c).gates`: the explicit polynomial runtime witness the on-tape `loopUntilSink` driver inherits (one micro-step = one bounded body pass).

Also includes the Qodo #1603 docstring precision fix for `DriveState.terminal` (raw loop halt/idle condition vs. full transcoding on reachable states).

All new lemmas surfaced in `AxiomsAudit` + `AlgorithmsToLowerBoundsSurfaceTests` (AGENTS.md Rules 2/3).

## Verification

`./scripts/check.sh` → **17/17 PASS**; `lake build PnP3 Pnp4` green. Standard `[propext, Classical.choice, Quot.sound]` triple.

**Progress classification (AGENTS.md): Infrastructure** — pure termination/bound proofs; build no machine, prove no separation. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_