### PR TITLE
transcoder(D2t-5b): encodePreorder — the certificate is the encoded preorder token stream

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -333,6 +333,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStepTerminates,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEncodePreorder,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEncodePreorder.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEncodePreorder.lean
@@ -42,7 +42,12 @@ def encodePreToken {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width) : PreToke
   | .leaf (SLGate.input i) =>
       [false, false, false] ++ encodeFin width ⟨i.val, lt_of_lt_of_le i.isLt h_width⟩
   | .leaf (SLGate.const b) => [false, false, true, b]
-  | .leaf _ => []
+  -- `notGate`/`andGate`/`orGate` leaves never occur in a `preorder` stream (they are produced by `settle`,
+  -- not read from the certificate).  Listed explicitly (rather than a wildcard) so a future `SLGate`
+  -- constructor forces an exhaustiveness error here instead of silently encoding as `[]`.
+  | .leaf (SLGate.notGate _) => []
+  | .leaf (SLGate.andGate _ _) => []
+  | .leaf (SLGate.orGate _ _) => []
 
 /-- The tape image of a preorder token list: the tokens' images concatenated. -/
 def encodePreorder {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width) : List (PreToken n) → List Bool

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEncodePreorder.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEncodePreorder.lean
@@ -1,0 +1,86 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack
+
+/-!
+# `encodePreorder` — D2t-5b: the certificate **is** the encoded preorder token stream
+
+The on-tape D2t-5b driver reads the certificate (`encodeCircuitTree`, a preorder serialisation) token by
+token, its abstract state tracking the **unread** tokens as a `List (PreToken n)` (`drive`/`DriveState`).
+To relate a running tape configuration to that abstract token list — the certificate region of the driver
+configuration invariant — we need the per-token tape codec and the fact that it reproduces
+`encodeCircuitTree` exactly.
+
+This module supplies both:
+
+* `encodePreToken` — one preorder token's tape image, matching `encodeCircuitTree`'s tag bits: nodes
+  `tnot = [0,1,0]`, `tand = [0,1,1]`, `tor = [1,0,0]`; leaves `input i = [0,0,0] ++ encodeFin width i`,
+  `const b = [0,0,1,b]`.  (The `notGate`/`andGate`/`orGate` leaves never occur in a `preorder` stream —
+  they are produced by `settle`, not read from the certificate — so they map to `[]`.)
+* `encodePreorder` — the token list's tape image, the tokens' images concatenated.
+* `encodePreorder_append` — the image distributes over list append.
+* **`encodePreorder_preorder`** — `encodePreorder width h (preorder c) = encodeCircuitTree width h c`: the
+  certificate is exactly the encoded preorder token stream, so the driver's abstract `toks = preorder c`
+  corresponds cell-for-cell to the on-tape certificate.
+
+**Progress classification (AGENTS.md): Infrastructure** — a tape-format codec proven against the verified
+`encodeCircuitTree`; builds no machine and proves no separation.  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- One preorder token's tape image — the same bits `encodeCircuitTree` writes for that node/leaf.  The
+`notGate`/`andGate`/`orGate` leaves are unreachable in a `preorder` stream (produced by `settle`, not the
+certificate), so they map to `[]`. -/
+def encodePreToken {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width) : PreToken n → List Bool
+  | .node ITag.tnot => [false, true, false]
+  | .node ITag.tand => [false, true, true]
+  | .node ITag.tor => [true, false, false]
+  | .leaf (SLGate.input i) =>
+      [false, false, false] ++ encodeFin width ⟨i.val, lt_of_lt_of_le i.isLt h_width⟩
+  | .leaf (SLGate.const b) => [false, false, true, b]
+  | .leaf _ => []
+
+/-- The tape image of a preorder token list: the tokens' images concatenated. -/
+def encodePreorder {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width) : List (PreToken n) → List Bool
+  | [] => []
+  | t :: ts => encodePreToken width h_width t ++ encodePreorder width h_width ts
+
+@[simp] theorem encodePreorder_nil {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width) :
+    encodePreorder width h_width ([] : List (PreToken n)) = [] := rfl
+
+@[simp] theorem encodePreorder_cons {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (t : PreToken n) (ts : List (PreToken n)) :
+    encodePreorder width h_width (t :: ts)
+      = encodePreToken width h_width t ++ encodePreorder width h_width ts := rfl
+
+/-- The token-stream image distributes over list append (the concatenation is a `foldr (· ++ ·)`). -/
+theorem encodePreorder_append {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (l1 l2 : List (PreToken n)) :
+    encodePreorder width h_width (l1 ++ l2)
+      = encodePreorder width h_width l1 ++ encodePreorder width h_width l2 := by
+  induction l1 with
+  | nil => simp
+  | cons t ts ih => simp [ih, List.append_assoc]
+
+/-- **The certificate is the encoded preorder token stream.**  `encodePreorder width h (preorder c)`
+equals `encodeCircuitTree width h c` cell for cell — so the driver's abstract unread-token list
+`toks = preorder c` decodes the on-tape certificate exactly.  Induction on the tree, matching each node's
+tag bits and recursing via `encodePreorder_append` at the binary nodes. -/
+theorem encodePreorder_preorder {n : Nat} (width : Nat) (h_width : n ≤ 2 ^ width) (c : CircuitTree n) :
+    encodePreorder width h_width (preorder c) = encodeCircuitTree width h_width c := by
+  induction c with
+  | input i => simp [preorder, encodePreToken, encodeCircuitTree]
+  | const b => simp [preorder, encodePreToken, encodeCircuitTree]
+  | not c ih => simp [preorder, encodePreToken, encodeCircuitTree, ih]
+  | and a b iha ihb =>
+      simp [preorder, encodePreToken, encodeCircuitTree, encodePreorder_append, iha, ihb]
+  | or a b iha ihb =>
+      simp [preorder, encodePreToken, encodeCircuitTree, encodePreorder_append, iha, ihb]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -89,6 +89,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCtrlFrameStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStepTerminates
+import Pnp4.Frontier.ContractExpansion.TreeMCSPEncodePreorder
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -3985,6 +3986,12 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.preorder_length
 #check @Pnp4.Frontier.ContractExpansion.mu_init
 #check @Pnp4.Frontier.ContractExpansion.driveStep_halts_bound
+-- D2t-5b: the certificate is the encoded preorder token stream (`encodePreorder (preorder c)
+-- = encodeCircuitTree c`) — the cert-region codec for the driver configuration invariant.
+#check @Pnp4.Frontier.ContractExpansion.encodePreorder_nil
+#check @Pnp4.Frontier.ContractExpansion.encodePreorder_cons
+#check @Pnp4.Frontier.ContractExpansion.encodePreorder_append
+#check @Pnp4.Frontier.ContractExpansion.encodePreorder_preorder
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -79,6 +79,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCtrlFrameStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStepTerminates
+import Pnp4.Frontier.ContractExpansion.TreeMCSPEncodePreorder
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -795,6 +796,12 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.preorder_length
 #print axioms Pnp4.Frontier.ContractExpansion.mu_init
 #print axioms Pnp4.Frontier.ContractExpansion.driveStep_halts_bound
+-- D2t-5b: the certificate is the encoded preorder token stream — `encodePreorder (preorder c)
+-- = encodeCircuitTree c` (the cert-region codec for the driver configuration invariant).
+#print axioms Pnp4.Frontier.ContractExpansion.encodePreorder_nil
+#print axioms Pnp4.Frontier.ContractExpansion.encodePreorder_cons
+#print axioms Pnp4.Frontier.ContractExpansion.encodePreorder_append
+#print axioms Pnp4.Frontier.ContractExpansion.encodePreorder_preorder
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
## Summary

**D2t-5b — the certificate-region codec** for the driver configuration invariant. The on-tape driver reads the certificate (`encodeCircuitTree`, a preorder serialisation) token by token, its abstract state tracking the **unread** tokens as a `List (PreToken n)` (`drive`/`DriveState`). To relate a running tape configuration to that abstract token list, this brick supplies the per-token tape codec and proves it reproduces `encodeCircuitTree` exactly.

## Lemmas (`TreeMCSPEncodePreorder.lean`)

- `encodePreToken` / `encodePreorder` — one token's / a token list's tape image, matching `encodeCircuitTree`'s tag bits (`tnot=[0,1,0]`, `tand=[0,1,1]`, `tor=[1,0,0]`; `input i=[0,0,0]++encodeFin width i`, `const b=[0,0,1,b]`). The `notGate`/`andGate`/`orGate` leaves never occur in a `preorder` stream (produced by `settle`, not the certificate), so they map to `[]`.
- `encodePreorder_append` — the image distributes over list append.
- **`encodePreorder_preorder`** — `encodePreorder width h (preorder c) = encodeCircuitTree width h c`: the certificate is exactly the encoded preorder token stream, so the driver's abstract `toks = preorder c` corresponds cell-for-cell to the on-tape certificate.

All surfaced in `AxiomsAudit` + `AlgorithmsToLowerBoundsSurfaceTests` (AGENTS.md Rules 2/3).

## Verification

`./scripts/check.sh` → **17/17 PASS**; `lake build PnP3 Pnp4` green. Standard `[propext, Classical.choice, Quot.sound]` triple.

**Progress classification (AGENTS.md): Infrastructure** — a tape-format codec proven against the verified `encodeCircuitTree`; builds no machine, proves no separation. **No `P ≠ NP` claim.**

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_