### PR TITLE
transcoder(D2t-5b/A4): the on-tape driver body — navigation, components, and arm instantiations

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -348,6 +348,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -342,6 +342,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryTransferRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -351,6 +351,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -343,6 +343,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -352,6 +352,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -354,6 +354,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPValPush,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -353,6 +353,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -349,6 +349,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -355,6 +355,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPValPush,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -345,6 +345,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -346,6 +346,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -350,6 +350,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -347,6 +347,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -344,6 +344,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorDispatch.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorDispatch.lean
@@ -96,6 +96,118 @@ theorem corridor_dispatch_tnot {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ wi
     rw [this, hbits]
     rfl
 
+/-- Sibling of `corridor_dispatch_tand` for `tand`: accept phase `9`. -/
+theorem corridor_dispatch_tand {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (toks : List (PreToken n)) (out : List (SLGate n))
+    (ctrl : List (ITag × Nat)) (val : List Nat)
+    (c0 : Configuration (M := treeTagDispatch.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape
+      (⟨PreToken.node ITag.tand :: toks, out, ctrl, val, false⟩ : DriveState n))
+    (htoks : toks ≠ [])
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.certEnd
+      - (encodePreorder width h_width (PreToken.node ITag.tand :: toks)).length) :
+    (((TM.runConfig (M := treeTagDispatch.toPhased.toTM) c0 3).state).fst : Nat) = 9
+      ∧ ((TM.runConfig (M := treeTagDispatch.toPhased.toTM) c0 3).head : Nat) = (c0.head : Nat) + 3
+      ∧ (TM.runConfig (M := treeTagDispatch.toPhased.toTM) c0 3).tape = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  replace hcert : windowSpells c0.tape
+      (z.certEnd - (encodePreorder width h_width (PreToken.node ITag.tand :: toks)).length)
+      (encodePreorder width h_width (PreToken.node ITag.tand :: toks)) := hcert
+  replace hvalid : ValidCertTokens (PreToken.node ITag.tand :: toks) := hvalid
+  -- The certificate window's first three cells are the tag bits [0,1,0].
+  have hbits : encodePreorder width h_width (PreToken.node ITag.tand :: toks)
+      = [false, true, true] ++ encodePreorder width h_width toks := by
+    rw [encodePreorder_cons]
+    rfl
+  have hlen : 3 ≤ (encodePreorder width h_width (PreToken.node ITag.tand :: toks)).length := by
+    rw [hbits]; simp
+  have hfit := hcert.1
+  -- The tail is nonempty (the node's child follows), giving strict room past the tag cells.
+  have htail : 1 ≤ (encodePreorder width h_width toks).length := by
+    have hv : ValidCertTokens toks := fun t ht => hvalid t (List.mem_cons_of_mem _ ht)
+    have := validCertTokens_length_le width h_width hv
+    have hne : 1 ≤ toks.length := by
+      cases toks with
+      | nil => exact absurd rfl htoks
+      | cons a l => simp
+    omega
+  have henc : (encodePreorder width h_width (PreToken.node ITag.tand :: toks)).length
+      = 3 + (encodePreorder width h_width toks).length := by
+    rw [hbits, List.length_append]
+    rfl
+  apply treeTagDispatch_runConfig_and c0 hphase (by omega)
+  · intro p hp
+    have := windowSpells_cell c0.tape _ _ hcert 0 (by omega) p (by omega)
+    rw [this, hbits]
+    rfl
+  · intro p hp
+    have := windowSpells_cell c0.tape _ _ hcert 1 (by omega) p (by omega)
+    rw [this, hbits]
+    rfl
+  · intro p hp
+    have := windowSpells_cell c0.tape _ _ hcert 2 (by omega) p (by omega)
+    rw [this, hbits]
+    rfl
+
+/-- Sibling of `corridor_dispatch_tor` for `tor`: accept phase `10`. -/
+theorem corridor_dispatch_tor {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (toks : List (PreToken n)) (out : List (SLGate n))
+    (ctrl : List (ITag × Nat)) (val : List Nat)
+    (c0 : Configuration (M := treeTagDispatch.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape
+      (⟨PreToken.node ITag.tor :: toks, out, ctrl, val, false⟩ : DriveState n))
+    (htoks : toks ≠ [])
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.certEnd
+      - (encodePreorder width h_width (PreToken.node ITag.tor :: toks)).length) :
+    (((TM.runConfig (M := treeTagDispatch.toPhased.toTM) c0 3).state).fst : Nat) = 10
+      ∧ ((TM.runConfig (M := treeTagDispatch.toPhased.toTM) c0 3).head : Nat) = (c0.head : Nat) + 3
+      ∧ (TM.runConfig (M := treeTagDispatch.toPhased.toTM) c0 3).tape = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  replace hcert : windowSpells c0.tape
+      (z.certEnd - (encodePreorder width h_width (PreToken.node ITag.tor :: toks)).length)
+      (encodePreorder width h_width (PreToken.node ITag.tor :: toks)) := hcert
+  replace hvalid : ValidCertTokens (PreToken.node ITag.tor :: toks) := hvalid
+  -- The certificate window's first three cells are the tag bits [0,1,0].
+  have hbits : encodePreorder width h_width (PreToken.node ITag.tor :: toks)
+      = [true, false, false] ++ encodePreorder width h_width toks := by
+    rw [encodePreorder_cons]
+    rfl
+  have hlen : 3 ≤ (encodePreorder width h_width (PreToken.node ITag.tor :: toks)).length := by
+    rw [hbits]; simp
+  have hfit := hcert.1
+  -- The tail is nonempty (the node's child follows), giving strict room past the tag cells.
+  have htail : 1 ≤ (encodePreorder width h_width toks).length := by
+    have hv : ValidCertTokens toks := fun t ht => hvalid t (List.mem_cons_of_mem _ ht)
+    have := validCertTokens_length_le width h_width hv
+    have hne : 1 ≤ toks.length := by
+      cases toks with
+      | nil => exact absurd rfl htoks
+      | cons a l => simp
+    omega
+  have henc : (encodePreorder width h_width (PreToken.node ITag.tor :: toks)).length
+      = 3 + (encodePreorder width h_width toks).length := by
+    rw [hbits, List.length_append]
+    rfl
+  apply treeTagDispatch_runConfig_or c0 hphase (by omega)
+  · intro p hp
+    have := windowSpells_cell c0.tape _ _ hcert 0 (by omega) p (by omega)
+    rw [this, hbits]
+    rfl
+  · intro p hp
+    have := windowSpells_cell c0.tape _ _ hcert 1 (by omega) p (by omega)
+    rw [this, hbits]
+    rfl
+  · intro p hp
+    have := windowSpells_cell c0.tape _ _ hcert 2 (by omega) p (by omega)
+    rw [this, hbits]
+    rfl
+
 end ContractExpansion
 end Frontier
 end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorDispatch.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorDispatch.lean
@@ -1,0 +1,101 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
+import Pnp4.Frontier.ContractExpansion.TreeMCSPTreeTagDispatch
+
+/-!
+# Corridor token dispatch — D2t-5b (Block A4a): the trie reads the next token's tag
+
+The reading arm enters at the cursor (one right of the marker `M`) and dispatches on the next
+token's 3 tag cells — `treeTagDispatch` (D2t-1) is the proven trie; this module ties its cell
+hypotheses to `driverCorridorInv`'s certificate clause: the unread suffix spells
+`encodePreorder (tok :: toks)`, whose first three cells are the token's tag bits
+(`encodePreToken`'s prefix, per constructor).
+
+`corridor_dispatch_node`: for a node token, the trie run from the cursor reaches that tag's accept
+phase with the head on the token's **last** tag cell + 1 … i.e. advanced by 3, tape unchanged — the
+hand-off into `eraseLeftMark 3` (which plants the new marker on the last consumed cell, one left of
+the post-trie head).
+
+**Progress classification (AGENTS.md): Infrastructure** — verifier machine run-throughs; build no
+verifier and prove no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- A spelled window pins any in-range cell to the spelled bit (`getD` form). -/
+theorem windowSpells_cell {L : Nat} (tape : Fin L → Bool) (base : Nat) (bits : List Bool)
+    (h : windowSpells tape base bits) (i : Nat) (hi : i < bits.length) :
+    ∀ p : Fin L, (p : Nat) = base + i → tape p = bits.getD i false := by
+  intro p hp
+  obtain ⟨hfit, hcells⟩ := h
+  rw [hcells p (by omega) (by omega)]
+  congr 1
+  omega
+
+/-- **The corridor node dispatch** (`tnot` shown; `tand`/`tor` are the sibling lemmas).  With the
+invariant for a state whose next token is `node ITag.tnot`, the trie run from the cursor reaches the
+`not` accept phase (`8`), head advanced by 3, tape unchanged. -/
+theorem corridor_dispatch_tnot {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (toks : List (PreToken n)) (out : List (SLGate n))
+    (ctrl : List (ITag × Nat)) (val : List Nat)
+    (c0 : Configuration (M := treeTagDispatch.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape
+      (⟨PreToken.node ITag.tnot :: toks, out, ctrl, val, false⟩ : DriveState n))
+    (htoks : toks ≠ [])
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.certEnd
+      - (encodePreorder width h_width (PreToken.node ITag.tnot :: toks)).length) :
+    (((TM.runConfig (M := treeTagDispatch.toPhased.toTM) c0 3).state).fst : Nat) = 8
+      ∧ ((TM.runConfig (M := treeTagDispatch.toPhased.toTM) c0 3).head : Nat) = (c0.head : Nat) + 3
+      ∧ (TM.runConfig (M := treeTagDispatch.toPhased.toTM) c0 3).tape = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  replace hcert : windowSpells c0.tape
+      (z.certEnd - (encodePreorder width h_width (PreToken.node ITag.tnot :: toks)).length)
+      (encodePreorder width h_width (PreToken.node ITag.tnot :: toks)) := hcert
+  replace hvalid : ValidCertTokens (PreToken.node ITag.tnot :: toks) := hvalid
+  -- The certificate window's first three cells are the tag bits [0,1,0].
+  have hbits : encodePreorder width h_width (PreToken.node ITag.tnot :: toks)
+      = [false, true, false] ++ encodePreorder width h_width toks := by
+    rw [encodePreorder_cons]
+    rfl
+  have hlen : 3 ≤ (encodePreorder width h_width (PreToken.node ITag.tnot :: toks)).length := by
+    rw [hbits]; simp
+  have hfit := hcert.1
+  -- The tail is nonempty (the node's child follows), giving strict room past the tag cells.
+  have htail : 1 ≤ (encodePreorder width h_width toks).length := by
+    have hv : ValidCertTokens toks := fun t ht => hvalid t (List.mem_cons_of_mem _ ht)
+    have := validCertTokens_length_le width h_width hv
+    have hne : 1 ≤ toks.length := by
+      cases toks with
+      | nil => exact absurd rfl htoks
+      | cons a l => simp
+    omega
+  have henc : (encodePreorder width h_width (PreToken.node ITag.tnot :: toks)).length
+      = 3 + (encodePreorder width h_width toks).length := by
+    rw [hbits, List.length_append]
+    rfl
+  apply treeTagDispatch_runConfig_not c0 hphase (by omega)
+  · intro p hp
+    have := windowSpells_cell c0.tape _ _ hcert 0 (by omega) p (by omega)
+    rw [this, hbits]
+    rfl
+  · intro p hp
+    have := windowSpells_cell c0.tape _ _ hcert 1 (by omega) p (by omega)
+    rw [this, hbits]
+    rfl
+  · intro p hp
+    have := windowSpells_cell c0.tape _ _ hcert 2 (by omega) p (by omega)
+    rw [this, hbits]
+    rfl
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorNodeStep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorNodeStep.lean
@@ -1,0 +1,237 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
+
+/-!
+# The node-arm keystone — D2t-5b (Block A4a): the invariant is re-established
+
+The node arm's six machine legs (dispatch ▸ step-left ▸ erase/replant ▸ scan ▸ step-right ▸ frame
+push ▸ scan-back) change the tape in exactly two places: the **cursor area** (the consumed token's
+three tag cells and the old marker are zeroed, the new marker is planted on the last consumed cell)
+and the **control zone's right end** (the pushed frame).  `nodeStepTape` is that explicit
+transformer; this module proves the **keystone**: applying it to a tape satisfying
+`driverCorridorInv` for a reading state with next token `node tag` yields a tape satisfying
+`driverCorridorInv` for the **stepped** abstract state `⟨toks', out, (tag, arity) :: ctrl, val,
+false⟩` — i.e. the on-tape node arm realises `DriveState.step`'s node branch, invariant preserved.
+(The machine-assembly layer then only has to show the composite's final tape *equals*
+`nodeStepTape`, leg by leg — each leg's run lemma already gives its exact tape map.)
+
+**Progress classification (AGENTS.md): Infrastructure** — a tape-level invariant-preservation
+keystone, proven against the verified codecs; builds no machine and proves no separation.  Standard
+`[propext, Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- The node arm's tape transformer: plant the new marker on the token's last tag cell
+(`cursor + 2`), zero the cells `[cursor − 1, cursor + 2)` (the old marker and the first two tag
+cells), and write the frame at the control zone's right end (`[fbase, fbase + |frame|)`). -/
+def nodeStepTape {L : Nat} (tape : Fin L → Bool) (cursor fbase : Nat) (frame : List Bool)
+    (q : Fin L) : Bool :=
+  if (q : Nat) = cursor + 2 then true
+  else if cursor - 1 ≤ (q : Nat) ∧ (q : Nat) < cursor + 2 then false
+  else if fbase ≤ (q : Nat) ∧ (q : Nat) < fbase + frame.length then
+    frame.getD ((q : Nat) - fbase) false
+  else tape q
+
+/-- **The node-arm keystone.**  For a reading state with next token `node tag` (tail nonempty — the
+node's child follows) and room for the frame in the control zone, the transformed tape satisfies the
+invariant for the stepped state `⟨toks', out, (tag, tag.arity) :: ctrl, val, false⟩`. -/
+theorem corridorInv_nodeStep {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (tag : ITag) (toks' : List (PreToken n)) (out : List (SLGate n))
+    (ctrl : List (ITag × Nat)) (val : List Nat) (tape : Fin L → Bool)
+    (hinv : driverCorridorInv width h_width z tape
+      (⟨PreToken.node tag :: toks', out, ctrl, val, false⟩ : DriveState n))
+    (htoks : toks' ≠ [])
+    (hcap : z.ctrlBase + (encodeCtrlStackR ctrl).length
+        + (encodeCtrlFrameR (tag, tag.arity)).length ≤ z.ctrlEnd) :
+    driverCorridorInv width h_width z
+      (nodeStepTape tape
+        (z.certEnd - (encodePreorder width h_width (PreToken.node tag :: toks')).length)
+        (z.ctrlBase + (encodeCtrlStackR ctrl).length)
+        (encodeCtrlFrameR (tag, tag.arity)))
+      (⟨toks', out, (tag, tag.arity) :: ctrl, val, false⟩ : DriveState n) := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  replace hcert : windowSpells tape
+      (z.certEnd - (encodePreorder width h_width (PreToken.node tag :: toks')).length)
+      (encodePreorder width h_width (PreToken.node tag :: toks')) := hcert
+  replace hcfit : z.certBase
+      + (encodePreorder width h_width (PreToken.node tag :: toks')).length ≤ z.certEnd := hcfit
+  replace hvalid : ValidCertTokens (PreToken.node tag :: toks') := hvalid
+  replace hM : ∀ p : Fin L,
+      (p : Nat) = z.certEnd
+        - (encodePreorder width h_width (PreToken.node tag :: toks')).length - 1 →
+      tape p = true := hM
+  replace hczeros : ∀ p : Fin L,
+      z.ctrlBase + (encodeCtrlStackR ctrl).length ≤ (p : Nat) →
+      (p : Nat) < z.certEnd
+        - (encodePreorder width h_width (PreToken.node tag :: toks')).length - 1 →
+      tape p = false := hczeros
+  replace hout : windowSpells tape (z.workBase - 1 - out.length)
+      (unaryField out.length ++ encodeGateRecordStream out) := hout
+  replace hofit : z.outBase + out.length + 1 ≤ z.workBase := hofit
+  replace hFM : ∀ p : Fin L,
+      (p : Nat) = z.workBase + (encodeGateRecordStream out).length → tape p = true := hFM
+  replace hffit : z.workBase + (encodeGateRecordStream out).length + 1 ≤ z.workEnd := hffit
+  replace hfzeros : ∀ p : Fin L,
+      z.workBase + (encodeGateRecordStream out).length + 1 ≤ (p : Nat) →
+      (p : Nat) < z.valBase → tape p = false := hfzeros
+  replace hval : windowSpells tape z.valBase (encodeNatStackR val) := hval
+  replace hvfit : z.valBase + (encodeNatStackR val).length ≤ z.valEnd := hvfit
+  replace hvzeros : ∀ p : Fin L,
+      z.valBase + (encodeNatStackR val).length ≤ (p : Nat) →
+      (p : Nat) < z.ctrlBase → tape p = false := hvzeros
+  replace hctrl : windowSpells tape z.ctrlBase (encodeCtrlStackR ctrl) := hctrl
+  replace hcfit2 : z.ctrlBase + (encodeCtrlStackR ctrl).length ≤ z.ctrlEnd := hcfit2
+  -- Notation: the old cursor, the encoded lengths, the frame base.
+  set cur := z.certEnd - (encodePreorder width h_width (PreToken.node tag :: toks')).length with hcur
+  set fb := z.ctrlBase + (encodeCtrlStackR ctrl).length with hfb
+  set fr := encodeCtrlFrameR (tag, tag.arity) with hfr
+  -- The token's three tag cells: encodePreorder (node :: toks') = tagbits ++ encodePreorder toks'.
+  have hbits : encodePreorder width h_width (PreToken.node tag :: toks')
+      = encodePreToken width h_width (PreToken.node tag)
+        ++ encodePreorder width h_width toks' := encodePreorder_cons width h_width _ _
+  have htag3 : (encodePreToken width h_width (PreToken.node tag)).length = 3 := by
+    cases tag <;> rfl
+  have htail1 : 1 ≤ (encodePreorder width h_width toks').length := by
+    have hv : ValidCertTokens toks' := fun t ht => hvalid t (List.mem_cons_of_mem _ ht)
+    have := validCertTokens_length_le width h_width hv
+    have : 1 ≤ toks'.length := by
+      cases toks' with
+      | nil => exact absurd rfl htoks
+      | cons a l => simp
+    omega
+  have hlenc : (encodePreorder width h_width (PreToken.node tag :: toks')).length
+      = 3 + (encodePreorder width h_width toks').length := by
+    rw [hbits, List.length_append, htag3]
+  have hfit := hcert.1
+  -- Geometry of the cursor area.
+  have hcur3 : cur + 3 + (encodePreorder width h_width toks').length = z.certEnd := by
+    rw [hcur]; omega
+  have hcurB : z.certBase ≤ cur := by rw [hcur]; omega
+  -- The frame region sits strictly left of the marker area.
+  have hfrlen : fr.length = tag.arity + tag.tagCode + 5 := by
+    rw [hfr, encodeCtrlFrameR_length]
+  have hfrR : fb + fr.length ≤ z.ctrlEnd := by rw [hfb, hfr]; exact hcap
+  have hsep : fb + fr.length < cur - 1 := by
+    have : z.ctrlEnd + 2 < z.certBase := h7
+    omega
+  dsimp only [driverCorridorInv]
+  refine ⟨⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_⟩
+  -- 1. The certificate suffix window at the new cursor (cur + 3), untouched by the update.
+  · have hsuf := windowSpells_append_right tape cur _ _ (by rw [← hbits]; exact hcert)
+    rw [htag3] at hsuf
+    rw [show z.certEnd - (encodePreorder width h_width toks').length = cur + 3 from by omega]
+    obtain ⟨hsf, hsc⟩ := hsuf
+    refine ⟨hsf, fun q hlo hhi => ?_⟩
+    rw [← hsc q hlo hhi]
+    show nodeStepTape tape cur fb fr q = tape q
+    unfold nodeStepTape
+    rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+  -- 2. The certificate fit at the new cursor.
+  · omega
+  -- 3. The new marker at (new cursor) − 1 = cur + 2.
+  · intro p hp
+    rw [show z.certEnd - (encodePreorder width h_width toks').length - 1 = cur + 2 from by omega]
+      at hp
+    show nodeStepTape tape cur fb fr p = true
+    unfold nodeStepTape
+    rw [if_pos hp]
+  -- 4. The consumed/dead corridor up to the new marker: grown ctrl content, erased cells, old zeros.
+  · intro p hp1 hp2
+    rw [show z.certEnd - (encodePreorder width h_width toks').length - 1 = cur + 2 from by omega]
+      at hp2
+    rw [encodeCtrlStackR_cons, List.length_append, ← hfr] at hp1
+    show nodeStepTape tape cur fb fr p = false
+    unfold nodeStepTape
+    rw [if_neg (by omega : ¬((p : Nat) = cur + 2))]
+    by_cases herase : cur - 1 ≤ (p : Nat) ∧ (p : Nat) < cur + 2
+    · rw [if_pos herase]
+    · rw [if_neg herase,
+        if_neg (by omega : ¬(fb ≤ (p : Nat) ∧ (p : Nat) < fb + fr.length))]
+      exact hczeros p (by omega) (by rw [hcur]; omega)
+  -- 5. The output window, untouched.
+  · refine ⟨hout.1, fun q hlo hhi => ?_⟩
+    have := hout.2 q hlo hhi
+    rw [← this]
+    show nodeStepTape tape cur fb fr q = tape q
+    unfold nodeStepTape
+    have hlist : (unaryField out.length ++ encodeGateRecordStream out).length
+        = out.length + 1 + (encodeGateRecordStream out).length := by
+      rw [List.length_append, unaryField_length]
+    rw [hlist] at hhi
+    rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+  -- 6. The output left fit.
+  · exact hofit
+  -- 7. The frontier marker, untouched.
+  · intro p hp
+    have := hFM p hp
+    rw [← this]
+    show nodeStepTape tape cur fb fr p = tape p
+    unfold nodeStepTape
+    rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+  -- 8. The frontier fit.
+  · exact hffit
+  -- 9. The FM→val dead corridor, untouched.
+  · intro p hp1 hp2
+    have := hfzeros p hp1 hp2
+    rw [← this]
+    show nodeStepTape tape cur fb fr p = tape p
+    unfold nodeStepTape
+    rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+  -- 10. The value window, untouched.
+  · refine ⟨hval.1, fun q hlo hhi => ?_⟩
+    have := hval.2 q hlo hhi
+    rw [← this]
+    show nodeStepTape tape cur fb fr q = tape q
+    unfold nodeStepTape
+    have hvE : z.valBase + (encodeNatStackR val).length ≤ z.valEnd := hvfit
+    rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+  -- 11. The value fit.
+  · exact hvfit
+  -- 12. The val→ctrl dead corridor (val unchanged; the frame sits inside the ctrl zone).
+  · intro p hp1 hp2
+    have := hvzeros p hp1 hp2
+    rw [← this]
+    show nodeStepTape tape cur fb fr p = tape p
+    unfold nodeStepTape
+    rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+  -- 13. The control window: the old content untouched, the frame written — the codec cons.
+  · rw [encodeCtrlStackR_cons, ← hfr]
+    refine ⟨by
+      rw [List.length_append]
+      have := hctrl.1
+      omega, fun q hlo hhi => ?_⟩
+    rw [List.length_append] at hhi
+    by_cases hq : (q : Nat) < fb
+    · -- old content
+      rw [List.getD_append _ _ _ _ (by rw [hfb] at hq; omega)]
+      rw [← hctrl.2 q hlo (by rw [hfb] at hq; omega)]
+      show nodeStepTape tape cur fb fr q = tape q
+      unfold nodeStepTape
+      rw [if_neg (by omega), if_neg (by omega), if_neg (by omega)]
+    · -- the frame cells
+      show nodeStepTape tape cur fb fr q
+          = (encodeCtrlStackR ctrl ++ fr).getD ((q : Nat) - z.ctrlBase) false
+      unfold nodeStepTape
+      rw [if_neg (by omega), if_neg (by omega),
+        if_pos (⟨by omega, by omega⟩ : fb ≤ (q : Nat) ∧ (q : Nat) < fb + fr.length),
+        List.getD_append_right _ _ _ _ (by omega)]
+      congr 1
+      omega
+  -- 14. The control fit (the capacity hypothesis).
+  · rw [encodeCtrlStackR_cons, List.length_append, ← hfr]
+    omega
+  -- 15. Validity of the tail.
+  · exact fun t ht => hvalid t (List.mem_cons_of_mem _ ht)
+  -- 16. Settling coherence (still reading).
+  · intro hs; cases hs
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorPushFrame.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorPushFrame.lean
@@ -1,0 +1,107 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
+import Pnp4.Frontier.ContractExpansion.TreeMCSPWriteBits
+
+/-!
+# Corridor frame push — D2t-5b (Block A4a): appending a control frame at the zone's right end
+
+The node arm pushes `(tag, tag.arity)` onto the control stack.  Under the corridor layout the stack
+is right-anchored (`encodeCtrlStackR`, top rightmost), so the push is a **rightward append**: from the
+first free cell past the content (`ctrlBase + |encodeCtrlStackR st.ctrl|`), `writeBits` lays down
+`encodeCtrlFrameR (tag, tag.arity)`, and the grown window spells exactly
+`encodeCtrlStackR ((tag, tag.arity) :: st.ctrl)` — the codec's push equation.
+
+* `writeBits_appends_window` — the generic fact: a `writeBits` run at the right end of a spelled
+  window grows it by the written bits (the old content is outside the write window, hence untouched).
+* `corridor_push_ctrl_frame` — the instantiation against `driverCorridorInv`'s clauses (fits within
+  the control zone's capacity given room for the frame).
+
+**Progress classification (AGENTS.md): Infrastructure** — verifier machine run-throughs; build no
+verifier and prove no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- **`writeBits` appends to a spelled window.**  If `[base, base + |xs|)` spells `xs` and the head
+sits at `base + |xs|` (the first free cell), then after the `writeBits bs` run the window
+`[base, base + |xs| + |bs|)` spells `xs ++ bs` — and every cell outside the write window keeps its
+old value. -/
+theorem writeBits_appends_window {L : Nat} (bs xs : List Bool) (base : Nat)
+    (c : Configuration (M := (writeBits bs).toPhased.toTM) L)
+    (hphase : (c.state.fst : Nat) = 0)
+    (hhead : (c.head : Nat) = base + xs.length)
+    (hroom : (c.head : Nat) + bs.length < (writeBits bs).toPhased.toTM.tapeLength L)
+    (hwin : windowSpells c.tape base xs) :
+    windowSpells (TM.runConfig (M := (writeBits bs).toPhased.toTM) c bs.length).tape base (xs ++ bs)
+    ∧ ((TM.runConfig (M := (writeBits bs).toPhased.toTM) c bs.length).head : Nat)
+        = base + xs.length + bs.length
+    ∧ ∀ q : Fin ((writeBits bs).toPhased.toTM.tapeLength L),
+        ((q : Nat) < base + xs.length ∨ base + xs.length + bs.length ≤ (q : Nat)) →
+        (TM.runConfig (M := (writeBits bs).toPhased.toTM) c bs.length).tape q = c.tape q := by
+  obtain ⟨hph, hhd, htp⟩ := writeBits_runConfig bs c hphase hroom
+  obtain ⟨hfit, hcells⟩ := hwin
+  refine ⟨⟨by rw [List.length_append]; omega, fun q hlo hhi => ?_⟩, by rw [hhd, hhead], fun q hq => ?_⟩
+  · rw [htp q]
+    simp only [List.length_append] at hhi
+    by_cases hqw : (c.head : Nat) ≤ (q : Nat) ∧ (q : Nat) < (c.head : Nat) + bs.length
+    · rw [if_pos hqw, List.getD_append_right _ _ _ _ (by omega)]
+      congr 1
+      omega
+    · rw [if_neg hqw]
+      have hql : (q : Nat) < base + xs.length := by omega
+      rw [hcells q hlo hql, List.getD_append _ _ _ _ (by omega)]
+  · rw [htp q, if_neg (by omega)]
+
+/-- **The corridor control-frame push.**  From the first free cell past the control content, the
+`writeBits (encodeCtrlFrameR (tag, tag.arity))` run grows the control window to spell the pushed
+stack `encodeCtrlStackR ((tag, tag.arity) :: st.ctrl)`, leaves every cell outside the frame window
+untouched, and parks the head on the cell just past the new content. -/
+theorem corridor_push_ctrl_frame {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n) (tag : ITag)
+    (c : Configuration (M := (writeBits (encodeCtrlFrameR (tag, tag.arity))).toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c.tape st)
+    (hphase : (c.state.fst : Nat) = 0)
+    (hhead : (c.head : Nat) = z.ctrlBase + (encodeCtrlStackR st.ctrl).length)
+    (hcap : z.ctrlBase + (encodeCtrlStackR st.ctrl).length
+        + (encodeCtrlFrameR (tag, tag.arity)).length ≤ z.ctrlEnd) :
+    windowSpells (TM.runConfig
+        (M := (writeBits (encodeCtrlFrameR (tag, tag.arity))).toPhased.toTM) c
+        (encodeCtrlFrameR (tag, tag.arity)).length).tape
+      z.ctrlBase (encodeCtrlStackR ((tag, tag.arity) :: st.ctrl))
+    ∧ ((TM.runConfig (M := (writeBits (encodeCtrlFrameR (tag, tag.arity))).toPhased.toTM) c
+        (encodeCtrlFrameR (tag, tag.arity)).length).head : Nat)
+        = z.ctrlBase + (encodeCtrlStackR ((tag, tag.arity) :: st.ctrl)).length
+    ∧ ∀ q : Fin ((writeBits (encodeCtrlFrameR (tag, tag.arity))).toPhased.toTM.tapeLength L),
+        ((q : Nat) < z.ctrlBase + (encodeCtrlStackR st.ctrl).length
+          ∨ z.ctrlBase + (encodeCtrlStackR ((tag, tag.arity) :: st.ctrl)).length ≤ (q : Nat)) →
+        (TM.runConfig (M := (writeBits (encodeCtrlFrameR (tag, tag.arity))).toPhased.toTM) c
+          (encodeCtrlFrameR (tag, tag.arity)).length).tape q = c.tape q := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have hlen : (encodeCtrlStackR ((tag, tag.arity) :: st.ctrl)).length
+      = (encodeCtrlStackR st.ctrl).length + (encodeCtrlFrameR (tag, tag.arity)).length := by
+    rw [encodeCtrlStackR_cons, List.length_append]
+  obtain ⟨hw, hh, hu⟩ := writeBits_appends_window (encodeCtrlFrameR (tag, tag.arity))
+    (encodeCtrlStackR st.ctrl) z.ctrlBase c hphase hhead
+    (by
+      have := hctrl.1
+      omega)
+    hctrl
+  refine ⟨?_, ?_, ?_⟩
+  · rw [encodeCtrlStackR_cons]
+    exact hw
+  · rw [hh, hlen]
+    omega
+  · intro q hq
+    exact hu q (by rw [hlen] at hq; omega)
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorRoutes.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorRoutes.lean
@@ -1,0 +1,213 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
+import Pnp4.Frontier.ContractExpansion.TreeMCSPScanLeftProgram
+
+/-!
+# Corridor routes — D2t-5b (Block A4r): the leftward cross-zone route, machine by machine
+
+The driver's settle/emit arms travel `M → control top → value top → WORK frontier`.  Under
+`driverCorridorInv` (A3, with the strict inter-zone gaps) every leg is one of two proven machines:
+
+* a **0-corridor scan** (`selfLoopScanLeft`: scan left over `0`s, stop on the first `1`), landing on a
+  pinned anchor — the stack's rightmost content cell (`windowSpells_getLast_true`) or the frontier
+  marker `FM`;
+* a **zone walk** (`zoneWalkLeft_runConfig_walkZone`, A4w), crossing a whole stack zone and parking on
+  the dead `0` just left of its base sentinel — exactly where the next scan starts.
+
+This module instantiates the five legs against the invariant's clauses (run lemmas with exact step
+counts, tape unchanged): `corridor_scan_M_to_ctrlTop`, `corridor_walk_ctrl`,
+`corridor_scan_to_valTop`, `corridor_walk_val`, `corridor_scan_to_FM`.  The A5 `driverBody` assembly
+sequences them (each leg is stated on its own component machine, as throughout the toolkit; the
+`seq`-composition layer transfers them into the assembled body).
+
+**Progress classification (AGENTS.md): Infrastructure** — verifier machine run-throughs; build no
+verifier and prove no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- A spelled window whose bit-list ends in `1` pins its **rightmost cell** to `1`. -/
+theorem windowSpells_getLast_true {L : Nat} (tape : Fin L → Bool) (base : Nat) (bits : List Bool)
+    (h : windowSpells tape base bits) (hlast : bits.getLast? = some true) :
+    ∀ p : Fin L, (p : Nat) = base + bits.length - 1 → tape p = true := by
+  intro p hp
+  have hne : bits ≠ [] := by
+    intro hb; rw [hb] at hlast; simp at hlast
+  have hlen : 1 ≤ bits.length := List.length_pos_iff.mpr hne
+  obtain ⟨hfit, hcells⟩ := h
+  rw [hcells p (by omega) (by omega)]
+  have hidx : (p : Nat) - base = bits.length - 1 := by omega
+  rw [hidx, List.getD_eq_getElem?_getD, ← List.getLast?_eq_getElem?, hlast]
+  rfl
+
+/-- **Leg 1 (scan M → control top).**  From the dead cell `cursor − 2` (just left of the cursor
+marker), the leftward 0-scan stops exactly on the control stack's rightmost content cell, in
+`(head − K) + 1` steps where `K = ctrlBase + |encodeCtrlStackR st.ctrl| − 1`, tape unchanged. -/
+theorem corridor_scan_M_to_ctrlTop {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := selfLoopScanLeft.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat)
+      = z.certEnd - (encodePreorder width h_width st.toks).length - 2) :
+    (((TM.runConfig (M := selfLoopScanLeft.toPhased.toTM) c0
+        (((c0.head : Nat) - (z.ctrlBase + (encodeCtrlStackR st.ctrl).length - 1)) + 1)).state).fst
+        : Nat) = 1
+    ∧ ((TM.runConfig (M := selfLoopScanLeft.toPhased.toTM) c0
+        (((c0.head : Nat) - (z.ctrlBase + (encodeCtrlStackR st.ctrl).length - 1)) + 1)).head : Nat)
+        = z.ctrlBase + (encodeCtrlStackR st.ctrl).length - 1
+    ∧ (TM.runConfig (M := selfLoopScanLeft.toPhased.toTM) c0
+        (((c0.head : Nat) - (z.ctrlBase + (encodeCtrlStackR st.ctrl).length - 1)) + 1)).tape
+        = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have hlen1 : 1 ≤ (encodeCtrlStackR st.ctrl).length := by
+    have := encodeCtrlStackR_getLast_true st.ctrl
+    cases hctrl' : encodeCtrlStackR st.ctrl with
+    | nil => rw [hctrl'] at this; simp at this
+    | cons a l => simp
+  exact selfLoopScanLeft_runConfig_terminator c0 hphase
+    (z.ctrlBase + (encodeCtrlStackR st.ctrl).length - 1)
+    (by omega)
+    (fun p hp1 hp2 => hczeros p (by omega) (by omega))
+    (windowSpells_getLast_true c0.tape z.ctrlBase _ hctrl (encodeCtrlStackR_getLast_true st.ctrl))
+
+/-- **Leg 2 (walk the control zone).**  From the control top (every frame's `rem ≥ 1` — the
+reachability fact from `Pending`), the walker crosses the whole control zone and parks on the dead
+`0` at `ctrlBase − 1`, in `walkZoneSteps` steps, tape unchanged. -/
+theorem corridor_walk_ctrl {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hrem : ∀ f ∈ st.ctrl, 1 ≤ f.2)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.ctrlBase + (encodeCtrlStackR st.ctrl).length - 1) :
+    (((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0
+        (walkZoneSteps (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1]))).state).fst : Nat) = 4
+    ∧ ((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0
+        (walkZoneSteps (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1]))).head : Nat)
+        = z.ctrlBase - 1
+    ∧ (TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0
+        (walkZoneSteps (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1]))).tape = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have hlen : (encodeCtrlStackR st.ctrl).length
+      = (walkZone (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1])).length := by
+    rw [encodeCtrlStackR_eq_walkZone]
+  exact zoneWalkLeft_runConfig_walkZone c0
+    (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1])
+    (by
+      intro k hk
+      rw [List.mem_flatMap] at hk
+      obtain ⟨f, hf, hkf⟩ := hk
+      have := hrem f hf
+      simp only [List.mem_cons] at hkf
+      rcases hkf with rfl | rfl | hfalse
+      · omega
+      · omega
+      · simp at hfalse)
+    z.ctrlBase (by omega) hphase
+    (by rw [hhead, hlen])
+    (by rw [← encodeCtrlStackR_eq_walkZone]; exact hctrl)
+    (fun p hp => hvzeros p (by omega) (by omega))
+
+/-- **Leg 3 (scan → value top).**  From the dead cell `ctrlBase − 1`, the leftward 0-scan stops on
+the value stack's rightmost content cell, tape unchanged. -/
+theorem corridor_scan_to_valTop {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := selfLoopScanLeft.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.ctrlBase - 1) :
+    (((TM.runConfig (M := selfLoopScanLeft.toPhased.toTM) c0
+        (((c0.head : Nat) - (z.valBase + (encodeNatStackR st.val).length - 1)) + 1)).state).fst
+        : Nat) = 1
+    ∧ ((TM.runConfig (M := selfLoopScanLeft.toPhased.toTM) c0
+        (((c0.head : Nat) - (z.valBase + (encodeNatStackR st.val).length - 1)) + 1)).head : Nat)
+        = z.valBase + (encodeNatStackR st.val).length - 1
+    ∧ (TM.runConfig (M := selfLoopScanLeft.toPhased.toTM) c0
+        (((c0.head : Nat) - (z.valBase + (encodeNatStackR st.val).length - 1)) + 1)).tape
+        = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have hlen1 : 1 ≤ (encodeNatStackR st.val).length := by
+    cases hv : encodeNatStackR st.val with
+    | nil =>
+        have := encodeNatStackR_getLast_true st.val
+        rw [hv] at this; simp at this
+    | cons a l => simp
+  exact selfLoopScanLeft_runConfig_terminator c0 hphase
+    (z.valBase + (encodeNatStackR st.val).length - 1)
+    (by omega)
+    (fun p hp1 hp2 => hvzeros p (by omega) (by omega))
+    (windowSpells_getLast_true c0.tape z.valBase _ hval (encodeNatStackR_getLast_true st.val))
+
+/-- **Leg 4 (walk the value zone).**  From the value top, the walker crosses the whole value zone
+and parks on the dead `0` at `valBase − 1` (value blocks are `v + 2 ≥ 2` unconditionally), tape
+unchanged. -/
+theorem corridor_walk_val {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.valBase + (encodeNatStackR st.val).length - 1) :
+    (((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0
+        (walkZoneSteps (st.val.map (· + 2)))).state).fst : Nat) = 4
+    ∧ ((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0
+        (walkZoneSteps (st.val.map (· + 2)))).head : Nat) = z.valBase - 1
+    ∧ (TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0
+        (walkZoneSteps (st.val.map (· + 2)))).tape = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have hlen : (encodeNatStackR st.val).length = (walkZone (st.val.map (· + 2))).length := by
+    rw [encodeNatStackR_eq_walkZone]
+  exact zoneWalkLeft_runConfig_walkZone c0 (st.val.map (· + 2))
+    (by
+      intro k hk
+      rw [List.mem_map] at hk
+      obtain ⟨v, -, rfl⟩ := hk
+      omega)
+    z.valBase (by omega) hphase
+    (by rw [hhead, hlen])
+    (by rw [← encodeNatStackR_eq_walkZone]; exact hval)
+    (fun p hp => hfzeros p (by omega) (by omega))
+
+/-- **Leg 5 (scan → the WORK frontier marker).**  From the dead cell `valBase − 1`, the leftward
+0-scan stops exactly on `FM` (the `1` just past the last record), tape unchanged. -/
+theorem corridor_scan_to_FM {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := selfLoopScanLeft.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.valBase - 1) :
+    (((TM.runConfig (M := selfLoopScanLeft.toPhased.toTM) c0
+        (((c0.head : Nat) - (z.workBase + (encodeGateRecordStream st.out).length)) + 1)).state).fst
+        : Nat) = 1
+    ∧ ((TM.runConfig (M := selfLoopScanLeft.toPhased.toTM) c0
+        (((c0.head : Nat) - (z.workBase + (encodeGateRecordStream st.out).length)) + 1)).head : Nat)
+        = z.workBase + (encodeGateRecordStream st.out).length
+    ∧ (TM.runConfig (M := selfLoopScanLeft.toPhased.toTM) c0
+        (((c0.head : Nat) - (z.workBase + (encodeGateRecordStream st.out).length)) + 1)).tape
+        = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  exact selfLoopScanLeft_runConfig_terminator c0 hphase
+    (z.workBase + (encodeGateRecordStream st.out).length)
+    (by omega)
+    (fun p hp1 hp2 => hfzeros p (by omega) (by omega))
+    (fun p hp => hFM p hp)
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorRoutesBack.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorRoutesBack.lean
@@ -1,0 +1,289 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
+import Pnp4.Frontier.ContractExpansion.TreeMCSPGammaScanProgram
+
+/-!
+# Corridor return routes — D2t-5b (Block A4r): the rightward cross-zone route back to the marker
+
+The mirror of `TreeMCSPCorridorRoutes`: after an emit at the WORK frontier the head returns
+`FM → value zone → control zone → M` rightward.  Each leg is a proven machine under
+`driverCorridorInv`:
+
+* a rightward **0-corridor scan** (`gammaSelfLoopScan`) landing on the next zone's **base sentinel**
+  (or the cursor marker `M`) — this module first supplies the arbitrary-configuration
+  scanning/terminator run lemmas the original module states only from `initialConfig`;
+* a rightward **zone traversal** (`zoneWalkRight_runConfig_walkZone`, A4w) exiting on the second dead
+  cell past the zone's content — where the next scan starts.
+
+Legs: `corridor_back_scan_to_valSentinel` (from the cell right of `FM`),
+`corridor_back_walk_val`, `corridor_back_scan_to_ctrlSentinel`, `corridor_back_walk_ctrl`,
+`corridor_back_scan_to_M`.
+
+**Progress classification (AGENTS.md): Infrastructure** — verifier machine run-throughs; build no
+verifier and prove no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-! ### `gammaSelfLoopScan` from an arbitrary configuration -/
+
+/-- Rightward 0-scan invariant from an arbitrary configuration: `j` zero cells from the head, `j`
+steps advance the head `j` cells, still scanning, tape unchanged. -/
+theorem gammaSelfLoopScan_runConfigFrom_scanning {L : Nat}
+    (c0 : Configuration (M := gammaSelfLoopScan.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) :
+    ∀ j : Nat, (c0.head : Nat) + j < gammaSelfLoopScan.toPhased.toTM.tapeLength L →
+      (∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+        (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + j → c0.tape p = false) →
+      (((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0 j).state).fst : Nat) = 0
+      ∧ ((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0 j).head : Nat)
+          = (c0.head : Nat) + j
+      ∧ (TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0 j).tape = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _; exact ⟨hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj h0
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (fun p hp1 hp2 => h0 p hp1 (by omega))
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0 j with hc
+      have hbit : c.tape c.head = false := by
+        rw [htp]; exact h0 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hbnd : (c.head : Nat) + 1 < gammaSelfLoopScan.toPhased.toTM.tapeLength L := by
+        rw [hhd]; omega
+      refine ⟨?_, ?_, ?_⟩
+      · exact gammaSelfLoopScan_stepConfig_scan_zero_phase c
+          (i := c.state.fst) (s := c.state.snd) hph rfl hbit
+      · rw [gammaSelfLoopScan_stepConfig_scan_zero_head c
+          (i := c.state.fst) (s := c.state.snd) hph rfl hbit]
+        simp only [Configuration.moveHead, dif_pos hbnd]
+        rw [hhd]
+        omega
+      · rw [gammaSelfLoopScan_stepConfig_scan_zero_tape c
+          (i := c.state.fst) (s := c.state.snd) hph rfl hbit, htp]
+
+/-- Rightward 0-scan terminator from an arbitrary configuration: with the cells `[head, head + m)`
+all `0` and a `1` at `head + m`, after `m + 1` steps the scan is done (phase `1`) **on** the `1`,
+tape unchanged. -/
+theorem gammaSelfLoopScan_runConfigFrom_terminator {L : Nat}
+    (c0 : Configuration (M := gammaSelfLoopScan.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (m : Nat)
+    (hroom : (c0.head : Nat) + m < gammaSelfLoopScan.toPhased.toTM.tapeLength L)
+    (hzeros : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + m → c0.tape p = false)
+    (hterm : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + m → c0.tape p = true) :
+    (((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0 (m + 1)).state).fst : Nat) = 1
+    ∧ ((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0 (m + 1)).head : Nat)
+        = (c0.head : Nat) + m
+    ∧ (TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0 (m + 1)).tape = c0.tape := by
+  rw [TM.runConfig_add]
+  obtain ⟨hph, hhd, htp⟩ := gammaSelfLoopScan_runConfigFrom_scanning c0 hphase m hroom hzeros
+  set c := TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0 m with hc
+  rw [TM.runConfig_one]
+  have hbit : c.tape c.head = true := by
+    rw [htp]; exact hterm c.head (by rw [hhd])
+  refine ⟨?_, ?_, ?_⟩
+  · exact gammaSelfLoopScan_stepConfig_scan_one_phase c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit
+  · rw [gammaSelfLoopScan_stepConfig_scan_one_head c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit, hhd]
+  · rw [gammaSelfLoopScan_stepConfig_scan_one_tape c
+      (i := c.state.fst) (s := c.state.snd) hph rfl hbit, htp]
+
+/-! ### The five return legs -/
+
+/-- **Return leg 1 (scan → the value zone's base sentinel).**  From the dead cell right of `FM`
+(`head = FM + 1`), the rightward 0-scan stops on the value sentinel at `valBase`. -/
+theorem corridor_back_scan_to_valSentinel {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := gammaSelfLoopScan.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.workBase + (encodeGateRecordStream st.out).length + 1) :
+    (((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0
+        ((z.valBase - (c0.head : Nat)) + 1)).state).fst : Nat) = 1
+    ∧ ((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0
+        ((z.valBase - (c0.head : Nat)) + 1)).head : Nat) = z.valBase
+    ∧ (TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0
+        ((z.valBase - (c0.head : Nat)) + 1)).tape = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have hsent : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (p : Nat) = z.valBase → c0.tape p = true := by
+    intro p hp
+    obtain ⟨hf, hc⟩ := hval
+    have := hc p (by omega) (by
+      have : 1 ≤ (encodeNatStackR st.val).length := by
+        cases hv : encodeNatStackR st.val with
+        | nil =>
+            have := encodeNatStackR_getLast_true st.val
+            rw [hv] at this; simp at this
+        | cons a l => simp
+      omega)
+    rw [this]
+    have hidx : (p : Nat) - z.valBase = 0 := by omega
+    rw [hidx]
+    have : encodeNatStackR st.val = true :: st.val.reverse.flatMap encodeNatEntryR := rfl
+    rw [this]
+    rfl
+  have hm : z.valBase - (c0.head : Nat) = z.valBase - z.workBase
+      - (encodeGateRecordStream st.out).length - 1 := by omega
+  exact (by
+    have := gammaSelfLoopScan_runConfigFrom_terminator c0 hphase (z.valBase - (c0.head : Nat))
+      (by omega)
+      (fun p hp1 hp2 => hfzeros p (by omega) (by omega))
+      (fun p hp => hsent p (by omega))
+    rwa [show (c0.head : Nat) + (z.valBase - (c0.head : Nat)) = z.valBase from by omega] at this)
+
+/-- **Return leg 2 (walk the value zone rightward).**  From the value sentinel, the rightward walker
+crosses the zone and exits on the second dead cell past its content. -/
+theorem corridor_back_walk_val {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.valBase) :
+    (((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0
+        (walkZoneStepsR (st.val.map (· + 2)))).state).fst : Nat) = 4
+    ∧ ((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0
+        (walkZoneStepsR (st.val.map (· + 2)))).head : Nat)
+        = z.valBase + (encodeNatStackR st.val).length + 1
+    ∧ (TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0
+        (walkZoneStepsR (st.val.map (· + 2)))).tape = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have hlen : (encodeNatStackR st.val).length = (walkZone (st.val.map (· + 2))).length := by
+    rw [encodeNatStackR_eq_walkZone]
+  obtain ⟨hf1, hf2, hf3⟩ := zoneWalkRight_runConfig_walkZone c0 (st.val.map (· + 2))
+    (by
+      intro k hk
+      rw [List.mem_map] at hk
+      obtain ⟨v, -, rfl⟩ := hk
+      omega)
+    z.valBase hphase hhead
+    (by rw [← hlen]; omega)
+    (by rw [← encodeNatStackR_eq_walkZone]; exact hval)
+    (fun p hp => hvzeros p (by rw [← hlen] at hp; omega) (by rw [← hlen] at hp; omega))
+    (fun p hp => hvzeros p (by rw [← hlen] at hp; omega) (by rw [← hlen] at hp; omega))
+  exact ⟨hf1, by rw [hf2, ← hlen], hf3⟩
+
+/-- **Return leg 3 (scan → the control zone's base sentinel).** -/
+theorem corridor_back_scan_to_ctrlSentinel {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := gammaSelfLoopScan.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.valBase + (encodeNatStackR st.val).length + 1) :
+    (((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0
+        ((z.ctrlBase - (c0.head : Nat)) + 1)).state).fst : Nat) = 1
+    ∧ ((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0
+        ((z.ctrlBase - (c0.head : Nat)) + 1)).head : Nat) = z.ctrlBase
+    ∧ (TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0
+        ((z.ctrlBase - (c0.head : Nat)) + 1)).tape = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have hsent : ∀ p : Fin (gammaSelfLoopScan.toPhased.toTM.tapeLength L),
+      (p : Nat) = z.ctrlBase → c0.tape p = true := by
+    intro p hp
+    obtain ⟨hf, hc⟩ := hctrl
+    have hlen1 : 1 ≤ (encodeCtrlStackR st.ctrl).length := by
+      cases hv : encodeCtrlStackR st.ctrl with
+      | nil =>
+          have := encodeCtrlStackR_getLast_true st.ctrl
+          rw [hv] at this; simp at this
+      | cons a l => simp
+    have := hc p (by omega) (by omega)
+    rw [this]
+    have hidx : (p : Nat) - z.ctrlBase = 0 := by omega
+    rw [hidx]
+    have : encodeCtrlStackR st.ctrl = true :: st.ctrl.reverse.flatMap encodeCtrlFrameR := rfl
+    rw [this]
+    rfl
+  have := gammaSelfLoopScan_runConfigFrom_terminator c0 hphase (z.ctrlBase - (c0.head : Nat))
+    (by omega)
+    (fun p hp1 hp2 => hvzeros p (by omega) (by omega))
+    (fun p hp => hsent p (by omega))
+  rwa [show (c0.head : Nat) + (z.ctrlBase - (c0.head : Nat)) = z.ctrlBase from by omega] at this
+
+/-- **Return leg 4 (walk the control zone rightward).**  Needs the reachability fact `rem ≥ 1`. -/
+theorem corridor_back_walk_ctrl {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hrem : ∀ f ∈ st.ctrl, 1 ≤ f.2)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.ctrlBase) :
+    (((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0
+        (walkZoneStepsR (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1]))).state).fst : Nat) = 4
+    ∧ ((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0
+        (walkZoneStepsR (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1]))).head : Nat)
+        = z.ctrlBase + (encodeCtrlStackR st.ctrl).length + 1
+    ∧ (TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0
+        (walkZoneStepsR (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1]))).tape = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have hlen : (encodeCtrlStackR st.ctrl).length
+      = (walkZone (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1])).length := by
+    rw [encodeCtrlStackR_eq_walkZone]
+  obtain ⟨hf1, hf2, hf3⟩ := zoneWalkRight_runConfig_walkZone c0
+    (st.ctrl.flatMap fun f => [f.1.tagCode + 2, f.2 + 1])
+    (by
+      intro k hk
+      rw [List.mem_flatMap] at hk
+      obtain ⟨f, hf, hkf⟩ := hk
+      have := hrem f hf
+      simp only [List.mem_cons] at hkf
+      rcases hkf with rfl | rfl | hfalse
+      · omega
+      · omega
+      · simp at hfalse)
+    z.ctrlBase hphase hhead
+    (by rw [← hlen]; omega)
+    (by rw [← encodeCtrlStackR_eq_walkZone]; exact hctrl)
+    (fun p hp => hczeros p (by rw [← hlen] at hp; omega) (by rw [← hlen] at hp; omega))
+    (fun p hp => hczeros p (by rw [← hlen] at hp; omega) (by rw [← hlen] at hp; omega))
+  exact ⟨hf1, by rw [hf2, ← hlen], hf3⟩
+
+/-- **Return leg 5 (scan → the cursor marker `M`).** -/
+theorem corridor_back_scan_to_M {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (st : DriveState n)
+    (c0 : Configuration (M := gammaSelfLoopScan.toPhased.toTM) L)
+    (hinv : driverCorridorInv width h_width z c0.tape st)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = z.ctrlBase + (encodeCtrlStackR st.ctrl).length + 1) :
+    (((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0
+        ((z.certEnd - (encodePreorder width h_width st.toks).length - 1 - (c0.head : Nat)) + 1)).state).fst
+        : Nat) = 1
+    ∧ ((TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0
+        ((z.certEnd - (encodePreorder width h_width st.toks).length - 1 - (c0.head : Nat)) + 1)).head
+        : Nat) = z.certEnd - (encodePreorder width h_width st.toks).length - 1
+    ∧ (TM.runConfig (M := gammaSelfLoopScan.toPhased.toTM) c0
+        ((z.certEnd - (encodePreorder width h_width st.toks).length - 1 - (c0.head : Nat)) + 1)).tape
+        = c0.tape := by
+  obtain ⟨hwf, hcert, hcfit, hM, hczeros, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  have := gammaSelfLoopScan_runConfigFrom_terminator c0 hphase
+    (z.certEnd - (encodePreorder width h_width st.toks).length - 1 - (c0.head : Nat))
+    (by omega)
+    (fun p hp1 hp2 => hczeros p (by omega) (by omega))
+    (fun p hp => hM p (by omega))
+  rwa [show (c0.head : Nat)
+      + (z.certEnd - (encodePreorder width h_width st.toks).length - 1 - (c0.head : Nat))
+      = z.certEnd - (encodePreorder width h_width st.toks).length - 1 from by omega] at this
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCursorStep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCursorStep.lean
@@ -1,0 +1,116 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
+
+/-!
+# `cursorStepTape` — D2t-5b (Block A4a): consuming a certificate token, re-anchored
+
+Every reading arm (`node`, `const`, `input`) advances the cursor the same way: consume the `tlen`-cell
+token, zero its cells and the old marker, plant the new marker on the token's last cell.
+`cursorStepTape tape cur tlen` is that transformer, and `cursorStepTape_cert` re-establishes the four
+**certificate-region** clauses of `driverCorridorInv` for the consumed token list `toks'` — the shared
+spine the three leaf/settle keystones reuse (the output / value / control regions are handled by their
+own transformers, disjoint from the cursor area).
+
+**Progress classification (AGENTS.md): Infrastructure** — a pure tape-window re-anchoring lemma for
+the verified certificate codec; builds no machine and proves no separation.  Standard `[propext,
+Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- A window's spelling depends only on the cells it covers: if `f` and `g` agree on `[base, base +
+|bits|)` and `g` spells `bits` there, so does `f`. -/
+theorem windowSpells_congr {L : Nat} (f g : Fin L → Bool) (base : Nat) (bits : List Bool)
+    (hg : windowSpells g base bits)
+    (hfg : ∀ q : Fin L, base ≤ (q : Nat) → (q : Nat) < base + bits.length → f q = g q) :
+    windowSpells f base bits := by
+  obtain ⟨hfit, hc⟩ := hg
+  exact ⟨hfit, fun q hlo hhi => by rw [hfg q hlo hhi]; exact hc q hlo hhi⟩
+
+/-- The cursor-area marker update for a `tlen`-cell token (`tlen ≥ 1`): plant the new marker on the
+token's last cell (`cur + tlen − 1`), zero the old marker and the token's preceding cells
+(`[cur − 1, cur + tlen − 1)`). -/
+def cursorStepTape {L : Nat} (tape : Fin L → Bool) (cur tlen : Nat) (q : Fin L) : Bool :=
+  if (q : Nat) = cur + tlen - 1 then true
+  else if cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + tlen - 1 then false
+  else tape q
+
+/-- The cursor update is the identity off `[cur − 1, cur + tlen − 1]`. -/
+theorem cursorStepTape_off {L : Nat} (tape : Fin L → Bool) (cur tlen : Nat) (q : Fin L)
+    (h1 : (q : Nat) ≠ cur + tlen - 1) (h2 : ¬ (cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + tlen - 1)) :
+    cursorStepTape tape cur tlen q = tape q := by
+  unfold cursorStepTape
+  rw [if_neg h1, if_neg h2]
+
+/-- **The cursor re-anchoring keystone.**  Consuming a `tlen`-cell token (`1 ≤ tlen`) whose tape image
+is the certificate's leading `tlen` cells, with `tail` nonempty (`1 ≤ |encodePreorder toks'|`) and the
+cursor area sitting strictly right of the corridor's content end `cbound`, the `cursorStepTape`
+re-establishes the four certificate-region clauses for `toks'`:
+
+* the unread suffix `encodePreorder toks'` now spells the window ending at `certEnd`, anchored at the
+  advanced cursor `cur + tlen` (`= certEnd − |encodePreorder toks'|`);
+* the certificate fit;
+* the new marker at `(cur + tlen) − 1`;
+* the consumed/dead corridor `[cbound, (cur + tlen) − 1)` is all `0`.
+
+Here `cur = certEnd − |encodePreorder (tok :: toks')|` and the token image has length `tlen`
+(`encodePreorder (tok :: toks') = tagImage ++ encodePreorder toks'`, `|tagImage| = tlen`). -/
+theorem cursorStepTape_cert {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (tape : Fin L → Bool) (certEnd cbound tlen : Nat) (tok : PreToken n) (toks' : List (PreToken n))
+    (htlen : (encodePreToken width h_width tok).length = tlen) (htpos : 1 ≤ tlen)
+    (hsep : cbound < certEnd - (encodePreorder width h_width (tok :: toks')).length - 1)
+    (hcwin : windowSpells tape (certEnd - (encodePreorder width h_width (tok :: toks')).length)
+      (encodePreorder width h_width (tok :: toks')))
+    (hcfit : 0 + (encodePreorder width h_width (tok :: toks')).length ≤ certEnd)
+    (hcorr : ∀ q : Fin L, cbound ≤ (q : Nat) →
+      (q : Nat) < certEnd - (encodePreorder width h_width (tok :: toks')).length - 1 →
+      tape q = false) :
+    let cur := certEnd - (encodePreorder width h_width (tok :: toks')).length
+    windowSpells (cursorStepTape tape cur tlen) (cur + tlen)
+        (encodePreorder width h_width toks')
+    ∧ (encodePreorder width h_width toks').length ≤ certEnd - (cur + tlen) + (cur + tlen)
+    ∧ (∀ q : Fin L, (q : Nat) = (cur + tlen) - 1 → cursorStepTape tape cur tlen q = true)
+    ∧ (∀ q : Fin L, cbound ≤ (q : Nat) → (q : Nat) < (cur + tlen) - 1 →
+        cursorStepTape tape cur tlen q = false) := by
+  intro cur
+  -- Length bookkeeping.
+  have hbits : encodePreorder width h_width (tok :: toks')
+      = encodePreToken width h_width tok ++ encodePreorder width h_width toks' :=
+    encodePreorder_cons width h_width _ _
+  have hlenc : (encodePreorder width h_width (tok :: toks')).length
+      = tlen + (encodePreorder width h_width toks').length := by
+    rw [hbits, List.length_append, htlen]
+  have hcurB : cur + tlen = certEnd - (encodePreorder width h_width toks').length := by
+    show certEnd - (encodePreorder width h_width (tok :: toks')).length + tlen = _
+    omega
+  refine ⟨?_, ?_, ?_, ?_⟩
+  -- 1. The suffix window at the advanced cursor.
+  · have hsuf := windowSpells_append_right tape cur _ _ (by rw [← hbits]; exact hcwin)
+    rw [htlen] at hsuf
+    refine windowSpells_congr _ tape (cur + tlen) _ hsuf (fun q hlo hhi => ?_)
+    apply cursorStepTape_off
+    · omega
+    · -- q ≥ cur + tlen > cur + tlen - 1, so not in the zeroed band
+      have := hsuf.1; omega
+  -- 2. The fit.
+  · omega
+  -- 3. The new marker.
+  · intro q hq
+    unfold cursorStepTape
+    rw [if_pos (by omega)]
+  -- 4. The consumed/dead corridor.
+  · intro q hlo hhi
+    unfold cursorStepTape
+    rw [if_neg (by omega)]
+    by_cases hband : cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + tlen - 1
+    · rw [if_pos hband]
+    · rw [if_neg hband]
+      -- q is left of the old marker `cur - 1`: it was a corridor `0`.
+      exact hcorr q hlo (by omega)
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
@@ -162,7 +162,7 @@ structure DriverCorridor where
   certEnd : Nat
 
 /-- Corridor zone-chain well-formedness: `outBase < workBase < workEnd ∧ workEnd + 1 < valBase <
-valEnd ∧ valEnd + 1 < ctrlBase < ctrlEnd ∧ ctrlEnd + 1 < certBase ≤ certEnd ≤ L`.  The inter-zone
+valEnd ∧ valEnd + 1 < ctrlBase < ctrlEnd ∧ ctrlEnd + 2 < certBase ≤ certEnd ≤ L`.  The inter-zone
 links guarantee **at least two dead `0` cells** between any zone's content capacity and the next
 zone's content (and before the cursor-marker slot `certBase − 1`) — so every inter-zone hop scan
 starts on a guaranteed-dead cell, and the **rightward** zone walk can tell a block boundary (`0,1`)
@@ -171,7 +171,7 @@ cell; `workBase < workEnd` the frontier marker even with empty WORK.) -/
 def DriverCorridor.WellFormed (z : DriverCorridor) (L : Nat) : Prop :=
   z.outBase < z.workBase ∧ z.workBase < z.workEnd ∧ z.workEnd + 1 < z.valBase
     ∧ z.valBase < z.valEnd ∧ z.valEnd + 1 < z.ctrlBase ∧ z.ctrlBase < z.ctrlEnd
-    ∧ z.ctrlEnd + 1 < z.certBase ∧ z.certBase ≤ z.certEnd ∧ z.certEnd ≤ L
+    ∧ z.ctrlEnd + 2 < z.certBase ∧ z.certBase ≤ z.certEnd ∧ z.certEnd ≤ L
 
 /-- **The corridor strong invariant.**  Live anchors derived from the abstract state (`cursor :=
 certEnd − |enc toks|`); every inter-region corridor is pinned all-`0` and every landing anchor is a

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
@@ -161,16 +161,17 @@ structure DriverCorridor where
   certBase : Nat
   certEnd : Nat
 
-/-- Corridor zone-chain well-formedness: `outBase < workBase < workEnd < valBase < valEnd < ctrlBase <
-ctrlEnd ∧ ctrlEnd + 1 < certBase ≤ certEnd ≤ L`.  The **strict** inter-zone links guarantee at least
-one dead `0` cell between any zone's content capacity and the next zone's content (and between the
-control zone and the cursor-marker slot `certBase − 1`) — so every inter-zone hop scan starts on a
-guaranteed-dead cell, with no zero-gap edge cases.  (`outBase < workBase` keeps the count terminator
+/-- Corridor zone-chain well-formedness: `outBase < workBase < workEnd ∧ workEnd + 1 < valBase <
+valEnd ∧ valEnd + 1 < ctrlBase < ctrlEnd ∧ ctrlEnd + 1 < certBase ≤ certEnd ≤ L`.  The inter-zone
+links guarantee **at least two dead `0` cells** between any zone's content capacity and the next
+zone's content (and before the cursor-marker slot `certBase − 1`) — so every inter-zone hop scan
+starts on a guaranteed-dead cell, and the **rightward** zone walk can tell a block boundary (`0,1`)
+from the zone exit (`0,0`) with a single peek.  (`outBase < workBase` keeps the count terminator
 cell; `workBase < workEnd` the frontier marker even with empty WORK.) -/
 def DriverCorridor.WellFormed (z : DriverCorridor) (L : Nat) : Prop :=
-  z.outBase < z.workBase ∧ z.workBase < z.workEnd ∧ z.workEnd < z.valBase ∧ z.valBase < z.valEnd
-    ∧ z.valEnd < z.ctrlBase ∧ z.ctrlBase < z.ctrlEnd ∧ z.ctrlEnd + 1 < z.certBase
-    ∧ z.certBase ≤ z.certEnd ∧ z.certEnd ≤ L
+  z.outBase < z.workBase ∧ z.workBase < z.workEnd ∧ z.workEnd + 1 < z.valBase
+    ∧ z.valBase < z.valEnd ∧ z.valEnd + 1 < z.ctrlBase ∧ z.ctrlBase < z.ctrlEnd
+    ∧ z.ctrlEnd + 1 < z.certBase ∧ z.certBase ≤ z.certEnd ∧ z.certEnd ≤ L
 
 /-- **The corridor strong invariant.**  Live anchors derived from the abstract state (`cursor :=
 certEnd − |enc toks|`); every inter-region corridor is pinned all-`0` and every landing anchor is a

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
@@ -161,13 +161,15 @@ structure DriverCorridor where
   certBase : Nat
   certEnd : Nat
 
-/-- Corridor zone-chain well-formedness: `outBase < workBase < workEnd ≤ valBase < valEnd ≤ ctrlBase <
-ctrlEnd < certBase ≤ certEnd ≤ L` (`ctrlEnd < certBase` leaves the cell `certBase − 1` for the initial
-cursor marker; `outBase < workBase` the count terminator cell; `workBase < workEnd` the frontier
-marker even with empty WORK). -/
+/-- Corridor zone-chain well-formedness: `outBase < workBase < workEnd < valBase < valEnd < ctrlBase <
+ctrlEnd ∧ ctrlEnd + 1 < certBase ≤ certEnd ≤ L`.  The **strict** inter-zone links guarantee at least
+one dead `0` cell between any zone's content capacity and the next zone's content (and between the
+control zone and the cursor-marker slot `certBase − 1`) — so every inter-zone hop scan starts on a
+guaranteed-dead cell, with no zero-gap edge cases.  (`outBase < workBase` keeps the count terminator
+cell; `workBase < workEnd` the frontier marker even with empty WORK.) -/
 def DriverCorridor.WellFormed (z : DriverCorridor) (L : Nat) : Prop :=
-  z.outBase < z.workBase ∧ z.workBase < z.workEnd ∧ z.workEnd ≤ z.valBase ∧ z.valBase < z.valEnd
-    ∧ z.valEnd ≤ z.ctrlBase ∧ z.ctrlBase < z.ctrlEnd ∧ z.ctrlEnd < z.certBase
+  z.outBase < z.workBase ∧ z.workBase < z.workEnd ∧ z.workEnd < z.valBase ∧ z.valBase < z.valEnd
+    ∧ z.valEnd < z.ctrlBase ∧ z.ctrlBase < z.ctrlEnd ∧ z.ctrlEnd + 1 < z.certBase
     ∧ z.certBase ≤ z.certEnd ∧ z.certEnd ≤ L
 
 /-- **The corridor strong invariant.**  Live anchors derived from the abstract state (`cursor :=

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPDriverCorridor.lean
@@ -22,8 +22,9 @@ scan over a guaranteed-all-`0` corridor onto a guaranteed-`1` anchor**:
   exactly on the next stack's top; each stack carries a permanent **base sentinel `1`** at its base
   cell, so the same scan is sound when the stack is empty — and "control stack empty" (the A1b sink
   test) becomes *land on a `1`, peek one cell left: a `0` means the base sentinel* (frame tag blocks
-  carry **`tagCode + 2 ≥ 2` ones** and value blocks **`v + 2 ≥ 2` ones**, so during a zone walk a
-  field edge is never confused with the single-`1` sentinel);
+  carry **`tagCode + 2 ≥ 2` ones**, frame remaining-count blocks **`rem + 1 ≥ 2` ones**, and value
+  blocks **`v + 2 ≥ 2` ones**, so during a zone walk no block edge is ever confused with the
+  single-`1` sentinel);
 * the **WORK frontier marker** `FM` is a single `1` just past the last record: the hop val → frontier
   is a leftward 0-scan onto `FM`; a record append overwrites `FM` and re-plants it at the new
   frontier.  Inside a record, the A2 transfer's home delimiters come for free: every operand field is
@@ -96,14 +97,18 @@ theorem encodeNatStackR_length (S : List Nat) :
   | nil => rfl
   | cons v rest ih => rw [encodeNatStackR_cons]; simp [encodeNatEntryR, ih]; omega
 
-/-- A right-anchored control frame: `[0] ++ 1^rem ++ [0] ++ 1^(tagCode+2)` — read right-to-left: the
-tag block (**≥ 2 ones**, distinguishing a frame's right edge from the single-`1` base sentinel), a `0`
-separator, the remaining-count block, the left `0` delimiter. -/
+/-- A right-anchored control frame: `[0] ++ 1^(rem+1) ++ [0] ++ 1^(tagCode+2)` — read right-to-left:
+the tag block, a `0` separator, the remaining-count block, the left `0` delimiter.  **Both** blocks
+carry `≥ 2` ones (`tagCode + 2 ≥ 2`; `rem + 1 ≥ 2` since reachable `rem ≥ 1`), so during a zone walk
+*neither* edge of a frame is ever confused with the single-`1` base sentinel — the `rem` block with
+`rem = 1` (every `tnot` frame; `tand`/`tor` before the pop) would otherwise be a bare `1` and stop the
+walker mid-zone. -/
 def encodeCtrlFrameR : ITag × Nat → List Bool
-  | (tag, rem) => false :: (List.replicate rem true ++ (false :: List.replicate (tag.tagCode + 2) true))
+  | (tag, rem) =>
+      false :: (List.replicate (rem + 1) true ++ (false :: List.replicate (tag.tagCode + 2) true))
 
 @[simp] theorem encodeCtrlFrameR_length (tag : ITag) (rem : Nat) :
-    (encodeCtrlFrameR (tag, rem)).length = rem + tag.tagCode + 4 := by
+    (encodeCtrlFrameR (tag, rem)).length = rem + tag.tagCode + 5 := by
   simp [encodeCtrlFrameR]; omega
 
 /-- The right-anchored control stack: base sentinel `1`, then the frames bottom-to-top left-to-right
@@ -129,7 +134,8 @@ theorem encodeCtrlStackR_getLast_true (S : List (ITag × Nat)) :
       rw [encodeCtrlStackR_cons, List.getLast?_append_of_ne_nil]
       · show (encodeCtrlFrameR (tag, rem)).getLast? = some true
         rw [show encodeCtrlFrameR (tag, rem)
-            = ([false] ++ List.replicate rem true) ++ ([false] ++ List.replicate (tag.tagCode + 2) true)
+            = ([false] ++ List.replicate (rem + 1) true)
+              ++ ([false] ++ List.replicate (tag.tagCode + 2) true)
             from by simp [encodeCtrlFrameR]]
         rw [List.getLast?_append_of_ne_nil]
         · rw [List.getLast?_append_of_ne_nil]

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEmitTape.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEmitTape.lean
@@ -1,0 +1,131 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
+
+/-!
+# `emitTape` — D2t-5b (Block A4a): the output-region update of a leaf emit
+
+Both leaf arms (`const`, `input`) do the same thing to the output region: **increment the unary gate
+count** (prepend one `1` at the count field's left, `out.length → out.length + 1`) and **append the
+new gate record** at the frontier marker `FM`, replanting `FM` just past it.  `emitTape` is that
+output-region transformer, and `emitTape_output_window` proves it turns the invariant's output window
+for `out` into the one for `out ++ [g]`:
+
+```
+unaryField (out.length+1) ++ encodeGateRecordStream (out ++ [g])
+  = [1] ++ (unaryField out.length ++ encodeGateRecordStream out) ++ encodeGateRecord g
+```
+
+i.e. the count window grows one cell **left** of its old anchor, the records grow one record **right**
+at the old `FM`, and everything between is untouched — so the new window still spells
+`encodeGateStream (out ++ [g])` (`driverStrongInv_out_encodeGateStream`'s shape).  `emitTape_FM` plants
+the new frontier marker.  These are the reusable output-region facts the `const`/`input` keystones
+consume; the cursor-area and value-stack updates are handled separately (as in the node keystone).
+
+**Progress classification (AGENTS.md): Infrastructure** — a pure tape-window update lemma for the
+verified gate-stream codec; builds no machine and proves no separation.  Standard `[propext,
+Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- The output-region transformer of a leaf emit: a fresh `1` at the count field's new left end
+(`oc − 1`, where `oc = workBase − 1 − out.length` is the old count anchor); the new record `rec` at
+the old frontier `[fm, fm + |rec|)`; the new frontier marker `1` at `fm + |rec|`; else unchanged. -/
+def emitTape {L : Nat} (tape : Fin L → Bool) (oc fm : Nat) (rec : List Bool) (q : Fin L) : Bool :=
+  if (q : Nat) = oc - 1 then true
+  else if fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length then rec.getD ((q : Nat) - fm) false
+  else if (q : Nat) = fm + rec.length then true
+  else tape q
+
+/-- The gate-stream window grows by exactly `[1]` on the left and `encodeGateRecord g` on the right:
+`unaryField (c+1) ++ encodeGateRecordStream (out ++ [g])
+  = true :: (unaryField c ++ encodeGateRecordStream out) ++ encodeGateRecord g`, where `c = |out|`. -/
+theorem gateStream_emit_eq {n : Nat} (out : List (SLGate n)) (g : SLGate n) :
+    unaryField (out.length + 1) ++ encodeGateRecordStream (out ++ [g])
+      = (true :: (unaryField out.length ++ encodeGateRecordStream out)) ++ encodeGateRecord g := by
+  have hrec : encodeGateRecordStream (out ++ [g])
+      = encodeGateRecordStream out ++ encodeGateRecord g := by
+    induction out with
+    | nil => simp [encodeGateRecordStream]
+    | cons a l ih => simp only [List.cons_append, encodeGateRecordStream, ih, List.append_assoc]
+  have hcount : unaryField (out.length + 1) = true :: unaryField out.length := by
+    simp [unaryField, List.replicate_succ]
+  rw [hrec, hcount]
+  simp [List.append_assoc]
+
+/-- **The output window after a leaf emit.**  If, before the emit, the combined output window at
+`oc = workBase − 1 − |out|` spells `unaryField |out| ++ encodeGateRecordStream out`, the frontier
+marker `fm = workBase + |encodeGateRecordStream out|` is just past the records, and there is room to
+the left (`1 ≤ oc`), then after `emitTape` the window at `oc − 1` spells
+`unaryField |out+1| ++ encodeGateRecordStream (out ++ [g])` — the invariant's output clause for the
+emitted state. -/
+theorem emitTape_output_window {n L : Nat} (tape : Fin L → Bool) (oc : Nat) (out : List (SLGate n))
+    (g : SLGate n) (hoc : 1 ≤ oc)
+    (hwin : windowSpells tape oc (unaryField out.length ++ encodeGateRecordStream out))
+    (hfmrec : oc + (unaryField out.length ++ encodeGateRecordStream out).length
+        = oc + out.length + 1 + (encodeGateRecordStream out).length)
+    (hfit : oc + (unaryField out.length ++ encodeGateRecordStream out).length
+        + (encodeGateRecord g).length < L) :
+    windowSpells (emitTape tape (oc - 1 + 1)
+        (oc + (unaryField out.length ++ encodeGateRecordStream out).length)
+        (encodeGateRecord g))
+      (oc - 1)
+      (unaryField (out.length + 1) ++ encodeGateRecordStream (out ++ [g])) := by
+  obtain ⟨hwfit, hwc⟩ := hwin
+  -- Abbreviations and lengths.
+  set body := unaryField out.length ++ encodeGateRecordStream out with hbody
+  set fm := oc + body.length with hfm
+  set rec := encodeGateRecord g with hrec
+  have hbl : body.length = out.length + 1 + (encodeGateRecordStream out).length := by
+    rw [hbody, List.length_append, unaryField_length]
+  have hsucc : oc - 1 + 1 = oc := by omega
+  rw [hsucc, gateStream_emit_eq, ← hbody, ← hrec]
+  -- The target window: (true :: body) ++ rec, at base oc - 1.
+  have hcl : ((true :: body) ++ rec).length = body.length + 1 + rec.length := by
+    simp only [List.length_append, List.length_cons]
+  refine ⟨?_, fun q hlo hhi => ?_⟩
+  · rw [hcl]; omega
+  · -- Cell value at q ∈ [oc-1, oc-1 + (1 + |body| + |rec|)).
+    rw [hcl] at hhi
+    unfold emitTape
+    by_cases h0 : (q : Nat) = oc - 1
+    · rw [if_pos (by omega), show (q : Nat) - (oc - 1) = 0 from by omega]
+      rw [List.getD_append (true :: body) rec false 0 (by simp)]
+      rfl
+    · rw [if_neg (by omega)]
+      by_cases h1 : fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length
+      · -- the new record
+        rw [if_pos h1,
+          List.getD_append_right (true :: body) rec false ((q : Nat) - (oc - 1))
+            (by simp only [List.length_cons]; rw [hfm] at h1; omega)]
+        congr 1
+        simp only [List.length_cons]; rw [hfm] at h1 ⊢; omega
+      · rw [if_neg h1]
+        by_cases h2 : (q : Nat) = fm + rec.length
+        · -- past the records: the window ends at fm + |rec|, excluded by hhi
+          exfalso; rw [hfm] at h2; omega
+        · rw [if_neg h2]
+          -- inside body: transport from the old window.
+          have hqbody : oc ≤ (q : Nat) ∧ (q : Nat) < oc + body.length := by
+            rw [hfm] at h1 h2; omega
+          rw [hwc q (by omega) (by omega)]
+          have hidx : (q : Nat) - (oc - 1) = ((q : Nat) - oc) + 1 := by omega
+          rw [hidx,
+            List.getD_append (true :: body) rec false ((q : Nat) - oc + 1)
+              (by simp only [List.length_cons]; omega),
+            List.getD_cons_succ]
+
+/-- After `emitTape`, the new frontier marker sits at `fm + |rec|`. -/
+theorem emitTape_FM {L : Nat} (tape : Fin L → Bool) (oc fm : Nat) (rec : List Bool)
+    (hfm : oc - 1 < fm) :
+    ∀ q : Fin L, (q : Nat) = fm + rec.length → emitTape tape oc fm rec q = true := by
+  intro q hq
+  unfold emitTape
+  rw [if_neg (by omega), if_neg (by omega), if_pos hq]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEraseLeftMark.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPEraseLeftMark.lean
@@ -1,0 +1,193 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
+
+/-!
+# `eraseLeftMark` — D2t-5b (Block A4a): plant the new cursor marker, erase the consumed token
+
+After a token's cells have been read (the head resting on its **last** cell), the reading arm must
+**advance the cursor**: the last consumed cell becomes the **new marker** `M` (write `1`), and the
+`w` cells to its left — the token's remaining cells and the **old** marker — are erased to `0`,
+re-establishing the all-`0` corridor between the control zone and the new marker.  `eraseLeftMark w`
+is that fixed-width writer (the width `w` is per-arm: `3` for a node token — two leading tag cells
+plus the old marker — `4` for a `const` leaf, `3 + width` for an `input` leaf), ending `w` cells left
+of the marker, exactly where the leftward corridor scan of the next leg starts.
+
+Phases: φ0 — write `1` (the new marker), step left; φ1 … φw — write `0`, step left; φ(w+1) — accept
+(the head rests on the cell `w + 1` left of the marker).
+
+**Progress classification (AGENTS.md): Infrastructure** — a verifier machine component; builds no
+verifier and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- **Plant-and-erase**: write `1` at the head (the new marker), then erase `w` cells leftward,
+ending a further cell left.  `w + 2` phases: φ0 the marker write, φ1…φw the erasures, φ(w+1) accept. -/
+def eraseLeftMark (w : Nat) : ConstStatePhasedProgram Unit where
+  numPhases := w + 2
+  startPhase := ⟨0, by omega⟩
+  startState := ()
+  acceptPhase := ⟨w + 1, by omega⟩
+  acceptState := ()
+  transition := fun i _ _ =>
+    if h : i.val = 0 then
+      (⟨1, by omega⟩, (), true, Move.left)
+    else if h2 : i.val ≤ w then
+      (⟨i.val + 1, by omega⟩, (), false, Move.left)
+    else
+      (⟨w + 1, by omega⟩, (), false, Move.stay)
+  timeBound := fun n => n
+
+@[simp] theorem eraseLeftMark_numPhases (w : Nat) : (eraseLeftMark w).numPhases = w + 2 := rfl
+
+@[simp] theorem eraseLeftMark_startPhase (w : Nat) : ((eraseLeftMark w).startPhase : Nat) = 0 := rfl
+
+@[simp] theorem eraseLeftMark_acceptPhase (w : Nat) :
+    ((eraseLeftMark w).acceptPhase : Nat) = w + 1 := rfl
+
+/-- φ0 marker-write step: phase to `1`. -/
+theorem eraseLeftMark_stepConfig_p0_phase {w L : Nat}
+    (c : Configuration (M := (eraseLeftMark w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (eraseLeftMark w).toPhased.toTM) c).state).fst.val = 1 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, eraseLeftMark, hi]
+
+theorem eraseLeftMark_stepConfig_p0_head {w L : Nat}
+    (c : Configuration (M := (eraseLeftMark w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (eraseLeftMark w).toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, eraseLeftMark, hi]
+
+theorem eraseLeftMark_stepConfig_p0_tape {w L : Nat}
+    (c : Configuration (M := (eraseLeftMark w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (eraseLeftMark w).toPhased.toTM) c).tape
+      = c.write c.head true := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, eraseLeftMark, hi]
+
+/-- Erasure step (`1 ≤ i ≤ w`): phase advances, head left, the cell is zeroed. -/
+theorem eraseLeftMark_stepConfig_erase_phase {w L : Nat}
+    (c : Configuration (M := (eraseLeftMark w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi1 : 1 ≤ i.val) (hi2 : i.val ≤ w) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := (eraseLeftMark w).toPhased.toTM) c).state).fst.val = i.val + 1 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, eraseLeftMark, Nat.ne_of_gt hi1, hi2]
+
+theorem eraseLeftMark_stepConfig_erase_head {w L : Nat}
+    (c : Configuration (M := (eraseLeftMark w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi1 : 1 ≤ i.val) (hi2 : i.val ≤ w) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (eraseLeftMark w).toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.left := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, eraseLeftMark, Nat.ne_of_gt hi1, hi2]
+
+theorem eraseLeftMark_stepConfig_erase_tape {w L : Nat}
+    (c : Configuration (M := (eraseLeftMark w).toPhased.toTM) L)
+    {i : Fin (w + 2)} {s : Unit} (hi1 : 1 ≤ i.val) (hi2 : i.val ≤ w) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := (eraseLeftMark w).toPhased.toTM) c).tape
+      = c.write c.head false := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, eraseLeftMark, Nat.ne_of_gt hi1, hi2]
+
+/-- **The plant-and-erase run.**  From φ0 at head `p` with `w + 1 ≤ p`, after `w + 1` steps: the
+machine accepts at `p − (w + 1)`; the cell `p` holds `1` (the new marker), the cells
+`[p − w, p)` hold `0` (the erased token/marker), and every other cell is untouched. -/
+theorem eraseLeftMark_runConfig {w L : Nat}
+    (c0 : Configuration (M := (eraseLeftMark w).toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (hh : w + 1 ≤ (c0.head : Nat)) :
+    (((TM.runConfig (M := (eraseLeftMark w).toPhased.toTM) c0 (w + 1)).state).fst : Nat) = w + 1
+    ∧ ((TM.runConfig (M := (eraseLeftMark w).toPhased.toTM) c0 (w + 1)).head : Nat)
+        = (c0.head : Nat) - (w + 1)
+    ∧ ∀ q : Fin ((eraseLeftMark w).toPhased.toTM.tapeLength L),
+        (TM.runConfig (M := (eraseLeftMark w).toPhased.toTM) c0 (w + 1)).tape q
+          = if (q : Nat) = (c0.head : Nat) then true
+            else if (c0.head : Nat) - w ≤ (q : Nat) ∧ (q : Nat) < (c0.head : Nat) then false
+            else c0.tape q := by
+  -- Invariant after 1 + j steps (j ≤ w): phase 1 + j, head = p − (1 + j), marker planted, j cells erased.
+  suffices H : ∀ j : Nat, j ≤ w →
+      (((TM.runConfig (M := (eraseLeftMark w).toPhased.toTM) c0 (1 + j)).state).fst : Nat) = 1 + j
+      ∧ ((TM.runConfig (M := (eraseLeftMark w).toPhased.toTM) c0 (1 + j)).head : Nat)
+          = (c0.head : Nat) - (1 + j)
+      ∧ ∀ q : Fin ((eraseLeftMark w).toPhased.toTM.tapeLength L),
+          (TM.runConfig (M := (eraseLeftMark w).toPhased.toTM) c0 (1 + j)).tape q
+            = if (q : Nat) = (c0.head : Nat) then true
+              else if (c0.head : Nat) - j ≤ (q : Nat) ∧ (q : Nat) < (c0.head : Nat) then false
+              else c0.tape q by
+    have := H w (le_refl w)
+    rwa [show 1 + w = w + 1 from by omega] at this
+  intro j
+  induction j with
+  | zero =>
+      intro _
+      rw [TM.runConfig_one]
+      have hst0 : c0.state = ⟨c0.state.fst, c0.state.snd⟩ := rfl
+      refine ⟨?_, ?_, ?_⟩
+      · exact eraseLeftMark_stepConfig_p0_phase c0 hphase hst0
+      · rw [eraseLeftMark_stepConfig_p0_head c0 hphase hst0]
+        simp only [Configuration.moveHead, dif_neg (by omega : ¬ (c0.head : Nat) = 0)]
+      · intro q
+        rw [eraseLeftMark_stepConfig_p0_tape c0 hphase hst0]
+        by_cases hq : q = c0.head
+        · subst hq; simp [Configuration.write]
+        · have hqn : (q : Nat) ≠ (c0.head : Nat) := fun h => hq (Fin.ext h)
+          simp only [Configuration.write, dif_neg hq]
+          rw [if_neg hqn,
+            if_neg (by omega : ¬((c0.head : Nat) - 0 ≤ (q : Nat) ∧ (q : Nat) < (c0.head : Nat)))]
+  | succ j ih =>
+      intro hj
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega)
+      rw [show 1 + (j + 1) = (1 + j) + 1 from by omega, TM.runConfig_succ]
+      set c := TM.runConfig (M := (eraseLeftMark w).toPhased.toTM) c0 (1 + j) with hc
+      have hst : c.state = ⟨c.state.fst, c.state.snd⟩ := rfl
+      have hi1 : 1 ≤ (c.state.fst : Nat) := by omega
+      have hi2 : (c.state.fst : Nat) ≤ w := by omega
+      refine ⟨?_, ?_, ?_⟩
+      · rw [eraseLeftMark_stepConfig_erase_phase c hi1 hi2 hst, hph]
+      · rw [eraseLeftMark_stepConfig_erase_head c hi1 hi2 hst]
+        simp only [Configuration.moveHead, dif_neg (by rw [hhd]; omega : ¬ (c.head : Nat) = 0)]
+        rw [hhd]
+        omega
+      · intro q
+        rw [eraseLeftMark_stepConfig_erase_tape c hi1 hi2 hst]
+        by_cases hq : q = c.head
+        · subst hq
+          have hqv : (c.head : Nat) = (c0.head : Nat) - (1 + j) := hhd
+          rw [if_neg (show ¬((c.head : Nat) = (c0.head : Nat)) by omega),
+            if_pos (show (c0.head : Nat) - (j + 1) ≤ (c.head : Nat)
+              ∧ (c.head : Nat) < (c0.head : Nat) by omega)]
+          simp [Configuration.write]
+        · have hqn : (q : Nat) ≠ (c.head : Nat) := fun h => hq (Fin.ext h)
+          simp only [Configuration.write, dif_neg hq]
+          rw [htp q]
+          have hqv : (c.head : Nat) = (c0.head : Nat) - (1 + j) := hhd
+          by_cases h1 : (q : Nat) = (c0.head : Nat)
+          · rw [if_pos h1, if_pos h1]
+          · rw [if_neg h1, if_neg h1]
+            by_cases h2 : (c0.head : Nat) - j ≤ (q : Nat) ∧ (q : Nat) < (c0.head : Nat)
+            · rw [if_pos h2, if_pos (by omega)]
+            · rw [if_neg h2, if_neg (by omega)]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPValPush.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPValPush.lean
@@ -1,0 +1,71 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
+
+/-!
+# `valPushTape` — D2t-5b (Block A4a): writing a block at a window's right end
+
+A driver value-stack push writes a new top **entry** just past the current right-anchored stack
+encoding (`encodeNatStackR (v :: val) = encodeNatStackR val ++ encodeNatEntryR v`).  `valPushTape` is
+the generic "write `ys` into the `|ys|` cells starting at `base + |xs|`, leave everything else fixed"
+transformer, and `windowSpells_writeAppend` proves it extends a window spelling `xs` to one spelling
+`xs ++ ys`.  Reused by both leaf arms' value-stack push and by the settle pop-emit's pushed index.
+
+**Progress classification (AGENTS.md): Infrastructure** — a pure tape-window append lemma; builds no
+machine and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- Write `ys` into the cells `[wbase, wbase + |ys|)`, leaving every other cell fixed. -/
+def writeBlockTape {L : Nat} (tape : Fin L → Bool) (wbase : Nat) (ys : List Bool) (q : Fin L) : Bool :=
+  if wbase ≤ (q : Nat) ∧ (q : Nat) < wbase + ys.length then ys.getD ((q : Nat) - wbase) false
+  else tape q
+
+/-- **Append a written block to a spelled window.**  If the window `[base, base + |xs|)` spells `xs`,
+then writing `ys` at `base + |xs|` (with room) yields a window `[base, base + |xs| + |ys|)` spelling
+`xs ++ ys`. -/
+theorem windowSpells_writeAppend {L : Nat} (tape : Fin L → Bool) (base : Nat) (xs ys : List Bool)
+    (hwin : windowSpells tape base xs) (hfit : base + xs.length + ys.length ≤ L) :
+    windowSpells (writeBlockTape tape (base + xs.length) ys) base (xs ++ ys) := by
+  obtain ⟨hxfit, hxc⟩ := hwin
+  refine ⟨by rw [List.length_append]; omega, fun q hlo hhi => ?_⟩
+  rw [List.length_append] at hhi
+  unfold writeBlockTape
+  by_cases hq : (q : Nat) < base + xs.length
+  · -- inside the old window xs
+    rw [if_neg (by omega), hxc q hlo hq, List.getD_append _ _ _ _ (by omega)]
+  · -- inside the freshly-written ys
+    rw [if_pos ⟨by omega, by omega⟩,
+      List.getD_append_right _ _ _ _ (by omega)]
+    congr 1
+    omega
+
+/-- Writing a block leaves cells left of its base untouched. -/
+theorem writeBlockTape_below {L : Nat} (tape : Fin L → Bool) (wbase : Nat) (ys : List Bool)
+    (q : Fin L) (hq : (q : Nat) < wbase) : writeBlockTape tape wbase ys q = tape q := by
+  unfold writeBlockTape
+  rw [if_neg (by omega)]
+
+/-- Writing a block leaves cells at or past its end untouched. -/
+theorem writeBlockTape_above {L : Nat} (tape : Fin L → Bool) (wbase : Nat) (ys : List Bool)
+    (q : Fin L) (hq : wbase + ys.length ≤ (q : Nat)) : writeBlockTape tape wbase ys q = tape q := by
+  unfold writeBlockTape
+  rw [if_neg (by omega)]
+
+/-- The value-stack push as a block append: writing `encodeNatEntryR v` at the value zone's right end
+turns `encodeNatStackR val` into `encodeNatStackR (v :: val)`. -/
+theorem valPush_window {L : Nat} (tape : Fin L → Bool) (valBase v : Nat) (val : List Nat)
+    (hwin : windowSpells tape valBase (encodeNatStackR val))
+    (hfit : valBase + (encodeNatStackR val).length + (encodeNatEntryR v).length ≤ L) :
+    windowSpells (writeBlockTape tape (valBase + (encodeNatStackR val).length) (encodeNatEntryR v))
+      valBase (encodeNatStackR (v :: val)) := by
+  rw [encodeNatStackR_cons]
+  exact windowSpells_writeAppend tape valBase (encodeNatStackR val) (encodeNatEntryR v) hwin hfit
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkFull.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkFull.lean
@@ -1,0 +1,177 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
+
+/-!
+# `zoneWalkLeft` full-zone walk — D2t-5b (Block A4w): the multi-block traversal
+
+The headline of the A4w walker line: from the rightmost content cell of a corridor stack zone,
+`zoneWalkLeft` traverses **every** block and stops, done, on the dead `0` just left of the base
+sentinel — in exactly `Σ (kᵢ + 3) + 2` steps, tape unchanged.
+
+The zone is abstracted as a **block list** `ks` (top-first; each block `≥ 2` ones — the corridor
+discipline): on tape it spells `walkZone ks = [1] ++ flatMap (fun k => [0] ++ 1^k) ks.reverse`
+(sentinel at `base`, blocks bottom-to-top left-to-right).  Both corridor codecs are instances:
+`encodeNatStackR S` is `walkZone (S.map (· + 2))` and `encodeCtrlStackR S` is
+`walkZone (S.flatMap fun (tag, rem) => [tag.tagCode + 2, rem + 1])` — proven here as the two
+instantiation equations, so the walk lemma applies to both stacks directly.
+
+Proof: induction on `ks`, stitching `zoneWalkLeft_runConfig_field_segment` (the top block's pass,
+`k + 3` steps, lands at φ0 on the next block's rightmost cell) and
+`zoneWalkLeft_runConfig_sentinel` (the base case, `2` steps) through `TM.runConfig_add`, with the
+pointwise tape facts extracted from the `windowSpells` hypothesis.
+
+**Progress classification (AGENTS.md): Infrastructure** — a verifier machine run-through; builds no
+verifier and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- A corridor zone as the walker sees it: the base sentinel `1`, then the blocks bottom-to-top
+left-to-right (`ks` lists them **top-first**), each block `[0] ++ 1^k`. -/
+def walkZone (ks : List Nat) : List Bool :=
+  true :: ks.reverse.flatMap (fun k => false :: List.replicate k true)
+
+@[simp] theorem walkZone_nil : walkZone [] = [true] := rfl
+
+@[simp] theorem walkZone_cons (k : Nat) (ks : List Nat) :
+    walkZone (k :: ks) = walkZone ks ++ (false :: List.replicate k true) := by
+  unfold walkZone
+  rw [List.reverse_cons, List.flatMap_append]
+  simp
+
+theorem walkZone_length (ks : List Nat) :
+    (walkZone ks).length = 1 + (ks.map (· + 1)).sum := by
+  induction ks with
+  | nil => rfl
+  | cons k ks ih => rw [walkZone_cons]; simp [ih]; omega
+
+/-- The value stack is a walk zone: blocks `v + 2`, top-first. -/
+theorem encodeNatStackR_eq_walkZone (S : List Nat) :
+    encodeNatStackR S = walkZone (S.map (· + 2)) := by
+  induction S with
+  | nil => rfl
+  | cons v rest ih =>
+      rw [encodeNatStackR_cons, ih, List.map_cons, walkZone_cons]
+      rfl
+
+/-- The control stack is a walk zone: each frame contributes the blocks `[tagCode + 2, rem + 1]`
+(top-first: the tag block is rightmost). -/
+theorem encodeCtrlStackR_eq_walkZone (S : List (ITag × Nat)) :
+    encodeCtrlStackR S
+      = walkZone (S.flatMap fun f => [f.1.tagCode + 2, f.2 + 1]) := by
+  induction S with
+  | nil => rfl
+  | cons f rest ih =>
+      obtain ⟨tag, rem⟩ := f
+      rw [encodeCtrlStackR_cons, ih, List.flatMap_cons]
+      simp only [List.cons_append, List.nil_append]
+      rw [walkZone_cons, walkZone_cons]
+      show _ ++ encodeCtrlFrameR (tag, rem) = _
+      rw [encodeCtrlFrameR]
+      simp [List.append_assoc]
+
+/-- The walker's step budget for a zone: `k + 3` per block plus the `2`-step sentinel finish. -/
+def walkZoneSteps (ks : List Nat) : Nat :=
+  (ks.map (· + 3)).sum + 2
+
+@[simp] theorem walkZoneSteps_nil : walkZoneSteps [] = 2 := rfl
+
+theorem walkZoneSteps_cons (k : Nat) (ks : List Nat) :
+    walkZoneSteps (k :: ks) = (k + 3) + walkZoneSteps ks := by
+  unfold walkZoneSteps
+  simp
+  omega
+
+/-- `getD` of a long-enough `replicate` is its element. -/
+theorem getD_replicate_of_lt {α : Type _} (a d : α) {i n : Nat} (h : i < n) :
+    (List.replicate n a).getD i d = a := by
+  simp [List.getD, h]
+
+/-- **The full-zone walk.**  If the window `[base, base + |walkZone ks|)` spells `walkZone ks` (every
+block `≥ 2` ones), the cell `base − 1` is the dead `0` (and `1 ≤ base`), and the walker starts at φ0 on
+the zone's rightmost content cell, then after `walkZoneSteps ks` steps it is **done** (φ4) with the
+head on `base − 1`, tape unchanged. -/
+theorem zoneWalkLeft_runConfig_walkZone {L : Nat}
+    (c0 : Configuration (M := zoneWalkLeft.toPhased.toTM) L) :
+    ∀ (ks : List Nat), (∀ k ∈ ks, 2 ≤ k) → ∀ (base : Nat), 1 ≤ base →
+      (c0.state.fst : Nat) = 0 →
+      (c0.head : Nat) = base + (walkZone ks).length - 1 →
+      windowSpells c0.tape base (walkZone ks) →
+      (∀ p : Fin (zoneWalkLeft.toPhased.toTM.tapeLength L),
+        (p : Nat) = base - 1 → c0.tape p = false) →
+      (((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 (walkZoneSteps ks)).state).fst : Nat) = 4
+      ∧ ((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 (walkZoneSteps ks)).head : Nat)
+          = base - 1
+      ∧ (TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 (walkZoneSteps ks)).tape = c0.tape := by
+  intro ks
+  induction ks generalizing c0 with
+  | nil =>
+      intro _ base hbase hphase hhead hwin hdead
+      -- The zone is the bare sentinel at `base`; the head sits on it.
+      have hh : (c0.head : Nat) = base := by
+        simpa [walkZone_nil] using hhead
+      rw [walkZoneSteps_nil]
+      obtain ⟨h1, h2, h3⟩ := zoneWalkLeft_runConfig_sentinel c0 hphase (by omega)
+        (fun p hp => hdead p (by omega))
+      exact ⟨h1, by rw [h2, hh], h3⟩
+  | cons k ks ih =>
+      intro hge base hbase hphase hhead hwin hdead
+      have hk : 2 ≤ k := hge k (List.mem_cons_self)
+      -- Window split: the prefix `walkZone ks` at `base`, the top block `[0] ++ 1^k` after it.
+      rw [walkZone_cons] at hwin hhead
+      have hwpre := windowSpells_append_left c0.tape base _ _ hwin
+      have hwblk := windowSpells_append_right c0.tape base _ _ hwin
+      obtain ⟨hfit, hcells⟩ := hwblk
+      rw [List.length_append] at hhead
+      simp only [List.length_cons, List.length_replicate] at hhead hfit
+      -- Head: on the top block's rightmost cell `base + |pre| + k`.
+      have hH : (c0.head : Nat) = base + (walkZone ks).length + k := by omega
+      -- The top block's ones and its delimiter, pointwise.
+      have hones : ∀ p : Fin (zoneWalkLeft.toPhased.toTM.tapeLength L),
+          (c0.head : Nat) - (k - 1) ≤ (p : Nat) → (p : Nat) ≤ (c0.head : Nat) - 1 →
+          c0.tape p = true := by
+        intro p hp1 hp2
+        have hcell := hcells p (by omega) (by simp; omega)
+        rw [hcell]
+        have hd : (p : Nat) - (base + (walkZone ks).length)
+            = ((p : Nat) - (base + (walkZone ks).length) - 1) + 1 := by omega
+        rw [hd, List.getD_cons_succ]
+        exact getD_replicate_of_lt true false (by omega)
+      have hdelim : ∀ p : Fin (zoneWalkLeft.toPhased.toTM.tapeLength L),
+          (p : Nat) = (c0.head : Nat) - (k - 1) - 1 → c0.tape p = false := by
+        intro p hp
+        have hcell := hcells p (by omega) (by simp; omega)
+        rw [hcell]
+        have hd : (p : Nat) - (base + (walkZone ks).length) = 0 := by omega
+        rw [hd, List.getD_cons_zero]
+      -- The top block's pass: k + 3 steps land at φ0 on the prefix zone's rightmost cell.
+      obtain ⟨hps, hhs, hts⟩ := zoneWalkLeft_runConfig_field_segment c0 hphase (k - 1)
+        (by omega) (by omega)
+        (fun p hp1 hp2 => hones p hp1 hp2)
+        (fun p hp => hdelim p hp)
+      -- Stitch with the remaining walk via runConfig_add.
+      rw [walkZoneSteps_cons, show k + 3 = (k - 1) + 4 by omega, TM.runConfig_add]
+      set c1 := TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 ((k - 1) + 4) with hc1
+      have hh1 : (c1.head : Nat) = base + (walkZone ks).length - 1 := by
+        rw [hc1, hhs]; omega
+      have hwin1 : windowSpells c1.tape base (walkZone ks) := by
+        rw [hc1, hts]; exact hwpre
+      have hdead1 : ∀ p : Fin (zoneWalkLeft.toPhased.toTM.tapeLength L),
+          (p : Nat) = base - 1 → c1.tape p = false := by
+        intro p hp
+        rw [hc1, hts]; exact hdead p hp
+      obtain ⟨hf1, hf2, hf3⟩ :=
+        ih c1 (fun k hk => hge k (List.mem_cons_of_mem _ hk)) base hbase hps hh1 hwin1 hdead1
+      refine ⟨hf1, hf2, ?_⟩
+      rw [hf3, hc1]
+      exact hts
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkRight.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkRight.lean
@@ -1,0 +1,322 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
+
+/-!
+# `zoneWalkRight` — D2t-5b (Block A4w): traversing a corridor stack zone left-to-right
+
+The **return** legs of the driver's routes (frontier → marker) cross the stack zones rightward.  A
+zone reads `[sentinel 1] [0 1^{k₁}] … [0 1^{kⱼ}]` left-to-right, and past its content lie **at least
+two** dead `0`s (the strict corridor gaps) — so the rightward walker distinguishes a block boundary
+from the zone exit with one extra peek: after a `0`, a `1` opens the next block, a second `0` is the
+exit.
+
+Phases (entry: head **on the base sentinel**, or any block's last `1`):
+
+* **φ0** — step right off the sentinel (→ φ1);
+* **φ1** — confirm the `0` after it (always a `0` under the invariant; a `1` routes to the explicit
+  fail phase φ5, keeping the semantics honest), move right (→ φ2);
+* **φ2** — decide: a `1` is the next block's first unit (→ φ3, walk it); a `0` is the second dead
+  cell — the zone exit (→ φ4, **done**, head resting on it);
+* **φ3** — walk the block's `1`s rightward; on the `0` past them, move right and re-decide (→ φ2);
+* **φ4** — done; **φ5** — fail (unreachable under the corridor invariant).
+
+Step budget: `2` (entry) `+ Σ (kᵢ + 2)` (per block) `+ 1` (exit decide) — the run lemmas land in the
+follow-up module; this brick ships the program and its single-step semantics.
+
+**Progress classification (AGENTS.md): Infrastructure** — a verifier machine component; builds no
+verifier and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- **The rightward zone walker** (6 phases).  φ0 step off the sentinel; φ1 confirm the `0` (→ right);
+φ2 decide (`1` = block → φ3 | `0` = exit → φ4 done); φ3 walk the block's ones (on the `0` past them,
+right and → φ2); φ4 done; φ5 fail (unreachable under the invariant). -/
+def zoneWalkRight : ConstStatePhasedProgram Unit where
+  numPhases := 6
+  startPhase := ⟨0, by decide⟩
+  startState := ()
+  acceptPhase := ⟨4, by decide⟩
+  acceptState := ()
+  transition := fun i _ b =>
+    if i.val = 0 then
+      -- on the base sentinel (a 1): step right
+      (⟨1, by decide⟩, (), b, Move.right)
+    else if i.val = 1 then
+      -- the cell after the sentinel: always a 0 under the invariant; confirm and move right
+      if b then (⟨5, by decide⟩, (), b, Move.stay)
+      else (⟨2, by decide⟩, (), b, Move.right)
+    else if i.val = 2 then
+      -- decide: 1 = the next block's first unit; 0 = the second dead cell (zone exit)
+      if b then (⟨3, by decide⟩, (), b, Move.stay)
+      else (⟨4, by decide⟩, (), b, Move.stay)
+    else if i.val = 3 then
+      -- walk the block's ones rightward; on the 0 past them, step right and re-decide
+      if b then (⟨3, by decide⟩, (), b, Move.right)
+      else (⟨2, by decide⟩, (), b, Move.right)
+    else if i.val = 4 then
+      -- done — idle
+      (⟨4, by decide⟩, (), b, Move.stay)
+    else
+      -- φ5: fail — idle
+      (⟨5, by decide⟩, (), b, Move.stay)
+  timeBound := fun n => n
+
+@[simp] theorem zoneWalkRight_numPhases : zoneWalkRight.numPhases = 6 := rfl
+
+@[simp] theorem zoneWalkRight_startPhase : (zoneWalkRight.startPhase : Nat) = 0 := rfl
+
+@[simp] theorem zoneWalkRight_acceptPhase : (zoneWalkRight.acceptPhase : Nat) = 4 := rfl
+
+/-! ### Transition lemmas -/
+
+theorem zoneWalkRight_t0 (b : Bool) :
+    zoneWalkRight.transition ⟨0, by decide⟩ () b = (⟨1, by decide⟩, (), b, Move.right) := rfl
+
+theorem zoneWalkRight_t1_one :
+    zoneWalkRight.transition ⟨1, by decide⟩ () true = (⟨5, by decide⟩, (), true, Move.stay) := rfl
+
+theorem zoneWalkRight_t1_zero :
+    zoneWalkRight.transition ⟨1, by decide⟩ () false = (⟨2, by decide⟩, (), false, Move.right) := rfl
+
+theorem zoneWalkRight_t2_one :
+    zoneWalkRight.transition ⟨2, by decide⟩ () true = (⟨3, by decide⟩, (), true, Move.stay) := rfl
+
+theorem zoneWalkRight_t2_zero :
+    zoneWalkRight.transition ⟨2, by decide⟩ () false = (⟨4, by decide⟩, (), false, Move.stay) := rfl
+
+theorem zoneWalkRight_t3_one :
+    zoneWalkRight.transition ⟨3, by decide⟩ () true = (⟨3, by decide⟩, (), true, Move.right) := rfl
+
+theorem zoneWalkRight_t3_zero :
+    zoneWalkRight.transition ⟨3, by decide⟩ () false = (⟨2, by decide⟩, (), false, Move.right) := rfl
+
+theorem zoneWalkRight_t4 (b : Bool) :
+    zoneWalkRight.transition ⟨4, by decide⟩ () b = (⟨4, by decide⟩, (), b, Move.stay) := rfl
+
+theorem zoneWalkRight_t5 (b : Bool) :
+    zoneWalkRight.transition ⟨5, by decide⟩ () b = (⟨5, by decide⟩, (), b, Move.stay) := rfl
+
+/-! ### `stepConfig` lemmas -/
+
+/-- φ0: phase to `1`, head right, tape unchanged. -/
+theorem zoneWalkRight_stepConfig_p0_phase {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    ((TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).state).fst.val = 1 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi]
+
+theorem zoneWalkRight_stepConfig_p0_head {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.right := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi]
+
+theorem zoneWalkRight_stepConfig_p0_tape {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 0) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape
+      = c.write c.head (c.tape c.head) := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- φ1 on a `0`: confirm — phase to `2`, head right, tape unchanged. -/
+theorem zoneWalkRight_stepConfig_p1_zero_phase {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).state).fst.val = 2 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+
+theorem zoneWalkRight_stepConfig_p1_zero_head {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.right := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+
+theorem zoneWalkRight_stepConfig_p1_zero_tape {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 1) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape
+      = c.write c.head false := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+/-- φ2 on a `1`: a block follows — phase to `3`, head stays, tape unchanged. -/
+theorem zoneWalkRight_stepConfig_p2_one_phase {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).state).fst.val = 3 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+
+theorem zoneWalkRight_stepConfig_p2_one_head {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).head = c.head := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit, Configuration.moveHead]
+
+/-- φ2 on a `0`: the zone exit — phase to the done phase `4`, head stays, tape unchanged. -/
+theorem zoneWalkRight_stepConfig_p2_zero_phase {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).state).fst.val = 4 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+
+theorem zoneWalkRight_stepConfig_p2_zero_head {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).head = c.head := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit, Configuration.moveHead]
+
+/-- φ2, either bit: the tape is unchanged. -/
+theorem zoneWalkRight_stepConfig_p2_tape {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 2) (hstate : c.state = ⟨i, s⟩) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape
+      = c.write c.head (c.tape c.head) := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi]
+    cases c.tape c.head <;> simp
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write]
+  · simp [Configuration.write, hj]
+
+/-- φ3 on a `1`: walk — phase stays `3`, head right, tape unchanged. -/
+theorem zoneWalkRight_stepConfig_p3_one_phase {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    ((TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).state).fst.val = 3 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+
+theorem zoneWalkRight_stepConfig_p3_one_head {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.right := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+
+theorem zoneWalkRight_stepConfig_p3_one_tape {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = true) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape
+      = c.write c.head true := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+/-- φ3 on a `0` (past the block): phase to `2`, head right, tape unchanged. -/
+theorem zoneWalkRight_stepConfig_p3_zero_phase {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    ((TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).state).fst.val = 2 := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+
+theorem zoneWalkRight_stepConfig_p3_zero_head {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).head
+      = Configuration.moveHead (c := c) Move.right := by
+  unfold TM.stepConfig
+  rw [hstate]
+  simp only [PhasedProgram.toTM_step]
+  simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+
+theorem zoneWalkRight_stepConfig_p3_zero_tape {L : Nat}
+    (c : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    {i : Fin 6} {s : Unit} (hi : i.val = 3) (hstate : c.state = ⟨i, s⟩)
+    (hbit : c.tape c.head = false) :
+    (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape = c.tape := by
+  have hwrite : (TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c).tape
+      = c.write c.head false := by
+    unfold TM.stepConfig
+    rw [hstate]
+    simp only [PhasedProgram.toTM_step]
+    simp [ConstStatePhasedProgram.toPhased, zoneWalkRight, hi, hbit]
+  rw [hwrite]
+  funext j
+  by_cases hj : j = c.head
+  · subst hj; simp [Configuration.write, hbit]
+  · simp [Configuration.write, hj]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkRightFull.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkRightFull.lean
@@ -1,0 +1,240 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
+
+/-!
+# `zoneWalkRight` full traversal — D2t-5b (Block A4w): the rightward multi-block walk
+
+The rightward mirror of `zoneWalkLeft_runConfig_walkZone`: from the **base sentinel** of a corridor
+stack zone, `zoneWalkRight` crosses every block and stops, done, on the **second dead cell** past the
+zone's content — in exactly `Σ (kᵢ + 2) + 3` steps, tape unchanged.
+
+Structure: the φ2-anchored **inner traversal** works over the *bottom-first* spelled form
+`innerSpell bs = flatMap (1^k ++ [0]) bs` (each block's ones then its trailing delimiter/dead cell);
+the bridging identity `walkZone ks ++ [0] = [1, 0] ++ innerSpell ks.reverse` re-anchors it to the
+zone codec, and the 2-step entry plus the 1-step exit close the ends.
+
+**Progress classification (AGENTS.md): Infrastructure** — a verifier machine run-through; builds no
+verifier and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- The bottom-first inner spelling: each block's ones, then its trailing `0` (for the last block that
+`0` is the zone's first dead cell). -/
+def innerSpell (bs : List Nat) : List Bool :=
+  bs.flatMap (fun k => List.replicate k true ++ [false])
+
+@[simp] theorem innerSpell_nil : innerSpell [] = [] := rfl
+
+@[simp] theorem innerSpell_cons (k : Nat) (bs : List Nat) :
+    innerSpell (k :: bs) = (List.replicate k true ++ [false]) ++ innerSpell bs := by
+  unfold innerSpell
+  rw [List.flatMap_cons]
+
+theorem innerSpell_length (bs : List Nat) :
+    (innerSpell bs).length = (bs.map (· + 1)).sum := by
+  induction bs with
+  | nil => rfl
+  | cons k bs ih => rw [innerSpell_cons]; simp [ih]; omega
+
+/-- **The bridging identity**: a zone codec extended by its first dead cell is the sentinel, the
+first delimiter, and the bottom-first inner spelling. -/
+theorem walkZone_append_false (ks : List Nat) :
+    walkZone ks ++ [false] = true :: false :: innerSpell ks.reverse := by
+  induction ks with
+  | nil => rfl
+  | cons k ks ih =>
+      rw [walkZone_cons, List.append_assoc, List.reverse_cons]
+      have : innerSpell (ks.reverse ++ [k])
+          = innerSpell ks.reverse ++ (List.replicate k true ++ [false]) := by
+        unfold innerSpell
+        rw [List.flatMap_append]
+        simp
+      rw [this, show (false :: List.replicate k true) ++ [false]
+          = (false :: (List.replicate k true ++ [false])) from by simp]
+      rw [show (true :: false :: (innerSpell ks.reverse ++ (List.replicate k true ++ [false])))
+          = (true :: false :: innerSpell ks.reverse) ++ (List.replicate k true ++ [false]) from by
+        simp]
+      rw [← ih]
+      simp
+
+/-- The inner step budget: `k + 2` per block plus the final exit step. -/
+def innerSteps (bs : List Nat) : Nat :=
+  (bs.map (· + 2)).sum + 1
+
+@[simp] theorem innerSteps_nil : innerSteps [] = 1 := rfl
+
+theorem innerSteps_cons (k : Nat) (bs : List Nat) :
+    innerSteps (k :: bs) = (k + 2) + innerSteps bs := by
+  unfold innerSteps
+  simp
+  omega
+
+/-- **The inner traversal.**  From φ2 on the first cell of `innerSpell bs` (every block `≥ 2`), with
+the cell just past it dead and on the tape, after `innerSteps bs` steps the walker is done (φ4) on
+that cell, tape unchanged. -/
+theorem zoneWalkRight_runConfig_inner {L : Nat}
+    (c0 : Configuration (M := zoneWalkRight.toPhased.toTM) L) :
+    ∀ (bs : List Nat), (∀ k ∈ bs, 2 ≤ k) →
+      (c0.state.fst : Nat) = 2 →
+      (c0.head : Nat) + (innerSpell bs).length < zoneWalkRight.toPhased.toTM.tapeLength L →
+      windowSpells c0.tape (c0.head : Nat) (innerSpell bs) →
+      (∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+        (p : Nat) = (c0.head : Nat) + (innerSpell bs).length → c0.tape p = false) →
+      (((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (innerSteps bs)).state).fst : Nat) = 4
+      ∧ ((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (innerSteps bs)).head : Nat)
+          = (c0.head : Nat) + (innerSpell bs).length
+      ∧ (TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (innerSteps bs)).tape = c0.tape := by
+  intro bs
+  induction bs generalizing c0 with
+  | nil =>
+      intro _ hphase hfit hwin hdead
+      rw [innerSteps_nil]
+      simp only [innerSpell_nil, List.length_nil, Nat.add_zero] at hdead ⊢
+      obtain ⟨h1, h2, h3⟩ := zoneWalkRight_runConfig_exit c0 hphase
+        (hdead c0.head rfl)
+      exact ⟨h1, h2, h3⟩
+  | cons k bs ih =>
+      intro hge hphase hfit hwin hdead
+      have hk : 2 ≤ k := hge k (List.mem_cons_self)
+      rw [innerSpell_cons] at hwin hfit hdead
+      rw [List.length_append, List.length_append, List.length_replicate,
+        List.length_singleton] at hfit hdead
+      -- The block's ones and delimiter, pointwise.
+      have hwblk := windowSpells_append_left c0.tape (c0.head : Nat) _ _ hwin
+      have hwrest := windowSpells_append_right c0.tape (c0.head : Nat) _ _ hwin
+      rw [List.length_append, List.length_replicate, List.length_singleton] at hwrest
+      obtain ⟨hbfit, hbcells⟩ := hwblk
+      rw [List.length_append, List.length_replicate, List.length_singleton] at hbfit
+      have hones : ∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+          (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + k → c0.tape p = true := by
+        intro p hp1 hp2
+        have := hbcells p (by omega) (by simp; omega)
+        rw [this, List.getD_append _ _ _ _ (by simp; omega)]
+        exact getD_replicate_of_lt true false (by omega)
+      have hdelim : ∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+          (p : Nat) = (c0.head : Nat) + k → c0.tape p = false := by
+        intro p hp
+        have := hbcells p (by omega) (by simp; omega)
+        rw [this, List.getD_append_right _ _ _ _ (by simp; omega)]
+        simp [hp]
+      -- The block pass, then the IH on the rest.
+      obtain ⟨hps, hhs, hts⟩ := zoneWalkRight_runConfig_block_segment c0 hphase k (by omega)
+        (by omega) hones hdelim
+      rw [innerSteps_cons, TM.runConfig_add]
+      set c1 := TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (k + 2) with hc1
+      have hh1 : (c1.head : Nat) = (c0.head : Nat) + k + 1 := by rw [hc1, hhs]
+      have hwin1 : windowSpells c1.tape (c1.head : Nat) (innerSpell bs) := by
+        rw [hc1, hts]
+        rw [hh1]
+        exact hwrest
+      have hfit1 : (c1.head : Nat) + (innerSpell bs).length
+          < zoneWalkRight.toPhased.toTM.tapeLength L := by
+        rw [hh1]; omega
+      have hdead1 : ∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+          (p : Nat) = (c1.head : Nat) + (innerSpell bs).length → c1.tape p = false := by
+        intro p hp
+        rw [hc1, hts]
+        exact hdead p (by rw [hh1] at hp; omega)
+      obtain ⟨hf1, hf2, hf3⟩ := ih c1 (fun x hx => hge x (List.mem_cons_of_mem _ hx))
+        hps hfit1 hwin1 hdead1
+      refine ⟨hf1, ?_, ?_⟩
+      · rw [hf2, hh1, innerSpell_cons, List.length_append, List.length_append,
+          List.length_replicate, List.length_singleton]
+        omega
+      · rw [hf3, hc1]; exact hts
+
+/-- Extending a spelled window by one pinned dead cell. -/
+theorem windowSpells_snoc_false {L : Nat} (tape : Fin L → Bool) (base : Nat) (bits : List Bool)
+    (h : windowSpells tape base bits)
+    (hfit : base + bits.length < L)
+    (hdead : ∀ p : Fin L, (p : Nat) = base + bits.length → tape p = false) :
+    windowSpells tape base (bits ++ [false]) := by
+  obtain ⟨hf, hc⟩ := h
+  refine ⟨by simp; omega, fun q hlo hhi => ?_⟩
+  simp only [List.length_append, List.length_singleton] at hhi
+  by_cases hq : (q : Nat) < base + bits.length
+  · rw [hc q hlo hq, List.getD_append _ _ _ _ (by omega)]
+  · have hq' : (q : Nat) = base + bits.length := by omega
+    rw [hdead q hq', List.getD_append_right _ _ _ _ (by omega)]
+    simp [hq']
+
+/-- The full rightward walk step budget: `k + 2` per block plus the entry (2) and exit (1). -/
+def walkZoneStepsR (ks : List Nat) : Nat :=
+  (ks.map (· + 2)).sum + 3
+
+theorem walkZoneStepsR_eq (ks : List Nat) : walkZoneStepsR ks = 2 + innerSteps ks.reverse := by
+  unfold walkZoneStepsR innerSteps
+  rw [List.map_reverse, List.sum_reverse]
+  omega
+
+/-- **The full rightward traversal.**  From φ0 on the base sentinel of a zone spelling `walkZone ks`
+(every block `≥ 2`), with the **two** dead cells just past the content pinned to `0`, after
+`walkZoneStepsR ks` steps the walker is done (φ4) on the second dead cell
+(`base + |walkZone ks| + 1`), tape unchanged. -/
+theorem zoneWalkRight_runConfig_walkZone {L : Nat}
+    (c0 : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    (ks : List Nat) (hge : ∀ k ∈ ks, 2 ≤ k) (base : Nat)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hhead : (c0.head : Nat) = base)
+    (hfit : base + (walkZone ks).length + 1 < zoneWalkRight.toPhased.toTM.tapeLength L)
+    (hwin : windowSpells c0.tape base (walkZone ks))
+    (hdead1 : ∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+      (p : Nat) = base + (walkZone ks).length → c0.tape p = false)
+    (hdead2 : ∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+      (p : Nat) = base + (walkZone ks).length + 1 → c0.tape p = false) :
+    (((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (walkZoneStepsR ks)).state).fst : Nat) = 4
+    ∧ ((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (walkZoneStepsR ks)).head : Nat)
+        = base + (walkZone ks).length + 1
+    ∧ (TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (walkZoneStepsR ks)).tape = c0.tape := by
+  -- Extend the window by the first dead cell and re-anchor it bottom-first.
+  have hwin' := windowSpells_snoc_false c0.tape base (walkZone ks) hwin (by omega) hdead1
+  rw [walkZone_append_false] at hwin'
+  have hlen : (walkZone ks).length = (innerSpell ks.reverse).length + 1 := by
+    have := congrArg List.length (walkZone_append_false ks)
+    simp at this
+    omega
+  -- The cell after the sentinel is the first delimiter/dead `0`.
+  have hcell1 : ∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+      (p : Nat) = base + 1 → c0.tape p = false := by
+    intro p hp
+    obtain ⟨hf, hc⟩ := hwin'
+    have := hc p (by omega) (by simp; omega)
+    rw [this]
+    have hidx : (p : Nat) - base = 1 := by omega
+    rw [hidx]
+    rfl
+  -- The inner window, anchored at `base + 2`.
+  have hwinInner : windowSpells c0.tape (base + 2) (innerSpell ks.reverse) := by
+    have := windowSpells_append_right c0.tape base [true, false] (innerSpell ks.reverse)
+      (by simpa using hwin')
+    simpa using this
+  -- Entry: 2 steps to φ2 on `base + 2`.
+  obtain ⟨heph, hehd, hetp⟩ := zoneWalkRight_runConfig_entry c0 hphase
+    (by omega) (fun p hp => hcell1 p (by omega))
+  rw [walkZoneStepsR_eq, TM.runConfig_add]
+  set c1 := TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 2 with hc1
+  have hh1 : (c1.head : Nat) = base + 2 := by rw [hc1, hehd, hhead]
+  -- Inner traversal from `base + 2`.
+  obtain ⟨hf1, hf2, hf3⟩ := zoneWalkRight_runConfig_inner c1 ks.reverse
+    (fun k hk => hge k (List.mem_reverse.mp hk))
+    heph
+    (by rw [hh1]; omega)
+    (by rw [hc1, hetp, hh1]; exact hwinInner)
+    (by
+      intro p hp
+      rw [hc1, hetp]
+      exact hdead2 p (by rw [hh1] at hp; omega))
+  refine ⟨hf1, ?_, ?_⟩
+  · rw [hf2, hh1]; omega
+  · rw [hf3, hc1]; exact hetp
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkRightRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkRightRun.lean
@@ -1,0 +1,154 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
+
+/-!
+# `zoneWalkRight` run segments — D2t-5b (Block A4w): the rightward per-block steps
+
+The mirror of the leftward segments (`TreeMCSPZoneWalkRun`): the φ3 ones-scan invariant, the
+single-block pass (from φ2 on a block's first `1`, `k + 2` steps to φ2 on the cell past its trailing
+`0`), the 2-step entry (off the sentinel onto the decide cell), and the 1-step exit (φ2 on a dead `0`
+is done).  The full rightward traversal (induction over the bottom-first block list) builds on these.
+
+**Progress classification (AGENTS.md): Infrastructure** — verifier machine run-throughs; build no
+verifier and prove no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- Rightward ones-scan invariant: from φ3 with the `j` cells `[head, head + j)` all `1`
+(`head + j` within the tape), after `j` steps φ3 has advanced `j` cells, tape unchanged. -/
+theorem zoneWalkRight_runConfig_p3_scanning {L : Nat}
+    (c0 : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 3) :
+    ∀ j : Nat, (c0.head : Nat) + j < zoneWalkRight.toPhased.toTM.tapeLength L →
+      (∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+        (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + j → c0.tape p = true) →
+      (((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 j).state).fst : Nat) = 3
+      ∧ ((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 j).head : Nat) = (c0.head : Nat) + j
+      ∧ (TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 j).tape = c0.tape := by
+  intro j
+  induction j with
+  | zero => intro _ _; exact ⟨hphase, by simp, rfl⟩
+  | succ j ih =>
+      intro hj h1
+      obtain ⟨hph, hhd, htp⟩ := ih (by omega) (fun p hp1 hp2 => h1 p hp1 (by omega))
+      rw [TM.runConfig_succ]
+      set c := TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 j with hc
+      have hbit : c.tape c.head = true := by
+        rw [htp]; exact h1 c.head (by rw [hhd]; omega) (by rw [hhd]; omega)
+      have hstate : c.state = ⟨c.state.fst, c.state.snd⟩ := rfl
+      have hlt : (c.head : Nat) + 1 < zoneWalkRight.toPhased.toTM.tapeLength L := by
+        rw [hhd]; omega
+      refine ⟨?_, ?_, ?_⟩
+      · exact zoneWalkRight_stepConfig_p3_one_phase c hph hstate hbit
+      · rw [zoneWalkRight_stepConfig_p3_one_head c hph hstate hbit]
+        simp only [Configuration.moveHead, dif_pos hlt]
+        omega
+      · rw [zoneWalkRight_stepConfig_p3_one_tape c hph hstate hbit, htp]
+
+/-- **One rightward block pass.**  From φ2 on a block's first `1` (`k ≥ 1` ones at `[head, head+k)`,
+a `0` at `head + k`, and `head + k + 1` on the tape), after `k + 2` steps the walker is back at φ2 on
+`head + k + 1` (the cell past the block's trailing `0`), tape unchanged. -/
+theorem zoneWalkRight_runConfig_block_segment {L : Nat}
+    (c0 : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 2) (k : Nat) (hk : 1 ≤ k)
+    (hroom : (c0.head : Nat) + k + 1 < zoneWalkRight.toPhased.toTM.tapeLength L)
+    (hones : ∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) ≤ (p : Nat) → (p : Nat) < (c0.head : Nat) + k → c0.tape p = true)
+    (hdelim : ∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + k → c0.tape p = false) :
+    (((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (k + 2)).state).fst : Nat) = 2
+    ∧ ((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (k + 2)).head : Nat)
+        = (c0.head : Nat) + k + 1
+    ∧ (TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 (k + 2)).tape = c0.tape := by
+  -- Split k + 2 = 1 + (k + 1): the φ2-decide step, the φ3 ones-scan, the φ3 0-step.
+  rw [show k + 2 = 1 + (k + 1) from by omega, TM.runConfig_add, TM.runConfig_one]
+  set c1 := TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c0 with hc1
+  have hst0 : c0.state = ⟨c0.state.fst, c0.state.snd⟩ := rfl
+  have hbit0 : c0.tape c0.head = true := hones c0.head (by omega) (by omega)
+  have h1ph : (c1.state.fst : Nat) = 3 := zoneWalkRight_stepConfig_p2_one_phase c0 hphase hst0 hbit0
+  have h1hd : (c1.head : Nat) = (c0.head : Nat) := by
+    rw [hc1, zoneWalkRight_stepConfig_p2_one_head c0 hphase hst0 hbit0]
+  have h1tp : c1.tape = c0.tape := by
+    rw [hc1, zoneWalkRight_stepConfig_p2_tape c0 hphase hst0]
+  -- φ3 scans the k ones.
+  rw [show k + 1 = k + 1 from rfl, TM.runConfig_add]
+  obtain ⟨h2ph, h2hd, h2tp⟩ :=
+    zoneWalkRight_runConfig_p3_scanning c1 h1ph k (by omega)
+      (fun p hp1 hp2 => by
+        rw [h1hd] at hp1 hp2
+        rw [h1tp]
+        exact hones p hp1 hp2)
+  set c2 := TM.runConfig (M := zoneWalkRight.toPhased.toTM) c1 k with hc2
+  rw [h1hd] at h2hd
+  -- φ3 reads the trailing 0 and steps right into φ2.
+  rw [TM.runConfig_one]
+  have hst2 : c2.state = ⟨c2.state.fst, c2.state.snd⟩ := rfl
+  have hbit2 : c2.tape c2.head = false := by
+    rw [h2tp, h1tp]
+    exact hdelim c2.head (by rw [h2hd])
+  have hlt2 : (c2.head : Nat) + 1 < zoneWalkRight.toPhased.toTM.tapeLength L := by
+    rw [h2hd]; omega
+  refine ⟨?_, ?_, ?_⟩
+  · exact zoneWalkRight_stepConfig_p3_zero_phase c2 h2ph hst2 hbit2
+  · rw [zoneWalkRight_stepConfig_p3_zero_head c2 h2ph hst2 hbit2]
+    simp only [Configuration.moveHead, dif_pos hlt2]
+    omega
+  · rw [zoneWalkRight_stepConfig_p3_zero_tape c2 h2ph hst2 hbit2, h2tp, h1tp]
+
+/-- **Entry.**  From φ0 on the base sentinel, with the `0` at `head + 1` (and room), after `2` steps
+the walker is at φ2 on `head + 2`, tape unchanged. -/
+theorem zoneWalkRight_runConfig_entry {L : Nat}
+    (c0 : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0)
+    (hroom : (c0.head : Nat) + 2 < zoneWalkRight.toPhased.toTM.tapeLength L)
+    (hzero : ∀ p : Fin (zoneWalkRight.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) + 1 → c0.tape p = false) :
+    (((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 2).state).fst : Nat) = 2
+    ∧ ((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 2).head : Nat) = (c0.head : Nat) + 2
+    ∧ (TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 2).tape = c0.tape := by
+  rw [show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_add, TM.runConfig_one, TM.runConfig_one]
+  set c1 := TM.stepConfig (M := zoneWalkRight.toPhased.toTM) c0 with hc1
+  have hst0 : c0.state = ⟨c0.state.fst, c0.state.snd⟩ := rfl
+  have h1ph : (c1.state.fst : Nat) = 1 := zoneWalkRight_stepConfig_p0_phase c0 hphase hst0
+  have h1hd : (c1.head : Nat) = (c0.head : Nat) + 1 := by
+    rw [hc1, zoneWalkRight_stepConfig_p0_head c0 hphase hst0]
+    simp only [Configuration.moveHead,
+      dif_pos (by omega : (c0.head : Nat) + 1 < zoneWalkRight.toPhased.toTM.tapeLength L)]
+  have h1tp : c1.tape = c0.tape := by
+    rw [hc1, zoneWalkRight_stepConfig_p0_tape c0 hphase hst0]
+  have hst1 : c1.state = ⟨c1.state.fst, c1.state.snd⟩ := rfl
+  have hbit1 : c1.tape c1.head = false := by
+    rw [h1tp]; exact hzero c1.head (by rw [h1hd])
+  have hlt1 : (c1.head : Nat) + 1 < zoneWalkRight.toPhased.toTM.tapeLength L := by
+    rw [h1hd]; omega
+  refine ⟨?_, ?_, ?_⟩
+  · exact zoneWalkRight_stepConfig_p1_zero_phase c1 h1ph hst1 hbit1
+  · rw [zoneWalkRight_stepConfig_p1_zero_head c1 h1ph hst1 hbit1]
+    simp only [Configuration.moveHead, dif_pos hlt1]
+    omega
+  · rw [zoneWalkRight_stepConfig_p1_zero_tape c1 h1ph hst1 hbit1, h1tp]
+
+/-- **Exit.**  From φ2 on a dead `0`, one step finishes: φ4, head unchanged, tape unchanged. -/
+theorem zoneWalkRight_runConfig_exit {L : Nat}
+    (c0 : Configuration (M := zoneWalkRight.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 2)
+    (hzero : c0.tape c0.head = false) :
+    (((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 1).state).fst : Nat) = 4
+    ∧ ((TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 1).head : Nat) = (c0.head : Nat)
+    ∧ (TM.runConfig (M := zoneWalkRight.toPhased.toTM) c0 1).tape = c0.tape := by
+  rw [TM.runConfig_one]
+  have hst0 : c0.state = ⟨c0.state.fst, c0.state.snd⟩ := rfl
+  refine ⟨?_, ?_, ?_⟩
+  · exact zoneWalkRight_stepConfig_p2_zero_phase c0 hphase hst0 hzero
+  · rw [zoneWalkRight_stepConfig_p2_zero_head c0 hphase hst0 hzero]
+  · rw [zoneWalkRight_stepConfig_p2_tape c0 hphase hst0]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkRun.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPZoneWalkRun.lean
@@ -1,0 +1,133 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
+
+/-!
+# `zoneWalkLeft` run segments — D2t-5b (Block A4w): the per-block walk steps
+
+`TreeMCSPZoneWalk` proved the inner field sub-scan (φ2).  This module assembles the two **segment**
+walk-throughs that the full-zone walk (next brick) stitches by induction:
+
+* `zoneWalkLeft_runConfig_field_segment` — one **field block** pass.  From φ0 on a block's rightmost
+  cell, with `m ≥ 1` ones at `[head − m, head − 1]` and the delimiter `0` at `head − m − 1`, after
+  `m + 4` steps the walker is back at φ0 on the **next** block's rightmost cell (`head − m − 2`), tape
+  unchanged.  (φ0 step-left, φ1 decide-field, φ2 scan the `m` ones, φ2 stop on the delimiter, φ3 cross.)
+* `zoneWalkLeft_runConfig_sentinel` — the **terminating** pass.  From φ0 on the single-`1` base
+  sentinel, with a `0` (dead zone) at `head − 1`, after `2` steps the walker is **done** (φ4) on that
+  `0`, tape unchanged.
+
+Both are pinned by the `stepConfig` layer + the φ2 scanning lemma, composed through `TM.runConfig_add`.
+
+**Progress classification (AGENTS.md): Infrastructure** — verifier machine run-throughs; build no
+verifier and prove no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly Pnp3.Internal.PsubsetPpoly.TM
+open Pnp3.Internal.PsubsetPpoly.TM.ConstStatePhasedProgram
+
+/-- **The terminating pass.**  From φ0 on the single-`1` base sentinel (`head > 0`, with a `0` at
+`head − 1`), after `2` steps the walker is in the done phase `4` with the head on that `0`
+(`head − 1`), tape unchanged. -/
+theorem zoneWalkLeft_runConfig_sentinel {L : Nat}
+    (c0 : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (hh : 0 < (c0.head : Nat))
+    (hdead : ∀ p : Fin (zoneWalkLeft.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) - 1 → c0.tape p = false) :
+    (((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 2).state).fst : Nat) = 4
+    ∧ ((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 2).head : Nat) = (c0.head : Nat) - 1
+    ∧ (TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 2).tape = c0.tape := by
+  rw [show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_add, TM.runConfig_one, TM.runConfig_one]
+  set c1 := TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c0 with hc1
+  have hst0 : c0.state = ⟨c0.state.fst, c0.state.snd⟩ := rfl
+  -- c1 = after φ0: phase 1, head head-1, tape unchanged.
+  have h1ph : (c1.state.fst : Nat) = 1 := zoneWalkLeft_stepConfig_p0_phase c0 hphase hst0
+  have h1hd : (c1.head : Nat) = (c0.head : Nat) - 1 := by
+    rw [hc1, zoneWalkLeft_stepConfig_p0_head c0 hphase hst0]
+    simp only [Configuration.moveHead, dif_neg (by omega : ¬ (c0.head : Nat) = 0)]
+  have h1tp : c1.tape = c0.tape := zoneWalkLeft_stepConfig_p0_tape c0 hphase hst0
+  -- c2 = after φ1 reading 0: phase 4, head unchanged, tape unchanged.
+  have hst1 : c1.state = ⟨c1.state.fst, c1.state.snd⟩ := rfl
+  have hbit : c1.tape c1.head = false := by
+    rw [h1tp]; exact hdead c1.head (by rw [h1hd])
+  refine ⟨?_, ?_, ?_⟩
+  · exact zoneWalkLeft_stepConfig_p1_zero_phase c1 h1ph hst1 hbit
+  · rw [zoneWalkLeft_stepConfig_p1_zero_head c1 h1ph hst1 hbit, h1hd]
+  · rw [zoneWalkLeft_stepConfig_p1_tape c1 h1ph hst1, h1tp]
+
+/-- **One field-block pass.**  From φ0 on a field block's rightmost cell (`head`), with `m ≥ 1` ones at
+`[head − m, head − 1]` and the delimiter `0` at `head − m − 1` (and `head ≥ m + 2` so no move clamps),
+after `m + 4` steps the walker is back at φ0 on the next block's rightmost cell (`head − m − 2`), tape
+unchanged. -/
+theorem zoneWalkLeft_runConfig_field_segment {L : Nat}
+    (c0 : Configuration (M := zoneWalkLeft.toPhased.toTM) L)
+    (hphase : (c0.state.fst : Nat) = 0) (m : Nat) (hm : 1 ≤ m)
+    (hh : m + 2 ≤ (c0.head : Nat))
+    (hones : ∀ p : Fin (zoneWalkLeft.toPhased.toTM.tapeLength L),
+      (c0.head : Nat) - m ≤ (p : Nat) → (p : Nat) ≤ (c0.head : Nat) - 1 → c0.tape p = true)
+    (hdelim : ∀ p : Fin (zoneWalkLeft.toPhased.toTM.tapeLength L),
+      (p : Nat) = (c0.head : Nat) - m - 1 → c0.tape p = false) :
+    (((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 (m + 4)).state).fst : Nat) = 0
+    ∧ ((TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 (m + 4)).head : Nat)
+        = (c0.head : Nat) - m - 2
+    ∧ (TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 (m + 4)).tape = c0.tape := by
+  -- Split m + 4 = 2 + (m + 2): the (φ0,φ1) entry, the φ2 scan of m ones, the (φ2-stop, φ3) exit.
+  have hsplit : m + 4 = 2 + (m + 2) := by omega
+  rw [hsplit, TM.runConfig_add]
+  -- c2 := after φ0, φ1: phase 2, head head-1, tape unchanged.
+  set c2 := TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c0 2 with hc2
+  have hst0 : c0.state = ⟨c0.state.fst, c0.state.snd⟩ := rfl
+  have hc2eq : c2 = TM.stepConfig (M := zoneWalkLeft.toPhased.toTM)
+      (TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c0) := by
+    rw [hc2, show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_add, TM.runConfig_one, TM.runConfig_one]
+  set c1 := TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c0 with hc1
+  have h1ph : (c1.state.fst : Nat) = 1 := zoneWalkLeft_stepConfig_p0_phase c0 hphase hst0
+  have h1hd : (c1.head : Nat) = (c0.head : Nat) - 1 := by
+    rw [hc1, zoneWalkLeft_stepConfig_p0_head c0 hphase hst0]
+    simp only [Configuration.moveHead, dif_neg (by omega : ¬ (c0.head : Nat) = 0)]
+  have h1tp : c1.tape = c0.tape := zoneWalkLeft_stepConfig_p0_tape c0 hphase hst0
+  have hst1 : c1.state = ⟨c1.state.fst, c1.state.snd⟩ := rfl
+  have hbit1 : c1.tape c1.head = true := by
+    rw [h1tp]; exact hones c1.head (by rw [h1hd]; omega) (by rw [h1hd])
+  have h2ph : (c2.state.fst : Nat) = 2 := by
+    rw [hc2eq]; exact zoneWalkLeft_stepConfig_p1_one_phase c1 h1ph hst1 hbit1
+  have h2hd : (c2.head : Nat) = (c0.head : Nat) - 1 := by
+    rw [hc2eq, zoneWalkLeft_stepConfig_p1_one_head c1 h1ph hst1 hbit1, h1hd]
+  have h2tp : c2.tape = c0.tape := by
+    rw [hc2eq, zoneWalkLeft_stepConfig_p1_tape c1 h1ph hst1, h1tp]
+  -- Scan the m ones: c3 := runConfig c2 m: phase 2, head head-1-m, tape unchanged.
+  rw [TM.runConfig_add]
+  obtain ⟨h3ph, h3hd, h3tp⟩ :=
+    zoneWalkLeft_runConfig_p2_scanning c2 h2ph m (by rw [h2hd]; omega)
+      (fun p hp1 hp2 => by
+        rw [h2hd] at hp1 hp2
+        rw [h2tp]
+        exact hones p (by omega) (by omega))
+  set c3 := TM.runConfig (M := zoneWalkLeft.toPhased.toTM) c2 m with hc3
+  rw [h2hd] at h3hd
+  -- c3.head = head - 1 - m = head - m - 1 (the delimiter).
+  have h3hd' : (c3.head : Nat) = (c0.head : Nat) - m - 1 := by omega
+  -- Exit: 2 more steps (φ2 reads delimiter 0 → φ3; φ3 steps left → φ0).
+  rw [show (2 : Nat) = 1 + 1 from rfl, TM.runConfig_add, TM.runConfig_one, TM.runConfig_one]
+  set c4 := TM.stepConfig (M := zoneWalkLeft.toPhased.toTM) c3 with hc4
+  have hst3 : c3.state = ⟨c3.state.fst, c3.state.snd⟩ := rfl
+  have hbit3 : c3.tape c3.head = false := by
+    rw [h3tp, h2tp]; exact hdelim c3.head (by rw [h3hd'])
+  have h4ph : (c4.state.fst : Nat) = 3 := zoneWalkLeft_stepConfig_p2_zero_phase c3 h3ph hst3 hbit3
+  have h4hd : (c4.head : Nat) = (c0.head : Nat) - m - 1 := by
+    rw [hc4, zoneWalkLeft_stepConfig_p2_zero_head c3 h3ph hst3 hbit3, h3hd']
+  have h4tp : c4.tape = c0.tape := by
+    rw [hc4, zoneWalkLeft_stepConfig_p2_zero_tape c3 h3ph hst3 hbit3, h3tp, h2tp]
+  have hst4 : c4.state = ⟨c4.state.fst, c4.state.snd⟩ := rfl
+  refine ⟨?_, ?_, ?_⟩
+  · exact zoneWalkLeft_stepConfig_p3_phase c4 h4ph hst4
+  · rw [zoneWalkLeft_stepConfig_p3_head c4 h4ph hst4]
+    simp only [Configuration.moveHead, dif_neg (by rw [h4hd]; omega : ¬ (c4.head : Nat) = 0)]
+    rw [h4hd]; omega
+  · rw [zoneWalkLeft_stepConfig_p3_tape c4 h4ph hst4, h4tp]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -103,6 +103,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4114,6 +4115,14 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.windowSpells_snoc_false
 #check @Pnp4.Frontier.ContractExpansion.walkZoneStepsR
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_walkZone
+-- D2t-5b (Block A4r): the return route (five instantiated rightward legs).
+#check @Pnp4.Frontier.ContractExpansion.gammaSelfLoopScan_runConfigFrom_scanning
+#check @Pnp4.Frontier.ContractExpansion.gammaSelfLoopScan_runConfigFrom_terminator
+#check @Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_valSentinel
+#check @Pnp4.Frontier.ContractExpansion.corridor_back_walk_val
+#check @Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_ctrlSentinel
+#check @Pnp4.Frontier.ContractExpansion.corridor_back_walk_ctrl
+#check @Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_M
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -98,6 +98,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryTransferRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4074,6 +4075,14 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5b (Block A4w): the zone-walk run segments (field-block pass + terminating sentinel pass).
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_sentinel
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_field_segment
+-- D2t-5b (Block A4w): the FULL zone walk (multi-block traversal) + codec instantiations.
+#check @Pnp4.Frontier.ContractExpansion.walkZone
+#check @Pnp4.Frontier.ContractExpansion.walkZone_length
+#check @Pnp4.Frontier.ContractExpansion.encodeNatStackR_eq_walkZone
+#check @Pnp4.Frontier.ContractExpansion.encodeCtrlStackR_eq_walkZone
+#check @Pnp4.Frontier.ContractExpansion.walkZoneSteps
+#check @Pnp4.Frontier.ContractExpansion.getD_replicate_of_lt
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_walkZone
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -97,6 +97,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDrivePending
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryTransferRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4070,6 +4071,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_one_head
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_zero_phase
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_p2_scanning
+-- D2t-5b (Block A4w): the zone-walk run segments (field-block pass + terminating sentinel pass).
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_sentinel
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_field_segment
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -99,6 +99,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4083,6 +4084,13 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.walkZoneSteps
 #check @Pnp4.Frontier.ContractExpansion.getD_replicate_of_lt
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_walkZone
+-- D2t-5b (Block A4r): the leftward cross-zone route (five instantiated legs).
+#check @Pnp4.Frontier.ContractExpansion.windowSpells_getLast_true
+#check @Pnp4.Frontier.ContractExpansion.corridor_scan_M_to_ctrlTop
+#check @Pnp4.Frontier.ContractExpansion.corridor_walk_ctrl
+#check @Pnp4.Frontier.ContractExpansion.corridor_scan_to_valTop
+#check @Pnp4.Frontier.ContractExpansion.corridor_walk_val
+#check @Pnp4.Frontier.ContractExpansion.corridor_scan_to_FM
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -105,6 +105,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4127,6 +4128,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5b (Block A4a): eraseLeftMark (cursor advance: plant marker + erase consumed token).
 #check @Pnp4.Frontier.ContractExpansion.eraseLeftMark
 #check @Pnp4.Frontier.ContractExpansion.eraseLeftMark_runConfig
+-- D2t-5b (Block A4a): the corridor control-frame push (writeBits window append).
+#check @Pnp4.Frontier.ContractExpansion.writeBits_appends_window
+#check @Pnp4.Frontier.ContractExpansion.corridor_push_ctrl_frame
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -4135,6 +4135,8 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5b (Block A4a): the corridor token dispatch (trie cell hypotheses from the cert clause).
 #check @Pnp4.Frontier.ContractExpansion.windowSpells_cell
 #check @Pnp4.Frontier.ContractExpansion.corridor_dispatch_tnot
+#check @Pnp4.Frontier.ContractExpansion.corridor_dispatch_tand
+#check @Pnp4.Frontier.ContractExpansion.corridor_dispatch_tor
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -107,6 +107,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4137,6 +4138,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.corridor_dispatch_tnot
 #check @Pnp4.Frontier.ContractExpansion.corridor_dispatch_tand
 #check @Pnp4.Frontier.ContractExpansion.corridor_dispatch_tor
+-- D2t-5b (Block A4a): the node-arm keystone (tape transformer re-establishes the invariant).
+#check @Pnp4.Frontier.ContractExpansion.nodeStepTape
+#check @Pnp4.Frontier.ContractExpansion.corridorInv_nodeStep
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -102,6 +102,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4104,6 +4105,15 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_block_segment
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_entry
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_exit
+-- D2t-5b (Block A4w): the FULL rightward traversal (inner induction + bridge + entry).
+#check @Pnp4.Frontier.ContractExpansion.innerSpell
+#check @Pnp4.Frontier.ContractExpansion.innerSpell_length
+#check @Pnp4.Frontier.ContractExpansion.walkZone_append_false
+#check @Pnp4.Frontier.ContractExpansion.innerSteps
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_inner
+#check @Pnp4.Frontier.ContractExpansion.windowSpells_snoc_false
+#check @Pnp4.Frontier.ContractExpansion.walkZoneStepsR
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_walkZone
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -101,6 +101,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4098,6 +4099,11 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p2_one_phase
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p2_zero_phase
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_one_phase
+-- D2t-5b (Block A4w): the rightward run segments (ones-scan / block pass / entry / exit).
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_p3_scanning
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_block_segment
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_entry
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_exit
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -100,6 +100,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4091,6 +4092,13 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.corridor_scan_to_valTop
 #check @Pnp4.Frontier.ContractExpansion.corridor_walk_val
 #check @Pnp4.Frontier.ContractExpansion.corridor_scan_to_FM
+-- D2t-5b (Block A4w): the RIGHTWARD zone walker (return legs) — program + step semantics.
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p0_phase
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p2_one_phase
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p2_zero_phase
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_one_phase
+#check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -106,6 +106,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4131,6 +4132,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5b (Block A4a): the corridor control-frame push (writeBits window append).
 #check @Pnp4.Frontier.ContractExpansion.writeBits_appends_window
 #check @Pnp4.Frontier.ContractExpansion.corridor_push_ctrl_frame
+-- D2t-5b (Block A4a): the corridor token dispatch (trie cell hypotheses from the cert clause).
+#check @Pnp4.Frontier.ContractExpansion.windowSpells_cell
+#check @Pnp4.Frontier.ContractExpansion.corridor_dispatch_tnot
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -104,6 +104,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
+import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4123,6 +4124,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_ctrlSentinel
 #check @Pnp4.Frontier.ContractExpansion.corridor_back_walk_ctrl
 #check @Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_M
+-- D2t-5b (Block A4a): eraseLeftMark (cursor advance: plant marker + erase consumed token).
+#check @Pnp4.Frontier.ContractExpansion.eraseLeftMark
+#check @Pnp4.Frontier.ContractExpansion.eraseLeftMark_runConfig
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -110,6 +110,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4152,6 +4153,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.writeBlockTape
 #check @Pnp4.Frontier.ContractExpansion.windowSpells_writeAppend
 #check @Pnp4.Frontier.ContractExpansion.valPush_window
+-- D2t-5b (Block A4a): the cursor re-anchoring keystone (shared cert spine of the reading/settle arms).
+#check @Pnp4.Frontier.ContractExpansion.windowSpells_congr
+#check @Pnp4.Frontier.ContractExpansion.cursorStepTape
+#check @Pnp4.Frontier.ContractExpansion.cursorStepTape_cert
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -108,6 +108,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4141,6 +4142,11 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5b (Block A4a): the node-arm keystone (tape transformer re-establishes the invariant).
 #check @Pnp4.Frontier.ContractExpansion.nodeStepTape
 #check @Pnp4.Frontier.ContractExpansion.corridorInv_nodeStep
+-- D2t-5b (Block A4a): the leaf-emit output-region helper (count increment + record append).
+#check @Pnp4.Frontier.ContractExpansion.emitTape
+#check @Pnp4.Frontier.ContractExpansion.gateStream_emit_eq
+#check @Pnp4.Frontier.ContractExpansion.emitTape_output_window
+#check @Pnp4.Frontier.ContractExpansion.emitTape_FM
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -109,6 +109,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
+import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4147,6 +4148,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.gateStream_emit_eq
 #check @Pnp4.Frontier.ContractExpansion.emitTape_output_window
 #check @Pnp4.Frontier.ContractExpansion.emitTape_FM
+-- D2t-5b (Block A4a): the value-stack push as a written-block append.
+#check @Pnp4.Frontier.ContractExpansion.writeBlockTape
+#check @Pnp4.Frontier.ContractExpansion.windowSpells_writeAppend
+#check @Pnp4.Frontier.ContractExpansion.valPush_window
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -87,6 +87,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDrivePending
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryTransferRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -887,6 +888,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p2_zero_phase
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_stepConfig_p3_phase
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_p2_scanning
+-- D2t-5b (Block A4w): the zone-walk run segments — one field-block pass (φ0→φ1→φ2→φ3, m+4 steps,
+-- lands at the next block's rightmost cell) and the terminating sentinel pass (φ0→φ1, 2 steps, done).
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_sentinel
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_field_segment
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -92,6 +92,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -928,6 +929,17 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_block_segment
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_entry
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_exit
+-- D2t-5b (Block A4w): the FULL rightward traversal — inner bottom-first induction + the bridging
+-- identity (walkZone ++ [0] = [1,0] ++ innerSpell reverse) + entry; done on the second dead cell.
+#print axioms Pnp4.Frontier.ContractExpansion.innerSpell_nil
+#print axioms Pnp4.Frontier.ContractExpansion.innerSpell_cons
+#print axioms Pnp4.Frontier.ContractExpansion.innerSpell_length
+#print axioms Pnp4.Frontier.ContractExpansion.walkZone_append_false
+#print axioms Pnp4.Frontier.ContractExpansion.innerSteps_cons
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_inner
+#print axioms Pnp4.Frontier.ContractExpansion.windowSpells_snoc_false
+#print axioms Pnp4.Frontier.ContractExpansion.walkZoneStepsR_eq
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_walkZone
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -100,6 +100,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -983,6 +984,11 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.writeBlockTape_below
 #print axioms Pnp4.Frontier.ContractExpansion.writeBlockTape_above
 #print axioms Pnp4.Frontier.ContractExpansion.valPush_window
+-- D2t-5b (Block A4a): the cursor re-anchoring keystone — consuming a tlen-cell token re-establishes
+-- the four certificate-region clauses for the tail (the shared spine of all reading/settle keystones).
+#print axioms Pnp4.Frontier.ContractExpansion.windowSpells_congr
+#print axioms Pnp4.Frontier.ContractExpansion.cursorStepTape_off
+#print axioms Pnp4.Frontier.ContractExpansion.cursorStepTape_cert
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -98,6 +98,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -970,6 +971,11 @@ end Pnp4
 -- D2t-5b (Block A4a): the node-arm KEYSTONE — the explicit six-leg tape transformer re-establishes
 -- driverCorridorInv for the stepped state (node branch of DriveState.step realised on tape).
 #print axioms Pnp4.Frontier.ContractExpansion.corridorInv_nodeStep
+-- D2t-5b (Block A4a): the leaf-emit output-region helper — count increment + record append at FM is
+-- exactly the new encodeGateStream window (reused by both the const and input keystones).
+#print axioms Pnp4.Frontier.ContractExpansion.gateStream_emit_eq
+#print axioms Pnp4.Frontier.ContractExpansion.emitTape_output_window
+#print axioms Pnp4.Frontier.ContractExpansion.emitTape_FM
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -95,6 +95,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -954,6 +955,10 @@ end Pnp4
 -- D2t-5b (Block A4a): eraseLeftMark — plant the new cursor marker and erase the consumed token
 -- (w+1 steps; exact final tape map: marker 1 at p, zeros on [p−w, p), all else untouched).
 #print axioms Pnp4.Frontier.ContractExpansion.eraseLeftMark_runConfig
+-- D2t-5b (Block A4a): the corridor control-frame push — writeBits appends to a spelled window;
+-- the grown window spells the pushed stack (the codec's cons equation), everything else untouched.
+#print axioms Pnp4.Frontier.ContractExpansion.writeBits_appends_window
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_push_ctrl_frame
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -88,6 +88,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryTransferRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -892,6 +893,16 @@ end Pnp4
 -- lands at the next block's rightmost cell) and the terminating sentinel pass (φ0→φ1, 2 steps, done).
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_sentinel
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_field_segment
+-- D2t-5b (Block A4w): the FULL zone walk — multi-block traversal by induction (Σ(kᵢ+3)+2 steps, done
+-- on the dead 0 left of the sentinel, tape unchanged), with both stack codecs as walkZone instances.
+#print axioms Pnp4.Frontier.ContractExpansion.walkZone_nil
+#print axioms Pnp4.Frontier.ContractExpansion.walkZone_cons
+#print axioms Pnp4.Frontier.ContractExpansion.walkZone_length
+#print axioms Pnp4.Frontier.ContractExpansion.encodeNatStackR_eq_walkZone
+#print axioms Pnp4.Frontier.ContractExpansion.encodeCtrlStackR_eq_walkZone
+#print axioms Pnp4.Frontier.ContractExpansion.walkZoneSteps_cons
+#print axioms Pnp4.Frontier.ContractExpansion.getD_replicate_of_lt
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_walkZone
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -97,6 +97,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -966,6 +967,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_dispatch_tnot
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_dispatch_tand
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_dispatch_tor
+-- D2t-5b (Block A4a): the node-arm KEYSTONE — the explicit six-leg tape transformer re-establishes
+-- driverCorridorInv for the stepped state (node branch of DriveState.step realised on tape).
+#print axioms Pnp4.Frontier.ContractExpansion.corridorInv_nodeStep
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -99,6 +99,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
+import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -976,6 +977,12 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.gateStream_emit_eq
 #print axioms Pnp4.Frontier.ContractExpansion.emitTape_output_window
 #print axioms Pnp4.Frontier.ContractExpansion.emitTape_FM
+-- D2t-5b (Block A4a): the value-stack push as a written-block append (windowSpells extends by the new
+-- top entry); reused by both leaf arms and the settle pop-emit.
+#print axioms Pnp4.Frontier.ContractExpansion.windowSpells_writeAppend
+#print axioms Pnp4.Frontier.ContractExpansion.writeBlockTape_below
+#print axioms Pnp4.Frontier.ContractExpansion.writeBlockTape_above
+#print axioms Pnp4.Frontier.ContractExpansion.valPush_window
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -964,6 +964,8 @@ end Pnp4
 -- the invariant's certificate clause (windowSpells_cell; tail-nonemptiness gives the strict room).
 #print axioms Pnp4.Frontier.ContractExpansion.windowSpells_cell
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_dispatch_tnot
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_dispatch_tand
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_dispatch_tor
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -93,6 +93,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -940,6 +941,15 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.windowSpells_snoc_false
 #print axioms Pnp4.Frontier.ContractExpansion.walkZoneStepsR_eq
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_walkZone
+-- D2t-5b (Block A4r): the return route FM→val→ctrl→M — arbitrary-config rightward 0-scan lemmas +
+-- five instantiated legs (the ctrl→cert gap widened to keep the walker's exit off the M slot).
+#print axioms Pnp4.Frontier.ContractExpansion.gammaSelfLoopScan_runConfigFrom_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.gammaSelfLoopScan_runConfigFrom_terminator
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_valSentinel
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_back_walk_val
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_ctrlSentinel
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_back_walk_ctrl
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_M
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -90,6 +90,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -912,6 +913,14 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_scan_to_valTop
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_walk_val
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_scan_to_FM
+-- D2t-5b (Block A4w): the RIGHTWARD zone walker (return legs) — step semantics; the two-dead-cell
+-- inter-zone gaps let one peek distinguish a block boundary (0,1) from the zone exit (0,0).
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p0_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p1_zero_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p2_one_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p2_zero_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_one_phase
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -91,6 +91,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
+import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -921,6 +922,12 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p2_zero_phase
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_one_phase
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
+-- D2t-5b (Block A4w): the rightward run segments — φ3 ones-scan, one block pass (k+2 steps), the
+-- 2-step entry off the sentinel, and the 1-step exit on the second dead cell.
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_p3_scanning
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_block_segment
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_entry
+#print axioms Pnp4.Frontier.ContractExpansion.zoneWalkRight_runConfig_exit
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -89,6 +89,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPDriverCorridor
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalk
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkFull
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutes
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -903,6 +904,14 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.walkZoneSteps_cons
 #print axioms Pnp4.Frontier.ContractExpansion.getD_replicate_of_lt
 #print axioms Pnp4.Frontier.ContractExpansion.zoneWalkLeft_runConfig_walkZone
+-- D2t-5b (Block A4r): the leftward cross-zone route — five legs (scan M→ctrl-top, walk ctrl, scan
+-- →val-top, walk val, scan →FM), each instantiated against driverCorridorInv's clauses.
+#print axioms Pnp4.Frontier.ContractExpansion.windowSpells_getLast_true
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_scan_M_to_ctrlTop
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_walk_ctrl
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_scan_to_valTop
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_walk_val
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_scan_to_FM
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -94,6 +94,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRight
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightRun
 import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
+import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -950,6 +951,9 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_ctrlSentinel
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_back_walk_ctrl
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_back_scan_to_M
+-- D2t-5b (Block A4a): eraseLeftMark — plant the new cursor marker and erase the consumed token
+-- (w+1 steps; exact final tape map: marker 1 at p, zeros on [p−w, p), all else untouched).
+#print axioms Pnp4.Frontier.ContractExpansion.eraseLeftMark_runConfig
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -96,6 +96,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPZoneWalkRightFull
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorRoutesBack
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEraseLeftMark
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorPushFrame
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -959,6 +960,10 @@ end Pnp4
 -- the grown window spells the pushed stack (the codec's cons equation), everything else untouched.
 #print axioms Pnp4.Frontier.ContractExpansion.writeBits_appends_window
 #print axioms Pnp4.Frontier.ContractExpansion.corridor_push_ctrl_frame
+-- D2t-5b (Block A4a): the corridor token dispatch — the D2t-1 trie's cell hypotheses discharged from
+-- the invariant's certificate clause (windowSpells_cell; tail-nonemptiness gives the strict room).
+#print axioms Pnp4.Frontier.ContractExpansion.windowSpells_cell
+#print axioms Pnp4.Frontier.ContractExpansion.corridor_dispatch_tnot
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
**Block A4 in one PR** (per agreed packaging; commits stack, squash keeps one brick). Status: **navigation complete, all reading-arm components proven and corridor-instantiated; the arm composition layer is in progress.**

## Navigation (complete, bidirectional)
* **`zoneWalkLeft`**: program + full `stepConfig` layer + the φ2 field sub-scan + per-block segments + **the full multi-block traversal** (`zoneWalkLeft_runConfig_walkZone`, exact `Σ(kᵢ+3)+2` steps) with both stack codecs as `walkZone` instances.
* **`zoneWalkRight`**: program + step layer + segments (ones-scan / block pass / entry / exit) + **the full rightward traversal** (`zoneWalkRight_runConfig_walkZone`, `Σ(kᵢ+2)+3` steps, done on the second dead cell) via the bottom-first `innerSpell` induction and the bridging identity `walkZone ks ++ [0] = [1,0] ++ innerSpell ks.reverse`.
* **Routes** (10 instantiated legs under `driverCorridorInv`): forward `M → ctrl-top → val-top → FM` and back `FM → val → ctrl → M`, incl. fresh arbitrary-configuration run lemmas for `gammaSelfLoopScan`.

## Reading-arm components (complete)
* **`corridor_dispatch_tnot/tand/tor`** — the D2t-1 trie's cell hypotheses discharged from the invariant's certificate clause (`windowSpells_cell`; strict room from tail-nonemptiness via `ValidCertTokens`).
* **`eraseLeftMark w`** — cursor advance: plant the new marker, erase the consumed token (`w+1` steps, exact final tape map).
* **`corridor_push_ctrl_frame`** — the frame push as the codec's cons equation (generic `writeBits_appends_window`).

## Self-caught design bugs fixed along the way (4)
1. `rem = 1` ctrl blocks indistinguishable from the base sentinel → `1^(rem+1)` blocks;
2–3. zero-gap zone boundaries breaking inter-zone scans → strict chain, then **two**-dead-cell gaps (the rightward walker's exit test);
4. the rightward exit cell colliding with the `M` slot at full ctrl capacity → `ctrlEnd + 2 < certBase`.

## Architectural decisions recorded for the remaining layers
* **COUNT pre-laid at initialization** (token count = `c.size` = final `|out|`; no runtime COUNT access — the D2t-6 init pass lays it while WORK is empty);
* operand/index moves as **routed transfers** (the A2 loop with the proven route legs as its shuttle);
* arm composition via the toolkit's **wholesale P2-embedding transfer** (`embedSeqP2Config_runConfig_eq` + `liftP1ToP2`): standalone run lemmas transfer into the `seqList` composite without re-derivation.

## Remaining in this brick
The arm composition chains (node arm first: trie ▸ stepLeft ▸ erase ▸ scan ▸ stepRight ▸ push ▸ scan-back, with the `driverCorridorInv (node-read st)` re-establishment keystone), then the leaf and settle arms on the same pattern.

## Verification
Every commit: `lake build PnP3 Pnp4` clean; `./scripts/check.sh` **17/17**; standard `[propext, Classical.choice, Quot.sound]` triple; registered in lakefile + AxiomsAudit + SurfaceTests; no `sorry`/holes.

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj