### PR TITLE
transcoder(D2t-5b/A4 part 2): arm keystones — const-arm off-factory (first brick)

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -358,6 +358,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorInputStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -359,6 +359,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorInputStep,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDecStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -356,6 +356,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPValPush,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -357,6 +357,7 @@ lean_lib Pnp4 where
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPValPush,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape,
+    Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch,
     Glob.one `Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder,

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPConstStepTape.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPConstStepTape.lean
@@ -1,0 +1,112 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
+import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
+
+/-!
+# `constStepTape` and its region identities — D2t-5b (Block A4a): the const-arm off-factory
+
+The `const b` reading arm touches three **disjoint** tape regions — the cursor area
+(`cursorStepTape`, consume the 4-cell token), the output region (`emitTape`, count `++` and record
+append), and the value zone (`writeBlockTape`, push the index).  This module defines the composed
+transformer `constStepTape` over **explicit numeric anchors** and proves the *off-factory*: on each
+region of interest the composition equals exactly the one transformer that owns it (the other two are
+the identity there).  The keystone (`corridorInv_constStep`, next) then routes each invariant clause
+through one off-lemma + one core lemma, with no inline disjointness reasoning.
+
+* `emitTape_off` — `emitTape` is the identity off its three cells/windows;
+* `constStepTape_eq_cursor` / `_eq_emit` / `_eq_write` / `_eq_id` — the composition seen from each
+  region (given the pairwise separation hypotheses).
+
+**Progress classification (AGENTS.md): Infrastructure** — pure tape-transformer identities; builds no
+machine and proves no separation.  Standard `[propext, Classical.choice, Quot.sound]` triple only.
+**No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- `emitTape` is the identity off the count cell `oc − 1`, the record window `[fm, fm + |rec|)`, and
+the new frontier `fm + |rec|`. -/
+theorem emitTape_off {L : Nat} (tape : Fin L → Bool) (oc fm : Nat) (rec : List Bool) (q : Fin L)
+    (h1 : (q : Nat) ≠ oc - 1) (h2 : ¬ (fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length))
+    (h3 : (q : Nat) ≠ fm + rec.length) : emitTape tape oc fm rec q = tape q := by
+  unfold emitTape
+  rw [if_neg h1, if_neg h2, if_neg h3]
+
+/-- The const-leaf tape transformer over explicit anchors: value push (innermost, block `ventry` at
+`vtop`), output emit (count cell `oc − 1`, record `rec` at `fm`), cursor-marker update (outermost,
+4-cell token at `cur`). -/
+def constStepTape {L : Nat} (tape : Fin L → Bool) (cur vtop oc fm : Nat)
+    (ventry rec : List Bool) : Fin L → Bool :=
+  cursorStepTape (emitTape (writeBlockTape tape vtop ventry) oc fm rec) cur 4
+
+/-- Off all three regions, `constStepTape` is the identity. -/
+theorem constStepTape_eq_id {L : Nat} (tape : Fin L → Bool) (cur vtop oc fm : Nat)
+    (ventry rec : List Bool) (q : Fin L)
+    (hc1 : (q : Nat) ≠ cur + 4 - 1) (hc2 : ¬ (cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + 4 - 1))
+    (he1 : (q : Nat) ≠ oc - 1) (he2 : ¬ (fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length))
+    (he3 : (q : Nat) ≠ fm + rec.length)
+    (hw : ¬ (vtop ≤ (q : Nat) ∧ (q : Nat) < vtop + ventry.length)) :
+    constStepTape tape cur vtop oc fm ventry rec q = tape q := by
+  unfold constStepTape
+  rw [cursorStepTape_off _ _ _ q hc1 hc2, emitTape_off _ _ _ _ q he1 he2 he3]
+  unfold writeBlockTape
+  rw [if_neg hw]
+
+/-- On the cursor area (and off the other regions), `constStepTape` is `cursorStepTape` of the
+original tape: the inner transformers are the identity there. -/
+theorem constStepTape_eq_cursor {L : Nat} (tape : Fin L → Bool) (cur vtop oc fm : Nat)
+    (ventry rec : List Bool) (q : Fin L)
+    (he1 : (q : Nat) ≠ oc - 1) (he2 : ¬ (fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length))
+    (he3 : (q : Nat) ≠ fm + rec.length)
+    (hw : ¬ (vtop ≤ (q : Nat) ∧ (q : Nat) < vtop + ventry.length)) :
+    constStepTape tape cur vtop oc fm ventry rec q = cursorStepTape tape cur 4 q := by
+  unfold constStepTape cursorStepTape
+  by_cases hq1 : (q : Nat) = cur + 4 - 1
+  · rw [if_pos hq1, if_pos hq1]
+  · rw [if_neg hq1, if_neg hq1]
+    by_cases hq2 : cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + 4 - 1
+    · rw [if_pos hq2, if_pos hq2]
+    · rw [if_neg hq2, if_neg hq2, emitTape_off _ _ _ _ q he1 he2 he3]
+      unfold writeBlockTape
+      rw [if_neg hw]
+
+/-- On the output region (and off the cursor band / value block), `constStepTape` is `emitTape` of
+the original tape. -/
+theorem constStepTape_eq_emit {L : Nat} (tape : Fin L → Bool) (cur vtop oc fm : Nat)
+    (ventry rec : List Bool) (q : Fin L)
+    (hc1 : (q : Nat) ≠ cur + 4 - 1) (hc2 : ¬ (cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + 4 - 1))
+    (hw : ¬ (vtop ≤ (q : Nat) ∧ (q : Nat) < vtop + ventry.length)) :
+    constStepTape tape cur vtop oc fm ventry rec q = emitTape tape oc fm rec q := by
+  unfold constStepTape
+  rw [cursorStepTape_off _ _ _ q hc1 hc2]
+  unfold emitTape
+  by_cases hq1 : (q : Nat) = oc - 1
+  · rw [if_pos hq1, if_pos hq1]
+  · rw [if_neg hq1, if_neg hq1]
+    by_cases hq2 : fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length
+    · rw [if_pos hq2, if_pos hq2]
+    · rw [if_neg hq2, if_neg hq2]
+      by_cases hq3 : (q : Nat) = fm + rec.length
+      · rw [if_pos hq3, if_pos hq3]
+      · rw [if_neg hq3, if_neg hq3]
+        unfold writeBlockTape
+        rw [if_neg hw]
+
+/-- On the value block (and off the cursor band / emit cells), `constStepTape` is `writeBlockTape` of
+the original tape. -/
+theorem constStepTape_eq_write {L : Nat} (tape : Fin L → Bool) (cur vtop oc fm : Nat)
+    (ventry rec : List Bool) (q : Fin L)
+    (hc1 : (q : Nat) ≠ cur + 4 - 1) (hc2 : ¬ (cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + 4 - 1))
+    (he1 : (q : Nat) ≠ oc - 1) (he2 : ¬ (fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length))
+    (he3 : (q : Nat) ≠ fm + rec.length) :
+    constStepTape tape cur vtop oc fm ventry rec q = writeBlockTape tape vtop ventry q := by
+  unfold constStepTape
+  rw [cursorStepTape_off _ _ _ q hc1 hc2, emitTape_off _ _ _ _ q he1 he2 he3]
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorConstStep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorConstStep.lean
@@ -1,0 +1,233 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape
+
+/-!
+# The const-leaf keystone — D2t-5b (Block A4a, part 2): `DriveState.step`'s `const` branch on tape
+
+`corridorInv_constStep`: applying `constStepTape` (the composed cursor/emit/val-push transformer,
+off-factory in `TreeMCSPConstStepTape`) to a tape satisfying `driverCorridorInv` for a reading state
+with next token `leaf (const b)` yields a tape satisfying the invariant for the **stepped** state
+`⟨toks', out ++ [const b], ctrl, out.length :: val, true⟩` — the on-tape const arm realises
+`DriveState.step`'s `const` branch, invariant preserved.  Each of the 16 clauses is routed through one
+off-lemma (`constStepTape_eq_*`) and one already-proven core (`cursorStepTape_cert` /
+`emitTape_output_window` / `valPush_window`).
+
+**Progress classification (AGENTS.md): Infrastructure** — a tape-level invariant-preservation
+keystone over the verified codecs; builds no machine and proves no separation.  Standard `[propext,
+Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- The record stream over a snoc: the new gate's record is appended on the right. -/
+theorem encodeGateRecordStream_snoc {n : Nat} (out : List (SLGate n)) (g : SLGate n) :
+    encodeGateRecordStream (out ++ [g]) = encodeGateRecordStream out ++ encodeGateRecord g := by
+  induction out with
+  | nil => simp [encodeGateRecordStream]
+  | cons a l ih => simp only [List.cons_append, encodeGateRecordStream, ih, List.append_assoc]
+
+/-- **The const-leaf keystone.**  For a reading state whose next token is `leaf (const b)` (tail
+nonempty), with output and value-zone capacity, `constStepTape` re-establishes `driverCorridorInv`
+for the stepped state. -/
+theorem corridorInv_constStep {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (b : Bool) (toks' : List (PreToken n)) (out : List (SLGate n))
+    (ctrl : List (ITag × Nat)) (val : List Nat) (tape : Fin L → Bool)
+    (hinv : driverCorridorInv width h_width z tape
+      (⟨PreToken.leaf (SLGate.const b) :: toks', out, ctrl, val, false⟩ : DriveState n))
+    (htoks : toks' ≠ [])
+    (hocap : z.outBase + out.length + 2 ≤ z.workBase)
+    (hwcap : z.workBase + (encodeGateRecordStream out).length + 4 ≤ z.workEnd)
+    (hvcap : z.valBase + (encodeNatStackR val).length + (out.length + 3) ≤ z.valEnd) :
+    driverCorridorInv width h_width z
+      (constStepTape tape
+        (z.certEnd - (encodePreorder width h_width
+          (PreToken.leaf (SLGate.const b) :: toks')).length)
+        (z.valBase + (encodeNatStackR val).length)
+        (z.workBase - 1 - out.length)
+        (z.workBase + (encodeGateRecordStream out).length)
+        (encodeNatEntryR out.length)
+        (encodeGateRecord (SLGate.const b : SLGate n)))
+      (⟨toks', out ++ [SLGate.const b], ctrl, out.length :: val, true⟩ : DriveState n) := by
+  obtain ⟨hwf, hcert, hcfit, hmark, hcorr, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  replace hcert : windowSpells tape
+      (z.certEnd - (encodePreorder width h_width (PreToken.leaf (SLGate.const b) :: toks')).length)
+      (encodePreorder width h_width (PreToken.leaf (SLGate.const b) :: toks')) := hcert
+  replace hcfit : z.certBase
+      + (encodePreorder width h_width (PreToken.leaf (SLGate.const b) :: toks')).length
+        ≤ z.certEnd := hcfit
+  replace hcorr : ∀ p : Fin L, z.ctrlBase + (encodeCtrlStackR ctrl).length ≤ (p : Nat) →
+      (p : Nat) < z.certEnd
+        - (encodePreorder width h_width (PreToken.leaf (SLGate.const b) :: toks')).length - 1 →
+      tape p = false := hcorr
+  replace hout : windowSpells tape (z.workBase - 1 - out.length)
+      (unaryField out.length ++ encodeGateRecordStream out) := hout
+  replace hofit : z.outBase + out.length + 1 ≤ z.workBase := hofit
+  replace hffit : z.workBase + (encodeGateRecordStream out).length + 1 ≤ z.workEnd := hffit
+  replace hfzeros : ∀ p : Fin L,
+      z.workBase + (encodeGateRecordStream out).length + 1 ≤ (p : Nat) →
+      (p : Nat) < z.valBase → tape p = false := hfzeros
+  replace hval : windowSpells tape z.valBase (encodeNatStackR val) := hval
+  replace hvfit : z.valBase + (encodeNatStackR val).length ≤ z.valEnd := hvfit
+  replace hvzeros : ∀ p : Fin L, z.valBase + (encodeNatStackR val).length ≤ (p : Nat) →
+      (p : Nat) < z.ctrlBase → tape p = false := hvzeros
+  replace hctrl : windowSpells tape z.ctrlBase (encodeCtrlStackR ctrl) := hctrl
+  replace hcfit2 : z.ctrlBase + (encodeCtrlStackR ctrl).length ≤ z.ctrlEnd := hcfit2
+  replace hvalid : ValidCertTokens (PreToken.leaf (SLGate.const b) :: toks') := hvalid
+  -- Length facts.
+  have hreclen : (encodeGateRecord (SLGate.const b : SLGate n)).length = 3 := rfl
+  have hventrylen : (encodeNatEntryR out.length).length = out.length + 3 :=
+    encodeNatEntryR_length out.length
+  have hbits : encodePreorder width h_width (PreToken.leaf (SLGate.const b) :: toks')
+      = [false, false, true, b] ++ encodePreorder width h_width toks' := by
+    rw [encodePreorder_cons]; rfl
+  have htag4 : (encodePreToken width h_width (PreToken.leaf (SLGate.const b))).length = 4 := rfl
+  have htail1 : 1 ≤ (encodePreorder width h_width toks').length := by
+    have hv : ValidCertTokens toks' := fun t ht => hvalid t (List.mem_cons_of_mem _ ht)
+    have := validCertTokens_length_le width h_width hv
+    have : 1 ≤ toks'.length := by cases toks' with
+      | nil => exact absurd rfl htoks
+      | cons a l => simp only [List.length_cons]; omega
+    omega
+  have hlenc : (encodePreorder width h_width (PreToken.leaf (SLGate.const b) :: toks')).length
+      = 4 + (encodePreorder width h_width toks').length := by
+    rw [hbits, List.length_append]; rfl
+  have hrecstream := encodeGateRecordStream_snoc out (SLGate.const b : SLGate n)
+  have hlen1 : (out ++ [(SLGate.const b : SLGate n)]).length = out.length + 1 := by simp
+  have hstreamlen : (encodeGateRecordStream (out ++ [(SLGate.const b : SLGate n)])).length
+      = (encodeGateRecordStream out).length + 3 := by
+    rw [hrecstream, List.length_append, hreclen]
+  -- Numeric anchors (plain definitions, no `set`).
+  have hcurdef : z.certEnd
+      - (encodePreorder width h_width (PreToken.leaf (SLGate.const b) :: toks')).length
+      + 4 = z.certEnd - (encodePreorder width h_width toks').length := by omega
+  -- Region order: oc-1 < fm ≤ fm+3 < workEnd < valBase ≤ vtop < vtop+|ventry| ≤ valEnd < ctrlBase
+  --               ≤ ctrl-end ≤ ctrlEnd < cur-1.
+  have hsep1 : z.workBase - 1 - out.length - 1 < z.workBase
+      + (encodeGateRecordStream out).length := by omega
+  have hsepcur : z.ctrlEnd + 2 < z.certEnd
+      - (encodePreorder width h_width (PreToken.leaf (SLGate.const b) :: toks')).length := by
+    omega
+  -- Shorthand for the off-side conditions at a cell q in a given region.
+  -- (Each clause discharges them by omega from the region bounds.)
+  dsimp only [driverCorridorInv]
+  refine ⟨⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_⟩
+  -- 1. cert suffix window (cursor region: constStepTape = cursorStepTape tape).
+  · obtain ⟨hc1, _, _, _⟩ := cursorStepTape_cert width h_width tape z.certEnd
+      (z.ctrlBase + (encodeCtrlStackR ctrl).length) 4 (PreToken.leaf (SLGate.const b)) toks'
+      htag4 (by omega) (by omega) hcert (by omega) hcorr
+    rw [show z.certEnd - (encodePreorder width h_width toks').length
+        = z.certEnd - (encodePreorder width h_width
+            (PreToken.leaf (SLGate.const b) :: toks')).length + 4 from by omega]
+    refine windowSpells_congr _ _ _ _ hc1 (fun q hlo hhi => ?_)
+    rw [constStepTape_eq_cursor tape _ _ _ _ _ _ q
+      (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+  -- 2. cert fit.
+  · omega
+  -- 3. new marker.
+  · intro p hp
+    rw [show (z.certEnd - (encodePreorder width h_width toks').length) - 1
+        = z.certEnd - (encodePreorder width h_width
+            (PreToken.leaf (SLGate.const b) :: toks')).length + 4 - 1 from by omega] at hp
+    rw [constStepTape_eq_cursor tape _ _ _ _ _ _ p
+      (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+    unfold cursorStepTape
+    rw [if_pos hp]
+  -- 4. consumed/dead corridor.
+  · intro p hlo hhi
+    rw [show (z.certEnd - (encodePreorder width h_width toks').length) - 1
+        = z.certEnd - (encodePreorder width h_width
+            (PreToken.leaf (SLGate.const b) :: toks')).length + 4 - 1 from by omega] at hhi
+    rw [constStepTape_eq_cursor tape _ _ _ _ _ _ p
+      (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+    unfold cursorStepTape
+    rw [if_neg (by omega)]
+    by_cases hband : z.certEnd - (encodePreorder width h_width
+        (PreToken.leaf (SLGate.const b) :: toks')).length - 1 ≤ (p : Nat)
+      ∧ (p : Nat) < z.certEnd - (encodePreorder width h_width
+        (PreToken.leaf (SLGate.const b) :: toks')).length + 4 - 1
+    · rw [if_pos hband]
+    · rw [if_neg hband]
+      exact hcorr p hlo (by omega)
+  -- 5. output window (emit region: constStepTape = emitTape tape; reuse the core).
+  · have hemit := emitTape_output_window tape (z.workBase - 1 - out.length) out
+      (SLGate.const b : SLGate n) (by omega) hout
+      (by rw [List.length_append, unaryField_length]; omega)
+      (by
+        rw [List.length_append, unaryField_length, hreclen]
+        have := hval.1
+        omega)
+    rw [hlen1, show z.workBase - 1 - (out.length + 1)
+        = z.workBase - 1 - out.length - 1 from by omega]
+    have hocfm : z.workBase - 1 - out.length
+        + (unaryField out.length ++ encodeGateRecordStream out).length
+        = z.workBase + (encodeGateRecordStream out).length := by
+      rw [List.length_append, unaryField_length]; omega
+    rw [show z.workBase - 1 - out.length - 1 + 1 = z.workBase - 1 - out.length from by omega,
+      hocfm] at hemit
+    refine windowSpells_congr _ _ _ _ hemit (fun q hlo hhi => ?_)
+    · rw [constStepTape_eq_emit tape _ _ _ _ _ _ q
+        (by rw [List.length_append, unaryField_length, hstreamlen] at hhi; omega)
+        (by rw [List.length_append, unaryField_length, hstreamlen] at hhi; omega)
+        (by rw [List.length_append, unaryField_length, hstreamlen] at hhi
+            rw [hventrylen]; omega)]
+  -- 6. output left fit.
+  · rw [hlen1]
+    omega
+  -- 7. new frontier marker.
+  · intro p hp
+    rw [hstreamlen] at hp
+    rw [constStepTape_eq_emit tape _ _ _ _ _ _ p
+      (by omega) (by omega) (by rw [hventrylen]; omega)]
+    exact emitTape_FM tape _ _ _ (by omega) p (by rw [hreclen]; omega)
+  -- 8. frontier fit.
+  · rw [hstreamlen]
+    omega
+  -- 9. FM→val dead corridor.
+  · intro p hlo hhi
+    rw [hstreamlen] at hlo
+    rw [constStepTape_eq_id tape _ _ _ _ _ _ p
+      (by omega) (by omega) (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+    exact hfzeros p (by omega) hhi
+  -- 10. value window (write region: constStepTape = writeBlockTape tape; reuse the core).
+  · have hvw := valPush_window tape z.valBase out.length val hval
+      (by rw [encodeNatEntryR_length]; omega)
+    refine windowSpells_congr _ _ _ _ hvw (fun q hlo hhi => ?_)
+    rw [encodeNatStackR_cons, List.length_append, encodeNatEntryR_length] at hhi
+    rw [constStepTape_eq_write tape _ _ _ _ _ _ q
+      (by omega) (by omega) (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)]
+  -- 11. value fit.
+  · rw [encodeNatStackR_cons, List.length_append, encodeNatEntryR_length]
+    omega
+  -- 12. val→ctrl dead corridor.
+  · intro p hlo hhi
+    rw [encodeNatStackR_cons, List.length_append, encodeNatEntryR_length] at hlo
+    rw [constStepTape_eq_id tape _ _ _ _ _ _ p
+      (by omega) (by omega) (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+    exact hvzeros p (by omega) hhi
+  -- 13. control window (untouched).
+  · refine windowSpells_congr _ _ _ _ hctrl (fun q hlo hhi => ?_)
+    have hq : (q : Nat) < z.ctrlEnd := by have := hctrl.1; omega
+    rw [constStepTape_eq_id tape _ _ _ _ _ _ q
+      (by omega) (by omega) (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+  -- 14. control fit.
+  · exact hcfit2
+  -- 15. validity.
+  · exact fun t ht => hvalid t (List.mem_cons_of_mem _ ht)
+  -- 16. settling coherence.
+  · intro _; exact List.cons_ne_nil _ _
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorDecStep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorDecStep.lean
@@ -1,0 +1,191 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorInputStep
+
+/-!
+# The settle-decrement keystone — D2t-5b (Block A4b): `DriveState.step`'s decrement branch on tape
+
+The settling arm with a top frame `(tag, rem)`, `rem ≥ 2`, decrements: `⟨toks, out, (tag, rem) ::
+ctrl', val, true⟩ → ⟨toks, out, (tag, rem − 1) :: ctrl', val, false⟩`.  On tape this is a **single
+bounded rewrite of the top-frame region**: the old frame (rightmost, at `fb = ctrlBase +
+|encodeCtrlStackR ctrl'|`) is overwritten by the decremented frame, and the one leftover cell (the
+new frame is one shorter) is zeroed — both effected by one `writeBlockTape` whose block is the new
+frame padded with a trailing `false` (`getD` past the block's end is `false` automatically).
+
+`corridorInv_decStep` re-establishes `driverCorridorInv` for the stepped state: the control window is
+the codec cons with the decremented frame; the corridor right of the (shrunk) content absorbs the
+leftover zero; every other region is untouched.
+
+**Progress classification (AGENTS.md): Infrastructure** — a tape-level invariant-preservation
+keystone over the verified codecs; builds no machine and proves no separation.  Standard `[propext,
+Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- Frame lengths: the decremented frame is exactly one cell shorter. -/
+theorem encodeCtrlFrameR_dec_length (tag : ITag) (rem : Nat) (hrem : 2 ≤ rem) :
+    (encodeCtrlFrameR (tag, rem - 1)).length + 1 = (encodeCtrlFrameR (tag, rem)).length := by
+  rw [encodeCtrlFrameR_length, encodeCtrlFrameR_length]
+  omega
+
+/-- **The settle-decrement keystone.**  For a settling state with top frame `(tag, rem)`, `rem ≥ 2`,
+overwriting the top-frame region with the decremented frame (plus the one-cell zero pad) yields the
+invariant for the stepped state `⟨toks, out, (tag, rem − 1) :: ctrl', val, false⟩`. -/
+theorem corridorInv_decStep {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (tag : ITag) (rem : Nat) (hrem : 2 ≤ rem)
+    (toks : List (PreToken n)) (out : List (SLGate n)) (ctrl' : List (ITag × Nat))
+    (val : List Nat) (tape : Fin L → Bool)
+    (hinv : driverCorridorInv width h_width z tape
+      (⟨toks, out, (tag, rem) :: ctrl', val, true⟩ : DriveState n)) :
+    driverCorridorInv width h_width z
+      (writeBlockTape tape (z.ctrlBase + (encodeCtrlStackR ctrl').length)
+        (encodeCtrlFrameR (tag, rem - 1) ++ [false]))
+      (⟨toks, out, (tag, rem - 1) :: ctrl', val, false⟩ : DriveState n) := by
+  obtain ⟨hwf, hcert, hcfit, hmark, hcorr, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  replace hcert : windowSpells tape
+      (z.certEnd - (encodePreorder width h_width toks).length)
+      (encodePreorder width h_width toks) := hcert
+  replace hcfit : z.certBase + (encodePreorder width h_width toks).length ≤ z.certEnd := hcfit
+  replace hmark : ∀ p : Fin L,
+      (p : Nat) = z.certEnd - (encodePreorder width h_width toks).length - 1 →
+      tape p = true := hmark
+  replace hcorr : ∀ p : Fin L,
+      z.ctrlBase + (encodeCtrlStackR ((tag, rem) :: ctrl')).length ≤ (p : Nat) →
+      (p : Nat) < z.certEnd - (encodePreorder width h_width toks).length - 1 →
+      tape p = false := hcorr
+  replace hout : windowSpells tape (z.workBase - 1 - out.length)
+      (unaryField out.length ++ encodeGateRecordStream out) := hout
+  replace hofit : z.outBase + out.length + 1 ≤ z.workBase := hofit
+  replace hFM : ∀ p : Fin L,
+      (p : Nat) = z.workBase + (encodeGateRecordStream out).length → tape p = true := hFM
+  replace hffit : z.workBase + (encodeGateRecordStream out).length + 1 ≤ z.workEnd := hffit
+  replace hfzeros : ∀ p : Fin L,
+      z.workBase + (encodeGateRecordStream out).length + 1 ≤ (p : Nat) →
+      (p : Nat) < z.valBase → tape p = false := hfzeros
+  replace hval : windowSpells tape z.valBase (encodeNatStackR val) := hval
+  replace hvfit : z.valBase + (encodeNatStackR val).length ≤ z.valEnd := hvfit
+  replace hvzeros : ∀ p : Fin L, z.valBase + (encodeNatStackR val).length ≤ (p : Nat) →
+      (p : Nat) < z.ctrlBase → tape p = false := hvzeros
+  replace hctrl : windowSpells tape z.ctrlBase (encodeCtrlStackR ((tag, rem) :: ctrl')) := hctrl
+  replace hcfit2 : z.ctrlBase + (encodeCtrlStackR ((tag, rem) :: ctrl')).length
+      ≤ z.ctrlEnd := hcfit2
+  replace hvalid : ValidCertTokens toks := hvalid
+  replace hcoh : True → val ≠ [] := fun _ => hcoh rfl
+  -- Lengths and the rewrite block.
+  have holdlen : (encodeCtrlStackR ((tag, rem) :: ctrl')).length
+      = (encodeCtrlStackR ctrl').length + (encodeCtrlFrameR (tag, rem)).length := by
+    rw [encodeCtrlStackR_cons, List.length_append]
+  have hnewlen : (encodeCtrlStackR ((tag, rem - 1) :: ctrl')).length
+      = (encodeCtrlStackR ctrl').length + (encodeCtrlFrameR (tag, rem - 1)).length := by
+    rw [encodeCtrlStackR_cons, List.length_append]
+  have hdec := encodeCtrlFrameR_dec_length tag rem hrem
+  have hblocklen : (encodeCtrlFrameR (tag, rem - 1) ++ [false]).length
+      = (encodeCtrlFrameR (tag, rem)).length := by
+    rw [List.length_append, List.length_singleton]; omega
+  -- The rewrite zone [fb, fb + |old frame|) lies inside [ctrlBase, ctrl-old-end] ⊆ [ctrlBase, ctrlEnd].
+  have hzone : z.ctrlBase + (encodeCtrlStackR ctrl').length
+      + (encodeCtrlFrameR (tag, rem - 1) ++ [false]).length ≤ z.ctrlEnd := by
+    rw [hblocklen]; omega
+  -- Off-zone transport: the rewrite touches only [fb, fb + |old frame|).
+  have hoff_below : ∀ q : Fin L, (q : Nat) < z.ctrlBase + (encodeCtrlStackR ctrl').length →
+      writeBlockTape tape (z.ctrlBase + (encodeCtrlStackR ctrl').length)
+        (encodeCtrlFrameR (tag, rem - 1) ++ [false]) q = tape q :=
+    fun q hq => writeBlockTape_below tape _ _ q hq
+  have hoff_above : ∀ q : Fin L,
+      z.ctrlBase + (encodeCtrlStackR ((tag, rem) :: ctrl')).length ≤ (q : Nat) →
+      writeBlockTape tape (z.ctrlBase + (encodeCtrlStackR ctrl').length)
+        (encodeCtrlFrameR (tag, rem - 1) ++ [false]) q = tape q := by
+    intro q hq
+    apply writeBlockTape_above
+    rw [hblocklen]; omega
+  dsimp only [driverCorridorInv]
+  refine ⟨⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_⟩
+  -- 1. cert suffix (untouched: cert region right of ctrlEnd).
+  · refine windowSpells_congr _ _ _ _ hcert (fun q hlo hhi => ?_)
+    exact hoff_above q (by omega)
+  -- 2. cert fit.
+  · exact hcfit
+  -- 3. marker (untouched).
+  · intro p hp
+    rw [hoff_above p (by omega)]
+    exact hmark p hp
+  -- 4. consumed/dead corridor: old corridor + the leftover zero cell.
+  · intro p hlo hhi
+    rw [hnewlen] at hlo
+    by_cases hzero : (p : Nat) < z.ctrlBase + (encodeCtrlStackR ((tag, rem) :: ctrl')).length
+    · -- p is the leftover pad cell inside the rewrite zone: the block's getD there is false.
+      unfold writeBlockTape
+      rw [if_pos ⟨by omega, by rw [hblocklen]; omega⟩]
+      rw [List.getD_append_right _ _ _ _ (by omega)]
+      have : (p : Nat) - (z.ctrlBase + (encodeCtrlStackR ctrl').length)
+          - (encodeCtrlFrameR (tag, rem - 1)).length = 0 := by omega
+      rw [this]
+      rfl
+    · rw [hoff_above p (by omega)]
+      exact hcorr p (by omega) hhi
+  -- 5. output window (untouched).
+  · refine windowSpells_congr _ _ _ _ hout (fun q hlo hhi => ?_)
+    apply hoff_below
+    rw [List.length_append, unaryField_length] at hhi
+    omega
+  -- 6. output left fit.
+  · exact hofit
+  -- 7. frontier marker (untouched).
+  · intro p hp
+    rw [hoff_below p (by omega)]
+    exact hFM p hp
+  -- 8. frontier fit.
+  · exact hffit
+  -- 9. FM→val corridor (untouched).
+  · intro p hlo hhi
+    rw [hoff_below p (by omega)]
+    exact hfzeros p hlo hhi
+  -- 10. value window (untouched).
+  · refine windowSpells_congr _ _ _ _ hval (fun q hlo hhi => ?_)
+    apply hoff_below
+    have := hvfit
+    omega
+  -- 11. value fit.
+  · exact hvfit
+  -- 12. val→ctrl corridor (untouched).
+  · intro p hlo hhi
+    rw [hoff_below p (by omega)]
+    exact hvzeros p hlo hhi
+  -- 13. control window: the prefix is untouched; the frame cells come from the written block.
+  · rw [encodeCtrlStackR_cons]
+    have hpre := windowSpells_append_left tape z.ctrlBase _ _
+      (by rw [← encodeCtrlStackR_cons]; exact hctrl)
+    refine ⟨by
+      rw [List.length_append]
+      have := hctrl.1
+      rw [holdlen] at this
+      omega, fun q hlo hhi => ?_⟩
+    rw [List.length_append] at hhi
+    by_cases hq : (q : Nat) < z.ctrlBase + (encodeCtrlStackR ctrl').length
+    · -- old prefix, untouched
+      rw [hoff_below q hq, List.getD_append _ _ _ _ (by omega)]
+      exact hpre.2 q hlo (by omega)
+    · -- the new frame's cells: from the written block
+      unfold writeBlockTape
+      rw [if_pos ⟨by omega, by rw [hblocklen]; omega⟩,
+        List.getD_append_right (encodeCtrlStackR ctrl') _ _ _ (by omega),
+        List.getD_append _ _ _ _ (by omega)]
+      congr 1
+      omega
+  -- 14. control fit.
+  · rw [hnewlen]
+    omega
+  -- 15. validity.
+  · exact hvalid
+  -- 16. settling coherence (now reading).
+  · intro hs; cases hs
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorInputStep.lean
+++ b/pnp4/Pnp4/Frontier/ContractExpansion/TreeMCSPCorridorInputStep.lean
@@ -1,0 +1,295 @@
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep
+
+/-!
+# The input-leaf keystone — D2t-5b (Block A4a, part 2): `DriveState.step`'s `input` branch on tape
+
+The `input i` arm is the `const` arm with a `(3 + width)`-cell token (tag `[0,0,0]` plus the binary
+index `encodeFin width i`) and the record `unaryField 0 ++ unaryField i.val`.  This module
+generalises the composed transformer over the **token length** (`leafStepTape … tlen …`, off-factory
+re-proven verbatim) and instantiates the keystone: `corridorInv_inputStep` re-establishes
+`driverCorridorInv` for the stepped state `⟨toks', out ++ [input i], ctrl, out.length :: val, true⟩`.
+
+**Progress classification (AGENTS.md): Infrastructure** — a tape-level invariant-preservation
+keystone over the verified codecs; builds no machine and proves no separation.  Standard `[propext,
+Classical.choice, Quot.sound]` triple only.  **No `P ≠ NP` claim.**
+-/
+
+namespace Pnp4
+namespace Frontier
+namespace ContractExpansion
+
+open Pnp3.Internal.PsubsetPpoly.TM.Encoding
+
+/-- The leaf-arm tape transformer, generic over the consumed token's length `tlen`: value push
+(inner), output emit (middle), cursor-marker update (outer). -/
+def leafStepTape {L : Nat} (tape : Fin L → Bool) (cur tlen vtop oc fm : Nat)
+    (ventry rec : List Bool) : Fin L → Bool :=
+  cursorStepTape (emitTape (writeBlockTape tape vtop ventry) oc fm rec) cur tlen
+
+/-- Off all three regions, `leafStepTape` is the identity. -/
+theorem leafStepTape_eq_id {L : Nat} (tape : Fin L → Bool) (cur tlen vtop oc fm : Nat)
+    (ventry rec : List Bool) (q : Fin L)
+    (hc1 : (q : Nat) ≠ cur + tlen - 1)
+    (hc2 : ¬ (cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + tlen - 1))
+    (he1 : (q : Nat) ≠ oc - 1) (he2 : ¬ (fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length))
+    (he3 : (q : Nat) ≠ fm + rec.length)
+    (hw : ¬ (vtop ≤ (q : Nat) ∧ (q : Nat) < vtop + ventry.length)) :
+    leafStepTape tape cur tlen vtop oc fm ventry rec q = tape q := by
+  unfold leafStepTape
+  rw [cursorStepTape_off _ _ _ q hc1 hc2, emitTape_off _ _ _ _ q he1 he2 he3]
+  unfold writeBlockTape
+  rw [if_neg hw]
+
+/-- On the cursor area, `leafStepTape` is `cursorStepTape` of the original tape. -/
+theorem leafStepTape_eq_cursor {L : Nat} (tape : Fin L → Bool) (cur tlen vtop oc fm : Nat)
+    (ventry rec : List Bool) (q : Fin L)
+    (he1 : (q : Nat) ≠ oc - 1) (he2 : ¬ (fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length))
+    (he3 : (q : Nat) ≠ fm + rec.length)
+    (hw : ¬ (vtop ≤ (q : Nat) ∧ (q : Nat) < vtop + ventry.length)) :
+    leafStepTape tape cur tlen vtop oc fm ventry rec q = cursorStepTape tape cur tlen q := by
+  unfold leafStepTape cursorStepTape
+  by_cases hq1 : (q : Nat) = cur + tlen - 1
+  · rw [if_pos hq1, if_pos hq1]
+  · rw [if_neg hq1, if_neg hq1]
+    by_cases hq2 : cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + tlen - 1
+    · rw [if_pos hq2, if_pos hq2]
+    · rw [if_neg hq2, if_neg hq2, emitTape_off _ _ _ _ q he1 he2 he3]
+      unfold writeBlockTape
+      rw [if_neg hw]
+
+/-- On the output region, `leafStepTape` is `emitTape` of the original tape. -/
+theorem leafStepTape_eq_emit {L : Nat} (tape : Fin L → Bool) (cur tlen vtop oc fm : Nat)
+    (ventry rec : List Bool) (q : Fin L)
+    (hc1 : (q : Nat) ≠ cur + tlen - 1)
+    (hc2 : ¬ (cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + tlen - 1))
+    (hw : ¬ (vtop ≤ (q : Nat) ∧ (q : Nat) < vtop + ventry.length)) :
+    leafStepTape tape cur tlen vtop oc fm ventry rec q = emitTape tape oc fm rec q := by
+  unfold leafStepTape
+  rw [cursorStepTape_off _ _ _ q hc1 hc2]
+  unfold emitTape
+  by_cases hq1 : (q : Nat) = oc - 1
+  · rw [if_pos hq1, if_pos hq1]
+  · rw [if_neg hq1, if_neg hq1]
+    by_cases hq2 : fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length
+    · rw [if_pos hq2, if_pos hq2]
+    · rw [if_neg hq2, if_neg hq2]
+      by_cases hq3 : (q : Nat) = fm + rec.length
+      · rw [if_pos hq3, if_pos hq3]
+      · rw [if_neg hq3, if_neg hq3]
+        unfold writeBlockTape
+        rw [if_neg hw]
+
+/-- On the value block, `leafStepTape` is `writeBlockTape` of the original tape. -/
+theorem leafStepTape_eq_write {L : Nat} (tape : Fin L → Bool) (cur tlen vtop oc fm : Nat)
+    (ventry rec : List Bool) (q : Fin L)
+    (hc1 : (q : Nat) ≠ cur + tlen - 1)
+    (hc2 : ¬ (cur - 1 ≤ (q : Nat) ∧ (q : Nat) < cur + tlen - 1))
+    (he1 : (q : Nat) ≠ oc - 1) (he2 : ¬ (fm ≤ (q : Nat) ∧ (q : Nat) < fm + rec.length))
+    (he3 : (q : Nat) ≠ fm + rec.length) :
+    leafStepTape tape cur tlen vtop oc fm ventry rec q = writeBlockTape tape vtop ventry q := by
+  unfold leafStepTape
+  rw [cursorStepTape_off _ _ _ q hc1 hc2, emitTape_off _ _ _ _ q he1 he2 he3]
+
+/-- **The input-leaf keystone.**  For a reading state whose next token is `leaf (input i)` (tail
+nonempty), with output and value-zone capacity, `leafStepTape` (token length `3 + width`)
+re-establishes `driverCorridorInv` for the stepped state. -/
+theorem corridorInv_inputStep {n L : Nat} (width : Nat) (h_width : n ≤ 2 ^ width)
+    (z : DriverCorridor) (i : Fin n) (toks' : List (PreToken n)) (out : List (SLGate n))
+    (ctrl : List (ITag × Nat)) (val : List Nat) (tape : Fin L → Bool)
+    (hinv : driverCorridorInv width h_width z tape
+      (⟨PreToken.leaf (SLGate.input i) :: toks', out, ctrl, val, false⟩ : DriveState n))
+    (htoks : toks' ≠ [])
+    (hocap : z.outBase + out.length + 2 ≤ z.workBase)
+    (hwcap : z.workBase + (encodeGateRecordStream out).length
+        + (encodeGateRecord (SLGate.input i : SLGate n)).length + 1 ≤ z.workEnd)
+    (hvcap : z.valBase + (encodeNatStackR val).length + (out.length + 3) ≤ z.valEnd) :
+    driverCorridorInv width h_width z
+      (leafStepTape tape
+        (z.certEnd - (encodePreorder width h_width
+          (PreToken.leaf (SLGate.input i) :: toks')).length)
+        (3 + width)
+        (z.valBase + (encodeNatStackR val).length)
+        (z.workBase - 1 - out.length)
+        (z.workBase + (encodeGateRecordStream out).length)
+        (encodeNatEntryR out.length)
+        (encodeGateRecord (SLGate.input i : SLGate n)))
+      (⟨toks', out ++ [SLGate.input i], ctrl, out.length :: val, true⟩ : DriveState n) := by
+  obtain ⟨hwf, hcert, hcfit, hmark, hcorr, hout, hofit, hFM, hffit, hfzeros, hval, hvfit, hvzeros,
+    hctrl, hcfit2, hvalid, hcoh⟩ := hinv
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩ := hwf
+  replace hcert : windowSpells tape
+      (z.certEnd - (encodePreorder width h_width (PreToken.leaf (SLGate.input i) :: toks')).length)
+      (encodePreorder width h_width (PreToken.leaf (SLGate.input i) :: toks')) := hcert
+  replace hcfit : z.certBase
+      + (encodePreorder width h_width (PreToken.leaf (SLGate.input i) :: toks')).length
+        ≤ z.certEnd := hcfit
+  replace hcorr : ∀ p : Fin L, z.ctrlBase + (encodeCtrlStackR ctrl).length ≤ (p : Nat) →
+      (p : Nat) < z.certEnd
+        - (encodePreorder width h_width (PreToken.leaf (SLGate.input i) :: toks')).length - 1 →
+      tape p = false := hcorr
+  replace hout : windowSpells tape (z.workBase - 1 - out.length)
+      (unaryField out.length ++ encodeGateRecordStream out) := hout
+  replace hofit : z.outBase + out.length + 1 ≤ z.workBase := hofit
+  replace hffit : z.workBase + (encodeGateRecordStream out).length + 1 ≤ z.workEnd := hffit
+  replace hfzeros : ∀ p : Fin L,
+      z.workBase + (encodeGateRecordStream out).length + 1 ≤ (p : Nat) →
+      (p : Nat) < z.valBase → tape p = false := hfzeros
+  replace hval : windowSpells tape z.valBase (encodeNatStackR val) := hval
+  replace hvfit : z.valBase + (encodeNatStackR val).length ≤ z.valEnd := hvfit
+  replace hvzeros : ∀ p : Fin L, z.valBase + (encodeNatStackR val).length ≤ (p : Nat) →
+      (p : Nat) < z.ctrlBase → tape p = false := hvzeros
+  replace hctrl : windowSpells tape z.ctrlBase (encodeCtrlStackR ctrl) := hctrl
+  replace hcfit2 : z.ctrlBase + (encodeCtrlStackR ctrl).length ≤ z.ctrlEnd := hcfit2
+  replace hvalid : ValidCertTokens (PreToken.leaf (SLGate.input i) :: toks') := hvalid
+  -- Length facts.
+  have hreclen : (encodeGateRecord (SLGate.input i : SLGate n)).length = i.val + 2 := by
+    show (unaryField 0 ++ unaryField i.val).length = i.val + 2
+    rw [List.length_append, unaryField_length, unaryField_length]
+    omega
+  have hventrylen : (encodeNatEntryR out.length).length = out.length + 3 :=
+    encodeNatEntryR_length out.length
+  have htagW : (encodePreToken width h_width (PreToken.leaf (SLGate.input i))).length
+      = 3 + width := by
+    show ([false, false, false]
+      ++ encodeFin width ⟨i.val, lt_of_lt_of_le i.isLt h_width⟩).length = 3 + width
+    rw [List.length_append, encodeFin_length]
+    rfl
+  have htail1 : 1 ≤ (encodePreorder width h_width toks').length := by
+    have hv : ValidCertTokens toks' := fun t ht => hvalid t (List.mem_cons_of_mem _ ht)
+    have := validCertTokens_length_le width h_width hv
+    have : 1 ≤ toks'.length := by cases toks' with
+      | nil => exact absurd rfl htoks
+      | cons a l => simp only [List.length_cons]; omega
+    omega
+  have hlenc : (encodePreorder width h_width (PreToken.leaf (SLGate.input i) :: toks')).length
+      = (3 + width) + (encodePreorder width h_width toks').length := by
+    rw [encodePreorder_cons, List.length_append, htagW]
+  have hrecstream := encodeGateRecordStream_snoc out (SLGate.input i : SLGate n)
+  have hlen1 : (out ++ [(SLGate.input i : SLGate n)]).length = out.length + 1 := by simp
+  have hstreamlen : (encodeGateRecordStream (out ++ [(SLGate.input i : SLGate n)])).length
+      = (encodeGateRecordStream out).length + (i.val + 2) := by
+    rw [hrecstream, List.length_append, hreclen]
+  have hsepcur : z.ctrlEnd + 2 < z.certEnd
+      - (encodePreorder width h_width (PreToken.leaf (SLGate.input i) :: toks')).length := by
+    omega
+  have hreccap : z.workBase + (encodeGateRecordStream out).length + (i.val + 2) + 1
+      ≤ z.workEnd := by
+    rw [hreclen] at hwcap; omega
+  dsimp only [driverCorridorInv]
+  refine ⟨⟨h1, h2, h3, h4, h5, h6, h7, h8, h9⟩, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+    ?_, ?_, ?_, ?_⟩
+  -- 1. cert suffix window.
+  · obtain ⟨hc1, _, _, _⟩ := cursorStepTape_cert width h_width tape z.certEnd
+      (z.ctrlBase + (encodeCtrlStackR ctrl).length) (3 + width) (PreToken.leaf (SLGate.input i))
+      toks' htagW (by omega) (by omega) hcert (by omega) hcorr
+    rw [show z.certEnd - (encodePreorder width h_width toks').length
+        = z.certEnd - (encodePreorder width h_width
+            (PreToken.leaf (SLGate.input i) :: toks')).length + (3 + width) from by omega]
+    refine windowSpells_congr _ _ _ _ hc1 (fun q hlo hhi => ?_)
+    rw [leafStepTape_eq_cursor tape _ _ _ _ _ _ _ q
+      (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+  -- 2. cert fit.
+  · omega
+  -- 3. new marker.
+  · intro p hp
+    rw [show (z.certEnd - (encodePreorder width h_width toks').length) - 1
+        = z.certEnd - (encodePreorder width h_width
+            (PreToken.leaf (SLGate.input i) :: toks')).length + (3 + width) - 1 from by omega] at hp
+    rw [leafStepTape_eq_cursor tape _ _ _ _ _ _ _ p
+      (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+    unfold cursorStepTape
+    rw [if_pos hp]
+  -- 4. consumed/dead corridor.
+  · intro p hlo hhi
+    rw [show (z.certEnd - (encodePreorder width h_width toks').length) - 1
+        = z.certEnd - (encodePreorder width h_width
+            (PreToken.leaf (SLGate.input i) :: toks')).length + (3 + width) - 1 from by omega]
+      at hhi
+    rw [leafStepTape_eq_cursor tape _ _ _ _ _ _ _ p
+      (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+    unfold cursorStepTape
+    rw [if_neg (by omega)]
+    by_cases hband : z.certEnd - (encodePreorder width h_width
+        (PreToken.leaf (SLGate.input i) :: toks')).length - 1 ≤ (p : Nat)
+      ∧ (p : Nat) < z.certEnd - (encodePreorder width h_width
+        (PreToken.leaf (SLGate.input i) :: toks')).length + (3 + width) - 1
+    · rw [if_pos hband]
+    · rw [if_neg hband]
+      exact hcorr p hlo (by omega)
+  -- 5. output window.
+  · have hemit := emitTape_output_window tape (z.workBase - 1 - out.length) out
+      (SLGate.input i : SLGate n) (by omega) hout
+      (by rw [List.length_append, unaryField_length]; omega)
+      (by
+        rw [List.length_append, unaryField_length, hreclen]
+        have := hval.1
+        omega)
+    rw [hlen1, show z.workBase - 1 - (out.length + 1)
+        = z.workBase - 1 - out.length - 1 from by omega]
+    have hocfm : z.workBase - 1 - out.length
+        + (unaryField out.length ++ encodeGateRecordStream out).length
+        = z.workBase + (encodeGateRecordStream out).length := by
+      rw [List.length_append, unaryField_length]; omega
+    rw [show z.workBase - 1 - out.length - 1 + 1 = z.workBase - 1 - out.length from by omega,
+      hocfm] at hemit
+    refine windowSpells_congr _ _ _ _ hemit (fun q hlo hhi => ?_)
+    rw [leafStepTape_eq_emit tape _ _ _ _ _ _ _ q
+      (by rw [List.length_append, unaryField_length, hstreamlen] at hhi; omega)
+      (by rw [List.length_append, unaryField_length, hstreamlen] at hhi; omega)
+      (by rw [List.length_append, unaryField_length, hstreamlen] at hhi
+          rw [hventrylen]; omega)]
+  -- 6. output left fit.
+  · rw [hlen1]
+    omega
+  -- 7. new frontier marker.
+  · intro p hp
+    rw [hstreamlen] at hp
+    rw [leafStepTape_eq_emit tape _ _ _ _ _ _ _ p
+      (by omega) (by omega) (by rw [hventrylen]; omega)]
+    exact emitTape_FM tape _ _ _ (by omega) p (by rw [hreclen]; omega)
+  -- 8. frontier fit.
+  · rw [hstreamlen]
+    omega
+  -- 9. FM→val dead corridor.
+  · intro p hlo hhi
+    rw [hstreamlen] at hlo
+    rw [leafStepTape_eq_id tape _ _ _ _ _ _ _ p
+      (by omega) (by omega) (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+    exact hfzeros p (by omega) hhi
+  -- 10. value window.
+  · have hvw := valPush_window tape z.valBase out.length val hval
+      (by rw [encodeNatEntryR_length]; omega)
+    refine windowSpells_congr _ _ _ _ hvw (fun q hlo hhi => ?_)
+    rw [encodeNatStackR_cons, List.length_append, encodeNatEntryR_length] at hhi
+    rw [leafStepTape_eq_write tape _ _ _ _ _ _ _ q
+      (by omega) (by omega) (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)]
+  -- 11. value fit.
+  · rw [encodeNatStackR_cons, List.length_append, encodeNatEntryR_length]
+    omega
+  -- 12. val→ctrl dead corridor.
+  · intro p hlo hhi
+    rw [encodeNatStackR_cons, List.length_append, encodeNatEntryR_length] at hlo
+    rw [leafStepTape_eq_id tape _ _ _ _ _ _ _ p
+      (by omega) (by omega) (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+    exact hvzeros p (by omega) hhi
+  -- 13. control window (untouched).
+  · refine windowSpells_congr _ _ _ _ hctrl (fun q hlo hhi => ?_)
+    have hq : (q : Nat) < z.ctrlEnd := by have := hctrl.1; omega
+    rw [leafStepTape_eq_id tape _ _ _ _ _ _ _ q
+      (by omega) (by omega) (by omega) (by rw [hreclen]; omega) (by rw [hreclen]; omega)
+      (by rw [hventrylen]; omega)]
+  -- 14. control fit.
+  · exact hcfit2
+  -- 15. validity.
+  · exact fun t ht => hvalid t (List.mem_cons_of_mem _ ht)
+  -- 16. settling coherence.
+  · intro _; exact List.cons_ne_nil _ _
+
+end ContractExpansion
+end Frontier
+end Pnp4

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -113,6 +113,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorInputStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4169,6 +4170,10 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 -- D2t-5b (Block A4a, part 2): the const-leaf keystone.
 #check @Pnp4.Frontier.ContractExpansion.encodeGateRecordStream_snoc
 #check @Pnp4.Frontier.ContractExpansion.corridorInv_constStep
+-- D2t-5b (Block A4a, part 2): the input-leaf keystone (token-length-generic leafStepTape).
+#check @Pnp4.Frontier.ContractExpansion.leafStepTape
+#check @Pnp4.Frontier.ContractExpansion.leafStepTape_eq_id
+#check @Pnp4.Frontier.ContractExpansion.corridorInv_inputStep
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -112,6 +112,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4165,6 +4166,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.constStepTape_eq_cursor
 #check @Pnp4.Frontier.ContractExpansion.constStepTape_eq_emit
 #check @Pnp4.Frontier.ContractExpansion.constStepTape_eq_write
+-- D2t-5b (Block A4a, part 2): the const-leaf keystone.
+#check @Pnp4.Frontier.ContractExpansion.encodeGateRecordStream_snoc
+#check @Pnp4.Frontier.ContractExpansion.corridorInv_constStep
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -111,6 +111,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4157,6 +4158,13 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.windowSpells_congr
 #check @Pnp4.Frontier.ContractExpansion.cursorStepTape
 #check @Pnp4.Frontier.ContractExpansion.cursorStepTape_cert
+-- D2t-5b (Block A4a, part 2): the const-arm off-factory.
+#check @Pnp4.Frontier.ContractExpansion.constStepTape
+#check @Pnp4.Frontier.ContractExpansion.emitTape_off
+#check @Pnp4.Frontier.ContractExpansion.constStepTape_eq_id
+#check @Pnp4.Frontier.ContractExpansion.constStepTape_eq_cursor
+#check @Pnp4.Frontier.ContractExpansion.constStepTape_eq_emit
+#check @Pnp4.Frontier.ContractExpansion.constStepTape_eq_write
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
+++ b/pnp4/Pnp4/Tests/AlgorithmsToLowerBoundsSurfaceTests.lean
@@ -114,6 +114,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorInputStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDecStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -4174,6 +4175,9 @@ def check_no_uniform_cklmEnvelopeFrequentEscape :
 #check @Pnp4.Frontier.ContractExpansion.leafStepTape
 #check @Pnp4.Frontier.ContractExpansion.leafStepTape_eq_id
 #check @Pnp4.Frontier.ContractExpansion.corridorInv_inputStep
+-- D2t-5b (Block A4b): the settle-decrement keystone.
+#check @Pnp4.Frontier.ContractExpansion.encodeCtrlFrameR_dec_length
+#check @Pnp4.Frontier.ContractExpansion.corridorInv_decStep
 #check @Pnp4.Frontier.ContractExpansion.zoneWalkRight_stepConfig_p3_zero_phase
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #check @Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -101,6 +101,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorNodeStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -989,6 +990,13 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.windowSpells_congr
 #print axioms Pnp4.Frontier.ContractExpansion.cursorStepTape_off
 #print axioms Pnp4.Frontier.ContractExpansion.cursorStepTape_cert
+-- D2t-5b (Block A4a, part 2): the const-arm off-factory — the composed transformer equals exactly
+-- the owning transformer on each disjoint region (the keystone routes clauses through these).
+#print axioms Pnp4.Frontier.ContractExpansion.emitTape_off
+#print axioms Pnp4.Frontier.ContractExpansion.constStepTape_eq_id
+#print axioms Pnp4.Frontier.ContractExpansion.constStepTape_eq_cursor
+#print axioms Pnp4.Frontier.ContractExpansion.constStepTape_eq_emit
+#print axioms Pnp4.Frontier.ContractExpansion.constStepTape_eq_write
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -102,6 +102,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPEmitTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -997,6 +998,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.constStepTape_eq_cursor
 #print axioms Pnp4.Frontier.ContractExpansion.constStepTape_eq_emit
 #print axioms Pnp4.Frontier.ContractExpansion.constStepTape_eq_write
+-- D2t-5b (Block A4a, part 2): the const-leaf KEYSTONE — constStepTape re-establishes
+-- driverCorridorInv for the stepped state (DriveState.step's const branch realised on tape).
+#print axioms Pnp4.Frontier.ContractExpansion.encodeGateRecordStream_snoc
+#print axioms Pnp4.Frontier.ContractExpansion.corridorInv_constStep
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -103,6 +103,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPValPush
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorInputStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -1002,6 +1003,13 @@ end Pnp4
 -- driverCorridorInv for the stepped state (DriveState.step's const branch realised on tape).
 #print axioms Pnp4.Frontier.ContractExpansion.encodeGateRecordStream_snoc
 #print axioms Pnp4.Frontier.ContractExpansion.corridorInv_constStep
+-- D2t-5b (Block A4a, part 2): the input-leaf KEYSTONE — leafStepTape (token-length-generic
+-- off-factory) re-establishes driverCorridorInv for the stepped state (the input branch on tape).
+#print axioms Pnp4.Frontier.ContractExpansion.leafStepTape_eq_id
+#print axioms Pnp4.Frontier.ContractExpansion.leafStepTape_eq_cursor
+#print axioms Pnp4.Frontier.ContractExpansion.leafStepTape_eq_emit
+#print axioms Pnp4.Frontier.ContractExpansion.leafStepTape_eq_write
+#print axioms Pnp4.Frontier.ContractExpansion.corridorInv_inputStep
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false

--- a/pnp4/Pnp4/Tests/AxiomsAudit.lean
+++ b/pnp4/Pnp4/Tests/AxiomsAudit.lean
@@ -104,6 +104,7 @@ import Pnp4.Frontier.ContractExpansion.TreeMCSPCursorStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPConstStepTape
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorConstStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorInputStep
+import Pnp4.Frontier.ContractExpansion.TreeMCSPCorridorDecStep
 import Pnp4.Frontier.ContractExpansion.TreeMCSPUnaryFieldReader
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateTagDispatch
 import Pnp4.Frontier.ContractExpansion.TreeMCSPGateRecordDecoder
@@ -1010,6 +1011,10 @@ end Pnp4
 #print axioms Pnp4.Frontier.ContractExpansion.leafStepTape_eq_emit
 #print axioms Pnp4.Frontier.ContractExpansion.leafStepTape_eq_write
 #print axioms Pnp4.Frontier.ContractExpansion.corridorInv_inputStep
+-- D2t-5b (Block A4b): the settle-DECREMENT keystone — one writeBlockTape (decremented frame + zero
+-- pad) re-establishes the invariant for (toks, out, (tag, rem-1) :: ctrl', val, false).
+#print axioms Pnp4.Frontier.ContractExpansion.encodeCtrlFrameR_dec_length
+#print axioms Pnp4.Frontier.ContractExpansion.corridorInv_decStep
 -- D2t-3 routing run-through (P2 region): scan→branch reaches composed phase 4 (B=0) / 5 (B>0).
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_true
 #print axioms Pnp4.Frontier.ContractExpansion.bZeroRouteProgram_P2_runConfig_branch_false


### PR DESCRIPTION
**Block A4, part 2** — the arm keystones and assembly, continuing from the merged part 1 (#1614: navigation, components, node keystone, emit/push cores).

## Commit 1: the const-arm off-factory (`TreeMCSPConstStepTape`)

Method fix from the part-1 retrospective: the const keystone failed to converge as a monolith because region disjointness was re-proven inline 16 times amid `set`-folding. Now the composed transformer and its **off-factory** land first, over explicit numeric anchors:

* `constStepTape tape cur vtop oc fm ventry rec` — value push (inner) ∘ output emit (middle) ∘ cursor-marker update (outer);
* `emitTape_off` and `constStepTape_eq_id` / `_eq_cursor` / `_eq_emit` / `_eq_write` — on each region of interest the composition **equals exactly the transformer that owns it** (pairwise separation as hypotheses).

The keystone (`corridorInv_constStep`, next commit) then routes each of the 16 invariant clauses through one off-lemma + one already-proven core (`cursorStepTape_cert` / `emitTape_output_window` / `valPush_window`) with no inline disjointness reasoning.

## Planned in this PR
const keystone → input keystone → settle keystones (decrement / pop-emit) → the `seqList` machine assembly via the wholesale P2-embedding transfer → the `loopUntilSink` `Configuration`-level discharge.

## Verification
`lake build PnP3 Pnp4` clean; `./scripts/check.sh` **17/17**; standard `[propext, Classical.choice, Quot.sound]` triple; registered in lakefile + AxiomsAudit + SurfaceTests; no `sorry`/holes.

https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LmjuKTSQsBLYTjT27sH7yj)_