### PR TITLE
transcoder(D2t-5b/A1): strong tape invariant + reachable-state coherence (driverStrongInv, Pending)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -336,6 +336,8 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEncodePreorder,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriverTapeInv,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCertTokens,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriverStrongInv,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDrivePending,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDrivePending.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDrivePending.lean
@@ -1,0 +1,589 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStepTerminates
+
+/-!
+# `DriveState.Pending` — D2t-5b (Block A1b): the reachable-state coherence invariant
+
+The small-step driver's *raw* terminal condition is deliberately permissive (`TreeMCSPDriveStep`), and the
+strong tape invariant's cheap coherence clause (`driverStrongInv`, A1a) is only pointwise.  The on-tape
+loop, however, needs **run-trace** facts: its sink test is "*in the settle phase the control stack is
+empty*" (control-stack emptiness is one cell of the stack's pointer field — whereas "the certificate is
+exhausted" is *not* detectable on a `Bool` tape, where blank cells are indistinguishable from a leaf tag).
+For that test to be sound the driver must satisfy, at every reachable state, the **pending-forest
+decomposition**: the unread tokens are exactly the preorders of the still-pending subtrees, grouped by the
+control-stack frames, with the completed-children indices sitting on the value stack in matching counts.
+
+This module defines that decomposition and proves it is an invariant of the run:
+
+* `PendingFrames` — the below-top frames: each `(tag, rem)` frame has `rem = |pending| + 1` (the `+1` is
+  the in-progress child occupying one slot) and `|completed on val| + |pending| + 1 = tag.arity`.
+* `PendingTop` — the whole-state judgment: an empty control stack means the tokens are a single full
+  preorder (reading) or nothing (settling — **the sink-soundness base case**, with the completed root's
+  index on the value stack); a top frame has `rem = |pending| + (1 if settling)` and
+  `|completed| + |pending| = tag.arity`.
+* `pending_init` / `pending_step` / `pending_iterate` — the invariant holds initially and is preserved by
+  every `DriveState.step` (the underflow arms are *excluded*: the value stack always matches the popped
+  frame's arity exactly).
+* **`driver_sink_sound`** — at any reachable state, `settling ∧ ctrl = [] → toks = []`: the machine sink
+  test never fires early.  (`driver_sink_val_ne_nil`: and the completed root's index is on the value
+  stack.)
+* **`driver_sink_exists`** — the run *reaches* the sink, within `3 · c.size` steps, **with the postorder
+  flatten already in WORK**: `∃ k < 3·c.size, settling ∧ ctrl = [] ∧ toks = [] ∧ out = (flatten c).gates`.
+  (The only reachable transition into the pure terminal state is the settle-empty arm, which fixes
+  everything but the flag — so stopping at the sink loses nothing.)
+* `pendingFrames_rem_bounds` — every below-top frame has `1 ≤ rem ≤ arity ≤ 2`: the on-tape frame is a
+  **fixed-width** (≤ 6-cell) object, so the settle decrement is a bounded rewrite (consumed by A4b).
+
+**Progress classification (AGENTS.md): Infrastructure** — a pure reachability invariant for the verified
+small-step driver; builds no machine and proves no separation.  Standard `[propext, Classical.choice,
+Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- The preorder serialization of a forest: the trees' preorders concatenated. -/
+def preorderForest {n : Nat} : List (CircuitTree n) → List (PreToken n)
+  | [] => []
+  | t :: ts => preorder t ++ preorderForest ts
+
+@[simp] theorem preorderForest_nil {n : Nat} : preorderForest ([] : List (CircuitTree n)) = [] := rfl
+
+@[simp] theorem preorderForest_cons {n : Nat} (t : CircuitTree n) (ts : List (CircuitTree n)) :
+    preorderForest (t :: ts) = preorder t ++ preorderForest ts := rfl
+
+/-- A preorder stream is never empty (one token per node, `≥ 1` node). -/
+theorem preorder_ne_nil {n : Nat} (t : CircuitTree n) : preorder t ≠ [] := by
+  intro h
+  have hlen := preorder_length t
+  have hpos := CircuitTree.one_le_size t
+  rw [h] at hlen
+  simp at hlen
+  omega
+
+/-- A list with a nonempty left factor is nonempty. -/
+theorem append_left_ne_nil {α : Type _} {xs ys : List α} (h : xs ≠ []) : xs ++ ys ≠ [] := by
+  cases xs with
+  | nil => exact absurd rfl h
+  | cons a as => simp
+
+/-- **The below-top frames' pending decomposition.**  Reading the control stack downward from just below
+the top: each frame `(tag, rem)` has one child **in progress** (the activity above it — the `+1`), `ts`
+pending (not-yet-started) subtrees whose preorders open the corresponding token segment, and `vs`
+completed-children indices on the value stack, with `|vs| + |ts| + 1 = tag.arity`; below the last frame no
+tokens remain (`nil`). -/
+inductive PendingFrames {n : Nat} : List (ITag × Nat) → List (PreToken n) → List Nat → Prop
+  | nil (val : List Nat) : PendingFrames [] [] val
+  | frame (tag : ITag) (ctrl' : List (ITag × Nat)) (ts : List (CircuitTree n))
+      (rest : List (PreToken n)) (vs val' : List Nat)
+      (harity : vs.length + ts.length + 1 = tag.arity)
+      (hdeep : PendingFrames ctrl' rest val') :
+      PendingFrames ((tag, ts.length + 1) :: ctrl') (preorderForest ts ++ rest) (vs ++ val')
+
+/-- **The whole-state pending judgment.**  With an empty control stack: reading means the tokens are
+nothing or one full preorder (the initial state); settling means the completed subtree was the **root** —
+no tokens remain and its index tops the value stack (the sink-soundness base case).  With a top frame
+`(tag, rem)`: `rem` counts the pending subtrees plus the just-completed one while settling
+(`rem = |ts| + 1`) and exactly the pending ones while reading (`rem = |ts|`, necessarily `≥ 1` — the next
+token always opens the top frame's next subtree); completed-children indices `vs` top the value stack with
+`|vs| + |ts| = tag.arity`; the deeper frames satisfy `PendingFrames`. -/
+def PendingTop {n : Nat} : Bool → List (ITag × Nat) → List (PreToken n) → List Nat → Prop
+  | false, [], toks, _ => toks = [] ∨ ∃ t : CircuitTree n, toks = preorder t
+  | true, [], toks, val => toks = [] ∧ val ≠ []
+  | occupied, (tag, rem) :: ctrl', toks, val =>
+      ∃ (ts : List (CircuitTree n)) (rest : List (PreToken n)) (vs val' : List Nat),
+        rem = ts.length + (if occupied then 1 else 0)
+        ∧ 1 ≤ rem
+        ∧ vs.length + ts.length = tag.arity
+        ∧ toks = preorderForest ts ++ rest
+        ∧ val = vs ++ val'
+        ∧ PendingFrames ctrl' rest val'
+
+/-- The driver coherence invariant: the micro-state satisfies the pending-forest decomposition. -/
+def DriveState.Pending {n : Nat} (s : DriveState n) : Prop :=
+  PendingTop s.settling s.ctrl s.toks s.val
+
+/-- The invariant holds at the initial state: the whole certificate is one full preorder. -/
+theorem pending_init {n : Nat} (c : CircuitTree n) :
+    (⟨preorder c, [], [], [], false⟩ : DriveState n).Pending :=
+  Or.inr ⟨c, rfl⟩
+
+/-- A reading state whose next token is an internal-node tag has more tokens behind it (the node's
+children follow in preorder) — so a node read never exhausts the certificate. -/
+theorem pending_reading_node {n : Nat} {ctrl : List (ITag × Nat)} {tag : ITag}
+    {toks' : List (PreToken n)} {val : List Nat}
+    (hp : PendingTop false ctrl (PreToken.node tag :: toks') val) : toks' ≠ [] := by
+  cases ctrl with
+  | nil =>
+      rcases hp with h | ⟨t, ht⟩
+      · exact absurd h (List.cons_ne_nil _ _)
+      · cases t with
+        | input i => exact absurd ht (by simp [preorder])
+        | const b => exact absurd ht (by simp [preorder])
+        | not c =>
+            rw [show preorder (CircuitTree.not c) = PreToken.node ITag.tnot :: preorder c from rfl] at ht
+            obtain ⟨-, htoks⟩ := List.cons.inj ht
+            rw [htoks]
+            exact preorder_ne_nil c
+        | and a b =>
+            rw [show preorder (CircuitTree.and a b)
+                = PreToken.node ITag.tand :: (preorder a ++ preorder b) from rfl] at ht
+            obtain ⟨-, htoks⟩ := List.cons.inj ht
+            rw [htoks]
+            exact append_left_ne_nil (preorder_ne_nil a)
+        | or a b =>
+            rw [show preorder (CircuitTree.or a b)
+                = PreToken.node ITag.tor :: (preorder a ++ preorder b) from rfl] at ht
+            obtain ⟨-, htoks⟩ := List.cons.inj ht
+            rw [htoks]
+            exact append_left_ne_nil (preorder_ne_nil a)
+  | cons f ctrl' =>
+      obtain ⟨tag₀, rem₀⟩ := f
+      obtain ⟨ts, rest, vs, val', hrem, hpos, -, htoks, -, -⟩ := hp
+      simp only [if_neg Bool.false_ne_true] at hrem
+      cases ts with
+      | nil => simp at hrem; omega
+      | cons t₁ ts'' =>
+          rw [preorderForest_cons, List.append_assoc] at htoks
+          cases t₁ with
+          | input i => exact absurd htoks (by simp [preorder])
+          | const b => exact absurd htoks (by simp [preorder])
+          | not c =>
+              rw [show preorder (CircuitTree.not c)
+                  = PreToken.node ITag.tnot :: preorder c from rfl, List.cons_append] at htoks
+              obtain ⟨-, htoks'⟩ := List.cons.inj htoks
+              rw [htoks']
+              exact append_left_ne_nil (preorder_ne_nil c)
+          | and a b =>
+              rw [show preorder (CircuitTree.and a b)
+                  = PreToken.node ITag.tand :: (preorder a ++ preorder b) from rfl,
+                List.cons_append, List.append_assoc] at htoks
+              obtain ⟨-, htoks'⟩ := List.cons.inj htoks
+              rw [htoks']
+              exact append_left_ne_nil (preorder_ne_nil a)
+          | or a b =>
+              rw [show preorder (CircuitTree.or a b)
+                  = PreToken.node ITag.tor :: (preorder a ++ preorder b) from rfl,
+                List.cons_append, List.append_assoc] at htoks
+              obtain ⟨-, htoks'⟩ := List.cons.inj htoks
+              rw [htoks']
+              exact append_left_ne_nil (preorder_ne_nil a)
+
+/-- **The pending decomposition is preserved by every micro-step.**  Case analysis on the action; the
+underflow arms cannot fire (the value stack always carries exactly the popped frame's arity). -/
+theorem pending_step {n : Nat} (s : DriveState n) (h : s.Pending) : s.step.Pending := by
+  obtain ⟨toks, out, ctrl, val, settling⟩ := s
+  replace h : PendingTop settling ctrl toks val := h
+  cases settling with
+  | false =>
+      cases toks with
+      | nil => exact h
+      | cons tok toks' =>
+          cases ctrl with
+          | nil =>
+              rcases h with habs | ⟨t, ht⟩
+              · exact absurd habs (List.cons_ne_nil _ _)
+              · cases t with
+                | input i =>
+                    obtain ⟨htok, htoks'⟩ := List.cons.inj ht
+                    subst htok; subst htoks'
+                    show PendingTop true [] [] (out.length :: val)
+                    exact ⟨rfl, List.cons_ne_nil _ _⟩
+                | const b =>
+                    obtain ⟨htok, htoks'⟩ := List.cons.inj ht
+                    subst htok; subst htoks'
+                    show PendingTop true [] [] (out.length :: val)
+                    exact ⟨rfl, List.cons_ne_nil _ _⟩
+                | not c =>
+                    rw [show preorder (CircuitTree.not c)
+                        = PreToken.node ITag.tnot :: preorder c from rfl] at ht
+                    obtain ⟨htok, htoks'⟩ := List.cons.inj ht
+                    subst htok; subst htoks'
+                    show PendingTop false [(ITag.tnot, ITag.arity ITag.tnot)] (preorder c) val
+                    exact ⟨[c], [], [], val, by simp [ITag.arity], by simp [ITag.arity],
+                      by simp [ITag.arity], by simp, by simp, PendingFrames.nil val⟩
+                | and a b =>
+                    rw [show preorder (CircuitTree.and a b)
+                        = PreToken.node ITag.tand :: (preorder a ++ preorder b) from rfl] at ht
+                    obtain ⟨htok, htoks'⟩ := List.cons.inj ht
+                    subst htok; subst htoks'
+                    show PendingTop false [(ITag.tand, ITag.arity ITag.tand)]
+                      (preorder a ++ preorder b) val
+                    exact ⟨[a, b], [], [], val, by simp [ITag.arity], by simp [ITag.arity],
+                      by simp [ITag.arity], by simp, by simp, PendingFrames.nil val⟩
+                | or a b =>
+                    rw [show preorder (CircuitTree.or a b)
+                        = PreToken.node ITag.tor :: (preorder a ++ preorder b) from rfl] at ht
+                    obtain ⟨htok, htoks'⟩ := List.cons.inj ht
+                    subst htok; subst htoks'
+                    show PendingTop false [(ITag.tor, ITag.arity ITag.tor)]
+                      (preorder a ++ preorder b) val
+                    exact ⟨[a, b], [], [], val, by simp [ITag.arity], by simp [ITag.arity],
+                      by simp [ITag.arity], by simp, by simp, PendingFrames.nil val⟩
+          | cons f ctrl' =>
+              obtain ⟨tag₀, rem₀⟩ := f
+              obtain ⟨ts, rest, vs, val', hrem, hpos, harity, htoks, hval, hframes⟩ := h
+              simp only [if_neg Bool.false_ne_true] at hrem
+              cases ts with
+              | nil => simp at hrem; omega
+              | cons t₁ ts'' =>
+                  simp only [List.length_cons] at hrem harity
+                  rw [preorderForest_cons, List.append_assoc] at htoks
+                  cases t₁ with
+                  | input i =>
+                      obtain ⟨htok, htoks'⟩ := List.cons.inj htoks
+                      subst htok; subst htoks'
+                      show PendingTop true ((tag₀, rem₀) :: ctrl')
+                        (preorderForest ts'' ++ rest) (out.length :: val)
+                      refine ⟨ts'', rest, out.length :: vs, val', by simp; omega, by omega,
+                        by simp only [List.length_cons]; omega, rfl, by simp [hval], hframes⟩
+                  | const b =>
+                      obtain ⟨htok, htoks'⟩ := List.cons.inj htoks
+                      subst htok; subst htoks'
+                      show PendingTop true ((tag₀, rem₀) :: ctrl')
+                        (preorderForest ts'' ++ rest) (out.length :: val)
+                      refine ⟨ts'', rest, out.length :: vs, val', by simp; omega, by omega,
+                        by simp only [List.length_cons]; omega, rfl, by simp [hval], hframes⟩
+                  | not c =>
+                      rw [show preorder (CircuitTree.not c)
+                          = PreToken.node ITag.tnot :: preorder c from rfl, List.cons_append] at htoks
+                      obtain ⟨htok, htoks'⟩ := List.cons.inj htoks
+                      subst htok; subst htoks'
+                      show PendingTop false ((ITag.tnot, ITag.arity ITag.tnot) :: (tag₀, rem₀) :: ctrl')
+                        (preorder c ++ (preorderForest ts'' ++ rest)) val
+                      refine ⟨[c], preorderForest ts'' ++ rest, [], val,
+                        by simp [ITag.arity], by simp [ITag.arity], by simp [ITag.arity],
+                        by simp, by simp, ?_⟩
+                      rw [hval, show rem₀ = ts''.length + 1 by simpa using hrem]
+                      exact PendingFrames.frame tag₀ ctrl' ts'' rest vs val'
+                        (by omega) hframes
+                  | and a b =>
+                      rw [show preorder (CircuitTree.and a b)
+                          = PreToken.node ITag.tand :: (preorder a ++ preorder b) from rfl,
+                        List.cons_append] at htoks
+                      obtain ⟨htok, htoks'⟩ := List.cons.inj htoks
+                      subst htok; subst htoks'
+                      show PendingTop false ((ITag.tand, ITag.arity ITag.tand) :: (tag₀, rem₀) :: ctrl')
+                        ((preorder a ++ preorder b) ++ (preorderForest ts'' ++ rest)) val
+                      refine ⟨[a, b], preorderForest ts'' ++ rest, [], val,
+                        by simp [ITag.arity], by simp [ITag.arity], by simp [ITag.arity],
+                        by simp, by simp, ?_⟩
+                      rw [hval, show rem₀ = ts''.length + 1 by simpa using hrem]
+                      exact PendingFrames.frame tag₀ ctrl' ts'' rest vs val'
+                        (by omega) hframes
+                  | or a b =>
+                      rw [show preorder (CircuitTree.or a b)
+                          = PreToken.node ITag.tor :: (preorder a ++ preorder b) from rfl,
+                        List.cons_append] at htoks
+                      obtain ⟨htok, htoks'⟩ := List.cons.inj htoks
+                      subst htok; subst htoks'
+                      show PendingTop false ((ITag.tor, ITag.arity ITag.tor) :: (tag₀, rem₀) :: ctrl')
+                        ((preorder a ++ preorder b) ++ (preorderForest ts'' ++ rest)) val
+                      refine ⟨[a, b], preorderForest ts'' ++ rest, [], val,
+                        by simp [ITag.arity], by simp [ITag.arity], by simp [ITag.arity],
+                        by simp, by simp, ?_⟩
+                      rw [hval, show rem₀ = ts''.length + 1 by simpa using hrem]
+                      exact PendingFrames.frame tag₀ ctrl' ts'' rest vs val'
+                        (by omega) hframes
+  | true =>
+      cases ctrl with
+      | nil =>
+          obtain ⟨htoks, -⟩ := h
+          subst htoks
+          show PendingTop false [] [] val
+          exact Or.inl rfl
+      | cons f ctrl' =>
+          obtain ⟨tag, rem⟩ := f
+          obtain ⟨ts, rest, vs, val', hrem, hpos, harity, htoks, hval, hframes⟩ := h
+          cases ts with
+          | cons t₁ ts'' =>
+              -- `rem = |ts| + 1 ≥ 2`: the decrement arm.
+              have hne : rem ≠ 1 := by simp at hrem; omega
+              have hstep : DriveState.step ⟨toks, out, (tag, rem) :: ctrl', val, true⟩
+                  = ⟨toks, out, (tag, rem - 1) :: ctrl', val, false⟩ := by
+                simp [DriveState.step, hne]
+              rw [hstep]
+              show PendingTop false ((tag, rem - 1) :: ctrl') toks val
+              refine ⟨t₁ :: ts'', rest, vs, val', by simp at hrem ⊢; omega, by simp at hrem ⊢; omega,
+                harity, htoks, hval, hframes⟩
+          | nil =>
+              -- `rem = 1`: the pop-emit arm; the value stack carries exactly `arity` entries.
+              have hrem1 : rem = 1 := by simpa using hrem
+              subst hrem1
+              simp only [preorderForest_nil, List.nil_append] at htoks
+              subst htoks
+              cases tag with
+              | tnot =>
+                  have hvs : vs.length = 1 := by simpa [ITag.arity] using harity
+                  obtain ⟨v, hv⟩ : ∃ v, vs = [v] := by
+                    cases vs with
+                    | nil => simp at hvs
+                    | cons a as =>
+                        cases as with
+                        | nil => exact ⟨a, rfl⟩
+                        | cons b bs => simp at hvs
+                  subst hv
+                  rw [hval]
+                  have hstep : DriveState.step ⟨toks, out, (ITag.tnot, 1) :: ctrl', [v] ++ val', true⟩
+                      = ⟨toks, out ++ [SLGate.notGate v], ctrl', out.length :: val', true⟩ := by
+                    simp [DriveState.step]
+                  rw [hstep]
+                  show PendingTop true ctrl' toks (out.length :: val')
+                  cases hframes with
+                  | nil => exact ⟨rfl, List.cons_ne_nil _ _⟩
+                  | frame tag' ctrl'' ts' rest' vs' val'' harity' hdeep' =>
+                      exact ⟨ts', rest', out.length :: vs', val'', by simp, by omega,
+                        by simp at harity' ⊢; omega, rfl, by simp, hdeep'⟩
+              | tand =>
+                  have hvs : vs.length = 2 := by simpa [ITag.arity] using harity
+                  obtain ⟨x, y, hv⟩ : ∃ x y, vs = [x, y] := by
+                    cases vs with
+                    | nil => simp at hvs
+                    | cons a as =>
+                        cases as with
+                        | nil => simp at hvs
+                        | cons b bs =>
+                            cases bs with
+                            | nil => exact ⟨a, b, rfl⟩
+                            | cons c cs => simp at hvs
+                  subst hv
+                  rw [hval]
+                  have hstep : DriveState.step
+                      ⟨toks, out, (ITag.tand, 1) :: ctrl', [x, y] ++ val', true⟩
+                      = ⟨toks, out ++ [SLGate.andGate y x], ctrl', out.length :: val', true⟩ := by
+                    simp [DriveState.step]
+                  rw [hstep]
+                  show PendingTop true ctrl' toks (out.length :: val')
+                  cases hframes with
+                  | nil => exact ⟨rfl, List.cons_ne_nil _ _⟩
+                  | frame tag' ctrl'' ts' rest' vs' val'' harity' hdeep' =>
+                      exact ⟨ts', rest', out.length :: vs', val'', by simp, by omega,
+                        by simp at harity' ⊢; omega, rfl, by simp, hdeep'⟩
+              | tor =>
+                  have hvs : vs.length = 2 := by simpa [ITag.arity] using harity
+                  obtain ⟨x, y, hv⟩ : ∃ x y, vs = [x, y] := by
+                    cases vs with
+                    | nil => simp at hvs
+                    | cons a as =>
+                        cases as with
+                        | nil => simp at hvs
+                        | cons b bs =>
+                            cases bs with
+                            | nil => exact ⟨a, b, rfl⟩
+                            | cons c cs => simp at hvs
+                  subst hv
+                  rw [hval]
+                  have hstep : DriveState.step
+                      ⟨toks, out, (ITag.tor, 1) :: ctrl', [x, y] ++ val', true⟩
+                      = ⟨toks, out ++ [SLGate.orGate y x], ctrl', out.length :: val', true⟩ := by
+                    simp [DriveState.step]
+                  rw [hstep]
+                  show PendingTop true ctrl' toks (out.length :: val')
+                  cases hframes with
+                  | nil => exact ⟨rfl, List.cons_ne_nil _ _⟩
+                  | frame tag' ctrl'' ts' rest' vs' val'' harity' hdeep' =>
+                      exact ⟨ts', rest', out.length :: vs', val'', by simp, by omega,
+                        by simp at harity' ⊢; omega, rfl, by simp, hdeep'⟩
+
+/-- The pending decomposition holds at **every** point of the run from the initial state. -/
+theorem pending_iterate {n : Nat} (c : CircuitTree n) (k : Nat) :
+    (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).Pending := by
+  induction k with
+  | zero => exact pending_init c
+  | succ k ih =>
+      rw [Function.iterate_succ_apply']
+      exact pending_step _ ih
+
+/-- **Sink soundness.**  At any reachable state, if the driver is settling with an empty control stack
+then the certificate is exhausted — the machine sink test never fires early. -/
+theorem driver_sink_sound {n : Nat} (c : CircuitTree n) (k : Nat)
+    (hset : (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).settling = true)
+    (hctrl : (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).ctrl = []) :
+    (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).toks = [] := by
+  have hp := pending_iterate c k
+  unfold DriveState.Pending at hp
+  rw [hset, hctrl] at hp
+  exact hp.1
+
+/-- At the sink, the completed root's WORK index tops the value stack. -/
+theorem driver_sink_val_ne_nil {n : Nat} (c : CircuitTree n) (k : Nat)
+    (hset : (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).settling = true)
+    (hctrl : (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).ctrl = []) :
+    (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).val ≠ [] := by
+  have hp := pending_iterate c k
+  unfold DriveState.Pending at hp
+  rw [hset, hctrl] at hp
+  exact hp.2
+
+/-- Every **below-top** control frame is bounded: `1 ≤ rem ≤ tag.arity` — so an on-tape frame is a
+fixed-width (≤ 6-cell) object and the settle decrement is a bounded rewrite. -/
+theorem pendingFrames_rem_bounds {n : Nat} {ctrl : List (ITag × Nat)} {rest : List (PreToken n)}
+    {val : List Nat} (h : PendingFrames ctrl rest val) :
+    ∀ f ∈ ctrl, 1 ≤ f.2 ∧ f.2 ≤ f.1.arity := by
+  induction h with
+  | nil => intro f hf; simp at hf
+  | frame tag ctrl' ts rest' vs val' harity hdeep ih =>
+      intro f hf
+      rcases List.mem_cons.mp hf with rfl | hf'
+      · exact ⟨by omega, by simp; omega⟩
+      · exact ih f hf'
+
+/-- A non-terminal reachable state stepping **into** a terminal state must be the settle-empty arm: it is
+settling with an empty control stack and an exhausted certificate, and the step changes nothing but the
+flag (in particular WORK is already final). -/
+theorem pending_pre_terminal {n : Nat} (s : DriveState n) (hp : s.Pending)
+    (hnt : ¬ s.terminal) (ht : s.step.terminal) :
+    s.settling = true ∧ s.ctrl = [] ∧ s.toks = [] ∧ s.step.out = s.out := by
+  obtain ⟨toks, out, ctrl, val, settling⟩ := s
+  replace hp : PendingTop settling ctrl toks val := hp
+  cases settling with
+  | false =>
+      cases toks with
+      | nil => exact absurd ⟨rfl, rfl⟩ hnt
+      | cons tok toks' =>
+          cases tok with
+          | leaf g =>
+              have hstep : DriveState.step ⟨PreToken.leaf g :: toks', out, ctrl, val, false⟩
+                  = ⟨toks', out ++ [g], ctrl, out.length :: val, true⟩ := by
+                simp [DriveState.step]
+              rw [hstep] at ht
+              exact absurd ht.1 (by simp)
+          | node tag =>
+              have hstep : DriveState.step ⟨PreToken.node tag :: toks', out, ctrl, val, false⟩
+                  = ⟨toks', out, (tag, tag.arity) :: ctrl, val, false⟩ := by
+                simp [DriveState.step]
+              rw [hstep] at ht
+              exact absurd ht.2 (pending_reading_node hp)
+  | true =>
+      cases ctrl with
+      | nil =>
+          obtain ⟨htoks, -⟩ := hp
+          exact ⟨rfl, rfl, htoks, rfl⟩
+      | cons f ctrl' =>
+          obtain ⟨tag, rem⟩ := f
+          obtain ⟨ts, rest, vs, val', hrem, hpos, harity, htoks, hval, hframes⟩ := hp
+          cases ts with
+          | cons t₁ ts'' =>
+              -- decrement arm: tokens unchanged and nonempty — the post-state is not terminal.
+              have hne : rem ≠ 1 := by simp at hrem; omega
+              have hstep : DriveState.step ⟨toks, out, (tag, rem) :: ctrl', val, true⟩
+                  = ⟨toks, out, (tag, rem - 1) :: ctrl', val, false⟩ := by
+                simp [DriveState.step, hne]
+              rw [hstep] at ht
+              refine absurd ht.2 ?_
+              rw [htoks, preorderForest_cons, List.append_assoc]
+              exact append_left_ne_nil (preorder_ne_nil t₁)
+          | nil =>
+              -- pop-emit arm: the post-state is settling — not terminal.
+              have hrem1 : rem = 1 := by simpa using hrem
+              subst hrem1
+              cases tag with
+              | tnot =>
+                  have hvs : vs.length = 1 := by simpa [ITag.arity] using harity
+                  obtain ⟨v, hv⟩ : ∃ v, vs = [v] := by
+                    cases vs with
+                    | nil => simp at hvs
+                    | cons a as =>
+                        cases as with
+                        | nil => exact ⟨a, rfl⟩
+                        | cons b bs => simp at hvs
+                  subst hv
+                  rw [hval] at ht
+                  have hstep : DriveState.step ⟨toks, out, (ITag.tnot, 1) :: ctrl', [v] ++ val', true⟩
+                      = ⟨toks, out ++ [SLGate.notGate v], ctrl', out.length :: val', true⟩ := by
+                    simp [DriveState.step]
+                  rw [hstep] at ht
+                  exact absurd ht.1 (by simp)
+              | tand =>
+                  have hvs : vs.length = 2 := by simpa [ITag.arity] using harity
+                  obtain ⟨x, y, hv⟩ : ∃ x y, vs = [x, y] := by
+                    cases vs with
+                    | nil => simp at hvs
+                    | cons a as =>
+                        cases as with
+                        | nil => simp at hvs
+                        | cons b bs =>
+                            cases bs with
+                            | nil => exact ⟨a, b, rfl⟩
+                            | cons c cs => simp at hvs
+                  subst hv
+                  rw [hval] at ht
+                  have hstep : DriveState.step
+                      ⟨toks, out, (ITag.tand, 1) :: ctrl', [x, y] ++ val', true⟩
+                      = ⟨toks, out ++ [SLGate.andGate y x], ctrl', out.length :: val', true⟩ := by
+                    simp [DriveState.step]
+                  rw [hstep] at ht
+                  exact absurd ht.1 (by simp)
+              | tor =>
+                  have hvs : vs.length = 2 := by simpa [ITag.arity] using harity
+                  obtain ⟨x, y, hv⟩ : ∃ x y, vs = [x, y] := by
+                    cases vs with
+                    | nil => simp at hvs
+                    | cons a as =>
+                        cases as with
+                        | nil => simp at hvs
+                        | cons b bs =>
+                            cases bs with
+                            | nil => exact ⟨a, b, rfl⟩
+                            | cons c cs => simp at hvs
+                  subst hv
+                  rw [hval] at ht
+                  have hstep : DriveState.step
+                      ⟨toks, out, (ITag.tor, 1) :: ctrl', [x, y] ++ val', true⟩
+                      = ⟨toks, out ++ [SLGate.orGate y x], ctrl', out.length :: val', true⟩ := by
+                    simp [DriveState.step]
+                  rw [hstep] at ht
+                  exact absurd ht.1 (by simp)
+
+/-- **The machine sink is reached — with the flatten already in WORK.**  Within `3 · c.size` micro-steps
+the run hits a state that is settling with an empty control stack and an exhausted certificate, whose WORK
+is exactly `(flatten c).gates`.  (The pure terminal state is entered only via the settle-empty arm, which
+changes nothing but the flag — so the on-tape loop may halt at this sink without running that last step.) -/
+theorem driver_sink_exists {n : Nat} (c : CircuitTree n) :
+    ∃ k < 3 * c.size,
+      (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).settling = true
+      ∧ (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).ctrl = []
+      ∧ (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).toks = []
+      ∧ (DriveState.step^[k] (⟨preorder c, [], [], [], false⟩ : DriveState n)).out
+          = (CircuitTree.flatten c).gates := by
+  classical
+  set s0 : DriveState n := ⟨preorder c, [], [], [], false⟩ with hs0
+  have hbound := driveStep_halts_bound c
+  have hex : ∃ k, (DriveState.step^[k] s0).terminal := ⟨3 * c.size, hbound.1⟩
+  set K := Nat.find hex with hK
+  have hKterm : (DriveState.step^[K] s0).terminal := Nat.find_spec hex
+  have hKle : K ≤ 3 * c.size := Nat.find_le hbound.1
+  have hK0 : K ≠ 0 := by
+    intro h0
+    have hterm0 : s0.terminal := by rw [h0] at hKterm; exact hKterm
+    obtain ⟨-, htoks⟩ := hterm0
+    have hnil : preorder c = [] := htoks
+    have hlen := preorder_length c
+    have hpos := CircuitTree.one_le_size c
+    rw [hnil] at hlen
+    simp at hlen
+    omega
+  have hpred : ¬ (DriveState.step^[K - 1] s0).terminal := Nat.find_min hex (by omega)
+  have hKeq : K - 1 + 1 = K := by omega
+  have hsucc : DriveState.step^[K] s0 = DriveState.step (DriveState.step^[K - 1] s0) := by
+    conv_lhs => rw [← hKeq]
+    rw [Function.iterate_succ_apply']
+  have hstepterm : (DriveState.step (DriveState.step^[K - 1] s0)).terminal := by
+    rw [← hsucc]; exact hKterm
+  obtain ⟨hset, hctrl, htoks, hout⟩ :=
+    pending_pre_terminal (DriveState.step^[K - 1] s0) (pending_iterate c (K - 1)) hpred hstepterm
+  refine ⟨K - 1, by omega, hset, hctrl, htoks, ?_⟩
+  -- WORK at the sink = WORK at the terminal state = the flatten (terminal states are absorbing).
+  have habs : DriveState.step^[3 * c.size] s0 = DriveState.step^[K] s0 :=
+    DriveState.step_after_terminal s0 hKterm hKle
+  have hKout : (DriveState.step^[K] s0).out = (CircuitTree.flatten c).gates := by
+    rw [← habs]; exact hbound.2
+  rw [hsucc] at hKout
+  rw [hout] at hKout
+  exact hKout
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverStrongInv.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverStrongInv.lean
@@ -1,0 +1,300 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverTapeInv
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCertTokens
+
+/-!
+# `driverStrongInv` — D2t-5b (Block A1a): the strong driver tape invariant
+
+`driverTapeInv` (#1605) pinned the region **contents**; this module supplies the **strong** invariant the
+step-realization proofs actually thread — closing the review-deferred geometry/coherence gaps and fixing a
+latent anchoring mismatch:
+
+* **Dynamic anchors, derived — not parameters.**  Every region's live anchor is a *function of the abstract
+  state*: the certificate cursor is `certEnd − |encodePreorder toks|` (the unread suffix **ends** at the fixed
+  `certEnd`), the output anchor is `workBase − 1 − |out|`, the stacks' tops are `valBound − |encodeNatStack1 val|`
+  / `ctrlBound − |encodeCtrlStack1 ctrl|` (the **shifted** stack codecs — see the section below: every field
+  opens with a `1`, so the tops are scan-detectable on a `Bool` tape).  The cursor/`certBase ≤ cursor` coupling (review concern #2) is
+  thereby **definitional**, and the push realization direction is honoured: `pushCtrlFrameRealizes` /
+  `writeNatField_extends_natStack` grow a stack **leftward from a moving top** (frame lands on `[p, p+len)`,
+  old stack at `[p+len, …)`), so the stacks here are anchored at their **moving top** against a **fixed
+  bottom** (`valBound`/`ctrlBound`) — *not* at a fixed left base as in `driverTapeInv`'s stack clauses, which
+  matched only the empty-stack initial state.  `driverTapeInv` remains valid for its merged uses
+  (initialisation; cert/WORK clauses); `driverStrongInv` is what the realization layer consumes.
+* **The COUNT region: the output window is `encodeGateStream`-shaped.**  The driver must push the fresh
+  WORK index `out.length` (a value no tape region of `driverTapeInv` stores) — so the strong invariant keeps
+  a **unary gate count** `1^|out|` growing **leftward** of a fixed terminator cell `workBase − 1`, with the
+  records extending rightward from `workBase`.  The combined window starting at `workBase − 1 − |out|` spells
+  `unaryField |out| ++ encodeGateRecordStream out` — which is **exactly `encodeGateStream out`**
+  (`driverStrongInv_out_encodeGateStream`): at the terminal state the output region *already* holds the
+  count-prefixed stream `transcodeWitness` demands, so D2t-6a (count prefix) needs no separate pass.
+* **Length-aware non-overlap (review concern #2).**  `DriverZones.WellFormed` chains the fixed zone bounds
+  `certBase ≤ certEnd ≤ outBase < workBase ≤ workEnd ≤ valLeft ≤ valBound ≤ ctrlLeft ≤ ctrlBound ≤ L`, and
+  the invariant carries the per-state **fit** clauses (count fits left of `workBase`, records fit below
+  `workEnd`, each stack fits above its `…Left` floor), so distinct regions provably never overlap at any
+  reachable extent.
+* **Validity + cheap coherence (the pointwise half of review concern #3).**  `ValidCertTokens toks` (non-vacuous
+  certificate clause, #1607) and `settling = true → val ≠ []` (a settling state always carries the
+  just-completed subtree's root index), the latter **step-preserved pointwise**
+  (`DriveState.step_preserves_settling_val`).  The *reachability-dependent* coherence (e.g. sink soundness
+  "settling ∧ ctrl = [] → toks = []") genuinely needs the run trace and is the next brick (A1b).
+
+Also ships the generic window splitters `windowSpells_append_left` / `windowSpells_append_right` (project a
+spelled concatenation onto its halves) and the derived projections `driverStrongInv_count_window` /
+`driverStrongInv_records_window` (the count field alone at its moving anchor; the records alone at the fixed
+`workBase`) — the shapes the per-arm body lemmas consume.
+
+**Progress classification (AGENTS.md): Infrastructure** — a strengthened tape-layout invariant + initial-state
+lemma + pointwise coherence preservation, proven against the verified codecs; builds no machine and proves no
+separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- Fixed zone bounds of the driver tape (the layout
+`[ input | certificate | COUNT ← | WORK → | STACK_val ← | STACK_ctrl ← | … ]`).  `certEnd` is the certificate's
+fixed right end (the cursor advances toward it); `workBase − 1` is the count field's fixed terminator cell,
+with the unary count growing leftward toward `outBase` and the records growing rightward toward `workEnd`;
+`valBound` / `ctrlBound` are the stacks' fixed bottoms, each stack growing leftward toward its `…Left` floor. -/
+structure DriverZones where
+  certBase : Nat
+  certEnd : Nat
+  outBase : Nat
+  workBase : Nat
+  workEnd : Nat
+  valLeft : Nat
+  valBound : Nat
+  ctrlLeft : Nat
+  ctrlBound : Nat
+
+/-- **Zone-chain well-formedness**: the fixed bounds sit in order on a length-`L` tape (`outBase < workBase`
+leaves room for the count terminator cell `workBase − 1` even at count `0`). -/
+def DriverZones.WellFormed (z : DriverZones) (L : Nat) : Prop :=
+  z.certBase ≤ z.certEnd ∧ z.certEnd ≤ z.outBase ∧ z.outBase < z.workBase ∧ z.workBase ≤ z.workEnd
+    ∧ z.workEnd ≤ z.valLeft ∧ z.valLeft ≤ z.valBound ∧ z.valBound ≤ z.ctrlLeft
+    ∧ z.ctrlLeft ≤ z.ctrlBound ∧ z.ctrlBound ≤ L
+
+/-! ### The driver's shifted stack codecs (navigation-sound on a `Bool` tape)
+
+A head hop between regions can only land by **scanning homogeneous content to a flip** (the proven
+`selfLoopScan*` pattern — there are no markers on a `Bool` tape).  A stack top is therefore only
+scan-detectable if its first cell is always `1`.  The plain codecs violate that: `unaryField 0 = [0]`
+(and index `0` is a *real* value-stack entry — the first gate), and `ITag.tagCode .tnot = 0` makes a
+`tnot` frame start with a bare `0`.  The driver's stacks are *internal* (written and read only by the
+driver), so their on-tape format is ours to choose: each value field is stored **shifted** as
+`unaryField (v + 1)` and each frame's tag field as `unaryField (tagCode + 1)` — every field now opens
+with a `1`, so region boundaries are unambiguous to scans in both directions.  (The `remaining` field
+needs no shift: reachable frames have `rem ≥ 1`, `pendingFrames_rem_bounds`.) -/
+
+/-- The **shifted** value-stack codec: entry `v` is stored as `unaryField (v + 1) = 1^(v+1) 0`, so every
+field opens with a `1` (index `0` included) and the stack top is scan-detectable. -/
+def encodeNatStack1 : List Nat → List Bool
+  | [] => []
+  | v :: rest => unaryField (v + 1) ++ encodeNatStack1 rest
+
+@[simp] theorem encodeNatStack1_nil : encodeNatStack1 [] = [] := rfl
+
+@[simp] theorem encodeNatStack1_cons (v : Nat) (rest : List Nat) :
+    encodeNatStack1 (v :: rest) = unaryField (v + 1) ++ encodeNatStack1 rest := rfl
+
+/-- Shifted pop: one unary-field read off the encoded stack returns `v + 1` and the encoded tail. -/
+@[simp] theorem decodeUnaryField_encodeNatStack1_cons (v : Nat) (rest : List Nat) :
+    decodeUnaryField (encodeNatStack1 (v :: rest)) = some (v + 1, encodeNatStack1 rest) := by
+  simp [encodeNatStack1]
+
+/-- A nonempty shifted value stack **opens with a `1`** — the scan-detectability fact. -/
+theorem encodeNatStack1_head_true (v : Nat) (rest : List Nat) :
+    (encodeNatStack1 (v :: rest)).head? = some true := by
+  simp [encodeNatStack1, unaryField, List.replicate_succ]
+
+/-- The **shifted** control-frame codec: the tag field is stored as `unaryField (tagCode + 1)` (codes
+`1`–`3`, never a bare `0`), the remaining-count field unshifted (reachable `rem ≥ 1`). -/
+def encodeCtrlFrame1 : ITag × Nat → List Bool
+  | (tag, rem) => unaryField (tag.tagCode + 1) ++ unaryField rem
+
+/-- The shifted control-stack codec (top-first, like `encodeCtrlStack`). -/
+def encodeCtrlStack1 : List (ITag × Nat) → List Bool
+  | [] => []
+  | f :: rest => encodeCtrlFrame1 f ++ encodeCtrlStack1 rest
+
+@[simp] theorem encodeCtrlStack1_nil : encodeCtrlStack1 [] = [] := rfl
+
+@[simp] theorem encodeCtrlStack1_cons (f : ITag × Nat) (rest : List (ITag × Nat)) :
+    encodeCtrlStack1 (f :: rest) = encodeCtrlFrame1 f ++ encodeCtrlStack1 rest := rfl
+
+/-- A nonempty shifted control stack **opens with a `1`**. -/
+theorem encodeCtrlStack1_head_true (f : ITag × Nat) (rest : List (ITag × Nat)) :
+    (encodeCtrlStack1 (f :: rest)).head? = some true := by
+  obtain ⟨tag, rem⟩ := f
+  simp [encodeCtrlFrame1, unaryField, List.replicate_succ]
+
+/-- A spelled concatenation spells its **left** half at the same base. -/
+theorem windowSpells_append_left {L : Nat} (tape : Fin L → Bool) (base : Nat)
+    (xs ys : List Bool) (h : windowSpells tape base (xs ++ ys)) :
+    windowSpells tape base xs := by
+  obtain ⟨hfit, hcells⟩ := h
+  have hl : (xs ++ ys).length = xs.length + ys.length := by simp
+  rw [hl] at hfit
+  refine ⟨by omega, fun q hlo hhi => ?_⟩
+  rw [hcells q hlo (by rw [hl]; omega),
+    List.getD_append xs ys false ((q : Nat) - base) (by omega)]
+
+/-- A spelled concatenation spells its **right** half at the shifted base. -/
+theorem windowSpells_append_right {L : Nat} (tape : Fin L → Bool) (base : Nat)
+    (xs ys : List Bool) (h : windowSpells tape base (xs ++ ys)) :
+    windowSpells tape (base + xs.length) ys := by
+  obtain ⟨hfit, hcells⟩ := h
+  have hl : (xs ++ ys).length = xs.length + ys.length := by simp
+  rw [hl] at hfit
+  refine ⟨by omega, fun q hlo hhi => ?_⟩
+  rw [hcells q (by omega) (by rw [hl]; omega),
+    List.getD_append_right xs ys false ((q : Nat) - base) (by omega)]
+  congr 1
+  omega
+
+/-- **The strong driver tape invariant.**  All four live anchors are *derived* from the abstract state `st`:
+
+* **certificate** — the unread suffix `encodePreorder st.toks` ends at the fixed `certEnd` (anchor
+  `certEnd − |·|`), and fits above `certBase` (the definitional cursor coupling);
+* **output** — the window at `workBase − 1 − |st.out|` spells `unaryField |st.out| ++
+  encodeGateRecordStream st.out` (unary count growing leftward of the fixed terminator cell, records growing
+  rightward from `workBase`), fitting between `outBase` and `workEnd`;
+* **stacks** — each stack's encoding (the **shifted** codecs `encodeNatStack1`/`encodeCtrlStack1`, see
+  above) ends at its fixed bottom (`valBound`/`ctrlBound`), the moving top `…Bound − |·|` staying above
+  its `…Left` floor (matching the leftward push realization);
+* **validity/coherence** — `ValidCertTokens st.toks`, and a settling state always carries a value-stack top;
+* **geometry** — the fixed zone chain `z.WellFormed L` is carried as the leading conjunct, so the invariant
+  alone supports every non-overlap argument (it is state-independent and threads through steps unchanged). -/
+def driverStrongInv {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverZones) (tape : Fin L → Bool) (st : DriveState n) : Prop :=
+  z.WellFormed L
+  ∧ windowSpells tape (z.certEnd - (encodePreorder width h_width st.toks).length)
+      (encodePreorder width h_width st.toks)
+  ∧ z.certBase + (encodePreorder width h_width st.toks).length ≤ z.certEnd
+  ∧ windowSpells tape (z.workBase - 1 - st.out.length)
+      (unaryField st.out.length ++ encodeGateRecordStream st.out)
+  ∧ z.outBase + st.out.length + 1 ≤ z.workBase
+  ∧ z.workBase + (encodeGateRecordStream st.out).length ≤ z.workEnd
+  ∧ windowSpells tape (z.valBound - (encodeNatStack1 st.val).length) (encodeNatStack1 st.val)
+  ∧ z.valLeft + (encodeNatStack1 st.val).length ≤ z.valBound
+  ∧ windowSpells tape (z.ctrlBound - (encodeCtrlStack1 st.ctrl).length) (encodeCtrlStack1 st.ctrl)
+  ∧ z.ctrlLeft + (encodeCtrlStack1 st.ctrl).length ≤ z.ctrlBound
+  ∧ ValidCertTokens st.toks
+  ∧ (st.settling = true → st.val ≠ [])
+
+/-- The output window of `driverStrongInv` **is** the self-delimiting gate stream: `unaryField |out| ++
+encodeGateRecordStream out = encodeGateStream out`.  At the terminal state (`out = (flatten c).gates`) the
+output region therefore already spells the count-prefixed stream `transcodeWitness` expects — the D2t-6a
+count prefix is maintained in-band, not added by a separate pass. -/
+theorem driverStrongInv_out_encodeGateStream {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverZones) (tape : Fin L → Bool) (st : DriveState n)
+    (h : driverStrongInv width h_width z tape st) :
+    windowSpells tape (z.workBase - 1 - st.out.length) (encodeGateStream st.out) := by
+  simpa [encodeGateStream] using h.2.2.2.1
+
+/-- Projection: the unary **count field** alone, at its moving anchor `workBase − 1 − |out|`. -/
+theorem driverStrongInv_count_window {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverZones) (tape : Fin L → Bool) (st : DriveState n)
+    (h : driverStrongInv width h_width z tape st) :
+    windowSpells tape (z.workBase - 1 - st.out.length) (unaryField st.out.length) :=
+  windowSpells_append_left tape _ _ _ h.2.2.2.1
+
+/-- Projection: the **record stream** alone, at the fixed `workBase` (the count terminator sits at
+`workBase − 1`, so the records start exactly at `workBase` whenever the count fits left of it). -/
+theorem driverStrongInv_records_window {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverZones) (tape : Fin L → Bool) (st : DriveState n)
+    (h : driverStrongInv width h_width z tape st) :
+    windowSpells tape z.workBase (encodeGateRecordStream st.out) := by
+  have hfit := h.2.2.2.2.1
+  have hproj := windowSpells_append_right tape (z.workBase - 1 - st.out.length)
+    (unaryField st.out.length) (encodeGateRecordStream st.out) h.2.2.2.1
+  rw [unaryField_length] at hproj
+  have : z.workBase - 1 - st.out.length + (st.out.length + 1) = z.workBase := by omega
+  rwa [this] at hproj
+
+/-- **The cheap coherence clause is step-preserved pointwise** (no reachability needed): a settling
+post-state always carries a value-stack top — the leaf read and the pop-emit arms push one, and every other
+arm clears the flag. -/
+theorem DriveState.step_preserves_settling_val {n : Nat} (s : DriveState n)
+    (h : s.settling = true → s.val ≠ []) :
+    s.step.settling = true → s.step.val ≠ [] := by
+  obtain ⟨toks, out, ctrl, val, settling⟩ := s
+  cases settling with
+  | false =>
+      cases toks with
+      | nil => exact h
+      | cons tok toks' =>
+          cases tok with
+          | leaf g => intro _; simp [DriveState.step]
+          | node tag => intro hs; simp [DriveState.step] at hs
+  | true =>
+      cases ctrl with
+      | nil => intro hs; simp [DriveState.step] at hs
+      | cons f ctrl' =>
+          obtain ⟨tag, rem⟩ := f
+          by_cases hrem : rem = 1
+          · subst hrem
+            cases tag with
+            | tnot =>
+                cases val with
+                | nil => intro hs; simp [DriveState.step] at hs
+                | cons i vs => intro _; simp [DriveState.step]
+            | tand =>
+                cases val with
+                | nil => intro hs; simp [DriveState.step] at hs
+                | cons i2 rest =>
+                    cases rest with
+                    | nil => intro hs; simp [DriveState.step] at hs
+                    | cons i1 vs => intro _; simp [DriveState.step]
+            | tor =>
+                cases val with
+                | nil => intro hs; simp [DriveState.step] at hs
+                | cons i2 rest =>
+                    cases rest with
+                    | nil => intro hs; simp [DriveState.step] at hs
+                    | cons i1 vs => intro _; simp [DriveState.step]
+          · intro hs; simp [DriveState.step, hrem] at hs
+
+/-- **The strong invariant holds at the start.**  Hypotheses: the zone chain is well-formed; the certificate
+`encodeCircuitTree c` is laid out at `certBase` and ends exactly at `certEnd`; and the count terminator cell
+`workBase − 1` holds `0` (the empty count field `unaryField 0 = [false]`).  Then the initial driver state
+`⟨preorder c, [], [], [], false⟩` satisfies `driverStrongInv`: the certificate clause is
+`encodePreorder_preorder` (#1604) re-anchored by the length equation; the output clause is the terminator
+cell; the stack windows are empty at their bottoms (`windowSpells_nil`); validity is
+`validCertTokens_preorder` (#1607). -/
+theorem driverStrongInv_init {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverZones) (tape : Fin L → Bool) (c : CircuitTree n)
+    (hwf : z.WellFormed L)
+    (hcert : windowSpells tape z.certBase (encodeCircuitTree width h_width c))
+    (hlen : z.certBase + (encodeCircuitTree width h_width c).length = z.certEnd)
+    (hcount0 : windowSpells tape (z.workBase - 1) [false]) :
+    driverStrongInv width h_width z tape (⟨preorder c, [], [], [], false⟩ : DriveState n) := by
+  obtain ⟨hce, hco, how, hwe, hev, hvl, hvc, hcl, hcb⟩ := hwf
+  refine ⟨⟨hce, hco, how, hwe, hev, hvl, hvc, hcl, hcb⟩, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · show windowSpells tape (z.certEnd - (encodePreorder width h_width (preorder c)).length)
+      (encodePreorder width h_width (preorder c))
+    rw [encodePreorder_preorder]
+    have ha : z.certEnd - (encodeCircuitTree width h_width c).length = z.certBase := by omega
+    rw [ha]
+    exact hcert
+  · rw [encodePreorder_preorder]; omega
+  · show windowSpells tape (z.workBase - 1 - List.length ([] : List (SLGate n)))
+      (unaryField (List.length ([] : List (SLGate n))) ++ encodeGateRecordStream ([] : List (SLGate n)))
+    simpa [unaryField, encodeGateRecordStream] using hcount0
+  · simp only [List.length_nil]; omega
+  · show z.workBase + (encodeGateRecordStream ([] : List (SLGate n))).length ≤ z.workEnd
+    simp only [encodeGateRecordStream, List.length_nil]; omega
+  · show windowSpells tape (z.valBound - (encodeNatStack1 []).length) (encodeNatStack1 [])
+    simpa [encodeNatStack1] using windowSpells_nil tape z.valBound (by omega)
+  · simp only [encodeNatStack1, List.length_nil]; omega
+  · show windowSpells tape (z.ctrlBound - (encodeCtrlStack1 []).length) (encodeCtrlStack1 [])
+    simpa [encodeCtrlStack1] using windowSpells_nil tape z.ctrlBound (by omega)
+  · simp only [encodeCtrlStack1, List.length_nil]; omega
+  · exact validCertTokens_preorder c
+  · intro hs; cases hs
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -92,6 +92,8 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStepTerminates
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEncodePreorder
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverTapeInv
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCertTokens
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverStrongInv
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDrivePending
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4004,6 +4006,38 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.validCertTokens_preorder
 #check @Pnp4.Frontier.ContractExpansion.validCertTokens_length_le
 #check @Pnp4.Frontier.ContractExpansion.validCertTokens_encodePreorder_eq_nil_iff
+-- D2t-5b (Block A1a): the strong driver tape invariant — derived dynamic anchors, encodeGateStream-shaped
+-- output window (D2t-6a count prefix maintained in-band), length-aware zone fits, settling coherence.
+#check @Pnp4.Frontier.ContractExpansion.encodeNatStack1_nil
+#check @Pnp4.Frontier.ContractExpansion.encodeNatStack1_cons
+#check @Pnp4.Frontier.ContractExpansion.decodeUnaryField_encodeNatStack1_cons
+#check @Pnp4.Frontier.ContractExpansion.encodeNatStack1_head_true
+#check @Pnp4.Frontier.ContractExpansion.encodeCtrlStack1_nil
+#check @Pnp4.Frontier.ContractExpansion.encodeCtrlStack1_cons
+#check @Pnp4.Frontier.ContractExpansion.encodeCtrlStack1_head_true
+#check @Pnp4.Frontier.ContractExpansion.windowSpells_append_left
+#check @Pnp4.Frontier.ContractExpansion.windowSpells_append_right
+#check @Pnp4.Frontier.ContractExpansion.driverStrongInv_out_encodeGateStream
+#check @Pnp4.Frontier.ContractExpansion.driverStrongInv_count_window
+#check @Pnp4.Frontier.ContractExpansion.driverStrongInv_records_window
+#check @Pnp4.Frontier.ContractExpansion.DriveState.step_preserves_settling_val
+#check @Pnp4.Frontier.ContractExpansion.driverStrongInv_init
+-- D2t-5b (Block A1b): the reachable-state coherence invariant (pending-forest decomposition) — preserved
+-- by every micro-step; sink soundness + sink existence (within 3·c.size steps, flatten in WORK); frame
+-- width bounds for the on-tape settle decrement.
+#check @Pnp4.Frontier.ContractExpansion.preorderForest_nil
+#check @Pnp4.Frontier.ContractExpansion.preorderForest_cons
+#check @Pnp4.Frontier.ContractExpansion.preorder_ne_nil
+#check @Pnp4.Frontier.ContractExpansion.append_left_ne_nil
+#check @Pnp4.Frontier.ContractExpansion.pending_init
+#check @Pnp4.Frontier.ContractExpansion.pending_reading_node
+#check @Pnp4.Frontier.ContractExpansion.pending_step
+#check @Pnp4.Frontier.ContractExpansion.pending_iterate
+#check @Pnp4.Frontier.ContractExpansion.driver_sink_sound
+#check @Pnp4.Frontier.ContractExpansion.driver_sink_val_ne_nil
+#check @Pnp4.Frontier.ContractExpansion.pendingFrames_rem_bounds
+#check @Pnp4.Frontier.ContractExpansion.pending_pre_terminal
+#check @Pnp4.Frontier.ContractExpansion.driver_sink_exists
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -82,6 +82,8 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDriveStepTerminates
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEncodePreorder
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverTapeInv
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCertTokens
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverStrongInv
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDrivePending
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -816,6 +818,38 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.validCertTokens_preorder
 #print axioms Pnp4.Frontier.ContractExpansion.validCertTokens_length_le
 #print axioms Pnp4.Frontier.ContractExpansion.validCertTokens_encodePreorder_eq_nil_iff
+-- D2t-5b (Block A1a): the strong driver tape invariant — derived dynamic anchors (cursor / count / stack
+-- tops), encodeGateStream-shaped output window, length-aware zone fits, pointwise settling coherence.
+#print axioms Pnp4.Frontier.ContractExpansion.encodeNatStack1_nil
+#print axioms Pnp4.Frontier.ContractExpansion.encodeNatStack1_cons
+#print axioms Pnp4.Frontier.ContractExpansion.decodeUnaryField_encodeNatStack1_cons
+#print axioms Pnp4.Frontier.ContractExpansion.encodeNatStack1_head_true
+#print axioms Pnp4.Frontier.ContractExpansion.encodeCtrlStack1_nil
+#print axioms Pnp4.Frontier.ContractExpansion.encodeCtrlStack1_cons
+#print axioms Pnp4.Frontier.ContractExpansion.encodeCtrlStack1_head_true
+#print axioms Pnp4.Frontier.ContractExpansion.windowSpells_append_left
+#print axioms Pnp4.Frontier.ContractExpansion.windowSpells_append_right
+#print axioms Pnp4.Frontier.ContractExpansion.driverStrongInv_out_encodeGateStream
+#print axioms Pnp4.Frontier.ContractExpansion.driverStrongInv_count_window
+#print axioms Pnp4.Frontier.ContractExpansion.driverStrongInv_records_window
+#print axioms Pnp4.Frontier.ContractExpansion.DriveState.step_preserves_settling_val
+#print axioms Pnp4.Frontier.ContractExpansion.driverStrongInv_init
+-- D2t-5b (Block A1b): the reachable-state coherence invariant — the pending-forest decomposition is
+-- preserved by every micro-step; sink soundness ("settling ∧ ctrl = [] → toks = []"), the sink is reached
+-- within 3·c.size steps with the flatten in WORK, and below-top frames are fixed-width (rem ≤ arity).
+#print axioms Pnp4.Frontier.ContractExpansion.preorderForest_nil
+#print axioms Pnp4.Frontier.ContractExpansion.preorderForest_cons
+#print axioms Pnp4.Frontier.ContractExpansion.preorder_ne_nil
+#print axioms Pnp4.Frontier.ContractExpansion.append_left_ne_nil
+#print axioms Pnp4.Frontier.ContractExpansion.pending_init
+#print axioms Pnp4.Frontier.ContractExpansion.pending_reading_node
+#print axioms Pnp4.Frontier.ContractExpansion.pending_step
+#print axioms Pnp4.Frontier.ContractExpansion.pending_iterate
+#print axioms Pnp4.Frontier.ContractExpansion.driver_sink_sound
+#print axioms Pnp4.Frontier.ContractExpansion.driver_sink_val_ne_nil
+#print axioms Pnp4.Frontier.ContractExpansion.pendingFrames_rem_bounds
+#print axioms Pnp4.Frontier.ContractExpansion.pending_pre_terminal
+#print axioms Pnp4.Frontier.ContractExpansion.driver_sink_exists
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
**Block A1 — complete, in one commit** (per review workflow: the whole A1 group as a single brick). Closes the review-deferred geometry gap (#2) **and** the full coherence gap (#3), plus **three latent design holes** surfaced by the Block-A design pass.

## A1a — `driverStrongInv` (`TreeMCSPDriverStrongInv.lean`)

1. **Anchoring mismatch (latent, fixed).** `driverTapeInv` (#1605) anchored stack windows at fixed left bases, but the merged push realizations (`pushCtrlFrameRealizes`, `writeNatField_extends_natStack`) grow stacks **leftward from a moving top**. `driverStrongInv` anchors every region at its **state-derived** live anchor (cert cursor `certEnd − |enc toks|`, stack tops `…Bound − |enc|`) — the `certBase ≤ cursor` coupling is definitional.
2. **COUNT region (latent hole: where does the machine get `out.length`?).** A unary gate count grows leftward of the fixed terminator cell `workBase − 1`; the output window **is `encodeGateStream out`** (`driverStrongInv_out_encodeGateStream`) — so the fresh WORK index is on tape and the **D2t-6a count prefix is maintained in-band** (no separate pass).
3. **Shifted stack codecs (navigation soundness on a `Bool` tape).** A head hop between regions can only land by scanning homogeneous content to a flip (`selfLoopScan*` — no markers on a `Bool` tape), so a stack top must always open with a `1`. The plain codecs violate that: `unaryField 0 = [0]` (index `0` is a *real* value-stack entry — the first gate) and `ITag.tagCode .tnot = 0`. The stacks are driver-internal, so the invariant stores value fields **shifted** (`encodeNatStack1`: entry `v` ↦ `unaryField (v+1)`) and frame tag fields as `unaryField (tagCode+1)` (`encodeCtrlStack1`) — every field opens with a `1` (`encodeNatStack1_head_true` / `encodeCtrlStack1_head_true`), boundaries are scan-detectable in both directions.
4. **Length-aware geometry** (`DriverZones.WellFormed` + per-state fit clauses) and **pointwise coherence** (`ValidCertTokens`, `settling → val ≠ []` step-preserved).
5. Generic window splitters `windowSpells_append_left/right` + count/records projections.

## A1b — `DriveState.Pending` (`TreeMCSPDrivePending.lean`)

6. **Pending-forest decomposition** (`PendingFrames`/`PendingTop`): unread tokens = preorders of pending subtrees grouped by control frames; completed-children indices on the value stack in matching counts. `pending_init`/`pending_step`/`pending_iterate`: an invariant of the run; **the underflow arms are excluded** (the value stack always matches the popped frame's arity).
7. **Sink soundness** (`driver_sink_sound`): at every reachable state, `settling ∧ ctrl = [] → toks = []` — the machine sink test (one pointer-field cell) never fires early, and **cert-end detection needs no end marker** (blank cells are indistinguishable from a leaf tag on a `Bool` tape — the third latent hole).
8. **Sink existence with bound** (`driver_sink_exists`): the run reaches the sink within `3·c.size` steps **with WORK already `(flatten c).gates`** (the only reachable transition into the pure terminal is the settle-empty arm, which only clears the flag).
9. **Frame width bounds** (`pendingFrames_rem_bounds`): below-top frames have `1 ≤ rem ≤ arity` — on-tape frames are fixed-width, so the settle decrement is a bounded rewrite (consumed by A4).

## Verification
* `lake build PnP3 Pnp4` clean (new modules elaborate with zero warnings); `./scripts/check.sh` — **17/17 passed**.
* All new theorems print within the standard `[propext, Classical.choice, Quot.sound]` triple.
* Registered in `lakefile.lean` + `AxiomsAudit.lean` + `AlgorithmsToLowerBoundsSurfaceTests.lean`.
* No changes to merged source modules; `driverTapeInv`/`encodeNatStack`/`encodeCtrlStack` remain valid for their merged uses.

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj