### PR TITLE
ci: stop per-PR duplicate build + make .lake cache incremental (build speedup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,17 @@
 name: CI
 
-on: [push, pull_request]
+# Run on every PR (any base) and on pushes to the integration branches.
+# Scoping `push` to integration branches removes the duplicate run that
+# `on: [push, pull_request]` produced on every feature-branch PR (the push
+# and the pull_request events both fired on the same commit).
+# Policy (intentional): all work reaches the integration/main branches via
+# PRs, and every PR is fully verified by this workflow, so direct pushes to
+# non-listed branches are deliberately NOT CI'd on push — open a PR to get
+# verification. (Add a branch here if it ever needs push-time CI without a PR.)
+on:
+  push:
+    branches: [main, master, claude/elegant-noether-CnlU5]
+  pull_request:
 
 jobs:
   build:
@@ -25,11 +36,27 @@ jobs:
       - name: Get prebuilt mathlib cache
         run: lake exe cache get
 
-      # 4. Cache .lake between runs.
-      - uses: actions/cache@v3
+      # 4. Cache this project's own build dir between runs (incremental).
+      #    Mathlib comes from `lake exe cache get` above; here we cache only
+      #    `.lake/build` (this project's oleans), keyed per-commit with a
+      #    prefix `restore-keys` fallback so that even on a key miss the most
+      #    recent build is restored and only changed modules + their dependents
+      #    recompile — instead of rebuilding the whole project every run.
+      #    (The previous key hashed `lakefile.lean`, which every brick edits,
+      #    so the cache missed on every PR and the full track was rebuilt.)
+      #    Safe: Lean's build is input-hash-based, so a restored `.lake` only
+      #    reuses artifacts whose inputs still match — a stale cache can never
+      #    yield an incorrect build, only redundant recompilation.
+      - uses: actions/cache@v4
         with:
-          path: .lake
-          key: ${{ runner.os }}-lake-${{ hashFiles('lakefile.lean') }}
+          path: .lake/build
+          # Namespace the cache by toolchain + dependency manifest so a Lean
+          # bump or `lake-manifest.json` change automatically starts a fresh
+          # cache lineage (no cross-toolchain restores); within a namespace the
+          # per-commit key + prefix `restore-keys` gives incremental reuse.
+          key: ${{ runner.os }}-lake-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-lake-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
 
       # 5. Build both libraries explicitly.
       #    `lake build` without args only compiles the @[default_target]

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -17,6 +17,14 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y ripgrep jq
       - name: Get mathlib cache
         run: lake exe cache get
+      # Incremental cache of this project's own build dir (see ci.yml for rationale).
+      - uses: actions/cache@v4
+        with:
+          path: .lake/build
+          # Toolchain/manifest-namespaced cache key (see ci.yml for rationale).
+          key: ${{ runner.os }}-lake-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-lake-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
       - name: Build project
         run: lake build PnP3 Pnp4
       - name: Run smoke test


### PR DESCRIPTION
## Summary

Two **safe, CI-only** speedups (no proof or audit content touched). Diagnosed from the actual config + project size (169 pnp4 files / ~45k LOC; the two aggregator test files import the whole track):

**A — stop the per-PR duplicate build.** `ci.yml` ran on `on: [push, pull_request]` with no branch filter, so every feature-branch PR triggered the build **twice on the same commit** (the `push` event *and* the `pull_request` event). Now:
```yaml
on:
  push: { branches: [main, master, claude/elegant-noether-CnlU5] }
  pull_request:
```
Every PR is still fully verified (`pull_request`, any base) and the integration branches are verified on push — the redundant feature-push run is gone (≈ ×2 saving per PR).

**B — make the `.lake` cache incremental.** The old key hashed `lakefile.lean`, which **every brick edits**, so the key changed each PR and (with no `restore-keys`) the cache always missed → the whole ~45k-line project rebuilt from the Mathlib baseline every run. Now:
```yaml
- uses: actions/cache@v4
  with:
    path: .lake/build
    key: ${{ runner.os }}-lake-${{ github.sha }}
    restore-keys: ${{ runner.os }}-lake-
```
A miss still **restores the most recent build** (prefix fallback), so only changed modules + their dependents recompile. Same block added to `lean.yml`. `nightly-unconditional.yml` is left **uncached on purpose** (a from-scratch nightly build is a useful cache-corruption canary).

## Why this is safe

- **Verification coverage is unchanged**: every PR + every integration-branch push still runs the full `lake build PnP3 Pnp4` + `lake test` + `./scripts/check.sh`.
- **A stale cache cannot corrupt a build**: Lean's build is input-hash-based, so a restored `.lake/build` only reuses artifacts whose inputs still match — worst case is redundant recompilation, never an incorrect build. Mathlib continues to come from `lake exe cache get`.
- No `.lean`, no proof, no axiom-audit/surface coverage is modified.

Touches only `.github/workflows/ci.yml` and `.github/workflows/lean.yml`.

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_