### PR TITLE
transcoder(D2t-5b/A4w): zoneWalkLeft — corridor zone-walker step semantics + inner field sub-scan

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -341,6 +341,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryTransferProgram,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryTransferRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
@@ -22,7 +22,8 @@ scan over a guaranteed-all-`0` corridor onto a guaranteed-`1` anchor**:
   exactly on the next stack's top; each stack carries a permanent **base sentinel `1`** at its base
   cell, so the same scan is sound when the stack is empty — and "control stack empty" (the A1b sink
   test) becomes *land on a `1`, peek one cell left: a `0` means the base sentinel* (frame tag blocks
-  are stored with **`tagCode + 2 ≥ 2` ones**, so a frame's right edge always has two `1`s);
+  carry **`tagCode + 2 ≥ 2` ones** and value blocks **`v + 2 ≥ 2` ones**, so during a zone walk a
+  field edge is never confused with the single-`1` sentinel);
 * the **WORK frontier marker** `FM` is a single `1` just past the last record: the hop val → frontier
   is a leftward 0-scan onto `FM`; a record append overwrites `FM` and re-plants it at the new
   frontier.  Inside a record, the A2 transfer's home delimiters come for free: every operand field is
@@ -47,12 +48,14 @@ open Pnp3.Internal.PsubsetPpoly.TM.Encoding
 
 /-! ### Right-anchored (corridor) stack codecs -/
 
-/-- A right-anchored value entry: `[0] ++ 1^(v+1)` — the left `0` delimits, the field is read
-right-to-left, and the **rightmost cell is a `1`** (the scan anchor), index `0` included. -/
+/-- A right-anchored value entry: `[0] ++ 1^(v+2)` — the left `0` delimits, the field is read
+right-to-left, and the **rightmost cell is a `1`** (the scan anchor), index `0` included.  The block
+carries `v + 2 ≥ 2` ones so that during a zone walk a value field is never confused with the
+**single-`1` base sentinel** (the same `≥ 2` discipline as the control frames' tag blocks). -/
 def encodeNatEntryR (v : Nat) : List Bool :=
-  false :: List.replicate (v + 1) true
+  false :: List.replicate (v + 2) true
 
-@[simp] theorem encodeNatEntryR_length (v : Nat) : (encodeNatEntryR v).length = v + 2 := by
+@[simp] theorem encodeNatEntryR_length (v : Nat) : (encodeNatEntryR v).length = v + 3 := by
   simp [encodeNatEntryR]
 
 /-- The right-anchored value stack: a permanent base sentinel `1` at the base cell, then the entries
@@ -79,16 +82,16 @@ theorem encodeNatStackR_getLast_true (S : List Nat) :
   | cons v rest =>
       rw [encodeNatStackR_cons, List.getLast?_append_of_ne_nil]
       · show (encodeNatEntryR v).getLast? = some true
-        rw [show encodeNatEntryR v = [false] ++ List.replicate (v + 1) true from rfl]
+        rw [show encodeNatEntryR v = [false] ++ List.replicate (v + 2) true from rfl]
         rw [List.getLast?_append_of_ne_nil]
         · rw [List.getLast?_replicate]
           simp
         · simp
       · simp [encodeNatEntryR]
 
-/-- Exact length of the right-anchored value stack: `1 + Σ (vᵢ + 2)`. -/
+/-- Exact length of the right-anchored value stack: `1 + Σ (vᵢ + 3)`. -/
 theorem encodeNatStackR_length (S : List Nat) :
-    (encodeNatStackR S).length = 1 + (S.map (· + 2)).sum := by
+    (encodeNatStackR S).length = 1 + (S.map (· + 3)).sum := by
   induction S with
   | nil => rfl
   | cons v rest ih => rw [encodeNatStackR_cons]; simp [encodeNatEntryR, ih]; omega

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalk.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalk.lean
@@ -1,22 +1,29 @@
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
-import Pnp4.Frontier.ContractExpansion.TreeMCSPLoopUntilSink
 
 /-!
 # `zoneWalkLeft` — D2t-5b (Block A4w): traversing a corridor stack zone right-to-left
 
-The corridor layout (A3) stores both stacks as `[sentinel 1] [0 1^{k₁}] [0 1^{k₂}] …` with every
-field block carrying **≥ 2** ones and the base sentinel exactly **1** — so a zone can be *walked*
-right-to-left without any markers: enter a block at its rightmost `1`, peek one cell left — another
-`1` means a field block (walk its remaining ones and hop its delimiter to the next block), a `0`
-means the block was the single-`1` **base sentinel**: stop.  `zoneWalkLeft` is that walker; the
-driver's cross-zone routes (cursor → control top → value top → WORK frontier and back) chain it with
-the 0-corridor scans.
+The corridor layout (A3) stores both stacks as `[sentinel 1] [0 1^{k₁}] [0 1^{k₂}] …` (left→right;
+the **top is rightmost**) with every field block carrying **≥ 2** ones and the base sentinel exactly
+**1** — so a zone can be *walked* right-to-left without any markers: from a block's rightmost `1`, step
+left and peek — another `1` means the block is a field (≥ 2 ones; walk its remaining ones and cross its
+`0` delimiter to the next block), a `0` means the block was the single-`1` **base sentinel** (we have
+stepped onto the dead-zone `0` just left of it): stop.  `zoneWalkLeft` is that walker; the driver's
+cross-zone routes (cursor → control top → value top → WORK frontier and back) chain it with the
+0-corridor scans.
 
-Phases: φ0 enter block (step left off its rightmost `1`); φ1 peek (`1` → field, φ2; `0` → it was the
-sentinel, φ5 done); φ2 walk the field's remaining ones (self-loop left, stop on the delimiter `0`);
-φ3 step left off the delimiter; φ4 confirm the next block's `1` (re-enter φ0 shape via a stay);
-φ5 done — the head rests on the `0` immediately **left of the sentinel**, exactly where the caller's
-next leftward 0-corridor scan begins.
+Phases (started on a block's rightmost `1`, the **loop-head invariant**):
+
+* **φ0** — step left to peek the cell left of the block's rightmost `1`;
+* **φ1** — decide: a `1` is a field block (→ φ2, walk it); a `0` is the dead-zone left of the base
+  sentinel (→ φ4, **done**);
+* **φ2** — walk the field's remaining ones (self-loop left, stop on the delimiter `0`);
+* **φ3** — step left off the delimiter onto the next block's rightmost `1` (→ φ0, the loop head);
+* **φ4** — done: the head rests on the `0` immediately **left of the sentinel**, exactly where the
+  caller's next leftward 0-corridor scan begins.
+
+(The single-`1` sentinel is handled uniformly: φ0 steps left off it onto the dead `0`, and φ1 reads
+that `0` and stops — no special case.)
 
 **Progress classification (AGENTS.md): Infrastructure** — a verifier machine component; builds no
 verifier and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
@@ -30,44 +37,39 @@ namespace ContractExpansion
 open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
 open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
 
-/-- **The leftward zone walker** (6 phases).  φ0 step into the block; φ1 peek (field vs sentinel);
-φ2 walk the field's ones; φ3 step off the delimiter; φ4 re-enter; φ5 done (sentinel found, head on
-the `0` just left of it). -/
+/-- **The leftward zone walker** (5 phases).  φ0 step-left-to-peek; φ1 decide (field → φ2 | sentinel
+dead-zone → φ4 done); φ2 walk the field's ones; φ3 cross the delimiter (→ φ0); φ4 done. -/
 def zoneWalkLeft : ConstStatePhasedProgram Unit where
-  numPhases := 6
+  numPhases := 5
   startPhase := ⟨0, by decide⟩
   startState := ()
-  acceptPhase := ⟨5, by decide⟩
+  acceptPhase := ⟨4, by decide⟩
   acceptState := ()
   transition := fun i _ b =>
     if i.val = 0 then
-      -- on the block's rightmost 1: step left to peek
+      -- on a block's rightmost 1: step left to peek the cell to its left
       (⟨1, by decide⟩, (), b, Move.left)
     else if i.val = 1 then
-      -- peek: 1 = a ≥2 field block (walk it); 0 = the block was the single-1 sentinel (done)
+      -- decide: 1 = a ≥2 field block (walk it); 0 = the dead 0 left of the single-1 sentinel (done)
       if b then (⟨2, by decide⟩, (), b, Move.stay)
-      else (⟨5, by decide⟩, (), b, Move.stay)
+      else (⟨4, by decide⟩, (), b, Move.stay)
     else if i.val = 2 then
       -- walk the field's remaining ones leftward; the 0 is the field's left delimiter
       if b then (⟨2, by decide⟩, (), b, Move.left)
       else (⟨3, by decide⟩, (), b, Move.stay)
     else if i.val = 3 then
-      -- step left off the delimiter onto the next block's rightmost 1
-      (⟨4, by decide⟩, (), b, Move.left)
-    else if i.val = 4 then
-      -- confirm and re-enter the block walk (the adjacency invariant guarantees a 1)
-      if b then (⟨1, by decide⟩, (), b, Move.left)
-      else (⟨5, by decide⟩, (), b, Move.stay)
+      -- step left off the delimiter onto the next block's rightmost 1 (back to the loop head)
+      (⟨0, by decide⟩, (), b, Move.left)
     else
-      -- φ5: done — idle
-      (⟨5, by decide⟩, (), b, Move.stay)
+      -- φ4: done — idle
+      (⟨4, by decide⟩, (), b, Move.stay)
   timeBound := fun n => n
 
-@[simp] theorem zoneWalkLeft_numPhases : zoneWalkLeft.numPhases = 6 := rfl
+@[simp] theorem zoneWalkLeft_numPhases : zoneWalkLeft.numPhases = 5 := rfl
 
 @[simp] theorem zoneWalkLeft_startPhase : (zoneWalkLeft.startPhase : Nat) = 0 := rfl
 
-@[simp] theorem zoneWalkLeft_acceptPhase : (zoneWalkLeft.acceptPhase : Nat) = 5 := rfl
+@[simp] theorem zoneWalkLeft_acceptPhase : (zoneWalkLeft.acceptPhase : Nat) = 4 := rfl
 
 /-! ### Transition lemmas -/
 
@@ -78,7 +80,7 @@ theorem zoneWalkLeft_t1_one :
     zoneWalkLeft.transition ⟨1, by decide⟩ () true = (⟨2, by decide⟩, (), true, Move.stay) := rfl
 
 theorem zoneWalkLeft_t1_zero :
-    zoneWalkLeft.transition ⟨1, by decide⟩ () false = (⟨5, by decide⟩, (), false, Move.stay) := rfl
+    zoneWalkLeft.transition ⟨1, by decide⟩ () false = (⟨4, by decide⟩, (), false, Move.stay) := rfl
 
 theorem zoneWalkLeft_t2_one :
     zoneWalkLeft.transition ⟨2, by decide⟩ () true = (⟨2, by decide⟩, (), true, Move.left) := rfl
@@ -87,33 +89,26 @@ theorem zoneWalkLeft_t2_zero :
     zoneWalkLeft.transition ⟨2, by decide⟩ () false = (⟨3, by decide⟩, (), false, Move.stay) := rfl
 
 theorem zoneWalkLeft_t3 (b : Bool) :
-    zoneWalkLeft.transition ⟨3, by decide⟩ () b = (⟨4, by decide⟩, (), b, Move.left) := rfl
+    zoneWalkLeft.transition ⟨3, by decide⟩ () b = (⟨0, by decide⟩, (), b, Move.left) := rfl
 
-theorem zoneWalkLeft_t4_one :
-    zoneWalkLeft.transition ⟨4, by decide⟩ () true = (⟨1, by decide⟩, (), true, Move.left) := rfl
-
-theorem zoneWalkLeft_t4_zero :
-    zoneWalkLeft.transition ⟨4, by decide⟩ () false = (⟨5, by decide⟩, (), false, Move.stay) := rfl
-
-theorem zoneWalkLeft_t5 (b : Bool) :
-    zoneWalkLeft.transition ⟨5, by decide⟩ () b = (⟨5, by decide⟩, (), b, Move.stay) := rfl
+theorem zoneWalkLeft_t4 (b : Bool) :
+    zoneWalkLeft.transition ⟨4, by decide⟩ () b = (⟨4, by decide⟩, (), b, Move.stay) := rfl
 
 /-! ### `stepConfig` lemmas (one machine step per phase/bit) -/
 
-/-- φ0 (enter block): the phase advances to `1`. -/
+/-- φ0 (step-left-to-peek): the phase advances to `1`, the head moves left, tape unchanged. -/
 theorem zoneWalkLeft_stepConfig_p0_phase {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    {i : Fin 5} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
     ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 1 := by
   unfold TM.stepConfig
   rw [hstate]
   simp only [PhasedProgram.toTM_step]
   simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
 
-/-- φ0: the head moves left. -/
 theorem zoneWalkLeft_stepConfig_p0_head {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    {i : Fin 5} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head
       = Configuration.moveHead (c := c) Move.left := by
   unfold TM.stepConfig
@@ -121,10 +116,9 @@ theorem zoneWalkLeft_stepConfig_p0_head {L : Nat}
   simp only [PhasedProgram.toTM_step]
   simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
 
-/-- φ0: the tape is unchanged (the read bit is written back). -/
 theorem zoneWalkLeft_stepConfig_p0_tape {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    {i : Fin 5} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
   have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
       = c.write c.head (c.tape c.head) := by
@@ -138,10 +132,10 @@ theorem zoneWalkLeft_stepConfig_p0_tape {L : Nat}
   · subst hj; simp [Configuration.write]
   · simp [Configuration.write, hj]
 
-/-- φ1 (peek) on a `1`: a field block — advance to `2`, head stays, tape unchanged. -/
+/-- φ1 (decide) on a `1`: a field block — advance to `2`, head stays. -/
 theorem zoneWalkLeft_stepConfig_p1_one_phase {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = true) :
     ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 2 := by
   unfold TM.stepConfig
@@ -151,7 +145,7 @@ theorem zoneWalkLeft_stepConfig_p1_one_phase {L : Nat}
 
 theorem zoneWalkLeft_stepConfig_p1_one_head {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = true) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head = c.head := by
   unfold TM.stepConfig
@@ -159,12 +153,12 @@ theorem zoneWalkLeft_stepConfig_p1_one_head {L : Nat}
   simp only [PhasedProgram.toTM_step]
   simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit, Configuration.moveHead]
 
-/-- φ1 (peek) on a `0`: the base sentinel — advance to the done phase `5`, head stays. -/
+/-- φ1 (decide) on a `0`: the dead-zone left of the sentinel — advance to the done phase `4`, head stays. -/
 theorem zoneWalkLeft_stepConfig_p1_zero_phase {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = false) :
-    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 5 := by
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 4 := by
   unfold TM.stepConfig
   rw [hstate]
   simp only [PhasedProgram.toTM_step]
@@ -172,7 +166,7 @@ theorem zoneWalkLeft_stepConfig_p1_zero_phase {L : Nat}
 
 theorem zoneWalkLeft_stepConfig_p1_zero_head {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = false) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head = c.head := by
   unfold TM.stepConfig
@@ -180,10 +174,10 @@ theorem zoneWalkLeft_stepConfig_p1_zero_head {L : Nat}
   simp only [PhasedProgram.toTM_step]
   simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit, Configuration.moveHead]
 
-/-- φ1 (peek), either bit: the tape is unchanged. -/
+/-- φ1 (decide), either bit: the tape is unchanged. -/
 theorem zoneWalkLeft_stepConfig_p1_tape {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩) :
+    {i : Fin 5} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
   have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
       = c.write c.head (c.tape c.head) := by
@@ -201,7 +195,7 @@ theorem zoneWalkLeft_stepConfig_p1_tape {L : Nat}
 /-- φ2 (walk a field's ones) on a `1`: the phase stays `2`, the head moves left. -/
 theorem zoneWalkLeft_stepConfig_p2_one_phase {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = true) :
     ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 2 := by
   unfold TM.stepConfig
@@ -211,7 +205,7 @@ theorem zoneWalkLeft_stepConfig_p2_one_phase {L : Nat}
 
 theorem zoneWalkLeft_stepConfig_p2_one_head {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = true) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head
       = Configuration.moveHead (c := c) Move.left := by
@@ -222,7 +216,7 @@ theorem zoneWalkLeft_stepConfig_p2_one_head {L : Nat}
 
 theorem zoneWalkLeft_stepConfig_p2_one_tape {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = true) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
   have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
@@ -240,7 +234,7 @@ theorem zoneWalkLeft_stepConfig_p2_one_tape {L : Nat}
 /-- φ2 on a `0`: the field's left delimiter — advance to `3`, head stays. -/
 theorem zoneWalkLeft_stepConfig_p2_zero_phase {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = false) :
     ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 3 := by
   unfold TM.stepConfig
@@ -250,7 +244,7 @@ theorem zoneWalkLeft_stepConfig_p2_zero_phase {L : Nat}
 
 theorem zoneWalkLeft_stepConfig_p2_zero_head {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = false) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head = c.head := by
   unfold TM.stepConfig
@@ -260,7 +254,7 @@ theorem zoneWalkLeft_stepConfig_p2_zero_head {L : Nat}
 
 theorem zoneWalkLeft_stepConfig_p2_zero_tape {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    {i : Fin 5} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
     (hbit : c.tape c.head = false) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
   have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
@@ -275,11 +269,11 @@ theorem zoneWalkLeft_stepConfig_p2_zero_tape {L : Nat}
   · subst hj; simp [Configuration.write, hbit]
   · simp [Configuration.write, hj]
 
-/-- φ3 (step off the delimiter): advance to `4`, head moves left, tape unchanged. -/
+/-- φ3 (cross the delimiter): advance to the loop head `0`, head moves left, tape unchanged. -/
 theorem zoneWalkLeft_stepConfig_p3_phase {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
-    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 4 := by
+    {i : Fin 5} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 0 := by
   unfold TM.stepConfig
   rw [hstate]
   simp only [PhasedProgram.toTM_step]
@@ -287,7 +281,7 @@ theorem zoneWalkLeft_stepConfig_p3_phase {L : Nat}
 
 theorem zoneWalkLeft_stepConfig_p3_head {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
+    {i : Fin 5} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head
       = Configuration.moveHead (c := c) Move.left := by
   unfold TM.stepConfig
@@ -297,7 +291,7 @@ theorem zoneWalkLeft_stepConfig_p3_head {L : Nat}
 
 theorem zoneWalkLeft_stepConfig_p3_tape {L : Nat}
     (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
+    {i : Fin 5} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
     (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
   have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
       = c.write c.head (c.tape c.head) := by
@@ -305,66 +299,6 @@ theorem zoneWalkLeft_stepConfig_p3_tape {L : Nat}
     rw [hstate]
     simp only [PhasedProgram.toTM_step]
     simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
-  rw [hwrite]
-  funext j
-  by_cases hj : j = c.head
-  · subst hj; simp [Configuration.write]
-  · simp [Configuration.write, hj]
-
-/-- φ4 (confirm next block) on a `1`: re-enter the peek loop at `1`, head moves left. -/
-theorem zoneWalkLeft_stepConfig_p4_one_phase {L : Nat}
-    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩)
-    (hbit : c.tape c.head = true) :
-    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 1 := by
-  unfold TM.stepConfig
-  rw [hstate]
-  simp only [PhasedProgram.toTM_step]
-  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
-
-theorem zoneWalkLeft_stepConfig_p4_one_head {L : Nat}
-    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩)
-    (hbit : c.tape c.head = true) :
-    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head
-      = Configuration.moveHead (c := c) Move.left := by
-  unfold TM.stepConfig
-  rw [hstate]
-  simp only [PhasedProgram.toTM_step]
-  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
-
-/-- φ4 on a `0`: the sentinel reached via the confirm path — advance to the done phase `5`, head stays. -/
-theorem zoneWalkLeft_stepConfig_p4_zero_phase {L : Nat}
-    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩)
-    (hbit : c.tape c.head = false) :
-    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 5 := by
-  unfold TM.stepConfig
-  rw [hstate]
-  simp only [PhasedProgram.toTM_step]
-  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
-
-theorem zoneWalkLeft_stepConfig_p4_zero_head {L : Nat}
-    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩)
-    (hbit : c.tape c.head = false) :
-    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head = c.head := by
-  unfold TM.stepConfig
-  rw [hstate]
-  simp only [PhasedProgram.toTM_step]
-  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit, Configuration.moveHead]
-
-theorem zoneWalkLeft_stepConfig_p4_tape {L : Nat}
-    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
-    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩) :
-    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
-  have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
-      = c.write c.head (c.tape c.head) := by
-    unfold TM.stepConfig
-    rw [hstate]
-    simp only [PhasedProgram.toTM_step]
-    simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
-    cases c.tape c.head <;> simp
   rw [hwrite]
   funext j
   by_cases hj : j = c.head
@@ -373,9 +307,10 @@ theorem zoneWalkLeft_stepConfig_p4_tape {L : Nat}
 
 /-! ### The field sub-scan: φ2 walks a block's `1`s leftward (the inner loop)
 
-The reusable inner step of the walk: from φ2 sitting on the rightmost `1` of a field block whose `j`
-cells `(head − j, head]` are all `1`, after `j` steps φ2 has retreated `j` cells (still in φ2), tape
-unchanged — the exact `selfLoopScanLeftOne`-shaped invariant, specialised to `zoneWalkLeft`'s φ2. -/
+The reusable inner step of the walk: from φ2 sitting on the second-rightmost cell of a field block
+whose `j` cells `(head − j, head]` are all `1`, after `j` steps φ2 has retreated `j` cells (still in
+φ2), tape unchanged — the exact `selfLoopScanLeftOne`-shaped invariant, specialised to `zoneWalkLeft`'s
+φ2. -/
 theorem zoneWalkLeft_runConfig_p2_scanning {L : Nat}
     (c0 : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
     (hphase : (c0.state.fst : Nat) = 2) :

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalk.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalk.lean
@@ -98,6 +98,312 @@ theorem zoneWalkLeft_t4_zero :
 theorem zoneWalkLeft_t5 (b : Bool) :
     zoneWalkLeft.transition ⟨5, by decide⟩ () b = (⟨5, by decide⟩, (), b, Move.stay) := rfl
 
+/-! ### `stepConfig` lemmas (one machine step per phase/bit) -/
+
+/-- φ0 (enter block): the phase advances to `1`. -/
+theorem zoneWalkLeft_stepConfig_p0_phase {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 1 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
+
+/-- φ0: the head moves left. -/
+theorem zoneWalkLeft_stepConfig_p0_head {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
+
+/-- φ0: the tape is unchanged (the read bit is written back). -/
+theorem zoneWalkLeft_stepConfig_p0_tape {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
+      = c.write c.head (c.tape c.head) := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- φ1 (peek) on a `1`: a field block — advance to `2`, head stays, tape unchanged. -/
+theorem zoneWalkLeft_stepConfig_p1_one_phase {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 2 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+
+theorem zoneWalkLeft_stepConfig_p1_one_head {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head = c.head := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit, Configuration.moveHead]
+
+/-- φ1 (peek) on a `0`: the base sentinel — advance to the done phase `5`, head stays. -/
+theorem zoneWalkLeft_stepConfig_p1_zero_phase {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 5 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+
+theorem zoneWalkLeft_stepConfig_p1_zero_head {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head = c.head := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit, Configuration.moveHead]
+
+/-- φ1 (peek), either bit: the tape is unchanged. -/
+theorem zoneWalkLeft_stepConfig_p1_tape {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
+      = c.write c.head (c.tape c.head) := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
+    cases c.tape c.head <;> simp
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- φ2 (walk a field's ones) on a `1`: the phase stays `2`, the head moves left. -/
+theorem zoneWalkLeft_stepConfig_p2_one_phase {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 2 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+
+theorem zoneWalkLeft_stepConfig_p2_one_head {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+
+theorem zoneWalkLeft_stepConfig_p2_one_tape {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
+      = c.write c.head true := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+/-- φ2 on a `0`: the field's left delimiter — advance to `3`, head stays. -/
+theorem zoneWalkLeft_stepConfig_p2_zero_phase {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 3 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+
+theorem zoneWalkLeft_stepConfig_p2_zero_head {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head = c.head := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit, Configuration.moveHead]
+
+theorem zoneWalkLeft_stepConfig_p2_zero_tape {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
+      = c.write c.head false := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+/-- φ3 (step off the delimiter): advance to `4`, head moves left, tape unchanged. -/
+theorem zoneWalkLeft_stepConfig_p3_phase {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 4 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
+
+theorem zoneWalkLeft_stepConfig_p3_head {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
+
+theorem zoneWalkLeft_stepConfig_p3_tape {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
+      = c.write c.head (c.tape c.head) := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- φ4 (confirm next block) on a `1`: re-enter the peek loop at `1`, head moves left. -/
+theorem zoneWalkLeft_stepConfig_p4_one_phase {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 1 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+
+theorem zoneWalkLeft_stepConfig_p4_one_head {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+
+/-- φ4 on a `0`: the sentinel reached via the confirm path — advance to the done phase `5`, head stays. -/
+theorem zoneWalkLeft_stepConfig_p4_zero_phase {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).state).fst.val = 5 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit]
+
+theorem zoneWalkLeft_stepConfig_p4_zero_head {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).head = c.head := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi, hbit, Configuration.moveHead]
+
+theorem zoneWalkLeft_stepConfig_p4_tape {L : Nat}
+    (c : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 4) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c).tape
+      = c.write c.head (c.tape c.head) := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkLeft, hi]
+    cases c.tape c.head <;> simp
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-! ### The field sub-scan: φ2 walks a block's `1`s leftward (the inner loop)
+
+The reusable inner step of the walk: from φ2 sitting on the rightmost `1` of a field block whose `j`
+cells `(head − j, head]` are all `1`, after `j` steps φ2 has retreated `j` cells (still in φ2), tape
+unchanged — the exact `selfLoopScanLeftOne`-shaped invariant, specialised to `zoneWalkLeft`'s φ2. -/
+theorem zoneWalkLeft_runConfig_p2_scanning {L : Nat}
+    (c0 : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 2) :
+    ∀ j : Nat, j ≤ (c0.head : Nat) →
+      (∀ p : Fin (zoneWalkLeft.toPhased.toTM.tapeLength L),
+        (c0.head : Nat) - j < (p : Nat) → (p : Nat) ≤ (c0.head : Nat) → c0.tape p = true) →
+      (((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 j).state).fst : Nat) = 2
+      ∧ ((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 j).head : Nat) = (c0.head : Nat) - j
+      ∧ (TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 j).tape = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _; exact ⟨hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj h1
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (fun p hp1 hp2 => h1 p (by omega) hp2)
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 j with hc
+      have hbit : c.tape c.head = true := by
+        rw [htp]; exact h1 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hheadne : ¬ (c.head : Nat) = 0 := by rw [hhd]; omega
+      have hstate : c.state = ⟨c.state.fst, c.state.snd⟩ := rfl
+      refine ⟨?_, ?_, ?_⟩
+      · exact zoneWalkLeft_stepConfig_p2_one_phase c hph hstate hbit
+      · rw [zoneWalkLeft_stepConfig_p2_one_head c hph hstate hbit]
+        simp only [Configuration.moveHead, dif_neg hheadne]
+        rw [hhd]; omega
+      · rw [zoneWalkLeft_stepConfig_p2_one_tape c hph hstate hbit, htp]
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalk.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalk.lean
@@ -1,0 +1,103 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
+import Pnp4.Frontier.ContractExpansion.TreeMCSPLoopUntilSink
+
+/-!
+# `zoneWalkLeft` — D2t-5b (Block A4w): traversing a corridor stack zone right-to-left
+
+The corridor layout (A3) stores both stacks as `[sentinel 1] [0 1^{k₁}] [0 1^{k₂}] …` with every
+field block carrying **≥ 2** ones and the base sentinel exactly **1** — so a zone can be *walked*
+right-to-left without any markers: enter a block at its rightmost `1`, peek one cell left — another
+`1` means a field block (walk its remaining ones and hop its delimiter to the next block), a `0`
+means the block was the single-`1` **base sentinel**: stop.  `zoneWalkLeft` is that walker; the
+driver's cross-zone routes (cursor → control top → value top → WORK frontier and back) chain it with
+the 0-corridor scans.
+
+Phases: φ0 enter block (step left off its rightmost `1`); φ1 peek (`1` → field, φ2; `0` → it was the
+sentinel, φ5 done); φ2 walk the field's remaining ones (self-loop left, stop on the delimiter `0`);
+φ3 step left off the delimiter; φ4 confirm the next block's `1` (re-enter φ0 shape via a stay);
+φ5 done — the head rests on the `0` immediately **left of the sentinel**, exactly where the caller's
+next leftward 0-corridor scan begins.
+
+**Progress classification (AGENTS.md): Infrastructure** — a verifier machine component; builds no
+verifier and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- **The leftward zone walker** (6 phases).  φ0 step into the block; φ1 peek (field vs sentinel);
+φ2 walk the field's ones; φ3 step off the delimiter; φ4 re-enter; φ5 done (sentinel found, head on
+the `0` just left of it). -/
+def zoneWalkLeft : ConstStatePhasedProgram Unit where
+  numPhases := 6
+  startPhase := ⟨0, by decide⟩
+  startState := ()
+  acceptPhase := ⟨5, by decide⟩
+  acceptState := ()
+  transition := fun i _ b =>
+    if i.val = 0 then
+      -- on the block's rightmost 1: step left to peek
+      (⟨1, by decide⟩, (), b, Move.left)
+    else if i.val = 1 then
+      -- peek: 1 = a ≥2 field block (walk it); 0 = the block was the single-1 sentinel (done)
+      if b then (⟨2, by decide⟩, (), b, Move.stay)
+      else (⟨5, by decide⟩, (), b, Move.stay)
+    else if i.val = 2 then
+      -- walk the field's remaining ones leftward; the 0 is the field's left delimiter
+      if b then (⟨2, by decide⟩, (), b, Move.left)
+      else (⟨3, by decide⟩, (), b, Move.stay)
+    else if i.val = 3 then
+      -- step left off the delimiter onto the next block's rightmost 1
+      (⟨4, by decide⟩, (), b, Move.left)
+    else if i.val = 4 then
+      -- confirm and re-enter the block walk (the adjacency invariant guarantees a 1)
+      if b then (⟨1, by decide⟩, (), b, Move.left)
+      else (⟨5, by decide⟩, (), b, Move.stay)
+    else
+      -- φ5: done — idle
+      (⟨5, by decide⟩, (), b, Move.stay)
+  timeBound := fun n => n
+
+@[simp] theorem zoneWalkLeft_numPhases : zoneWalkLeft.numPhases = 6 := rfl
+
+@[simp] theorem zoneWalkLeft_startPhase : (zoneWalkLeft.startPhase : Nat) = 0 := rfl
+
+@[simp] theorem zoneWalkLeft_acceptPhase : (zoneWalkLeft.acceptPhase : Nat) = 5 := rfl
+
+/-! ### Transition lemmas -/
+
+theorem zoneWalkLeft_t0 (b : Bool) :
+    zoneWalkLeft.transition ⟨0, by decide⟩ () b = (⟨1, by decide⟩, (), b, Move.left) := rfl
+
+theorem zoneWalkLeft_t1_one :
+    zoneWalkLeft.transition ⟨1, by decide⟩ () true = (⟨2, by decide⟩, (), true, Move.stay) := rfl
+
+theorem zoneWalkLeft_t1_zero :
+    zoneWalkLeft.transition ⟨1, by decide⟩ () false = (⟨5, by decide⟩, (), false, Move.stay) := rfl
+
+theorem zoneWalkLeft_t2_one :
+    zoneWalkLeft.transition ⟨2, by decide⟩ () true = (⟨2, by decide⟩, (), true, Move.left) := rfl
+
+theorem zoneWalkLeft_t2_zero :
+    zoneWalkLeft.transition ⟨2, by decide⟩ () false = (⟨3, by decide⟩, (), false, Move.stay) := rfl
+
+theorem zoneWalkLeft_t3 (b : Bool) :
+    zoneWalkLeft.transition ⟨3, by decide⟩ () b = (⟨4, by decide⟩, (), b, Move.left) := rfl
+
+theorem zoneWalkLeft_t4_one :
+    zoneWalkLeft.transition ⟨4, by decide⟩ () true = (⟨1, by decide⟩, (), true, Move.left) := rfl
+
+theorem zoneWalkLeft_t4_zero :
+    zoneWalkLeft.transition ⟨4, by decide⟩ () false = (⟨5, by decide⟩, (), false, Move.stay) := rfl
+
+theorem zoneWalkLeft_t5 (b : Bool) :
+    zoneWalkLeft.transition ⟨5, by decide⟩ () b = (⟨5, by decide⟩, (), b, Move.stay) := rfl
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -4069,7 +4069,6 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p0_phase
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_one_head
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_zero_phase
-#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p4_one_phase
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_p2_scanning
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -96,6 +96,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverStrongInv
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDrivePending
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryTransferRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4063,6 +4064,13 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.encodeCtrlStackR_cons
 #check @Pnp4.Frontier.ContractExpansion.encodeCtrlStackR_getLast_true
 #check @Pnp4.Frontier.ContractExpansion.driverCorridorInv_init
+-- D2t-5b (Block A4w): the corridor zone walker — step semantics + the inner field sub-scan.
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p0_phase
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_one_head
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_zero_phase
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p4_one_phase
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_p2_scanning
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -86,6 +86,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverStrongInv
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDrivePending
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryTransferRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -877,6 +878,17 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.encodeCtrlStackR_cons
 #print axioms Pnp4.Frontier.ContractExpansion.encodeCtrlStackR_getLast_true
 #print axioms Pnp4.Frontier.ContractExpansion.driverCorridorInv_init
+-- D2t-5b (Block A4w): the corridor zone walker — step semantics for every phase + the inner field
+-- sub-scan (φ2 walks a block's 1s leftward), the reusable foundation of the cross-zone routes.
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p0_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p1_one_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p1_zero_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_one_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_zero_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p3_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p4_one_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p4_zero_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_p2_scanning
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -886,8 +886,6 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_one_phase
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_zero_phase
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p3_phase
-#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p4_one_phase
-#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p4_zero_phase
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_p2_scanning
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true


### PR DESCRIPTION
**Block A4, brick 1** — the corridor **zone walker** (the foundation layer the cross-zone routes are built from). First genuinely-proven machine component of the A4–A6 driver core.

## What it does
The corridor stacks (A3) are right-anchored with every field block ending in `1` and a single-`1` base sentinel. `zoneWalkLeft` traverses such a zone **right-to-left without markers**: enter a block (step left), **peek** (`1` = a field block, walk it; `0` = the base sentinel → done), walk the field's `1`s, hop the delimiter, re-enter; on the sentinel it stops with the head on the `0` just left of it (where the caller's next 0-corridor scan begins).

## Contents (all hole-free)
* **Codec disambiguation** (`encodeNatEntryR` → `v + 2 ≥ 2` ones): a value field is now never confused with the single-`1` sentinel during a walk (the same `≥ 2` discipline the ctrl tag blocks already use). Length lemmas updated; this only tightens the A3 codec the walk consumes — nothing else reads it yet.
* **`zoneWalkLeft`** (6-phase program) + all transition lemmas.
* **Full `stepConfig` layer** — phase/head/tape for every phase/bit arm (φ0…φ4), each discharged by the proven `unfold TM.stepConfig / toTM_step / toPhased` pattern.
* **`zoneWalkLeft_runConfig_p2_scanning`** — the inner field sub-scan: from φ2 on a block's rightmost `1` with `j` ones to its left, after `j` steps the head has retreated `j` cells (still φ2), tape unchanged. The reusable inner loop the per-block segment and the full-zone walk (next brick) build on.

## Honest scope
This is the **foundation layer** of the A4 machine core. The full multi-block walk `runConfig` + the cross-zone routes + the reading/settle passes + the `loopUntilSink` `Configuration`-level discharge are the remaining A4–A6 bricks (the binToUnary-class, multi-session core). Per the agreed cadence, the machine core lands brick-by-brick.

## Verification
`lake build PnP3 Pnp4` clean; `./scripts/check.sh` **17/17**; standard `[propext, Classical.choice, Quot.sound]` triple; registered in lakefile + AxiomsAudit + SurfaceTests; no `sorry`/holes.

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_