### PR TITLE
test(D2t-5b): surface drive_preorder + driveStep_drive in the audit aggregators

### DIFF
--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -3968,12 +3968,14 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5a: on-tape control-stack format (pending `(tag, remaining)` frames) round-trip.
 #check @Pnp4.Frontier.ContractExpansion.decodeCtrlStack_encodeCtrlStack
 -- D2t-5b: preorder-streaming driver (control + value stacks) produces the postorder flatten.
+#check @Pnp4.Frontier.ContractExpansion.drive_preorder
 #check @Pnp4.Frontier.ContractExpansion.driveWORK_eq_flatten
 -- D2t-5b: small-step driver semantics — `step` iterated reproduces `settle`/`drive`/`flatten`, with a
 -- strictly-decreasing termination measure (the `μ` for the on-tape `loopUntilSink` driver).
 #check @Pnp4.Frontier.ContractExpansion.step_iterate_settle
 #check @Pnp4.Frontier.ContractExpansion.step_iterate_processToken
 #check @Pnp4.Frontier.ContractExpansion.step_iterate_drive
+#check @Pnp4.Frontier.ContractExpansion.driveStep_drive
 #check @Pnp4.Frontier.ContractExpansion.driveStep_out_eq_flatten
 #check @Pnp4.Frontier.ContractExpansion.DriveState.step_terminal
 #check @Pnp4.Frontier.ContractExpansion.DriveState.mu_step_lt

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -777,12 +777,14 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.decodeCtrlStack_encodeCtrlStack
 -- D2t-5b: the preorder-streaming driver (control + value stacks, settle cascade) produces the postorder
 -- flatten — the pure spec the on-tape D2t-5b loop realises.
+#print axioms Pnp4.Frontier.ContractExpansion.drive_preorder
 #print axioms Pnp4.Frontier.ContractExpansion.driveWORK_eq_flatten
 -- D2t-5b: small-step (one-micro-step) driver semantics — iterating `step` reproduces `settle`/`drive`,
 -- leaves the postorder flatten in WORK, and a measure that strictly decreases off terminal states.
 #print axioms Pnp4.Frontier.ContractExpansion.step_iterate_settle
 #print axioms Pnp4.Frontier.ContractExpansion.step_iterate_processToken
 #print axioms Pnp4.Frontier.ContractExpansion.step_iterate_drive
+#print axioms Pnp4.Frontier.ContractExpansion.driveStep_drive
 #print axioms Pnp4.Frontier.ContractExpansion.driveStep_out_eq_flatten
 #print axioms Pnp4.Frontier.ContractExpansion.DriveState.step_terminal
 #print axioms Pnp4.Frontier.ContractExpansion.DriveState.mu_step_lt


### PR DESCRIPTION
Chain re-audit follow-up (the only real gap found by the full D2t-5 re-check).

AGENTS.md check requirements say new public theorem surfaces must appear in
`AlgorithmsToLowerBoundsSurfaceTests.lean` and `AxiomsAudit.lean`. Two public
theorems of the merged D2t-5b spine were skipped:

* **`drive_preorder`** (`TreeMCSPDriveStack`) — the driver-invariant workhorse
  behind `driveWORK_eq_flatten`; had no `#print axioms` / `#check` entry.
* **`driveStep_drive`** (`TreeMCSPDriveStep`) — the public bridge consumed
  directly by `TreeMCSPDriveStepTerminates`; likewise unsurfaced.

This PR adds the 4 missing aggregator lines (2 × `#print axioms`,
2 × `#check`) at their in-section positions. No source-module changes.

Verification:
* `drive_preorder` prints `[propext, Classical.choice, Quot.sound]` (standard triple);
* `driveStep_drive` prints `[propext, Quot.sound]` (a subset);
* `./scripts/check.sh` — **17/17 passed** locally on top of the integration tip.

Re-audit scope (for the record): all four `driverTapeInv` clause codecs checked
for `encodePreToken`-style lossiness — `unaryField` ≥ 1 cell (incl. `v = 0`),
`encodeGateRecord` ≥ 2, `encodeCtrlFrame` ≥ 2 — no further vacuity gaps; the
`step`/`settle` underflow arms agree; `encodeGateStream = unaryField count ++
encodeGateRecordStream` confirms the D2t-6 hand-off point. The deliberately
deferred geometry/coherence strengthenings (review concerns #2/#3) remain
scheduled as the first Block A brick.

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_